### PR TITLE
[Cherry pick] Add TLS support for Inference Loggers (kserve#3863) 

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -70,6 +70,8 @@ var (
 	readinessProbeTimeout = flag.Duration("probe-period", -1, "run readiness probe with given timeout")
 	// This creates an abstract socket instead of an actual file.
 	unixSocketPath = "@/kserve/agent.sock"
+	CaCertFile     = flag.String("logger-ca-cert-file", "service-ca.crt", "The logger CA certificate file")
+	TlsSkipVerify  = flag.Bool("logger-tls-skip-verify", false, "Skip verification of TLS certificate")
 )
 
 const (
@@ -105,6 +107,8 @@ type loggerArgs struct {
 	namespace        string
 	endpoint         string
 	component        string
+	certName         string
+	tlsSkipVerify    bool
 }
 
 type batcherArgs struct {
@@ -270,6 +274,8 @@ func startLogger(workers int, logger *zap.SugaredLogger) *loggerArgs {
 		endpoint:         *endpoint,
 		namespace:        *namespace,
 		component:        *component,
+		certName:         *CaCertFile,
+		tlsSkipVerify:    *TlsSkipVerify,
 	}
 }
 
@@ -324,7 +330,8 @@ func buildServer(ctx context.Context, port string, userPort int, loggerArgs *log
 	}
 	if loggerArgs != nil {
 		composedHandler = kfslogger.New(loggerArgs.logUrl, loggerArgs.sourceUrl, loggerArgs.loggerType,
-			loggerArgs.inferenceService, loggerArgs.namespace, loggerArgs.endpoint, loggerArgs.component, composedHandler)
+			loggerArgs.inferenceService, loggerArgs.namespace, loggerArgs.endpoint, loggerArgs.component, composedHandler,
+			loggerArgs.metadataHeaders, loggerArgs.certName, loggerArgs.tlsSkipVerify)
 	}
 
 	composedHandler = queue.ForwardedShimHandler(composedHandler)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -331,7 +331,7 @@ func buildServer(ctx context.Context, port string, userPort int, loggerArgs *log
 	if loggerArgs != nil {
 		composedHandler = kfslogger.New(loggerArgs.logUrl, loggerArgs.sourceUrl, loggerArgs.loggerType,
 			loggerArgs.inferenceService, loggerArgs.namespace, loggerArgs.endpoint, loggerArgs.component, composedHandler,
-			loggerArgs.metadataHeaders, loggerArgs.certName, loggerArgs.tlsSkipVerify)
+			loggerArgs.certName, loggerArgs.tlsSkipVerify)
 	}
 
 	composedHandler = queue.ForwardedShimHandler(composedHandler)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -73,6 +73,12 @@ const (
 	AgentModelDirArgName  = "--model-dir"
 )
 
+// InferenceLogger Constants
+const (
+	LoggerCaBundleVolume  = "agent-ca-bundle"
+	LoggerCaCertMountPath = "/etc/tls/logger"
+)
+
 // InferenceService Annotations
 var (
 	InferenceServiceGKEAcceleratorAnnotationKey = KServeAPIGroupName + "/gke-accelerator"

--- a/pkg/logger/handler.go
+++ b/pkg/logger/handler.go
@@ -46,7 +46,7 @@ type LoggerHandler struct {
 }
 
 func New(logUrl *url.URL, sourceUri *url.URL, logMode v1beta1.LoggerType,
-	inferenceService string, namespace string, endpoint string, component string, next http.Handler, metadataHeaders []string,
+	inferenceService string, namespace string, endpoint string, component string, next http.Handler,
 	certName string, tlsSkipVerify bool) http.Handler {
 	logf.SetLogger(zap.New())
 	return &LoggerHandler{

--- a/pkg/logger/handler.go
+++ b/pkg/logger/handler.go
@@ -41,10 +41,13 @@ type LoggerHandler struct {
 	component        string
 	endpoint         string
 	next             http.Handler
+	certName         string
+	tlsSkipVerify    bool
 }
 
 func New(logUrl *url.URL, sourceUri *url.URL, logMode v1beta1.LoggerType,
-	inferenceService string, namespace string, endpoint string, component string, next http.Handler) http.Handler {
+	inferenceService string, namespace string, endpoint string, component string, next http.Handler, metadataHeaders []string,
+	certName string, tlsSkipVerify bool) http.Handler {
 	logf.SetLogger(zap.New())
 	return &LoggerHandler{
 		log:              logf.Log.WithName("Logger"),
@@ -56,6 +59,8 @@ func New(logUrl *url.URL, sourceUri *url.URL, logMode v1beta1.LoggerType,
 		component:        component,
 		endpoint:         endpoint,
 		next:             next,
+		certName:         certName,
+		tlsSkipVerify:    tlsSkipVerify,
 	}
 }
 
@@ -98,6 +103,8 @@ func (eh *LoggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			Namespace:        eh.namespace,
 			Endpoint:         eh.endpoint,
 			Component:        eh.component,
+			CertName:         eh.certName,
+			TlsSkipVerify:    eh.tlsSkipVerify,
 		}); err != nil {
 			eh.log.Error(err, "Failed to log request")
 		}
@@ -126,6 +133,8 @@ func (eh *LoggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				Namespace:        eh.namespace,
 				Endpoint:         eh.endpoint,
 				Component:        eh.component,
+				CertName:         eh.certName,
+				TlsSkipVerify:    eh.tlsSkipVerify,
 			}); err != nil {
 				eh.log.Error(err, "Failed to log response")
 			}

--- a/pkg/logger/handler_test.go
+++ b/pkg/logger/handler_test.go
@@ -78,7 +78,7 @@ func TestLogger(t *testing.T) {
 
 	StartDispatcher(5, logger)
 	httpProxy := httputil.NewSingleHostReverseProxy(targetUri)
-	oh := New(logSvcUrl, sourceUri, v1beta1.LogAll, "mymodel", "default", "default", "default", httpProxy)
+	oh := New(logSvcUrl, sourceUri, v1beta1.LogAll, "mymodel", "default", "default", "default", httpProxy, "", false)
 
 	oh.ServeHTTP(w, r)
 
@@ -122,7 +122,7 @@ func TestBadResponse(t *testing.T) {
 	StartDispatcher(1, logger)
 	httpProxy := httputil.NewSingleHostReverseProxy(targetUri)
 	oh := New(logSvcUrl, sourceUri, v1beta1.LogAll, "mymodel", "default", "default",
-		"default", httpProxy, nil, "", true)
+		"default", httpProxy, "", true)
 
 	oh.ServeHTTP(w, r)
 	g.Expect(w.Code).To(gomega.Equal(400))

--- a/pkg/logger/handler_test.go
+++ b/pkg/logger/handler_test.go
@@ -121,7 +121,8 @@ func TestBadResponse(t *testing.T) {
 
 	StartDispatcher(1, logger)
 	httpProxy := httputil.NewSingleHostReverseProxy(targetUri)
-	oh := New(logSvcUrl, sourceUri, v1beta1.LogAll, "mymodel", "default", "default", "default", httpProxy)
+	oh := New(logSvcUrl, sourceUri, v1beta1.LogAll, "mymodel", "default", "default",
+		"default", httpProxy, nil, "", true)
 
 	oh.ServeHTTP(w, r)
 	g.Expect(w.Code).To(gomega.Equal(400))

--- a/pkg/logger/types.go
+++ b/pkg/logger/types.go
@@ -31,4 +31,6 @@ type LogRequest struct {
 	Namespace        string
 	Component        string
 	Endpoint         string
+	CertName         string
+	TlsSkipVerify    bool
 }

--- a/pkg/logger/worker.go
+++ b/pkg/logger/worker.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"os"

--- a/pkg/logger/worker.go
+++ b/pkg/logger/worker.go
@@ -18,7 +18,13 @@ package logger
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"go.uber.org/zap"
@@ -37,6 +43,7 @@ const (
 	EndpointAttr = "endpoint"
 
 	LoggerWorkerQueueSize = 100
+	LoggerCaCertMountPath = "/etc/tls/logger"
 	CloudEventsIdHeader   = "Ce-Id"
 )
 
@@ -79,6 +86,29 @@ func (w *Worker) sendCloudEvent(logReq LogRequest) error {
 
 	if err != nil {
 		return fmt.Errorf("while creating http transport: %s", err)
+	}
+
+	if logReq.Url.Scheme == "https" {
+		caCertFilePath := filepath.Join(LoggerCaCertMountPath, logReq.CertName)
+		caCertFile, err := os.ReadFile(caCertFilePath)
+		// Do not fail if certificates not found, for backwards compatibility
+		if err == nil {
+			clientCertPool := x509.NewCertPool()
+			if !clientCertPool.AppendCertsFromPEM(caCertFile) {
+				return fmt.Errorf("while parsing CA certificate")
+			}
+
+			tlsTransport := &http.Transport{
+				TLSClientConfig: &tls.Config{
+					RootCAs:            clientCertPool,
+					MinVersion:         tls.VersionTLS12,
+					InsecureSkipVerify: logReq.TlsSkipVerify, // #nosec G402
+				},
+			}
+			t.Client.Transport = tlsTransport
+		} else {
+			w.Log.Warnf("using https endpoint but could not find CA cert file %s", caCertFilePath)
+		}
 	}
 
 	c, err := cloudevents.NewClient(t,

--- a/pkg/webhook/admission/pod/agent_injector.go
+++ b/pkg/webhook/admission/pod/agent_injector.go
@@ -19,6 +19,7 @@ package pod
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -39,6 +40,8 @@ const (
 	LoggerArgumentNamespace        = "--namespace"
 	LoggerArgumentEndpoint         = "--endpoint"
 	LoggerArgumentComponent        = "--component"
+	LoggerArgumentCaCertFile       = "--logger-ca-cert-file"
+	LoggerArgumentTlsSkipVerify    = "--logger-tls-skip-verify"
 )
 
 type AgentConfig struct {
@@ -56,6 +59,9 @@ type LoggerConfig struct {
 	MemoryRequest string `json:"memoryRequest"`
 	MemoryLimit   string `json:"memoryLimit"`
 	DefaultUrl    string `json:"defaultUrl"`
+	CaBundle      string `json:"caBundle"`
+	CaCertFile    string `json:"caCertFile"`
+	TlsSkipVerify bool   `json:"tlsSkipVerify"`
 }
 
 type AgentInjector struct {
@@ -112,7 +118,6 @@ func getLoggerConfigs(configMap *v1.ConfigMap) (*LoggerConfig, error) {
 			return loggerConfig, fmt.Errorf("Failed to parse resource configuration for %q: %q", LoggerConfigMapKeyName, err.Error())
 		}
 	}
-
 	return loggerConfig, nil
 }
 
@@ -197,6 +202,13 @@ func (ag *AgentInjector) InjectAgent(pod *v1.Pod) error {
 			component,
 		}
 		args = append(args, loggerArgs...)
+
+		// Add TLS cert name if specified. If not specified it will fall back to the arg's default.
+		if ag.loggerConfig.CaCertFile != "" {
+			args = append(args, LoggerArgumentCaCertFile, ag.loggerConfig.CaCertFile)
+		}
+		// Whether to skip TLS verification. If not present in the ConfigMap, this will default to `false`
+		args = append(args, LoggerArgumentTlsSkipVerify, strconv.FormatBool(ag.loggerConfig.TlsSkipVerify))
 	}
 
 	var queueProxyEnvs []v1.EnvVar
@@ -277,6 +289,31 @@ func (ag *AgentInjector) InjectAgent(pod *v1.Pod) error {
 				},
 			},
 		},
+	}
+
+	// If the Logger TLS bundle ConfigMap is specified, mount it
+	if injectLogger && ag.loggerConfig.CaBundle != "" {
+		// Optional. If the ConfigMap is not found, this will not make the Pod fail
+		optionalVolume := true
+		configMapVolume := v1.VolumeSource{
+			ConfigMap: &v1.ConfigMapVolumeSource{
+				LocalObjectReference: v1.LocalObjectReference{
+					Name: ag.loggerConfig.CaBundle,
+				},
+				Optional: &optionalVolume,
+			},
+		}
+
+		pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
+			Name:         constants.LoggerCaBundleVolume,
+			VolumeSource: configMapVolume,
+		})
+
+		agentContainer.VolumeMounts = append(agentContainer.VolumeMounts, v1.VolumeMount{
+			Name:      constants.LoggerCaBundleVolume,
+			MountPath: constants.LoggerCaCertMountPath,
+			ReadOnly:  true,
+		})
 	}
 
 	// Inject credentials

--- a/pkg/webhook/admission/pod/agent_injector_test.go
+++ b/pkg/webhook/admission/pod/agent_injector_test.go
@@ -17,6 +17,10 @@ limitations under the License.
 package pod
 
 import (
+	"k8s.io/utils/ptr"
+	"strconv"
+	"testing"
+
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
 	"testing"
 
@@ -53,6 +57,13 @@ var (
 	loggerConfig = &LoggerConfig{
 		Image:      "gcr.io/kfserving/agent:latest",
 		DefaultUrl: "http://httpbin.org/",
+	}
+	loggerTLSConfig = &LoggerConfig{
+		Image:         "gcr.io/kfserving/agent:latest",
+		DefaultUrl:    "https://httpbin.org/",
+		CaBundle:      "kserve-tls-bundle",
+		CaCertFile:    "ca.crt",
+		TlsSkipVerify: true,
 	}
 	batcherTestConfig = &BatcherConfig{
 		Image: "gcr.io/kfserving/batcher:latest",
@@ -320,6 +331,8 @@ func TestAgentInjector(t *testing.T) {
 								"default",
 								LoggerArgumentComponent,
 								"predictor",
+								LoggerArgumentTlsSkipVerify,
+								"false",
 							},
 							Ports: []v1.ContainerPort{
 								{
@@ -790,6 +803,8 @@ func TestAgentInjector(t *testing.T) {
 								"default",
 								LoggerArgumentComponent,
 								"predictor",
+								LoggerArgumentTlsSkipVerify,
+								"false",
 								"--component-port",
 								constants.InferenceServiceDefaultHttpPort,
 							},
@@ -919,6 +934,8 @@ func TestAgentInjector(t *testing.T) {
 								"default",
 								LoggerArgumentComponent,
 								"predictor",
+								LoggerArgumentTlsSkipVerify,
+								"false",
 								"--component-port",
 								constants.InferenceServiceDefaultHttpPort,
 							},
@@ -1101,6 +1118,158 @@ func TestAgentInjector(t *testing.T) {
 			},
 		},
 	}
+	scenariosTls := map[string]struct {
+		original *v1.Pod
+		expected *v1.Pod
+	}{
+		"AddLogger": {
+			original: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deployment",
+					Namespace: "default",
+					Annotations: map[string]string{
+						constants.LoggerInternalAnnotationKey:        "true",
+						constants.LoggerSinkUrlInternalAnnotationKey: "https://httpbin.org/",
+						constants.LoggerModeInternalAnnotationKey:    string(v1beta1.LogAll),
+					},
+					Labels: map[string]string{
+						"serving.kserve.io/inferenceservice": "sklearn",
+						constants.KServiceModelLabel:         "sklearn",
+						constants.KServiceEndpointLabel:      "default",
+						constants.KServiceComponentLabel:     "predictor",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "sklearn",
+							ReadinessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									TCPSocket: &v1.TCPSocketAction{
+										Port: intstr.IntOrString{
+											IntVal: 8080,
+										},
+									},
+								},
+								InitialDelaySeconds: 0,
+								TimeoutSeconds:      1,
+								PeriodSeconds:       10,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
+							},
+						},
+						{
+							Name: "queue-proxy",
+							Env:  []v1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":8080},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
+						},
+					},
+				},
+			},
+			expected: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "deployment",
+					Annotations: map[string]string{
+						constants.LoggerInternalAnnotationKey:        "true",
+						constants.LoggerSinkUrlInternalAnnotationKey: "https://httpbin.org/",
+						constants.LoggerModeInternalAnnotationKey:    string(v1beta1.LogAll),
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "sklearn",
+							ReadinessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									TCPSocket: &v1.TCPSocketAction{
+										Port: intstr.IntOrString{
+											IntVal: 8080,
+										},
+									},
+								},
+								InitialDelaySeconds: 0,
+								TimeoutSeconds:      1,
+								PeriodSeconds:       10,
+								SuccessThreshold:    1,
+								FailureThreshold:    3,
+							},
+						},
+						{
+							Name: "queue-proxy",
+							Env:  []v1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":8080},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
+						},
+						{
+							Name:  constants.AgentContainerName,
+							Image: loggerConfig.Image,
+							Args: []string{
+								LoggerArgumentLogUrl,
+								"https://httpbin.org/",
+								LoggerArgumentSourceUri,
+								"deployment",
+								LoggerArgumentMode,
+								"all",
+								LoggerArgumentInferenceService,
+								"sklearn",
+								LoggerArgumentNamespace,
+								"default",
+								LoggerArgumentEndpoint,
+								"default",
+								LoggerArgumentComponent,
+								"predictor",
+								LoggerArgumentCaCertFile,
+								loggerTLSConfig.CaCertFile,
+								LoggerArgumentTlsSkipVerify,
+								strconv.FormatBool(loggerTLSConfig.TlsSkipVerify),
+							},
+							Ports: []v1.ContainerPort{
+								{
+									Name:          "agent-port",
+									ContainerPort: constants.InferenceServiceDefaultAgentPort,
+									Protocol:      "TCP",
+								},
+							},
+							Env:       []v1.EnvVar{{Name: "SERVING_READINESS_PROBE", Value: "{\"tcpSocket\":{\"port\":8080},\"timeoutSeconds\":1,\"periodSeconds\":10,\"successThreshold\":1,\"failureThreshold\":3}"}},
+							Resources: agentResourceRequirement,
+							ReadinessProbe: &v1.Probe{
+								ProbeHandler: v1.ProbeHandler{
+									HTTPGet: &v1.HTTPGetAction{
+										HTTPHeaders: []v1.HTTPHeader{
+											{
+												Name:  "K-Network-Probe",
+												Value: "queue",
+											},
+										},
+										Port:   intstr.FromInt(9081),
+										Path:   "/",
+										Scheme: "HTTP",
+									},
+								},
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{
+									Name:      constants.LoggerCaBundleVolume,
+									ReadOnly:  true,
+									MountPath: constants.LoggerCaCertMountPath,
+								},
+							},
+						},
+					},
+					Volumes: []v1.Volume{
+						{
+							Name: constants.LoggerCaBundleVolume,
+							VolumeSource: v1.VolumeSource{
+								ConfigMap: &v1.ConfigMapVolumeSource{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: loggerTLSConfig.CaBundle,
+									},
+									Optional: ptr.To(true),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 	clientset := fakeclientset.NewSimpleClientset()
 	credentialBuilder := credentials.NewCredentialBuilder(c, clientset, &v1.ConfigMap{
 		Data: map[string]string{},
@@ -1111,6 +1280,32 @@ func TestAgentInjector(t *testing.T) {
 			credentialBuilder,
 			agentConfig,
 			loggerConfig,
+			batcherTestConfig,
+		}
+		injector.InjectAgent(scenario.original)
+		if diff, _ := kmp.SafeDiff(scenario.expected.Spec, scenario.original.Spec); diff != "" {
+			t.Errorf("Test %q unexpected result (-want +got): %v", name, diff)
+		}
+	}
+	// Run TLS logger config with non-TLS scenarios
+	for name, scenario := range scenarios {
+		injector := &AgentInjector{
+			credentialBuilder,
+			agentConfig,
+			loggerTLSConfig,
+			batcherTestConfig,
+		}
+		injector.InjectAgent(scenario.original)
+		if diff, _ := kmp.SafeDiff(scenario.expected.Spec, scenario.original.Spec); diff != "" {
+			t.Errorf("Test %q unexpected result (-want +got): %v", name, diff)
+		}
+	}
+	// Run TLS logger config with TLS scenarios
+	for name, scenario := range scenariosTls {
+		injector := &AgentInjector{
+			credentialBuilder,
+			agentConfig,
+			loggerTLSConfig,
 			batcherTestConfig,
 		}
 		injector.InjectAgent(scenario.original)

--- a/pkg/webhook/admission/pod/agent_injector_test.go
+++ b/pkg/webhook/admission/pod/agent_injector_test.go
@@ -17,12 +17,13 @@ limitations under the License.
 package pod
 
 import (
-	"k8s.io/utils/ptr"
 	"strconv"
+
+	"k8s.io/utils/ptr"
+
 	"testing"
 
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
-	"testing"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/credentials"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR adds support for TLS in Inference Loggers.
It adds two new optional fields to the global ConfigMap: `tlsBundle` and `tlsCertName`.

If a ConfigMap matching `tlsBundle` is present in the Inference Service's namespace, it will be mounted as a volume on the agent. 
* If the logger's endpoint protocol is of type `https`, the logger will use the CA cert specified with `tlsCertName` to configure the transport.
  * If TLS is configured in ConfigMap, but the bundle is not available or the CA cert is not found, the logger will continue to behave as before this PR (no TLS transport configured)
* If the logger's endpoint protocol is of type `http`, the inference logger will behave as previously

_why we need it_

The current implementation does not configure HTTP transport for TLS.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
TLS support for Inference Logger by specifying certificate bundle in the global configuration
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.