### PR TITLE
[release-v0.12.1] Fix params.env

### DIFF
--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -1,4 +1,4 @@
-kserve-controller=quay.io/opendatahub/kserve-controller:v0.12.1.0-latest
-kserve-agent=quay.io/opendatahub/kserve-agent:v0.12.1.0-latest
-kserve-router=quay.io/opendatahub/kserve-router:v0.12.1.0-latest
-kserve-storage-initializer=quay.io/opendatahub/kserve-storage-initializer:v0.12.1.0-latest
+kserve-controller=quay.io/opendatahub/kserve-controller:v0.12.1-latest
+kserve-agent=quay.io/opendatahub/kserve-agent:v0.12.1-latest
+kserve-router=quay.io/opendatahub/kserve-router:v0.12.1-latest
+kserve-storage-initializer=quay.io/opendatahub/kserve-storage-initializer:v0.12.1-latest


### PR DESCRIPTION
**What this PR does / why we need it**:
Current tags in the `release-v0.12.1` branch do not exist. Fixing to the ones that do exist.

