### PR TITLE
Increase memory limit of kserve-controller pod

### DIFF
--- a/config/overlays/odh/set-resources-manager-patch.yaml
+++ b/config/overlays/odh/set-resources-manager-patch.yaml
@@ -11,4 +11,4 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 500Mi
+            memory: 5Gi


### PR DESCRIPTION
**What this PR does / why we need it**:

The increased memory limit is for the controller pod to work normally in clusters having 9k+ secrets.

**Which issue(s) this PR fixes** 

Related to https://issues.redhat.com/browse/RHOAIENG-3996

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

With KServe deployed:
* Use a script available in this gist: https://gist.github.com/skonto/188b2c45c5af449629caaa69a190392c, with a minor modification: edit line 3 to NC=64
* Try to deploy an  InferenceService (any ISVC simple should work).
  * Without the patch, observe an OOMKill.
  * With the patch, the pod should not die.

