### PR TITLE
[v0.14] Enable forwarding Authorization header in InferenceGraphs

### DIFF
--- a/config/overlays/odh/inferenceservice-config-patch.yaml
+++ b/config/overlays/odh/inferenceservice-config-patch.yaml
@@ -60,7 +60,12 @@ data:
         "memoryRequest": "100Mi",
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
-        "cpuLimit": "1"
+        "cpuLimit": "1",
+        "headers": {
+          "propagate": [
+            "Authorization"
+          ]
+        }
     }
   deploy: |-
     {


### PR DESCRIPTION
**What this PR does / why we need it**:

This will configure all `InferenceGraph` workloads to forward the standard HTTP `Authorization` header to the backing `InferenceServices`.

The `Authorization` header is used to receive/send credentials and let ODH stack to validate access.

By enabling forwarding of the `Authorization` header, we cover the case when there is an (some) auth-protected InferenceService(s) as part of an InferenceGraph. Access is fine-grained, so access to an InferenceGraph does not guarantee access to some InferenceService. The user needs to provide credentials to all resources (IGs and ISVC) that the request needs to go through. Since each workload validates credentials on its own, credentials need to be forwarded to all workloads of an InferenceGraph.

**Which issue(s) this PR fixes** 
Fixes https://issues.redhat.com/browse/RHOAIENG-17827

**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

**Feature/Issue validation/testing**:

1. Deploy an InferenceGraph with some of the ISVCs with auth enabled. The IG doesn't need to be auth-protected.
2. Test that requests that don't require to go through the auth-protected ISVCs will succeed.
3. Test that requests that require to go through the auth-protected ISVCs will fail with no credentials, or credentials without enough privileges.
4. Test that requests that require to go through the auth-protected ISVCs will succeed with credentials having enough privileges.

**Checklist**:

- N/A Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- N/A Have you made corresponding changes to the documentation?
