### PR TITLE
[Cherry pick] fixes to current release branch 0.11.1

### DIFF
--- a/charts/kserve-resources/templates/configmap.yaml
+++ b/charts/kserve-resources/templates/configmap.yaml
@@ -181,7 +181,8 @@ data:
            "ingressClassName" : "istio",
            "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
            "urlScheme": "http",
-           "disableIstioVirtualHost": false
+           "disableIstioVirtualHost": false,
+           "disableIngressCreation": false
        }
      ingress: |-
        {
@@ -233,7 +234,10 @@ data:
            # By setting this field to true, user can use other networking layers supported by knative.
            # For more info https://github.com/kserve/kserve/pull/2380, https://kserve.github.io/website/master/admin/serverless/kourier_networking/.
            # NOTE: This configuration is only applicable to serverless deployment.
-           "disableIstioVirtualHost": false
+           "disableIstioVirtualHost": false,
+
+           # disableIngressCreation controls whether to disable ingress creation for raw deployment mode.
+           "disableIngressCreation": false,
 
            # pathTemplate specifies the template for generating path based url for each inference service.
            # The following variables can be used in the template for generating url.
@@ -466,7 +470,8 @@ data:
         "ingressClassName" : "{{ .Values.kserve.controller.gateway.ingressGateway.className }}",
         "ingressDomain"  : "{{ .Values.kserve.controller.gateway.domain }}",
         "domainTemplate": "{{ .Values.kserve.controller.gateway.domainTemplate }}",
-        "urlScheme": "{{ .Values.kserve.controller.gateway.urlScheme }}"
+        "urlScheme": "{{ .Values.kserve.controller.gateway.urlScheme }}",
+        "disableIngressCreation": {{ .Values.kserve.controller.gateway.disableIngressCreation }}
     }
   logger: |-
     {

--- a/charts/kserve-resources/templates/configmap.yaml
+++ b/charts/kserve-resources/templates/configmap.yaml
@@ -64,7 +64,7 @@ data:
            "memoryLimit": "1Gi",
            "cpuRequest": "100m",
            "cpuLimit": "1",
-           "enableDirectPvcVolumeMount": false
+           "enableDirectPvcVolumeMount": true
        }
      storageInitializer: |-
        {
@@ -86,7 +86,7 @@ data:
            # enableDirectPvcVolumeMount controls whether users can mount pvc volumes directly.
            # if pvc volume is provided in storageuri then the pvc volume is directly mounted to /mnt/models in the user container.
            # rather than symlink it to a shared volume. For more info see https://github.com/kserve/kserve/issues/2737
-           "enableDirectPvcVolumeMount": false
+           "enableDirectPvcVolumeMount": true
        }
 
      # ====================================== CREDENTIALS ======================================
@@ -483,7 +483,8 @@ data:
         "memoryRequest": "100Mi",
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
-        "cpuLimit": "1"
+        "cpuLimit": "1",
+        "enableDirectPvcVolumeMount": true
     }
   metricsAggregator: |-
     {

--- a/charts/kserve-resources/values.yaml
+++ b/charts/kserve-resources/values.yaml
@@ -32,6 +32,7 @@ kserve:
       domain: example.com
       domainTemplate: "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}"
       urlScheme: http
+      disableIngressCreation: false
       localGateway:
         gateway: knative-serving/knative-local-gateway
         gatewayService: knative-local-gateway.istio-system.svc.cluster.local

--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -188,7 +188,8 @@ data:
            "ingressClassName" : "istio",
            "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
            "urlScheme": "http",
-           "disableIstioVirtualHost": false
+           "disableIstioVirtualHost": false,
+           "disableIngressCreation": false
        }
      ingress: |-
        {
@@ -240,7 +241,10 @@ data:
            # By setting this field to true, user can use other networking layers supported by knative.
            # For more info https://github.com/kserve/kserve/pull/2380, https://kserve.github.io/website/master/admin/serverless/kourier_networking/.
            # NOTE: This configuration is only applicable to serverless deployment.
-           "disableIstioVirtualHost": false
+           "disableIstioVirtualHost": false,
+
+           # disableIngressCreation controls whether to disable ingress creation for raw deployment mode.
+           "disableIngressCreation": false,
      
            # pathTemplate specifies the template for generating path based url for each inference service.
            # The following variables can be used in the template for generating url.
@@ -460,7 +464,8 @@ data:
         "ingressClassName" : "istio",
         "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
         "urlScheme": "http",
-        "disableIstioVirtualHost": false
+        "disableIstioVirtualHost": false,
+        "disableIngressCreation": false
     }
 
   logger: |-

