### PR TITLE
[RHOAIENG-16851] - Rawdeployment bug fixes

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -336,9 +336,12 @@ func (ss *InferenceServiceStatus) PropagateRawStatus(
 	}
 
 	condition := getDeploymentCondition(deploymentList, appsv1.DeploymentAvailable)
-	if condition != nil && condition.Status == v1.ConditionTrue {
-		statusSpec.URL = url
-	}
+	// currently the component url is disabled as this url generated based on ingressConfig. This is incompatible with
+	// rawdeployment changes as the url depends on the route creation, if a route is requested.
+	// TODO: add back component url deterministicly
+	// if condition != nil && condition.Status == v1.ConditionTrue {
+	//	 statusSpec.URL = url
+	//}
 	readyCondition := readyConditionsMap[component]
 	ss.SetCondition(readyCondition, condition)
 	ss.Components[component] = statusSpec

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -2652,7 +2652,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				},
 				Address: &duckv1.Addressable{
 					URL: &apis.URL{
-						Scheme: "http",
+						Scheme: "https",
 						Host:   fmt.Sprintf("%s-predictor.%s.svc.cluster.local:8443", serviceKey.Name, serviceKey.Namespace),
 					},
 				},

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -425,10 +425,10 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Components: map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
 					v1beta1.PredictorComponent: {
 						LatestCreatedRevision: "",
-						URL: &apis.URL{
-							Scheme: "http",
-							Host:   "raw-foo-predictor-default.example.com",
-						},
+						//URL: &apis.URL{
+						//	Scheme: "http",
+						//	Host:   "raw-foo-predictor-default.example.com",
+						//},
 					},
 				},
 				ModelStatus: v1beta1.ModelStatus{
@@ -840,10 +840,10 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Components: map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
 					v1beta1.PredictorComponent: {
 						LatestCreatedRevision: "",
-						URL: &apis.URL{
-							Scheme: "http",
-							Host:   "raw-foo-customized-predictor-default.example.com",
-						},
+						//URL: &apis.URL{
+						//	Scheme: "http",
+						//	Host:   "raw-foo-customized-predictor-default.example.com",
+						//},
 					},
 				},
 				ModelStatus: v1beta1.ModelStatus{
@@ -1246,10 +1246,10 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Components: map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
 					v1beta1.PredictorComponent: {
 						LatestCreatedRevision: "",
-						URL: &apis.URL{
-							Scheme: "http",
-							Host:   "raw-foo-2-predictor-default.example.com",
-						},
+						//URL: &apis.URL{
+						//	Scheme: "http",
+						//	Host:   "raw-foo-2-predictor-default.example.com",
+						//},
 					},
 				},
 				ModelStatus: v1beta1.ModelStatus{
@@ -1723,10 +1723,10 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Components: map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
 					v1beta1.PredictorComponent: {
 						LatestCreatedRevision: "",
-						URL: &apis.URL{
-							Scheme: "http",
-							Host:   fmt.Sprintf("%s-predictor-default.example.com", serviceName),
-						},
+						//URL: &apis.URL{
+						//	Scheme: "http",
+						//	Host:   fmt.Sprintf("%s-predictor-default.example.com", serviceName),
+						//},
 					},
 				},
 				ModelStatus: v1beta1.ModelStatus{
@@ -2156,10 +2156,10 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Components: map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
 					v1beta1.PredictorComponent: {
 						LatestCreatedRevision: "",
-						URL: &apis.URL{
-							Scheme: "http",
-							Host:   fmt.Sprintf("%s-predictor.%s.%s", serviceName, serviceKey.Namespace, domain),
-						},
+						//URL: &apis.URL{
+						//	Scheme: "http",
+						//	Host:   fmt.Sprintf("%s-predictor.%s.%s", serviceName, serviceKey.Namespace, domain),
+						//},
 					},
 				},
 				ModelStatus: v1beta1.ModelStatus{
@@ -2659,10 +2659,10 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Components: map[v1beta1.ComponentType]v1beta1.ComponentStatusSpec{
 					v1beta1.PredictorComponent: {
 						LatestCreatedRevision: "",
-						URL: &apis.URL{
-							Scheme: "http",
-							Host:   "raw-auth-predictor-default.example.com",
-						},
+						//URL: &apis.URL{
+						//	Scheme: "http",
+						//	Host:   "raw-auth-predictor-default.example.com",
+						//},
 					},
 				},
 				ModelStatus: v1beta1.ModelStatus{

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -269,15 +269,24 @@ func createRawWorkerDeployment(componentMeta metav1.ObjectMeta,
 }
 
 func GetKServeContainerPort(podSpec *corev1.PodSpec) string {
+	var kserveContainerPort string
+
 	for _, container := range podSpec.Containers {
-		if container.Name == "kserve-container" {
+		if container.Name == "transformer-container" {
 			if len(container.Ports) > 0 {
 				return strconv.Itoa(int(container.Ports[0].ContainerPort))
 			}
 		}
+		if container.Name == "kserve-container" {
+			if len(container.Ports) > 0 {
+				kserveContainerPort = strconv.Itoa(int(container.Ports[0].ContainerPort))
+			}
+		}
 	}
-	return ""
+
+	return kserveContainerPort
 }
+
 func generateOauthProxyContainer(clientset kubernetes.Interface, isvc string, namespace string, upstreamPort string, sa string) (*corev1.Container, error) {
 	isvcConfigMap, err := clientset.CoreV1().ConfigMaps(constants.KServeNamespace).Get(context.TODO(), constants.InferenceServiceConfigMapName, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
@@ -80,19 +80,14 @@ func createRawURL(client client.Client, isvc *v1beta1.InferenceService, authEnab
 			return nil, err
 		}
 	} else {
-		var scheme string
-		if authEnabled {
-			scheme = "https"
-		} else {
-			scheme = "http"
-		}
 		url = &apis.URL{
 			Host:   getRawServiceHost(isvc, client),
-			Scheme: scheme,
+			Scheme: "http",
 			Path:   "",
 		}
 		if authEnabled {
 			url.Host += ":" + strconv.Itoa(constants.OauthProxyPort)
+			url.Scheme = "https"
 		}
 	}
 	return url, nil
@@ -343,19 +338,18 @@ func (r *RawIngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
 		return err
 	}
 	internalHost := getRawServiceHost(isvc, r.client)
-	var scheme string
+	url := &apis.URL{
+		Host:   internalHost,
+		Scheme: "http",
+		Path:   "",
+	}
 	if authEnabled {
 		internalHost += ":" + strconv.Itoa(constants.OauthProxyPort)
-		scheme = "https"
-	} else {
-		scheme = "http"
+		url.Host = internalHost
+		url.Scheme = "https"
 	}
 	isvc.Status.Address = &duckv1.Addressable{
-		URL: &apis.URL{
-			Host:   internalHost,
-			Scheme: scheme,
-			Path:   "",
-		},
+		URL: url,
 	}
 	isvc.Status.SetCondition(v1beta1.IngressReady, &apis.Condition{
 		Type:   v1beta1.IngressReady,

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
@@ -80,9 +80,15 @@ func createRawURL(client client.Client, isvc *v1beta1.InferenceService, authEnab
 			return nil, err
 		}
 	} else {
+		var scheme string
+		if authEnabled {
+			scheme = "https"
+		} else {
+			scheme = "http"
+		}
 		url = &apis.URL{
 			Host:   getRawServiceHost(isvc, client),
-			Scheme: "http",
+			Scheme: scheme,
 			Path:   "",
 		}
 		if authEnabled {
@@ -337,13 +343,17 @@ func (r *RawIngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
 		return err
 	}
 	internalHost := getRawServiceHost(isvc, r.client)
+	var scheme string
 	if authEnabled {
 		internalHost += ":" + strconv.Itoa(constants.OauthProxyPort)
+		scheme = "https"
+	} else {
+		scheme = "http"
 	}
 	isvc.Status.Address = &duckv1.Addressable{
 		URL: &apis.URL{
 			Host:   internalHost,
-			Scheme: r.ingressConfig.UrlScheme,
+			Scheme: scheme,
 			Path:   "",
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: 
- Fix bug regarding inconsistent schemas in isvc.status.url and isvc.status.address.url for rawdeployment
- Remove component URL temporarily (follow up JIRA to add them back correctly : https://issues.redhat.com/browse/RHOAIENG-17765) 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/RHOAIENG-16851 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

```
    kserve:
      defaultDeploymentMode: RawDeployment
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: overlays/odh
            uri: 'https://github.com/VedantMahabaleshwarkar/kserve/tarball/devflags'
          - contextDir: config
            sourcePath: ''
            uri: 'https://github.com/VedantMahabaleshwarkar/odh-model-controller/tarball/devflags'
      managementState: Managed
      serving:
        ingressGateway:
          certificate:
            type: OpenshiftDefaultIngress
        managementState: Managed
        name: knative-serving
```
- Install DSC with devflags as given above. 
- Modify the `inferenceservice-config` ConfigMap in the ODH application namespace (opendatahub) as follows 
-- Add annotation `opendatahub.io/managed: false` 
-- Modify 
```
service: |-
    {
        "serviceClusterIPNone": true
    }
``` 
to 
```
service: |-
    {
        "serviceClusterIPNone": false
    }
```
- Resources used to test : https://gist.github.com/VedantMahabaleshwarkar/b84d876cab99d2f1db708757b26f5c63 
-- this is in line with previous tests done [here](https://github.com/opendatahub-io/kserve/pull/419#issuecomment-2524125126)
-- results for this test (to address all the yellows in the previous round of testing) : https://gist.github.com/VedantMahabaleshwarkar/fdc6b4bf4226a0ffdf7b76219a2365f1 
-- addressing the red (failure to perform inference against unprotected exposed isvc) 
![image](https://github.com/user-attachments/assets/0ff1b351-ebda-4d6f-a170-51f7e288a1d3)


**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.