### PR TITLE
Prepare ODH's v0.12.0 branch cut

### DIFF
--- a/python/kserve/kserve/protocol/infer_type.py
+++ b/python/kserve/kserve/protocol/infer_type.py
@@ -621,12 +621,13 @@ class InferOutput:
 class InferResponse:
     id: str
     model_name: str
+    model_version: Optional[str]
     parameters: Optional[Dict]
     outputs: List[InferOutput]
     from_grpc: bool
 
     def __init__(self, response_id: str, model_name: str, infer_outputs: List[InferOutput],
-                 raw_outputs=None, from_grpc: Optional[bool] = False,
+                 model_version: Optional[str] = None, raw_outputs=None, from_grpc: Optional[bool] = False,
                  parameters: Optional[Union[Dict, MessageMap[str, InferParameter]]] = None):
         """The InferResponse Data Model
 
@@ -634,6 +635,7 @@ class InferResponse:
             response_id: The id of the inference response.
             model_name: The name of the model.
             infer_outputs: The inference outputs of the inference response.
+            model_version: The version of the model.
             raw_outputs: The raw binary data of the inference outputs.
             from_grpc: Indicate if the InferResponse is constructed from a gRPC response.
             parameters: The additional inference parameters.
@@ -641,6 +643,7 @@ class InferResponse:
 
         self.id = response_id
         self.model_name = model_name
+        self.model_version = model_version
         self.outputs = infer_outputs
         self.parameters = parameters
         self.from_grpc = from_grpc
@@ -657,8 +660,9 @@ class InferResponse:
                                      data=get_content(output.datatype, output.contents),
                                      parameters=output.parameters)
                          for output in response.outputs]
-        return cls(model_name=response.model_name, response_id=response.id, parameters=response.parameters,
-                   infer_outputs=infer_outputs, raw_outputs=response.raw_output_contents, from_grpc=True)
+        return cls(model_name=response.model_name, model_version=response.model_version, response_id=response.id,
+                   parameters=response.parameters, infer_outputs=infer_outputs,
+                   raw_outputs=response.raw_output_contents, from_grpc=True)
 
     @classmethod
     def from_rest(cls, model_name: str, response: Dict) -> 'InferResponse':
@@ -672,6 +676,7 @@ class InferResponse:
                                      parameters=output.get('parameters', None))
                          for output in response['outputs']]
         return cls(model_name=model_name,
+                   model_version=response.get('model_version', None),
                    response_id=response.get('id', None),
                    parameters=response.get('parameters', None),
                    infer_outputs=infer_outputs)
@@ -702,6 +707,7 @@ class InferResponse:
         res = {
             'id': self.id,
             'model_name': self.model_name,
+            'model_version': self.model_version,
             'outputs': infer_outputs
         }
         if self.parameters:
@@ -742,14 +748,16 @@ class InferResponse:
                     raise InvalidInput("to_grpc: invalid output datatype")
             infer_outputs.append(infer_output_dict)
 
-        return ModelInferResponse(id=self.id, model_name=self.model_name, outputs=infer_outputs,
-                                  raw_output_contents=raw_output_contents,
+        return ModelInferResponse(id=self.id, model_name=self.model_name, model_version=self.model_version,
+                                  outputs=infer_outputs, raw_output_contents=raw_output_contents,
                                   parameters=to_grpc_parameters(self.parameters) if self.parameters else None)
 
     def __eq__(self, other):
         if not isinstance(other, InferResponse):
             return False
         if self.model_name != other.model_name:
+            return False
+        if self.model_version != other.model_version:
             return False
         if self.id != other.id:
             return False

--- a/python/kserve/test/test_infer_type.py
+++ b/python/kserve/test/test_infer_type.py
@@ -139,7 +139,7 @@ class TestInferRequest:
 
     class TestInferResponse:
         def test_to_rest(self):
-            infer_res = InferResponse(model_name="TestModel", response_id="123",
+            infer_res = InferResponse(model_name="TestModel", response_id="123", model_version="v1",
                                       parameters={
                                           "test-str": InferParameter(string_param="dummy"),
                                           "test-bool": InferParameter(bool_param=True),
@@ -156,6 +156,7 @@ class TestInferRequest:
             expected = {
                 "id": "123",
                 "model_name": "TestModel",
+                "model_version": "v1",
                 "outputs": [
                     {
                         "name": "output-0",
@@ -179,7 +180,7 @@ class TestInferRequest:
             assert res == expected
 
         def test_to_grpc(self):
-            infer_res = InferResponse(model_name="TestModel", response_id="123",
+            infer_res = InferResponse(model_name="TestModel", response_id="123", model_version="v1",
                                       parameters={
                                           "test-str": "dummy",
                                           "test-bool": True,
@@ -193,7 +194,7 @@ class TestInferRequest:
                                                           "test-int": 100
                                                       })]
                                       )
-            expected = ModelInferResponse(model_name="TestModel", id="123",
+            expected = ModelInferResponse(model_name="TestModel", id="123", model_version="v1",
                                           parameters={
                                               "test-str": InferParameter(string_param="dummy"),
                                               "test-bool": InferParameter(bool_param=True),
@@ -218,7 +219,7 @@ class TestInferRequest:
             assert res == expected
 
         def test_from_grpc(self):
-            infer_res = ModelInferResponse(model_name="TestModel", id="123",
+            infer_res = ModelInferResponse(model_name="TestModel", id="123", model_version="v1",
                                            parameters={
                                                "test-str": InferParameter(string_param="dummy"),
                                                "test-bool": InferParameter(bool_param=True),
@@ -239,7 +240,7 @@ class TestInferRequest:
                                                    },
                                                }]
                                            )
-            expected = InferResponse(model_name="TestModel", response_id="123",
+            expected = InferResponse(model_name="TestModel", response_id="123", model_version="v1",
                                      parameters={
                                          "test-str": InferParameter(string_param="dummy"),
                                          "test-bool": InferParameter(bool_param=True),


### PR DESCRIPTION
**What this PR does / why we need it**:

This brings the pending commits from upstream `v0.12.0` tag to ODH `release-v0.12.0` branch.

The ODH `release-v0.12.0` branch was cut to the closest commit to upstream `v0.12.0` tag. This brings the additional commits present in upstream `v0.12.0` tag to ODH `release-v0.12.0` branch to make the branch equivalent to upstream v0.12.0 release.

**Which issue(s) this PR fixes** 
Related to https://issues.redhat.com/browse/RHOAIENG-4180