--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -93,7 +93,7 @@ data:
            # enableDirectPvcVolumeMount controls whether users can mount pvc volumes directly.
            # if pvc volume is provided in storageuri then the pvc volume is directly mounted to /mnt/models in the user container.
            # rather than symlink it to a shared volume. For more info see https://github.com/kserve/kserve/issues/2737
-           "enableDirectPvcVolumeMount": false
+           "enableDirectPvcVolumeMount": true
        }
      
      # ====================================== CREDENTIALS ======================================
@@ -427,7 +427,7 @@ data:
         "cpuLimit": "1",
         "caBundleConfigMapName": "",
         "caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-        "enableDirectPvcVolumeMount": false
+        "enableDirectPvcVolumeMount": true
     }
 
   credentials: |-

--- a/pkg/apis/serving/v1beta1/configmap.go
+++ b/pkg/apis/serving/v1beta1/configmap.go
@@ -75,6 +75,7 @@ type IngressConfig struct {
 	UrlScheme               string  `json:"urlScheme,omitempty"`
 	DisableIstioVirtualHost bool    `json:"disableIstioVirtualHost,omitempty"`
 	PathTemplate            string  `json:"pathTemplate,omitempty"`
+	DisableIngressCreation  bool    `json:"disableIngressCreation,omitempty"`
 }
 
 // +kubebuilder:object:generate=false

--- a/pkg/apis/serving/v1beta1/openapi_generated.go
+++ b/pkg/apis/serving/v1beta1/openapi_generated.go
@@ -4730,6 +4730,12 @@ func schema_pkg_apis_serving_v1beta1_IngressConfig(ref common.ReferenceCallback)
 							Format: "",
 						},
 					},
