### PR TITLE
Use leader election for better compatibility with in-place upgrades

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -31,4 +31,3 @@ spec:
       - name: manager
         args:
         - "--metrics-addr=127.0.0.1:8080"
-        - "--leader-elect"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,6 +27,8 @@ spec:
       containers:
       - command:
         - /manager
+        args:
+        - "--leader-elect"
         image: ko://github.com/kserve/kserve/cmd/manager
         imagePullPolicy: Always
         name: manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -12,9 +12,6 @@ spec:
     matchLabels:
       control-plane: kserve-controller-manager
       controller-tools.k8s.io: "1.0"
-  strategy:
-    type: Recreate
-    rollingUpdate: nil
   template:
     metadata:
       labels:


### PR DESCRIPTION
**What this PR does / why we need it**:

Following up with comments here: https://github.com/opendatahub-io/kserve/pull/491#discussion_r1947222525

The reverts commit 2a917eafe8ec716254423c9079f05aaa7f59ab0f (PR #491), which changed the configuration of the Deployment for the manager to use `Recreate` strategy. Such change was for better compatibility for in-place upgrades (see description of PR #491).

Instead of changing the Deployment strategy, this is enabling leader election in the manager. The leader election also solves the issues mentioned in PR #491. Also, not changing the Deployment strategy works better with odh-operator.

**Which issue(s) this PR fixes**
Fixes https://issues.redhat.com/browse/RHOAIENG-18977

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

Similar testing as in PR #491. However, logs should reveal that when duplicating the kserve-controller Deployment, the second deployment should wait until it is capable of acquiring the lease.

**Special notes for your reviewer**:

On the very first upgrade, despite the updated configuration, the new version of the manager would still run in parallel along the old version. This is expected, because the older version doesn't have enabled leader election. This should be OK, as we still don't promote InferenceGraphs as supported in ODH. Once this change is released, on following ODH upgrades we should observe the expected behavior of the new version not fully booting until it acquires the lease to be the leader. This is the reason for testing this PR by duplicating the deployment.

**Checklist**:

- [N/A] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [N/A] Has code been commented, particularly in hard-to-understand areas?
- [N/A] Have you made corresponding changes to the documentation?

