### PR TITLE
Fix the tags used in the ODH release process on release-v0.14

### DIFF
--- a/.github/workflows/odh-create-release-tag.yml
+++ b/.github/workflows/odh-create-release-tag.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Get latest tag
         id: get_tag
         run: |
-          echo "old_tag_name=$(git ls-remote --tags origin | awk -F'/' '{print $3}' | grep -v '{}' | sort -V | tail -n1)" >> $GITHUB_OUTPUT
+          echo "old_tag_name=$(git for-each-ref --sort=creatordate --format '%(refname)' refs/tags | awk -F'/' '{print $3}' | tail -n1)" >> $GITHUB_OUTPUT
       - name: print tag
         id: print_tag
         run: | 

--- a/.github/workflows/odh-create-release-tag.yml
+++ b/.github/workflows/odh-create-release-tag.yml
@@ -15,8 +15,6 @@ permissions:
 jobs:
   fetch-tag:
     runs-on: ubuntu-latest
-    outputs:
-      old_tag: ${{ steps.get_tag.outputs.old_tag_name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -27,11 +25,9 @@ jobs:
       - name: Get latest tag
         id: get_tag
         run: |
-          echo "old_tag_name=$(git for-each-ref --sort=creatordate --format '%(refname)' refs/tags | awk -F'/' '{print $3}' | tail -n1)" >> $GITHUB_OUTPUT
       - name: print tag
         id: print_tag
         run: | 
-          echo "Old Tag=${{ steps.get_tag.outputs.old_tag_name }}"
           echo "NEW_TAG=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV
           echo "$(basename ${{ github.ref }})"
 

--- a/.github/workflows/odh-create-release-tag.yml
+++ b/.github/workflows/odh-create-release-tag.yml
@@ -66,7 +66,7 @@ jobs:
               
       - name: Update params.env with new release version
         run: |     
-          sed -i 's|:v[0-9.]*\b|:${{ github.event.inputs.tag_name }}|gm' config/overlays/odh/params.env
+          sed -i 's|:v[0-9.]*\b-latest|:${{ github.event.inputs.tag_name }}|gm' config/overlays/odh/params.env
       - name: Commit changes
         run: |
           git config --global user.email "github-actions@github.com"

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -1,5 +1,5 @@
-kserve-controller=quay.io/opendatahub/kserve-controller:v0.14
-kserve-agent=quay.io/opendatahub/kserve-agent:v0.14
-kserve-router=quay.io/opendatahub/kserve-router:v0.14
-kserve-storage-initializer=quay.io/opendatahub/kserve-storage-initializer:v0.14
+kserve-controller=quay.io/opendatahub/kserve-controller:v0.14-latest
+kserve-agent=quay.io/opendatahub/kserve-agent:v0.14-latest
+kserve-router=quay.io/opendatahub/kserve-router:v0.14-latest
+kserve-storage-initializer=quay.io/opendatahub/kserve-storage-initializer:v0.14-latest
 oauth-proxy=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:234af927030921ab8f7333f61f967b4b4dee37a1b3cf85689e9e63240dd62800


### PR DESCRIPTION
**What this PR does / why we need it**:
[RHOAIENG-18934](https://issues.redhat.com/browse/RHOAIENG-18934) Fixes the old_tag_name and uses the v0.14-latest tag from params.env 

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.