### PR TITLE
[Cherry-Pick] Support verify variable with storage-config json style (fix-3263) 

### DIFF
--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -117,6 +117,7 @@ class Storage(object):  # pylint: disable=too-few-public-methods
             os.environ["AWS_SECRET_ACCESS_KEY"] = storage_secret_json.get("secret_access_key", "")
             os.environ["AWS_DEFAULT_REGION"] = storage_secret_json.get("region", "")
             os.environ["AWS_CA_BUNDLE"] = storage_secret_json.get("certificate", "")
+            os.environ["S3_VERIFY_SSL"] = storage_secret_json.get("verify_ssl", "1")
             os.environ["awsAnonymousCredential"] = storage_secret_json.get("anonymous", "")
 
         if storage_secret_json.get("type", "") == "hdfs" or storage_secret_json.get("type", "") == "webhdfs":
@@ -168,7 +169,7 @@ class Storage(object):  # pylint: disable=too-few-public-methods
             kwargs.update({"endpoint_url": endpoint_url})
         verify_ssl = os.getenv("S3_VERIFY_SSL")
         if verify_ssl:
-            verify_ssl = verify_ssl != "0"
+            verify_ssl = not verify_ssl.lower() in ["0", "false"]
             kwargs.update({"verify": verify_ssl})
         s3 = boto3.resource("s3", **kwargs)
         parsed = urlparse(uri, scheme='s3')


### PR DESCRIPTION
This is cherry-pick of https://github.com/kserve/kserve/pull/3267

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [X] Test A

Test Step:
1. install opendatahub operator and kserve
  2. The detail guide is here: https://docs.google.com/document/d/1pf0x1geayFr-06lAQKr96ynVsnOCcpgmAfbgoHgg8AI/edit

*Scale down odh operator pod*
~~~
oc scale deploy/opendatahub-operator-controller-manager -n openshift-operators --replicas=0
~~~

*Update storage initializer image and restart kserve controler* 
~~~
oc edit cm inferenceservice-config -o yaml -n opendatahub
....
 storageInitializer: |-
    {
        "image" : "quay.io/jooholee/kserve-storage-initializer:ssl-verify",
...

oc delete pod -l control-plane=kserve-controller-manager --force 
~~~

3. deploy test isvc(model) in aws https s3 (I used QE team s3 @bdattoma)


**Check point**
Check the log of init-container "storage-initializer". If the log looks like the following, it works fine
~~~
oc logs deploy/caikit-example-isvc-predictor-00001-deployment  -c storage-initializer
INFO:root:Initializing, args: src_uri [s3://modelmesh-example-models/llm/models] dest_path[ [/mnt/models]
INFO:root:Copying contents of s3://modelmesh-example-models/llm/models to local
INFO:botocore.credentials:Found credentials in environment variables.
INFO:root:Downloaded object llm/models/flan-t5-small-caikit/artifacts/config.json to /mnt/models/flan-t5-small-caikit/artifacts/config.json
INFO:root:Downloaded object llm/models/flan-t5-small-caikit/artifacts/generation_config.json to /mnt/models/flan-t5-small-caikit/artifacts/generation_config.json
INFO:root:Downloaded object llm/models/flan-t5-small-caikit/artifacts/pytorch_model.bin to /mnt/models/flan-t5-small-caikit/artifacts/pytorch_model.bin
INFO:root:Downloaded object llm/models/flan-t5-small-caikit/artifacts/special_tokens_map.json to /mnt/models/flan-t5-small-caikit/artifacts/special_tokens_map.json
INFO:root:Downloaded object llm/models/flan-t5-small-caikit/artifacts/spiece.model to /mnt/models/flan-t5-small-caikit/artifacts/spiece.model
INFO:root:Downloaded object llm/models/flan-t5-small-caikit/artifacts/tokenizer.json to /mnt/models/flan-t5-small-caikit/artifacts/tokenizer.json
INFO:root:Downloaded object llm/models/flan-t5-small-caikit/artifacts/tokenizer_config.json to /mnt/models/flan-t5-small-caikit/artifacts/tokenizer_config.json
INFO:root:Downloaded object llm/models/flan-t5-small-caikit/config.yml to /mnt/models/flan-t5-small-caikit/config.yml
INFO:root:Successfully copied s3://modelmesh-example-models/llm/models to /mnt/models
~~~


- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
5. If no release note is required, just write "NONE".
-->
```release-note

```
