### PR TITLE
[RHOAIENG-11034] - Disabling Authorino Token Authorization forces a Model Pod to rollout

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -368,6 +368,9 @@ var (
 		autoscaling.MaxScaleAnnotationKey,
 		StorageInitializerSourceUriInternalAnnotationKey,
 		"kubectl.kubernetes.io/last-applied-configuration",
+		// remove when https://issues.redhat.com/browse/RHOAIENG-15662 is merged on community and ported to ODH
+		// Plus, this annotation must be moved to the inferenceservice-config
+		"security.opendatahub.io/enable-auth",
 	}
 
 	RevisionTemplateLabelDisallowedList = []string{


### PR DESCRIPTION
chore:	Adds the `security.opendatahub.io/enable-auth` label to the ServiceAnnotationDisallowedList
	to prevents the model to be rolled out in case the auth is disabled / enabled


## How to test:
- install the Authorino operator (tech preview version)

Update the DSC:
```yaml
spec:
  components:
    codeflare:
      managementState: Removed
    kserve:
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: ''
            uri: 'https://github.com/spolti/kserve/tarball/test1234'
      managementState: Managed
      serving:
        ingressGateway:
          certificate:
            secretName: knative-serving-cert
            type: SelfSigned
        managementState: Managed
        name: knative-serving
    trustyai:
      managementState: Removed
    ray:
      managementState: Removed
    kueue:
      managementState: Removed
    workbenches:
      managementState: Managed
    dashboard:
      managementState: Managed
    modelmeshserving:
      managementState: Removed
    datasciencepipelines:
      managementState: Removed
```

Then:

- Navigate to the dashboard and create a model with auth disabled
- wait for the model to get deployed, make an inference request
- get back to the dashboard and update the model by enabling the auth
- watch the model's pod, It should not be reconciled.
- try to do a inference request by passing the token, it should succeed.