### PR TITLE
Trust OpenShift service CA in kserve-router

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -496,6 +496,11 @@ var (
 	MultiNodeHead         = "head"
 )
 
+// OpenShift constants
+const (
+	OpenShiftServiceCaConfigMapName = "openshift-service-ca.crt"
+)
+
 // GetRawServiceLabel generate native service label
 func GetRawServiceLabel(service string) string {
 	return "isvc." + service

--- a/pkg/controller/v1alpha1/inferencegraph/controller_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller_test.go
@@ -148,6 +148,10 @@ var _ = Describe("Inference Graph controller test", func() {
 											Image: "kserve/router:v0.10.0",
 											Env: []v1.EnvVar{
 												{
+													Name:  "SSL_CERT_FILE",
+													Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
+												},
+												{
 													Name:  "PROPAGATE_HEADERS",
 													Value: "Authorization,Intuit_tid",
 												},
@@ -175,9 +179,27 @@ var _ = Describe("Inference Graph controller test", func() {
 													Drop: []v1.Capability{v1.Capability("ALL")},
 												},
 											},
+											VolumeMounts: []v1.VolumeMount{
+												{
+													Name:      "openshift-service-ca-bundle",
+													MountPath: "/etc/odh/openshift-service-ca-bundle",
+												},
+											},
 										},
 									},
 									AutomountServiceAccountToken: proto.Bool(false),
+									Volumes: []v1.Volume{
+										{
+											Name: "openshift-service-ca-bundle",
+											VolumeSource: v1.VolumeSource{
+												ConfigMap: &v1.ConfigMapVolumeSource{
+													LocalObjectReference: v1.LocalObjectReference{
+														Name: constants.OpenShiftServiceCaConfigMapName,
+													},
+												},
+											},
+										},
+									},
 								},
 							},
 						},
@@ -284,6 +306,10 @@ var _ = Describe("Inference Graph controller test", func() {
 											Image: "kserve/router:v0.10.0",
 											Env: []v1.EnvVar{
 												{
+													Name:  "SSL_CERT_FILE",
+													Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
+												},
+												{
 													Name:  "PROPAGATE_HEADERS",
 													Value: "Authorization,Intuit_tid",
 												},
@@ -311,9 +337,27 @@ var _ = Describe("Inference Graph controller test", func() {
 													Drop: []v1.Capability{v1.Capability("ALL")},
 												},
 											},
+											VolumeMounts: []v1.VolumeMount{
+												{
+													Name:      "openshift-service-ca-bundle",
+													MountPath: "/etc/odh/openshift-service-ca-bundle",
+												},
+											},
 										},
 									},
 									AutomountServiceAccountToken: proto.Bool(false),
+									Volumes: []v1.Volume{
+										{
+											Name: "openshift-service-ca-bundle",
+											VolumeSource: v1.VolumeSource{
+												ConfigMap: &v1.ConfigMapVolumeSource{
+													LocalObjectReference: v1.LocalObjectReference{
+														Name: constants.OpenShiftServiceCaConfigMapName,
+													},
+												},
+											},
+										},
+									},
 								},
 							},
 						},
@@ -434,6 +478,10 @@ var _ = Describe("Inference Graph controller test", func() {
 											Image: "kserve/router:v0.10.0",
 											Env: []v1.EnvVar{
 												{
+													Name:  "SSL_CERT_FILE",
+													Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
+												},
+												{
 													Name:  "PROPAGATE_HEADERS",
 													Value: "Authorization,Intuit_tid",
 												},
@@ -459,6 +507,12 @@ var _ = Describe("Inference Graph controller test", func() {
 												AllowPrivilegeEscalation: proto.Bool(false),
 												Capabilities: &v1.Capabilities{
 													Drop: []v1.Capability{v1.Capability("ALL")},
+												},
+											},
+											VolumeMounts: []v1.VolumeMount{
+												{
+													Name:      "openshift-service-ca-bundle",
+													MountPath: "/etc/odh/openshift-service-ca-bundle",
 												},
 											},
 										},
@@ -487,6 +541,18 @@ var _ = Describe("Inference Graph controller test", func() {
 										},
 									},
 									AutomountServiceAccountToken: proto.Bool(false),
+									Volumes: []v1.Volume{
+										{
+											Name: "openshift-service-ca-bundle",
+											VolumeSource: v1.VolumeSource{
+												ConfigMap: &v1.ConfigMapVolumeSource{
+													LocalObjectReference: v1.LocalObjectReference{
+														Name: constants.OpenShiftServiceCaConfigMapName,
+													},
+												},
+											},
+										},
+									},
 								},
 							},
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:

This changes kserve-controller to mount the OpenShift Service CA bundle into kserve-router container and a configures it to trust the bundle. This affects InferenceGraph deployed in Serverless mode.

With these changes, InferenceGraphs will work correctly when deployed without an Istio sidecar.

These changes are needed because in ODH the InferenceServices are secured with TLS. The internal endpoints (which are the ones InferenceGraph uses) are using OpenShift service serving certificates.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to: https://issues.redhat.com/browse/RHOAIENG-13448

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Deploy Inference Graph without a sidecar, and validate that it can connect correctly to an inference service (i.e. infer requests succeed)

- Logs

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [N/A] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Trust OpenShift service CA in kserve-router
```
