### PR TITLE
Better compatibility with in-place upgrades

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -12,6 +12,9 @@ spec:
     matchLabels:
       control-plane: kserve-controller-manager
       controller-tools.k8s.io: "1.0"
+  strategy:
+    type: Recreate
+    rollingUpdate: nil
   template:
     metadata:
       labels:


### PR DESCRIPTION
**What this PR does / why we need it**:

For in-place upgrades the manifests of the new version are applied in a cluster where KServe may already be installed. The old version of the kserve-controller is terminated and the new version is deployed.

The default strategy is Rolling. This has the consequence that during an in-place upgrade, there will be two different versions of kserve-controller running in parallel. Most importantly, the two instances will be running with different configs, which include references to different versions of kserve-agent, kserve-router, storage-initializer, etc. During an in-place upgrade, the new version of the controller will upgrade the deployed models to use the new versions of the images. However, since the old version of kserve-controller is running in parallel, this old version will do rollback. The two instances will conflict with each other, leading to Deployments/KSVCs being changed very quickly which will lead to the cluster spawning pods without control.

Eventually, the cluster will terminate the old version of kserve-controller. However, because of the very, very quick updates to deployments the resources of the cluster can be exhausted leading to instability.

By changing the `strategy` to `Recreate`, during an in-place upgrade the cluster will make sure that the old version of kserve-controller is fully terminated before starting the new version. This prevents cluster instability.



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes https://issues.redhat.com/browse/RHOAIENG-18977

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

Manual validation: Having kserve-controller installed, scale to zero odh-operator. Then, modify kserve-controller Deployment to  have `strategy: Recreate`. Despite the image remains unchanged, the new strategy will lead to the cluster re-deploying kserve-controller pod. Observe that, this time, the old pod will be removed and, later, the new pod will be started.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
