### PR TITLE
Fix apiGroups in aggregate roles on manifests

### DIFF
--- a/config/overlays/odh/user-cluster-roles.yaml
+++ b/config/overlays/odh/user-cluster-roles.yaml
@@ -43,7 +43,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
   - apiGroups:
-      - kubeflow.org
+      - serving.kserve.io
     resources:
       - servingruntimes
       - servingruntimes/status


### PR DESCRIPTION
One of the aggregate roles were using `kubeflow.org` in the API groups, which is incorrect.

This fixes the manifests to use the right API group.

Related to opendatahub-io/odh-model-controller#255