### PR TITLE
[RHOAIENG-4617] - follow up - remove hardcoded fastapi from Dockerfile

### DIFF
--- a/python/storage-initializer.Dockerfile
+++ b/python/storage-initializer.Dockerfile
@@ -33,10 +33,7 @@ RUN apt-get update && apt-get install -y \
     krb5-config \
     && rm -rf /var/lib/apt/lists/*
 
-# Fixes CVE-2024-24762 - Regular Expression Denial of Service (ReDoS)
-# Remove the fastapi when this is addressed:  https://issues.redhat.com/browse/RHOAIENG-3894
-# or ray releses a new version that removes the fastapi version pinning and it gets updated on KServe
-RUN pip install --no-cache-dir krbcontext==0.10 hdfs~=2.6.0 requests-kerberos==0.14.0 fastapi==0.109.1
+RUN pip install --no-cache-dir krbcontext==0.10 hdfs~=2.6.0 requests-kerberos==0.14.0
 # Fixes Quay alert GHSA-2jv5-9r88-3w3p https://github.com/Kludex/python-multipart/security/advisories/GHSA-2jv5-9r88-3w3p
 RUN pip install --no-cache-dir starlette==0.36.2
 


### PR DESCRIPTION
As the Ray Serve latest release removed the hard dependency of old fastapi version we can now remove the workaround from the Storage Initializer Container Image.



**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
