### PR TITLE
Use odh-model-controller incubating branch

### DIFF
--- a/test/scripts/openshift-ci/kustomization.yaml
+++ b/test/scripts/openshift-ci/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - github.com/opendatahub-io/odh-model-controller/config/base?ref=main
+  - github.com/opendatahub-io/odh-model-controller/config/base?ref=incubating
 
 namespace: kserve


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the odh-model-controller incubating branch as part of the new odh-model-controller branching strategy
