### PR TITLE
Add well-known label to InferenceGraphs

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -30,15 +30,15 @@ import (
 )
 
 // KServe Constants
-var (
+const (
 	KServeName                       = "kserve"
 	KServeAPIGroupName               = "serving.kserve.io"
 	KnativeAutoscalingAPIGroupName   = "autoscaling.knative.dev"
 	KnativeServingAPIGroupNamePrefix = "serving.knative"
 	KnativeServingAPIGroupName       = KnativeServingAPIGroupNamePrefix + ".dev"
-	KServeNamespace                  = getEnvOrDefault("POD_NAMESPACE", "kserve")
-	KServeDefaultVersion             = "v0.5.0"
 )
+
+var KServeNamespace = getEnvOrDefault("POD_NAMESPACE", "kserve")
 
 // InferenceService Constants
 var (
@@ -300,6 +300,7 @@ const (
 	KServiceComponentLabel = "component"
 	KServiceModelLabel     = "model"
 	KServiceEndpointLabel  = "endpoint"
+	KServeWorkloadKind     = KServeAPIGroupName + "/kind"
 )
 
 // Labels for TrainedModel

--- a/pkg/controller/v1alpha1/inferencegraph/controller_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller_test.go
@@ -21,9 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
-	"github.com/kserve/kserve/pkg/constants"
-	"github.com/kserve/kserve/pkg/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/proto"
@@ -36,6 +33,10 @@ import (
 	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/utils"
 )
 
 var _ = Describe("Inference Graph controller test", func() {
@@ -132,6 +133,7 @@ var _ = Describe("Inference Graph controller test", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
 									"serving.kserve.io/inferencegraph": graphName,
+									constants.KServeWorkloadKind:       "InferenceGraph",
 								},
 								Annotations: map[string]string{
 									"autoscaling.knative.dev/min-scale": "1",
@@ -290,6 +292,7 @@ var _ = Describe("Inference Graph controller test", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
 									"serving.kserve.io/inferencegraph": graphName,
+									constants.KServeWorkloadKind:       "InferenceGraph",
 								},
 								Annotations: map[string]string{
 									"autoscaling.knative.dev/min-scale": "1",
@@ -462,6 +465,7 @@ var _ = Describe("Inference Graph controller test", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Labels: map[string]string{
 									"serving.kserve.io/inferencegraph": graphName,
+									constants.KServeWorkloadKind:       "InferenceGraph",
 								},
 								Annotations: map[string]string{
 									"autoscaling.knative.dev/min-scale": "1",

--- a/pkg/controller/v1alpha1/inferencegraph/knative_reconciler.go
+++ b/pkg/controller/v1alpha1/inferencegraph/knative_reconciler.go
@@ -23,9 +23,6 @@ import (
 	"reflect"
 	"strings"
 
-	v1alpha1api "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
-	"github.com/kserve/kserve/pkg/constants"
-	"github.com/kserve/kserve/pkg/utils"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 	v1 "k8s.io/api/core/v1"
@@ -42,6 +39,10 @@ import (
 	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	v1alpha1api "github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/utils"
 )
 
 var log = logf.Log.WithName("GraphKsvcReconciler")
@@ -169,6 +170,7 @@ func createKnativeService(componentMeta metav1.ObjectMeta, graph *v1alpha1api.In
 		return !utils.Includes(constants.RevisionTemplateLabelDisallowedList, key)
 	})
 	labels[constants.InferenceGraphLabel] = componentMeta.Name
+	labels[constants.KServeWorkloadKind] = "InferenceGraph"
 	service := &knservingv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        componentMeta.Name,


### PR DESCRIPTION
**What this PR does / why we need it**:

Implementation of authentication for InferenceGraphs using Serverless mode will use ServiceMesh with Authorino (like InferenceServices case). For this, an Istio AuthorizationPolicy is applied mesh-wide. The AuthorizationPolicy uses a static label selector that is expected to be present on all Pods that require to be protected.

Currently, the InferenceGraph does not have a static label that can be used.

This PR is adding the `serving.kserve.io/kind: InferenceGraph` to pods that belong to InferenceGraph to properly protect them per user request.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to: https://issues.redhat.com/browse/RHOAIENG-13449

**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

**Feature/Issue validation/testing**:

Deploy an InferenceGraph in Serverless mode, and check that the new label is present on the resulting pod.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [N/A] Have you made corresponding changes to the documentation?

