### PR TITLE
add tls to kserve-router and add certs to ig service and always mount…

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/pkg/errors"
-
 	"github.com/tidwall/gjson"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -368,8 +367,8 @@ func main() {
 		WriteTimeout: time.Minute,                    // set the maximum duration before timing out writes of the response
 		IdleTimeout:  3 * time.Minute,                // set the maximum amount of time to wait for the next request when keep-alives are enabled
 	}
-	err = server.ListenAndServe()
 
+	err = server.ListenAndServeTLS("/etc/tls/private/tls.crt", "/etc/tls/private/tls.key")
 	if err != nil {
 		log.Error(err, "failed to listen on 8080")
 		os.Exit(1)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -132,14 +132,15 @@ var (
 
 // kserve networking constants
 const (
-	NetworkVisibility       = "networking.kserve.io/visibility"
-	ClusterLocalVisibility  = "cluster-local"
-	ClusterLocalDomain      = "svc.cluster.local"
-	IsvcNameHeader          = "KServe-Isvc-Name"
-	IsvcNamespaceHeader     = "KServe-Isvc-Namespace"
-	ODHKserveRawAuth        = "security.opendatahub.io/enable-auth"
-	ODHRouteEnabled         = "exposed"
-	ServingCertSecretSuffix = "-serving-cert"
+	NetworkVisibility              = "networking.kserve.io/visibility"
+	ClusterLocalVisibility         = "cluster-local"
+	ClusterLocalDomain             = "svc.cluster.local"
+	IsvcNameHeader                 = "KServe-Isvc-Name"
+	IsvcNamespaceHeader            = "KServe-Isvc-Namespace"
+	ODHKserveRawAuth               = "security.opendatahub.io/enable-auth"
+	ODHRouteEnabled                = "exposed"
+	ServingCertSecretSuffix        = "-serving-cert"
+	OpenshiftServingCertAnnotation = "service.beta.openshift.io/serving-cert-secret-name"
 )
 
 // StorageSpec Constants
@@ -516,6 +517,13 @@ var (
 // OpenShift constants
 const (
 	OpenShiftServiceCaConfigMapName = "openshift-service-ca.crt"
+)
+
+type ResourceType string
+
+const (
+	InferenceServiceResource ResourceType = "InferenceService"
+	InferenceGraphResource   ResourceType = "InferenceGraph"
 )
 
 // GetRawServiceLabel generate native service label

--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
@@ -89,7 +89,6 @@ func createInferenceGraphPodSpec(graph *v1alpha1api.InferenceGraph, config *Rout
 			},
 		}
 	}
-
 	return podSpec
 }
 
