### PR TITLE
[Cherry-Pick] s3 storage initializer: only set environment variables if variables are set in storage secret json 

### DIFF
--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -112,12 +112,16 @@ class Storage(object):  # pylint: disable=too-few-public-methods
                 storage_secret_json[key] = value
 
         if storage_secret_json.get("type", "") == "s3":
-            os.environ["AWS_ENDPOINT_URL"] = storage_secret_json.get("endpoint_url", "")
-            os.environ["AWS_ACCESS_KEY_ID"] = storage_secret_json.get("access_key_id", "")
-            os.environ["AWS_SECRET_ACCESS_KEY"] = storage_secret_json.get("secret_access_key", "")
-            os.environ["AWS_DEFAULT_REGION"] = storage_secret_json.get("region", "")
-            os.environ["AWS_CA_BUNDLE"] = storage_secret_json.get("certificate", "")
-            os.environ["awsAnonymousCredential"] = storage_secret_json.get("anonymous", "")
+            for env_var, key in (
+                ("AWS_ENDPOINT_URL", "endpoint_url"),
+                ("AWS_ACCESS_KEY_ID", "access_key_id"),
+                ("AWS_SECRET_ACCESS_KEY", "secret_access_key"),
+                ("AWS_DEFAULT_REGION", "region"),
+                ("AWS_CA_BUNDLE", "certificate"),
+                ("awsAnonymousCredential", "anonymous"),
+            ):
+                if key in storage_secret_json:
+                    os.environ[env_var] = storage_secret_json.get(key)
 
         if storage_secret_json.get("type", "") == "hdfs" or storage_secret_json.get("type", "") == "webhdfs":
             temp_dir = tempfile.mkdtemp()

--- a/python/kserve/kserve/storage/test/test_s3_storage.py
+++ b/python/kserve/kserve/storage/test/test_s3_storage.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import json
 import unittest.mock as mock
 
 from botocore.client import Config
@@ -174,3 +175,47 @@ def test_get_S3_config():
     with mock.patch.dict(os.environ, {"S3_USER_VIRTUAL_BUCKET": "True"}):
         config7 = Storage.get_S3_config()
     assert config7.s3["addressing_style"] == VIRTUAL_CONFIG.s3["addressing_style"]
+
+
+def test_update_with_storage_spec_s3(monkeypatch):
+    # save the environment and restore it after the test to avoid mutating it
+    # since _update_with_storage_spec modifies it
+    previous_env = os.environ.copy()
+
+    monkeypatch.setenv("STORAGE_CONFIG", '{"type": "s3"}')
+    Storage._update_with_storage_spec()
+
+    for var in (
+        "AWS_ENDPOINT_URL",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_DEFAULT_REGION",
+        "AWS_CA_BUNDLE",
+        "awsAnonymousCredential",
+    ):
+        assert os.getenv(var) is None
+
+    storage_config = {
+        "access_key_id": "xxxxxxxxxxxxxxxxxxxx",
+        "bucket": "abucketname",
+        "default_bucket": "abucketname",
+        "endpoint_url": "https://s3.us-east-2.amazonaws.com/",
+        "region": "us-east-2",
+        "secret_access_key": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+        "type": "s3",
+        "certificate": "/path/to/ca.bundle",
+        "anonymous": "True",
+    }
+
+    monkeypatch.setenv("STORAGE_CONFIG", json.dumps(storage_config))
+    Storage._update_with_storage_spec()
+
+    assert os.getenv("AWS_ENDPOINT_URL") == storage_config["endpoint_url"]
+    assert os.getenv("AWS_ACCESS_KEY_ID") == storage_config["access_key_id"]
+    assert os.getenv("AWS_SECRET_ACCESS_KEY") == storage_config["secret_access_key"]
+    assert os.getenv("AWS_DEFAULT_REGION") == storage_config["region"]
+    assert os.getenv("AWS_CA_BUNDLE") == storage_config["certificate"]
+    assert os.getenv("awsAnonymousCredential") == storage_config["anonymous"]
+
+    # revert changes
+    os.environ = previous_env


### PR DESCRIPTION
This is cherry-pick of [pr-3259]https://github.com/kserve/kserve/pull/3259

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [X] Test A

Test Step:
1. install opendatahub operator and kserve
  2. The detail guide is here: https://docs.google.com/document/d/1pf0x1geayFr-06lAQKr96ynVsnOCcpgmAfbgoHgg8AI/edit

*Scale down odh operator pod*
~~~
oc scale deploy/opendatahub-operator-controller-manager -n openshift-operators --replicas=0
~~~

*Update storage initializer image and restart kserve controler* 
~~~
oc edit cm inferenceservice-config -o yaml -n opendatahub
....
 storageInitializer: |-
    {
        "image" : "quay.io/jooholee/kserve-storage-initializer:ssl-verify",
...

oc delete pod -l control-plane=kserve-controller-manager --force 
~~~

3. deploy test isvc(model) in aws https s3 (I used QE team s3 @bdattoma)


**Check point**
Check the log of init-container "storage-initializer". If the log looks like the following, it works fine
~~~
oc logs deploy/caikit-example-isvc-predictor-00001-deployment  -c storage-initializer
INFO:root:Initializing, args: src_uri [s3://modelmesh-example-models/llm/models] dest_path[ [/mnt/models]
INFO:root:Copying contents of s3://modelmesh-example-models/llm/models to local
INFO:botocore.credentials:Found credentials in environment variables.
INFO:root:Downloaded object llm/models/flan-t5-small-caikit/artifacts/config.json to /mnt/models/flan-t5-small-caikit/artifacts/config.json
INFO:root:Downloaded object llm/models/flan-t5-small-caikit/artifacts/generation_config.json to /mnt/models/flan-t5-small-caikit/artifacts/generation_config.json
INFO:root:Downloaded object llm/models/flan-t5-small-caikit/artifacts/pytorch_model.bin to /mnt/models/flan-t5-small-caikit/artifacts/pytorch_model.bin
INFO:root:Downloaded object llm/models/flan-t5-small-caikit/artifacts/special_tokens_map.json to /mnt/models/flan-t5-small-caikit/artifacts/special_tokens_map.json
INFO:root:Downloaded object llm/models/flan-t5-small-caikit/artifacts/spiece.model to /mnt/models/flan-t5-small-caikit/artifacts/spiece.model
INFO:root:Downloaded object llm/models/flan-t5-small-caikit/artifacts/tokenizer.json to /mnt/models/flan-t5-small-caikit/artifacts/tokenizer.json
INFO:root:Downloaded object llm/models/flan-t5-small-caikit/artifacts/tokenizer_config.json to /mnt/models/flan-t5-small-caikit/artifacts/tokenizer_config.json
INFO:root:Downloaded object llm/models/flan-t5-small-caikit/config.yml to /mnt/models/flan-t5-small-caikit/config.yml
INFO:root:Successfully copied s3://modelmesh-example-models/llm/models to /mnt/models
~~~


- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
5. If no release note is required, just write "NONE".
-->
```release-note

```
