### PR TITLE
Add ODH overlay

### DIFF
--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../default
+- user-cluster-roles.yaml
+
+patchesStrategicMerge:
+- remove-namespace.yaml

--- a/config/overlays/odh/remove-namespace.yaml
+++ b/config/overlays/odh/remove-namespace.yaml
@@ -1,0 +1,6 @@
+# Remove namespace resource as namespace will already exist.
+$patch: delete
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kserve

--- a/config/overlays/odh/user-cluster-roles.yaml
+++ b/config/overlays/odh/user-cluster-roles.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kserve-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-kserve-admin: "true"
+rules: []
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kserve-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-kserve-admin: "true"
+rules:
+  - apiGroups:
+      - serving.kserve.io
+    resources:
+      - inferenceservices
+      - servingruntimes
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kserve-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups:
+      - kubeflow.org
+    resources:
+      - servingruntimes
+      - servingruntimes/status
+      - servingruntimes/finalizers
+      - inferenceservices
+      - inferenceservices/status
+      - inferenceservices/finalizers
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
**What this PR does / why we need it**:

Augments the `default` profile with some changes expected by an ODH installation:
* Removes the `Namespace` CR, because the ODH operator does not expect such resource. The Namespace is expected to be created in advance to later create a KfDef on it, where resources are going to be installed.
* Adds cluster roles, to extend the cluster's default user-facing roles with KServe privileges.
  * Changes from the following PR are being moved  here: opendatahub-io/odh-manifests#887

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

* Related to: opendatahub-io/odh-manifests#884
* Related to: opendatahub-io/odh-manifests#887

**Feature/Issue validation/testing**:

Tested by a simple run of `kustomize build ./config/overlays/odh` and checking that the manifest builds correctly. No additional testing was done other than simple build.

**Checklist**:

- [N/A] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [N/A] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