+					"disableIngressCreation": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/apis/serving/v1beta1/swagger.json
+++ b/pkg/apis/serving/v1beta1/swagger.json
@@ -2572,6 +2572,9 @@
     "v1beta1.IngressConfig": {
       "type": "object",
       "properties": {
+        "disableIngressCreation": {
+          "type": "boolean"
+        },
         "disableIstioVirtualHost": {
           "type": "boolean"
         },

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
@@ -271,7 +271,7 @@ func (r *RawIngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
 	if r.ingressConfig.IngressDomain == constants.ClusterLocalDomain {
 		isInternal = true
 	}
-	if !isInternal {
+	if !isInternal && !r.ingressConfig.DisableIngressCreation {
 		ingress, err := createRawIngress(r.scheme, isvc, r.ingressConfig, r.client)
 		if ingress == nil {
 			return nil

--- a/python/kserve/docs/V1beta1IngressConfig.md
+++ b/python/kserve/docs/V1beta1IngressConfig.md
@@ -3,6 +3,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**disable_ingress_creation** | **bool** |  | [optional] 
 **disable_istio_virtual_host** | **bool** |  | [optional] 
 **domain_template** | **str** |  | [optional] 
 **ingress_class_name** | **str** |  | [optional] 

--- a/python/kserve/kserve/models/v1beta1_ingress_config.py
+++ b/python/kserve/kserve/models/v1beta1_ingress_config.py
@@ -47,6 +47,7 @@ class V1beta1IngressConfig(object):
                             and the value is json key in definition.
     """
     openapi_types = {
+        'disable_ingress_creation': 'bool',
         'disable_istio_virtual_host': 'bool',
         'domain_template': 'str',
         'ingress_class_name': 'str',
@@ -60,6 +61,7 @@ class V1beta1IngressConfig(object):
     }
 
     attribute_map = {
+        'disable_ingress_creation': 'disableIngressCreation',
         'disable_istio_virtual_host': 'disableIstioVirtualHost',
         'domain_template': 'domainTemplate',
         'ingress_class_name': 'ingressClassName',
@@ -72,12 +74,13 @@ class V1beta1IngressConfig(object):
         'url_scheme': 'urlScheme'
     }
 
-    def __init__(self, disable_istio_virtual_host=None, domain_template=None, ingress_class_name=None, ingress_domain=None, ingress_gateway=None, ingress_service=None, local_gateway=None, local_gateway_service=None, path_template=None, url_scheme=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, disable_ingress_creation=None, disable_istio_virtual_host=None, domain_template=None, ingress_class_name=None, ingress_domain=None, ingress_gateway=None, ingress_service=None, local_gateway=None, local_gateway_service=None, path_template=None, url_scheme=None, local_vars_configuration=None):  # noqa: E501
         """V1beta1IngressConfig - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
         self.local_vars_configuration = local_vars_configuration
 
+        self._disable_ingress_creation = None
         self._disable_istio_virtual_host = None
         self._domain_template = None
         self._ingress_class_name = None
@@ -90,6 +93,8 @@ class V1beta1IngressConfig(object):
         self._url_scheme = None
         self.discriminator = None
 
+        if disable_ingress_creation is not None:
+            self.disable_ingress_creation = disable_ingress_creation
         if disable_istio_virtual_host is not None:
             self.disable_istio_virtual_host = disable_istio_virtual_host
         if domain_template is not None:
@@ -110,6 +115,27 @@ class V1beta1IngressConfig(object):
             self.path_template = path_template
         if url_scheme is not None:
             self.url_scheme = url_scheme
+
+    @property
+    def disable_ingress_creation(self):
+        """Gets the disable_ingress_creation of this V1beta1IngressConfig.  # noqa: E501
+
+
+        :return: The disable_ingress_creation of this V1beta1IngressConfig.  # noqa: E501
+        :rtype: bool
+        """
+        return self._disable_ingress_creation
+
+    @disable_ingress_creation.setter
+    def disable_ingress_creation(self, disable_ingress_creation):
+        """Sets the disable_ingress_creation of this V1beta1IngressConfig.
+
+
+        :param disable_ingress_creation: The disable_ingress_creation of this V1beta1IngressConfig.  # noqa: E501
+        :type: bool
+        """
+
+        self._disable_ingress_creation = disable_ingress_creation
 
     @property
     def disable_istio_virtual_host(self):

--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -112,13 +112,17 @@ class Storage(object):  # pylint: disable=too-few-public-methods
                 storage_secret_json[key] = value
 
         if storage_secret_json.get("type", "") == "s3":
-            os.environ["AWS_ENDPOINT_URL"] = storage_secret_json.get("endpoint_url", "")
-            os.environ["AWS_ACCESS_KEY_ID"] = storage_secret_json.get("access_key_id", "")
-            os.environ["AWS_SECRET_ACCESS_KEY"] = storage_secret_json.get("secret_access_key", "")
-            os.environ["AWS_DEFAULT_REGION"] = storage_secret_json.get("region", "")
-            os.environ["AWS_CA_BUNDLE"] = storage_secret_json.get("ca_bundle", "")
-            os.environ["S3_VERIFY_SSL"] = storage_secret_json.get("verify_ssl", "1")
-            os.environ["awsAnonymousCredential"] = storage_secret_json.get("anonymous", "")
+            for env_var, key in (
+                ("AWS_ENDPOINT_URL", "endpoint_url"),
+                ("AWS_ACCESS_KEY_ID", "access_key_id"),
+                ("AWS_SECRET_ACCESS_KEY", "secret_access_key"),
+                ("AWS_DEFAULT_REGION", "region"),
+                ("AWS_CA_BUNDLE", "ca_bundle"),
+                ("S3_VERIFY_SSL", "verify_ssl"),
+                ("awsAnonymousCredential", "anonymous"),
+            ):
+                if key in storage_secret_json:
+                    os.environ[env_var] = storage_secret_json.get(key)
 
         if storage_secret_json.get("type", "") == "hdfs" or storage_secret_json.get("type", "") == "webhdfs":
             temp_dir = tempfile.mkdtemp()

--- a/python/kserve/kserve/storage/test/test_s3_storage.py
+++ b/python/kserve/kserve/storage/test/test_s3_storage.py
@@ -242,7 +242,7 @@ def test_update_with_storage_spec_s3(monkeypatch):
         "region": "us-east-2",
         "secret_access_key": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
         "type": "s3",
-        "certificate": "/path/to/ca.bundle",
+        "ca_bundle": "/path/to/ca.bundle",
         "verify_ssl": "false",
         "anonymous": "True",
     }
@@ -254,7 +254,7 @@ def test_update_with_storage_spec_s3(monkeypatch):
     assert os.getenv("AWS_ACCESS_KEY_ID") == storage_config["access_key_id"]
     assert os.getenv("AWS_SECRET_ACCESS_KEY") == storage_config["secret_access_key"]
     assert os.getenv("AWS_DEFAULT_REGION") == storage_config["region"]
-    assert os.getenv("AWS_CA_BUNDLE") == storage_config["certificate"]
+    assert os.getenv("AWS_CA_BUNDLE") == storage_config["ca_bundle"]
     assert os.getenv("S3_VERIFY_SSL") == storage_config["verify_ssl"]
     assert os.getenv("awsAnonymousCredential") == storage_config["anonymous"]
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry pick:
- kserve/kserve#3259 - Fix python library around environment variables
- kserve/kserve#3371 - By default, mount PVC volumes directly
- kserve/kserve#3436 - Add capability to disable ingress creation in RawDeployment mode

