### PR TITLE
[cherry-pick][RHOAIENG-3551] - fastapi - Regular Expression Denial of Service (ReDoS)

### DIFF
--- a/python/storage-initializer.Dockerfile
+++ b/python/storage-initializer.Dockerfile
@@ -33,7 +33,12 @@ RUN apt-get update && apt-get install -y \
     krb5-config \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir krbcontext==0.10 hdfs~=2.6.0 requests-kerberos==0.14.0
+# Fixes CVE-2024-24762 - Regular Expression Denial of Service (ReDoS)
+# Remove the fastapi when this is addressed:  https://issues.redhat.com/browse/RHOAIENG-3894
+# or ray releses a new version that removes the fastapi version pinning and it gets updated on KServe
+RUN pip install --no-cache-dir krbcontext==0.10 hdfs~=2.6.0 requests-kerberos==0.14.0 fastapi==0.109.1
+# Fixes Quay alert GHSA-2jv5-9r88-3w3p https://github.com/Kludex/python-multipart/security/advisories/GHSA-2jv5-9r88-3w3p
+RUN pip install --no-cache-dir starlette==0.36.2
 
 
 FROM ${BASE_IMAGE} as prod


### PR DESCRIPTION
Fixes CVE-2024-24762 - Regular Expression Denial of Service (ReDoS) Remove the fastapi when this is addressed:  https://issues.redhat.com/browse/RHOAIENG-3894 or ray releses a new version that removes the fastapi version pinning and it gets updated on KServe

Cherry-picks d779e7e065e85d2a00b0328a5e303e9cb9d80595
