### PR TITLE
[v0.11] Adapt qpext workflow for OpenDataHub

### DIFF
--- a/.github/workflows/qpext-docker-publish.yml
+++ b/.github/workflows/qpext-docker-publish.yml
@@ -5,6 +5,7 @@ on:
     # Publish `master` as Docker `latest` image.
     branches:
       - master
+      - release-*
 
     # Publish `v1.2.3` tags as releases.
     tags:
@@ -14,7 +15,7 @@ on:
   pull_request:
 
 env:
-  IMAGE_NAME: qpext
+  IMAGE_NAME: kserve-qpext
 
 jobs:
   # Run tests.
@@ -53,15 +54,16 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Login to DockerHub
+      - name: Login to Quay
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: export version variable
         run: |
-          IMAGE_ID=kserve/$IMAGE_NAME
+          IMAGE_ID=quay.io/${{ vars.QUAY_OWNER }}/$IMAGE_NAME
 
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
@@ -74,9 +76,14 @@ jobs:
 
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
+          [[ "$VERSION" =~ ^release- ]] && VERSION=$(echo $VERSION | sed 's/^release-//')-latest
 
-          echo VERSION=$VERSION >> $GITHUB_ENV
-          echo IMAGE_ID=$IMAGE_ID >> $GITHUB_ENV
+          TAGS=$IMAGE_ID:$VERSION
+
+          # If a vX.Y.Z release is being built, also update the vX.Y tag.
+          [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && TAGS=$TAGS,$IMAGE_ID:$(echo $VERSION | sed 's/\(.*\)\.[[:digit:]]\+$/\1/')
+
+          echo CONTAINER_TAGS=$TAGS >> $GITHUB_ENV
 
       - name: Build and push
         uses: docker/build-push-action@v3
@@ -85,4 +92,4 @@ jobs:
           context: "{{defaultContext}}:qpext"
           file: qpext.Dockerfile
           push: true
-          tags: ${{ env.IMAGE_ID }}:${{ env.VERSION }}
+          tags: ${{ env.CONTAINER_TAGS }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This adapts the _Queue Proxy Extension Docker Publisher_ workflow to build an publish a container image to Quay. 

Related #15 

**Feature/Issue validation/testing**:

A test run can be found here: https://github.com/israel-hdez/kserve/actions/runs/5957673480

**Release note**:

```release-note
NONE
```
