### PR TITLE
Preparation for odh-opeartor v2

### DIFF
--- a/config/overlays/odh/inferenceservice-config-patch.yaml
+++ b/config/overlays/odh/inferenceservice-config-patch.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inferenceservice-config
+  namespace: kserve
+data:
+  explainers: "{}"
+  storageInitializer: |-
+    {
+        "image" : "$(kserve-storage-initializer)",
+        "memoryRequest": "100Mi",
+        "memoryLimit": "1Gi",
+        "cpuRequest": "100m",
+        "cpuLimit": "1",
+        "enableDirectPvcVolumeMount": false
+    }
+  ingress: |-
+    {
+        "ingressGateway" : "knative-serving/knative-ingress-gateway",
+        "ingressService" : "istio-ingressgateway.istio-system.svc.cluster.local",
+        "localGateway" : "knative-serving/knative-local-gateway",
+        "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",
+        "ingressDomain"  : "example.com",
+        "ingressClassName" : "istio",
+        "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
+        "urlScheme": "https",
+        "disableIstioVirtualHost": true
+    }
+  logger: |-
+    {
+        "image" : "$(kserve-agent)",
+        "memoryRequest": "100Mi",
+        "memoryLimit": "1Gi",
+        "cpuRequest": "100m",
+        "cpuLimit": "1",
+        "defaultUrl": "http://default-broker"
+    }
+  batcher: |-
+    {
+        "image" : "$(kserve-agent)",
+        "memoryRequest": "1Gi",
+        "memoryLimit": "1Gi",
+        "cpuRequest": "1",
+        "cpuLimit": "1"
+    }
+  agent: |-
+    {
+        "image" : "$(kserve-agent)",
+        "memoryRequest": "100Mi",
+        "memoryLimit": "1Gi",
+        "cpuRequest": "100m",
+        "cpuLimit": "1"
+    }
+  router: |-
+    {
+        "image" : "$(kserve-router)",
+        "memoryRequest": "100Mi",
+        "memoryLimit": "1Gi",
+        "cpuRequest": "100m",
+        "cpuLimit": "1"
+    }
+  deploy: |-
+    {
+      "defaultDeploymentMode": "Serverless"
+    }
+  metricsAggregator: |-
+    {
+      "enableMetricAggregation": "false",
+      "enablePrometheusScraping" : "false"
+    }

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -5,5 +5,55 @@ resources:
 - ../../default
 - user-cluster-roles.yaml
 
-patchesStrategicMerge:
-- remove-namespace.yaml
+namespace: opendatahub
+
+patches:
+- path: remove-namespace.yaml
+- path: inferenceservice-config-patch.yaml
+
+replacements:
+- source:
+    kind: ConfigMap
+    name: kserve-parameters
+    fieldpath: data.kserve-controller
+  targets:
+  - select:
+      kind: Deployment
+      name: kserve-controller-manager
+    fieldPaths:
+    - spec.template.spec.containers.[name=manager].image
+
+configMapGenerator:
+- envs:
+  - params.env
+  name: kserve-parameters
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+vars:
+- fieldref:
+    fieldpath: data.kserve-storage-initializer
+  name: kserve-storage-initializer
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: kserve-parameters
+- fieldref:
+    fieldpath: data.kserve-agent
+  name: kserve-agent
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: kserve-parameters
+- fieldref:
+    fieldpath: data.kserve-router
+  name: kserve-router
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: kserve-parameters
+
+configurations:
+  - params.yaml
+

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -1,0 +1,4 @@
+kserve-controller=quay.io/opendatahub/kserve-controller:v0.11.0
+kserve-agent=quay.io/opendatahub/kserve-agent:v0.11.0
+kserve-router=quay.io/opendatahub/kserve-router:v0.11.0
+kserve-storage-initializer=quay.io/opendatahub/kserve-storage-initializer:v0.11.0

--- a/config/overlays/odh/params.yaml
+++ b/config/overlays/odh/params.yaml
@@ -1,0 +1,5 @@
+varReference:
+  - path: spec/template/spec/containers/image
+    kind: Deployment
+  - path: data
+    kind: ConfigMap

--- a/python/storage-initializer.Dockerfile
+++ b/python/storage-initializer.Dockerfile
@@ -9,7 +9,7 @@ ARG POETRY_HOME=/opt/poetry
 ARG POETRY_VERSION=1.4.0
 
 # Required for building packages for arm64 arch
-RUN yum -y update && yum -y install python39 python39-devel
+RUN yum -y update && yum -y install python39 python39-devel gcc
 
 RUN python3 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install poetry==${POETRY_VERSION}
 ENV PATH="$PATH:${POETRY_HOME}/bin"


### PR DESCRIPTION
**What this PR does / why we need it**:

Open Data Hub operator v2 is going to be consuming Kustomize manifests from component repos, and `odh-manifests` repo is going to be archived.

This is moving/copying artifacts from `odh-manifests` into an already existent odh overlay. With these changes, the overlay can be directly consumed by ODH-operator v2.

Additionally, this should fix a build issue in the storage-initializer.

Related #72 

**Type of changes**

- [x] New feature (non-breaking change which adds functionality)


## Testing

You can test in two ways:

### Testing with kustomize

Simply, build with kustomize:

```sh
kustomize build config/overlays/odh
```

It should render the manifests without error.

### Testing with odh-operator v2

Use the following YAML in the DSC:

```yaml
spec:
  components:
    kserve:
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: overlays/odh
            uri: 'https://github.com/israel-hdez/kserve/tarball/manifest-opv2-0110'
      managementState: Managed
```

The operator should deploy and KServe should be ready to deploy models.