### PR TITLE
[Cherry-Pick] Remove starlette pinned version because it is already in the requirem…

### DIFF
--- a/python/storage-initializer.Dockerfile
+++ b/python/storage-initializer.Dockerfile
@@ -26,8 +26,6 @@ COPY kserve kserve
 RUN cd kserve && poetry install --no-interaction --no-cache --extras "storage"
 
 RUN pip install --no-cache-dir krbcontext==0.10 hdfs~=2.6.0 requests-kerberos==0.14.0
-# Fixes Quay alert GHSA-2jv5-9r88-3w3p https://github.com/Kludex/python-multipart/security/advisories/GHSA-2jv5-9r88-3w3p
-RUN pip install --no-cache-dir starlette==0.36.2
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS prod
 


### PR DESCRIPTION
…ents

**What this PR does / why we need it**:
Cherry-pick of https://github.com/opendatahub-io/kserve/pull/473 for [RHOAIENG-17835](https://issues.redhat.com/browse/RHOAIENG-17835)

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.