### PR TITLE
Fix typo in sed command + Add shell options to scripts

### DIFF
--- a/test/scripts/openshift-ci/run-e2e-tests.sh
+++ b/test/scripts/openshift-ci/run-e2e-tests.sh
@@ -18,6 +18,10 @@
 # like kustomize and the mc client are installed by the script if not available.
 # The oc CLI is assumed to be configured with the credentials of the
 # target cluster. The target cluster is assumed to be a clean cluster.
+set -o errexit
+set -o nounset
+set -o pipefail
+
 MY_PATH=$(dirname "$0")
 PROJECT_ROOT=$MY_PATH/../../../
 

--- a/test/scripts/openshift-ci/setup-e2e-tests.sh
+++ b/test/scripts/openshift-ci/setup-e2e-tests.sh
@@ -18,7 +18,9 @@
 # like kustomize and the mc client are installed by the script if not available.
 # The oc CLI is assumed to be configured with the credentials of the
 # target cluster. The target cluster is assumed to be a clean cluster.
-set -eu
+set -o errexit
+set -o nounset
+set -o pipefail
 
 : "${SKLEARN_IMAGE:=kserve/sklearnserver:latest}"
 : "${KSERVE_CONTROLLER_IMAGE:=quay.io/opendatahub/kserve-controller:latest}"

--- a/test/scripts/openshift-ci/setup-e2e-tests.sh
+++ b/test/scripts/openshift-ci/setup-e2e-tests.sh
@@ -98,7 +98,7 @@ oc wait --for=condition=ready pod -l control-plane=kserve-controller-manager -n 
 if [ "$1" != "raw" ]; then
   echo "Installing odh-model-controller"
   # authorino
-  curl -sL https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/utils/install.sh | "s|kubectl|oc|" | 
+  curl -sL https://raw.githubusercontent.com/Kuadrant/authorino-operator/main/utils/install.sh | sed "s|kubectl|oc|" | 
     bash -s -- -v 0.16.0
 
   # kserve-local-gateway


### PR DESCRIPTION
**What this PR does / why we need it**:
Accidentally left out the sed command from https://github.com/opendatahub-io/kserve/pull/477 
Added shell options to the scripts so they would correctly report errors in the CI

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.