### PR TITLE
Removed arm/v7 to make the jobs working again for now

### DIFF
--- a/.github/workflows/agent-docker-publish.yml
+++ b/.github/workflows/agent-docker-publish.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x
           context: .
           file: agent.Dockerfile
           push: true

--- a/.github/workflows/kserve-controller-docker-publish.yml
+++ b/.github/workflows/kserve-controller-docker-publish.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x
           context: .
           file: Dockerfile
           push: true

--- a/.github/workflows/qpext-docker-publish.yml
+++ b/.github/workflows/qpext-docker-publish.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x
           context: "."
           file: qpext/qpext.Dockerfile
           push: true

--- a/.github/workflows/router-docker-publish.yml
+++ b/.github/workflows/router-docker-publish.yml
@@ -94,7 +94,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x
           context: .
           file: router.Dockerfile
           push: true


### PR DESCRIPTION
*What this PR does / why we need it**:
This PR fixes the build jobs for some of the images like kserve-controller, qpext, router, agent.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/opendatahub-io/kserve/issues/389

**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:
The image build jobs were failing because go-toolset 1.21 version image is not available for linux/arm/v7 architecture.
So, for now removed that architecture from the GH workflows so that the build job passes and pushed the images for other architectures.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.