### PR TITLE
Use ThirdParty tokens for CI, for compatibility with ROSA-Hosted clusters

### DIFF
--- a/test/scripts/openshift-ci/deploy.ossm.sh
+++ b/test/scripts/openshift-ci/deploy.ossm.sh
@@ -111,25 +111,24 @@ metadata:
   name: basic
   namespace: istio-system
 spec:
-  version: v2.3
-  tracing:
-    type: Jaeger
-    sampling: 10000
-# Uncomment if on ROSA
-#  security:
-#    identity:
-#      type: ThirdParty
   addons:
+    grafana:
+      enabled: false
+    kiali:
+      enabled: false
+      name: kiali
+    prometheus:
+      enabled: false
     jaeger:
       name: jaeger
-      install:
-        storage:
-          type: Memory
-    kiali:
-      enabled: true
-      name: kiali
-    grafana:
-      enabled: true
+  gateways:
+    openshiftRoute:
+      enabled: false
+  security:
+    identity:
+      type: ThirdParty
+  tracing:
+    type: None
 EOF
 
 # Waiting for OSSM minimum start

--- a/test/scripts/openshift-ci/deploy.serverless.sh
+++ b/test/scripts/openshift-ci/deploy.serverless.sh
@@ -29,7 +29,7 @@ waitpodready() {
   local podlabel=${1?pod label is required}; shift
 
   waitforpodlabeled "$ns" "$podlabel"
-  sleep 10
+  sleep 2
   oc get pod -n $ns -l $podlabel
 
   echo "Waiting for pod -l $podlabel to become ready"


### PR DESCRIPTION
Also, remove Mesh-related components that are not needed.

Should fix CI failures for openshift/release#46506