### PR TITLE
Enable Istio Virtual Host

### DIFF
--- a/config/overlays/odh/inferenceservice-config-patch.yaml
+++ b/config/overlays/odh/inferenceservice-config-patch.yaml
@@ -24,7 +24,7 @@ data:
         "ingressClassName" : "istio",
         "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
         "urlScheme": "https",
-        "disableIstioVirtualHost": true
+        "disableIstioVirtualHost": false
     }
   logger: |-
     {


### PR DESCRIPTION
Partial revert of
https://github.com/opendatahub-io/odh-manifests/pull/916, because https://github.com/opendatahub-io/odh-model-controller/pull/84 has been completed.

Testing instructions are the same as in #107, but use `uri: 'https://github.com/israel-hdez/kserve/tarball/enable-istio-vh` in `devFlags`.