@@ -145,7 +144,7 @@ func handleInferenceGraphRawDeployment(cl client.Client, clientset kubernetes.In
 	objectMeta, componentExtSpec := constructForRawDeployment(graph)
 
 	// create the reconciler
-	reconciler, err := raw.NewRawKubeReconciler(cl, clientset, scheme, objectMeta, metav1.ObjectMeta{}, &componentExtSpec, desiredSvc, nil)
+	reconciler, err := raw.NewRawKubeReconciler(cl, clientset, scheme, constants.InferenceGraphResource, objectMeta, metav1.ObjectMeta{}, &componentExtSpec, desiredSvc, nil)
 
 	if err != nil {
 		return nil, reconciler.URL, errors.Wrapf(err, "fails to create NewRawKubeReconciler for inference graph")
@@ -158,6 +157,7 @@ func handleInferenceGraphRawDeployment(cl client.Client, clientset kubernetes.In
 	}
 	// set Service Controller
 	for _, svc := range reconciler.Service.ServiceList {
+		svc.ObjectMeta.Annotations[constants.OpenshiftServingCertAnnotation] = graph.Name + constants.ServingCertSecretSuffix
 		if err := controllerutil.SetControllerReference(graph, svc, scheme); err != nil {
 			return nil, reconciler.URL, errors.Wrapf(err, "fails to set service owner reference for inference graph")
 		}

--- a/pkg/controller/v1beta1/inferenceservice/components/explainer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/explainer.go
@@ -160,7 +160,7 @@ func (e *Explainer) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 
 	// Here we allow switch between knative and vanilla deployment
 	if e.deploymentMode == constants.RawDeployment {
-		r, err := raw.NewRawKubeReconciler(e.client, e.clientset, e.scheme, objectMeta, metav1.ObjectMeta{},
+		r, err := raw.NewRawKubeReconciler(e.client, e.clientset, e.scheme, constants.InferenceServiceResource, objectMeta, metav1.ObjectMeta{},
 			&isvc.Spec.Explainer.ComponentExtensionSpec, &podSpec, nil)
 		if err != nil {
 			return ctrl.Result{}, errors.Wrapf(err, "fails to create NewRawKubeReconciler for explainer")

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -365,7 +365,7 @@ func (p *Predictor) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 		rawDeployment = true
 		podLabelKey = constants.RawDeploymentAppLabel
 		// This is main RawKubeReconciler to create objects (deployment, svc, scaler)
-		r, err := raw.NewRawKubeReconciler(p.client, p.clientset, p.scheme, objectMeta, workerObjectMeta, &isvc.Spec.Predictor.ComponentExtensionSpec,
+		r, err := raw.NewRawKubeReconciler(p.client, p.clientset, p.scheme, constants.InferenceServiceResource, objectMeta, workerObjectMeta, &isvc.Spec.Predictor.ComponentExtensionSpec,
 			&podSpec, workerPodSpec)
 		if err != nil {
 			return ctrl.Result{}, errors.Wrapf(err, "fails to create NewRawKubeReconciler for predictor")

--- a/pkg/controller/v1beta1/inferenceservice/components/transformer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/transformer.go
@@ -188,7 +188,7 @@ func (p *Transformer) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, er
 
 	// Here we allow switch between knative and vanilla deployment
 	if p.deploymentMode == constants.RawDeployment {
-		r, err := raw.NewRawKubeReconciler(p.client, p.clientset, p.scheme, objectMeta, metav1.ObjectMeta{},
+		r, err := raw.NewRawKubeReconciler(p.client, p.clientset, p.scheme, constants.InferenceServiceResource, objectMeta, metav1.ObjectMeta{},
 			&isvc.Spec.Transformer.ComponentExtensionSpec, &podSpec, nil)
 		if err != nil {
 			return ctrl.Result{}, errors.Wrapf(err, "fails to create NewRawKubeReconciler for transformer")

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/onsi/gomega/format"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
@@ -100,6 +101,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 
 		It("Should have ingress/service/deployment/hpa created", func() {
 			By("By creating a new InferenceService")
+			format.MaxLength = 1000000
 			// Create configmap
 			var configMap = &v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -229,6 +231,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 								"serving.kserve.io/autoscalerClass":                        "hpa",
 								"serving.kserve.io/metrics":                                "cpu",
 								"serving.kserve.io/targetUtilizationPercentage":            "75",
+								constants.OpenshiftServingCertAnnotation:                   predictorDeploymentKey.Name + constants.ServingCertSecretSuffix,
 							},
 						},
 						Spec: v1.PodSpec{
@@ -648,6 +651,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 								"serving.kserve.io/autoscalerClass":                        "hpa",
 								"serving.kserve.io/metrics":                                "cpu",
 								"serving.kserve.io/targetUtilizationPercentage":            "75",
+								constants.OpenshiftServingCertAnnotation:                   "raw-foo-customized-predictor-serving-cert",
 							},
 						},
 						Spec: v1.PodSpec{
@@ -1052,6 +1056,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 								constants.StorageInitializerSourceUriInternalAnnotationKey: *isvc.Spec.Predictor.Model.StorageURI,
 								"serving.kserve.io/deploymentMode":                         "RawDeployment",
 								"serving.kserve.io/autoscalerClass":                        "external",
+								constants.OpenshiftServingCertAnnotation:                   predictorDeploymentKey.Name + constants.ServingCertSecretSuffix,
 							},
 						},
 						Spec: v1.PodSpec{
@@ -1723,6 +1728,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 								"serving.kserve.io/autoscalerClass":                        "hpa",
 								"serving.kserve.io/metrics":                                "cpu",
 								"serving.kserve.io/targetUtilizationPercentage":            "75",
+								constants.OpenshiftServingCertAnnotation:                   predictorDeploymentKey.Name + constants.ServingCertSecretSuffix,
 							},
 						},
 						Spec: v1.PodSpec{
@@ -2157,6 +2163,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 								"serving.kserve.io/autoscalerClass":                        "hpa",
 								"serving.kserve.io/metrics":                                "cpu",
 								"serving.kserve.io/targetUtilizationPercentage":            "75",
+								constants.OpenshiftServingCertAnnotation:                   predictorDeploymentKey.Name + constants.ServingCertSecretSuffix,
 							},
 						},
 						Spec: v1.PodSpec{
@@ -2596,6 +2603,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 										"--rest_api_port=" + v1beta1.TensorflowServingRestPort,
 										"--model_base_path=" + constants.DefaultModelLocalMountPath,
 										"--rest_api_timeout_in_ms=60000",
+									},
+									VolumeMounts: []v1.VolumeMount{
+										{
+											Name:      "proxy-tls",
+											MountPath: "/etc/tls/private",
+										},
 									},
 									Resources: defaultResource,
 									ReadinessProbe: &v1.Probe{

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/kserve/kserve/pkg/constants"
 	autoscaler "github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/reconcilers/autoscaler"
 	deployment "github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment"
 	"github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress"
@@ -51,6 +52,7 @@ type RawKubeReconciler struct {
 func NewRawKubeReconciler(client client.Client,
 	clientset kubernetes.Interface,
 	scheme *runtime.Scheme,
+	resourceType constants.ResourceType,
 	componentMeta metav1.ObjectMeta,
 	workerComponentMeta metav1.ObjectMeta,
 	componentExt *v1beta1.ComponentExtensionSpec,
@@ -76,7 +78,7 @@ func NewRawKubeReconciler(client client.Client,
 		log.Error(err1, "failed to get service config")
 	}
 
-	depl, err := deployment.NewDeploymentReconciler(client, clientset, scheme, componentMeta, workerComponentMeta, componentExt, podSpec, workerPodSpec)
+	depl, err := deployment.NewDeploymentReconciler(client, clientset, scheme, resourceType, componentMeta, workerComponentMeta, componentExt, podSpec, workerPodSpec)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
@@ -170,11 +170,12 @@ func createDefaultSvc(componentMeta metav1.ObjectMeta, componentExt *v1beta1.Com
 		},
 	}
 
+	if service.ObjectMeta.Annotations == nil {
+		service.ObjectMeta.Annotations = make(map[string]string)
+	}
+	service.ObjectMeta.Annotations[constants.OpenshiftServingCertAnnotation] = componentMeta.Name + constants.ServingCertSecretSuffix
+
 	if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && strings.EqualFold(val, "true") {
-		if service.ObjectMeta.Annotations == nil {
-			service.ObjectMeta.Annotations = make(map[string]string)
-		}
-		service.ObjectMeta.Annotations["service.beta.openshift.io/serving-cert-secret-name"] = componentMeta.Name + constants.ServingCertSecretSuffix
 		httpsPort := corev1.ServicePort{
 			Name: "https",
 			Port: constants.OauthProxyPort,

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_test.go
@@ -118,7 +118,8 @@ func TestCreateDefaultDeployment(t *testing.T) {
 						constants.DeploymentMode:  string(constants.RawDeployment),
 					},
 					Annotations: map[string]string{
-						"annotation": "annotation-value",
+						"annotation":                             "annotation-value",
+						constants.OpenshiftServingCertAnnotation: "default-predictor-serving-cert",
 					},
 				},
 				Spec: corev1.ServiceSpec{
@@ -149,7 +150,8 @@ func TestCreateDefaultDeployment(t *testing.T) {
 						constants.InferenceServiceGenerationPodLabelKey: "1",
 					},
 					Annotations: map[string]string{
-						"annotation": "annotation-value",
+						"annotation":                             "annotation-value",
+						constants.OpenshiftServingCertAnnotation: "default-predictor-serving-cert",
 					},
 				},
 				Spec: corev1.ServiceSpec{
@@ -178,7 +180,8 @@ func TestCreateDefaultDeployment(t *testing.T) {
 						constants.MultiNodeRoleLabelKey:                 constants.MultiNodeHead,
 					},
 					Annotations: map[string]string{
-						"annotation": "annotation-value",
+						"annotation":                             "annotation-value",
+						constants.OpenshiftServingCertAnnotation: "default-predictor-serving-cert",
 					},
 				},
 				Spec: corev1.ServiceSpec{
@@ -268,9 +271,13 @@ func TestCreateServiceRawTrueAndConfigNil(t *testing.T) {
 }
 
 func runTestServiceCreate(serviceConfig *v1beta1.ServiceConfig, expectedClusterIP string, t *testing.T) {
+	// Adding the annotation here as the test it is expected that this annotation is injected automatically for all services
 	componentMeta := metav1.ObjectMeta{
 		Name:      "test-service",
 		Namespace: "default",
+		Annotations: map[string]string{
+			constants.OpenshiftServingCertAnnotation: "default-predictor-serving-cert",
+		},
 	}
 	componentExt := &v1beta1.ComponentExtensionSpec{}
 	podSpec := &corev1.PodSpec{}


### PR DESCRIPTION
… serving cert secret to raw deployment

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes : [RHOAIENG-18978 ](https://issues.redhat.com/browse/RHOAIENG-18978)
- create server in router with TLS using certs mounted by adding annotation `service.beta.openshift.io/serving-cert-secret-name=graph_name` to the graph service
- always mount service cert secret to deployments so that router can reliably find `tls.crt` and `tls.key` files 

**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

- create raw ig and isvcs
- all isvcs + ig deployment should have the serving secret volume mounted
- In the graph deployment, verify the graph deployment starts correctly and test the graph 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.