### PR TITLE
[cherry-pick] Prevent the PassthroughCluster for clients in the service mesh

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -231,6 +231,7 @@ const (
 
 var (
 	LocalGatewayHost = "knative-local-gateway.istio-system.svc." + network.GetClusterDomainName()
+	IstioMeshGateway = "mesh"
 )
 
 // InferenceService Component enums

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -316,6 +316,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Spec: istiov1beta1.VirtualService{
 					Gateways: []string{
 						constants.KnativeLocalGateway,
+						constants.IstioMeshGateway,
 						constants.KnativeIngressGateway,
 					},
 					Hosts: []string{
@@ -326,7 +327,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						{
 							Match: []*istiov1beta1.HTTPMatchRequest{
 								{
-									Gateways: []string{constants.KnativeLocalGateway},
+									Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway},
 									Authority: &istiov1beta1.StringMatch{
 										MatchType: &istiov1beta1.StringMatch_Regex{
 											Regex: constants.HostRegExp(network.GetServiceHostname(serviceKey.Name, serviceKey.Namespace)),

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -289,7 +289,7 @@ func createHTTPMatchRequest(prefix, targetHost, internalHost string, additionalH
 					Regex: constants.HostRegExp(internalHost),
 				},
 			},
-			Gateways: []string{config.LocalGateway},
+			Gateways: []string{config.LocalGateway, constants.IstioMeshGateway},
 		},
 	}
 	if !isInternal {
@@ -431,6 +431,7 @@ func createIngress(isvc *v1beta1.InferenceService, useDefault bool, config *v1be
 
 	gateways := []string{
 		config.LocalGateway,
+		constants.IstioMeshGateway,
 	}
 	if !isInternal {
 		hosts = append(hosts, serviceHost)

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
@@ -57,7 +57,7 @@ func TestCreateVirtualService(t *testing.T) {
 					Regex: constants.HostRegExp(network.GetServiceHostname(serviceName, namespace)),
 				},
 			},
-			Gateways: []string{constants.KnativeLocalGateway},
+			Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway},
 		},
 		{
 			Authority: &istiov1beta1.StringMatch{
@@ -132,7 +132,7 @@ func TestCreateVirtualService(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 			Spec: istiov1beta1.VirtualService{
 				Hosts:    []string{serviceInternalHostName, serviceHostName},
-				Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
+				Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway, constants.KnativeIngressGateway},
 				Http: []*istiov1beta1.HTTPRoute{
 					{
 						Match: predictorRouteMatch,
@@ -187,7 +187,7 @@ func TestCreateVirtualService(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 			Spec: istiov1beta1.VirtualService{
 				Hosts:    []string{serviceInternalHostName},
-				Gateways: []string{constants.KnativeLocalGateway},
+				Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway},
 				Http: []*istiov1beta1.HTTPRoute{
 					{
 						Match: []*istiov1beta1.HTTPMatchRequest{
@@ -197,7 +197,7 @@ func TestCreateVirtualService(t *testing.T) {
 										Regex: constants.HostRegExp(network.GetServiceHostname(serviceName, namespace)),
 									},
 								},
-								Gateways: []string{constants.KnativeLocalGateway},
+								Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway},
 							},
 						},
 						Route: []*istiov1beta1.HTTPRouteDestination{
@@ -295,7 +295,7 @@ func TestCreateVirtualService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 				Spec: istiov1beta1.VirtualService{
 					Hosts:    []string{serviceInternalHostName, serviceHostName},
-					Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
+					Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway, constants.KnativeIngressGateway},
 					Http: []*istiov1beta1.HTTPRoute{
 						{
 							Match: predictorRouteMatch,
@@ -367,7 +367,7 @@ func TestCreateVirtualService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 				Spec: istiov1beta1.VirtualService{
 					Hosts:    []string{serviceInternalHostName, serviceHostName},
-					Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
+					Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway, constants.KnativeIngressGateway},
 					Http: []*istiov1beta1.HTTPRoute{
 						{
 							Match: predictorRouteMatch,
@@ -466,7 +466,7 @@ func TestCreateVirtualService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 				Spec: istiov1beta1.VirtualService{
 					Hosts:    []string{serviceInternalHostName, serviceHostName},
-					Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
+					Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway, constants.KnativeIngressGateway},
 					Http: []*istiov1beta1.HTTPRoute{
 						{
 							Match: []*istiov1beta1.HTTPMatchRequest{
@@ -481,7 +481,7 @@ func TestCreateVirtualService(t *testing.T) {
 											Regex: constants.HostRegExp(network.GetServiceHostname(serviceName, namespace)),
 										},
 									},
-									Gateways: []string{constants.KnativeLocalGateway},
+									Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway},
 								},
 								{
 									Uri: &istiov1beta1.StringMatch{
@@ -567,7 +567,7 @@ func TestCreateVirtualService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 				Spec: istiov1beta1.VirtualService{
 					Hosts:    []string{serviceInternalHostName, serviceHostName, "my-domain.com"},
-					Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
+					Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway, constants.KnativeIngressGateway},
 					Http: []*istiov1beta1.HTTPRoute{
 						{
 							Match: []*istiov1beta1.HTTPMatchRequest{
@@ -577,7 +577,7 @@ func TestCreateVirtualService(t *testing.T) {
 											Regex: constants.HostRegExp(network.GetServiceHostname(serviceName, namespace)),
 										},
 									},
-									Gateways: []string{constants.KnativeLocalGateway},
+									Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway},
 								},
 								{
 									Authority: &istiov1beta1.StringMatch{
@@ -689,7 +689,7 @@ func TestCreateVirtualService(t *testing.T) {
 				Spec: istiov1beta1.VirtualService{
 					Hosts: []string{serviceInternalHostName, serviceHostName, "my-domain.com",
 						"my-model.test.my-additional-domain.com", "my-model.test.my-second-additional-domain.com"},
-					Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
+					Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway, constants.KnativeIngressGateway},
 					Http: []*istiov1beta1.HTTPRoute{
 						{
 							Match: []*istiov1beta1.HTTPMatchRequest{
@@ -699,7 +699,7 @@ func TestCreateVirtualService(t *testing.T) {
 											Regex: constants.HostRegExp(network.GetServiceHostname(serviceName, namespace)),
 										},
 									},
-									Gateways: []string{constants.KnativeLocalGateway},
+									Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway},
 								},
 								{
 									Authority: &istiov1beta1.StringMatch{
@@ -820,7 +820,7 @@ func TestCreateVirtualService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 				Spec: istiov1beta1.VirtualService{
 					Hosts:    []string{serviceInternalHostName, serviceHostName},
-					Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
+					Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway, constants.KnativeIngressGateway},
 					Http: []*istiov1beta1.HTTPRoute{
 						{
 							Match: predictorRouteMatch,
@@ -891,7 +891,7 @@ func TestCreateVirtualService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 				Spec: istiov1beta1.VirtualService{
 					Hosts:    []string{serviceInternalHostName, serviceHostName},
-					Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
+					Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway, constants.KnativeIngressGateway},
 					Http: []*istiov1beta1.HTTPRoute{
 						{
 							Match: predictorRouteMatch,
@@ -1089,7 +1089,7 @@ func TestCreateVirtualService(t *testing.T) {
 				}},
 				Spec: istiov1beta1.VirtualService{
 					Hosts:    []string{serviceInternalHostName},
-					Gateways: []string{constants.KnativeLocalGateway},
+					Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway},
 					Http: []*istiov1beta1.HTTPRoute{
 						{
 							Match: []*istiov1beta1.HTTPMatchRequest{
@@ -1099,7 +1099,7 @@ func TestCreateVirtualService(t *testing.T) {
 											Regex: constants.HostRegExp(network.GetServiceHostname(serviceName, namespace)),
 										},
 									},
-									Gateways: []string{constants.KnativeLocalGateway},
+									Gateways: []string{constants.KnativeLocalGateway, constants.IstioMeshGateway},
 								},
 							},
 							Route: []*istiov1beta1.HTTPRouteDestination{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Because we are short on time, we cherry-pick upstream PRs.(https://github.com/kserve/kserve/pull/3711)


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
# Loopy Setup
[refer this doc](https://github.com/Jooho/loopy/blob/main/docs/quickstart.md )
~~~
git clone   git@github.com:Jooho/loopy.git
cd loopy
make init
 
or

docker run -it quay.io/jooholee/loopy

cat cluster_info.sh
CLUSTER_CONSOLE_URL=https://console-openshift-console.XXXX
CLUSTER_API_URL=https://api.XXX:443
CLUSTER_ADMIN_ID=admin
CLUSTER_ADMIN_PW=password
CLUSTER_TOKEN=sha256~XXX
CLUSTER_TYPE=ROSA
~~~

# Install Kserve with a new manifests
~~~
loopy playbooks run  odh-stable-install-kserve-serverless-on-existing-cluster -p CUSTOM_KSERVE_MANIFESTS=https://github.com/jooho/kserve/tarball/test-manifest -vvv -i ./cluster_info.sh
~~~
# Deploy sample sklearn model
~~~
loopy units run test-kserve-sklearn-v2-iris-role -vvv -i ./cluster_info.sh 
~~~
# Check
~~~
oc get vs sklearn-example-isvc-iris-v2-rest 
sklearn-example-isvc-iris-v2-rest   ["istio-system/kserve-local-gateway","mesh","knative-serving/knative-ingress-gateway"]   
~~~
if there is `mesh` in the [], it succeeds.

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.