### PR TITLE
update codeQL to v3

### DIFF
--- a/.github/workflows/scheduled-image-scan.yml
+++ b/.github/workflows/scheduled-image-scan.yml
@@ -45,7 +45,8 @@ jobs:
 
       - name: Upload sarif file to Github Code Scanning
         if: always()
-        uses: github/codeql-action/upload-sarif@v2
+        continue-on-error: true #avoid fail the pipeline if the SARIF upload fails.
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: application/${{ matrix.image.name }}/docker.snyk.sarif
 


### PR DESCRIPTION
chore:	Update CodeQL to V3 to get rid of this warning:
	`Warning: CodeQL Action v2 will be deprecated on December 5th, 2024`
	Plus, attenpt to fix the Snyk Container scan failures due errors when trying to
	upload the SERIF file:
```
Processing sarif files: ["application/storage-initializer/docker.snyk.sarif"]
  Uploading results
  Successfully uploaded results
Waiting for processing to finish
Error: Code Scanning could not process the submitted SARIF file:
could not convert rules: invalid security severity value, is not a number: null
ConfigurationError: Code Scanning could not process the submitted SARIF file:
could not convert rules: invalid security severity value, is not a number: null
    at run (/home/runner/work/_actions/github/codeql-action/v2/lib/upload-sarif-action.js:65:15)
```


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
