### PR TITLE
Use annotation instead of label to enable auth for RawDeployment

### DIFF
--- a/config/overlays/odh/inferenceservice-config-patch.yaml
+++ b/config/overlays/odh/inferenceservice-config-patch.yaml
@@ -84,3 +84,15 @@ data:
       "enableMetricAggregation": "false",
       "enablePrometheusScraping" : "false"
     }
+    # annotation "security.opendatahub.io/enable-auth" is filtered out of the serviceAnnotationDisallowedList 
+    # when the inferenceService is using RawDeployment mode
+  inferenceService: |-
+    {
+      "serviceAnnotationDisallowedList": [
+        "autoscaling.knative.dev/min-scale",
+        "autoscaling.knative.dev/max-scale",
+        "internal.serving.kserve.io/storage-initializer-sourceuri",
+        "kubectl.kubernetes.io/last-applied-configuration",
+        "security.opendatahub.io/enable-auth"
+      ]
+     }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -381,6 +381,9 @@ var (
 	RevisionTemplateLabelDisallowedList = []string{
 		VisibilityLabel,
 	}
+	// https://issues.redhat.com/browse/RHOAIENG-20326
+	// For RawDeployment, we allow the security.opendatahub.io/enable-auth annotation
+	RawServiceAnnotationDisallowedList = filterList(ServiceAnnotationDisallowedList, "security.opendatahub.io/enable-auth")
 )
 
 // CheckResultType raw k8s deployment, resource exist check result
@@ -719,4 +722,15 @@ func GetProtocolVersionString(protocol ProtocolVersion) InferenceServiceProtocol
 	default:
 		return ProtocolUnknown
 	}
+}
+
+// filterOut returns a new slice with the specified element removed
+func filterList(slice []string, element string) []string {
+	var result []string
+	for _, item := range slice {
+		if item != element {
+			result = append(result, item)
+		}
+	}
+	return result
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -373,19 +373,11 @@ var (
 		autoscaling.MaxScaleAnnotationKey,
 		StorageInitializerSourceUriInternalAnnotationKey,
 		"kubectl.kubernetes.io/last-applied-configuration",
-		// remove when https://issues.redhat.com/browse/RHOAIENG-15662 is merged on community and ported to ODH
-		// Plus, this annotation must be moved to the inferenceservice-config
 		"security.opendatahub.io/enable-auth",
 	}
 
 	RevisionTemplateLabelDisallowedList = []string{
 		VisibilityLabel,
-	}
-	// https://issues.redhat.com/browse/RHOAIENG-20326
-	// For RawDeployment, we allow the security.opendatahub.io/enable-auth annotation
-	RawServiceAnnotationDisallowedList = []string{
-		StorageInitializerSourceUriInternalAnnotationKey,
-		"kubectl.kubernetes.io/last-applied-configuration",
 	}
 )
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -383,7 +383,10 @@ var (
 	}
 	// https://issues.redhat.com/browse/RHOAIENG-20326
 	// For RawDeployment, we allow the security.opendatahub.io/enable-auth annotation
-	RawServiceAnnotationDisallowedList = filterList(ServiceAnnotationDisallowedList, "security.opendatahub.io/enable-auth")
+	RawServiceAnnotationDisallowedList = []string{
+		StorageInitializerSourceUriInternalAnnotationKey,
+		"kubectl.kubernetes.io/last-applied-configuration",
+	}
 )
 
 // CheckResultType raw k8s deployment, resource exist check result
@@ -722,15 +725,4 @@ func GetProtocolVersionString(protocol ProtocolVersion) InferenceServiceProtocol
 	default:
 		return ProtocolUnknown
 	}
-}
-
-// filterOut returns a new slice with the specified element removed
-func filterList(slice []string, element string) []string {
-	var result []string
-	for _, item := range slice {
-		if item != element {
-			result = append(result, item)
-		}
-	}
-	return result
 }

--- a/pkg/controller/v1beta1/inferenceservice/components/explainer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/explainer.go
@@ -104,7 +104,7 @@ func (e *Explainer) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 	}
 
 	// Labels and annotations from explainer component
-	// Label filter will be handled in ksvc_reconciler
+	// Label filter will be handled in ksvc_reconciler and raw reconciler
 	explainerLabels := isvc.Spec.Explainer.Labels
 	explainerAnnotations := utils.Filter(isvc.Spec.Explainer.Annotations, func(key string) bool {
 		return !utils.Includes(e.inferenceServiceConfig.ServiceAnnotationDisallowedList, key)

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -88,10 +88,18 @@ func (p *Predictor) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 	if isvc.Spec.Predictor.WorkerSpec != nil {
 		multiNodeEnabled = true
 	}
-
-	annotations := utils.Filter(isvc.Annotations, func(key string) bool {
-		return !utils.Includes(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, key)
-	})
+	var annotations map[string]string
+	if p.deploymentMode == constants.RawDeployment {
+		annotations = utils.Filter(isvc.Annotations, func(key string) bool {
+			// https://issues.redhat.com/browse/RHOAIENG-20326
+			// For RawDeployment, we allow the security.opendatahub.io/enable-auth annotation
+			return !utils.Includes(isvcutils.FilterList(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, constants.ODHKserveRawAuth), key)
+		})
+	} else {
+		annotations = utils.Filter(isvc.Annotations, func(key string) bool {
+			return !utils.Includes(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, key)
+		})
+	}
 
 	p.Log.V(1).Info("Predictor custom annotations", "annotations", p.inferenceServiceConfig.ServiceAnnotationDisallowedList)
 	p.Log.V(1).Info("Predictor custom labels", "labels", p.inferenceServiceConfig.ServiceLabelDisallowedList)
@@ -231,9 +239,17 @@ func (p *Predictor) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 
 		// Label filter will be handled in ksvc_reconciler
 		sRuntimeLabels = sRuntime.ServingRuntimePodSpec.Labels
-		sRuntimeAnnotations = utils.Filter(sRuntime.ServingRuntimePodSpec.Annotations, func(key string) bool {
-			return !utils.Includes(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, key)
-		})
+		if p.deploymentMode == constants.RawDeployment {
+			sRuntimeAnnotations = utils.Filter(sRuntime.ServingRuntimePodSpec.Annotations, func(key string) bool {
+				// https://issues.redhat.com/browse/RHOAIENG-20326
+				// For RawDeployment, we allow the security.opendatahub.io/enable-auth annotation
+				return !utils.Includes(isvcutils.FilterList(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, constants.ODHKserveRawAuth), key)
+			})
+		} else {
+			sRuntimeAnnotations = utils.Filter(sRuntime.ServingRuntimePodSpec.Annotations, func(key string) bool {
+				return !utils.Includes(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, key)
+			})
+		}
 	} else {
 		container = predictor.GetContainer(isvc.ObjectMeta, isvc.Spec.Predictor.GetExtensions(), p.inferenceServiceConfig)
 
@@ -265,9 +281,18 @@ func (p *Predictor) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 	// Labels and annotations from predictor component
 	// Label filter will be handled in ksvc_reconciler and raw reconciler
 	predictorLabels := isvc.Spec.Predictor.Labels
-	predictorAnnotations := utils.Filter(isvc.Spec.Predictor.Annotations, func(key string) bool {
-		return !utils.Includes(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, key)
-	})
+	var predictorAnnotations map[string]string
+	if p.deploymentMode == constants.RawDeployment {
+		predictorAnnotations = utils.Filter(isvc.Spec.Predictor.Annotations, func(key string) bool {
+			// https://issues.redhat.com/browse/RHOAIENG-20326
+			// For RawDeployment, we allow the security.opendatahub.io/enable-auth annotation
+			return !utils.Includes(isvcutils.FilterList(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, constants.ODHKserveRawAuth), key)
+		})
+	} else {
+		predictorAnnotations = utils.Filter(isvc.Spec.Predictor.Annotations, func(key string) bool {
+			return !utils.Includes(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, key)
+		})
+	}
 
 	// Labels and annotations priority: predictor component > isvc > ServingRuntimePodSpec
 	// Labels and annotations from high priority will overwrite that from low priority

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -263,7 +263,7 @@ func (p *Predictor) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 	}
 
 	// Labels and annotations from predictor component
-	// Label filter will be handled in ksvc_reconciler
+	// Label filter will be handled in ksvc_reconciler and raw reconciler
 	predictorLabels := isvc.Spec.Predictor.Labels
 	predictorAnnotations := utils.Filter(isvc.Spec.Predictor.Annotations, func(key string) bool {
 		return !utils.Includes(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, key)

--- a/pkg/controller/v1beta1/inferenceservice/components/transformer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/transformer.go
@@ -106,7 +106,7 @@ func (p *Transformer) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, er
 	}
 
 	// Labels and annotations from transformer component
-	// Label filter will be handled in ksvc_reconciler
+	// Label filter will be handled in ksvc_reconciler and raw reconciler
 	transformerLabels := isvc.Spec.Transformer.Labels
 	transformerAnnotations := utils.Filter(isvc.Spec.Transformer.Annotations, func(key string) bool {
 		return !utils.Includes(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, key)

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -112,22 +112,12 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return reconcile.Result{}, err
 	}
 
-	isvcConfig, err := v1beta1api.NewInferenceServicesConfig(r.Clientset)
-	if err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "fails to create InferenceServicesConfig")
-	}
-
-	// get annotations from isvc
-	annotations := utils.Filter(isvc.Annotations, func(key string) bool {
-		return !utils.Includes(isvcConfig.ServiceAnnotationDisallowedList, key)
-	})
-
 	deployConfig, err := v1beta1api.NewDeployConfig(r.Clientset)
 	if err != nil {
 		return reconcile.Result{}, errors.Wrapf(err, "fails to create DeployConfig")
 	}
 
-	deploymentMode := isvcutils.GetDeploymentMode(isvc.Status.DeploymentMode, annotations, deployConfig)
+	deploymentMode := isvcutils.GetDeploymentMode(isvc.Status.DeploymentMode, isvc.Annotations, deployConfig)
 	r.Log.Info("Inference service deployment mode ", "deployment mode ", deploymentMode)
 
 	if deploymentMode == constants.ModelMeshDeployment {
@@ -196,6 +186,10 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	// Setup reconcilers
 	r.Log.Info("Reconciling inference service", "apiVersion", isvc.APIVersion, "isvc", isvc.Name)
+	isvcConfig, err := v1beta1api.NewInferenceServicesConfig(r.Clientset)
+	if err != nil {
+		return reconcile.Result{}, errors.Wrapf(err, "fails to create InferenceServicesConfig")
+	}
 
 	// Reconcile cabundleConfigMap
 	caBundleConfigMapReconciler := cabundleconfigmap.NewCaBundleConfigMapReconciler(r.Client, r.Clientset, r.Scheme)

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -2314,9 +2314,9 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					Namespace: serviceKey.Namespace,
 					Annotations: map[string]string{
 						"serving.kserve.io/deploymentMode": "RawDeployment",
+						constants.ODHKserveRawAuth:         "true",
 					},
 					Labels: map[string]string{
-						constants.ODHKserveRawAuth:  "true",
 						constants.NetworkVisibility: constants.ODHRouteEnabled,
 					},
 				},
@@ -2382,12 +2382,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 								constants.KServiceComponentLabel:      constants.Predictor.String(),
 								constants.InferenceServicePodLabelKey: serviceName,
 								"serving.kserve.io/inferenceservice":  serviceName,
-								constants.ODHKserveRawAuth:            "true",
 								constants.NetworkVisibility:           constants.ODHRouteEnabled,
 							},
 							Annotations: map[string]string{
 								constants.StorageInitializerSourceUriInternalAnnotationKey: *isvc.Spec.Predictor.Model.StorageURI,
 								"serving.kserve.io/deploymentMode":                         "RawDeployment",
+								constants.ODHKserveRawAuth:                                 "true",
 								"service.beta.openshift.io/serving-cert-secret-name":       predictorDeploymentKey.Name + constants.ServingCertSecretSuffix,
 							},
 						},

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -87,7 +87,7 @@ func createRawDeploymentODH(clientset kubernetes.Interface, componentMeta metav1
 	if err != nil {
 		return nil, err
 	}
-	if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && val == "true" {
+	if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && strings.EqualFold(val, "true") {
 		for _, deployment := range deploymentList {
 			err := addOauthContainerToDeployment(clientset, deployment, componentMeta, componentExt, podSpec)
 			if err != nil {
@@ -197,7 +197,7 @@ func addOauthContainerToDeployment(clientset kubernetes.Interface, deployment *a
 	} else {
 		isvcname = componentMeta.Name
 	}
-	if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && val == "true" {
+	if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && strings.EqualFold(val, "true") {
 		switch {
 		case componentExt != nil && componentExt.Batcher != nil:
 			upstreamPort = constants.InferenceServiceDefaultAgentPortStr

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -87,7 +87,7 @@ func createRawDeploymentODH(clientset kubernetes.Interface, componentMeta metav1
 	if err != nil {
 		return nil, err
 	}
-	if val, ok := componentMeta.Labels[constants.ODHKserveRawAuth]; ok && val == "true" {
+	if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && val == "true" {
 		for _, deployment := range deploymentList {
 			err := addOauthContainerToDeployment(clientset, deployment, componentMeta, componentExt, podSpec)
 			if err != nil {
@@ -197,7 +197,7 @@ func addOauthContainerToDeployment(clientset kubernetes.Interface, deployment *a
 	} else {
 		isvcname = componentMeta.Name
 	}
-	if val, ok := componentMeta.Labels[constants.ODHKserveRawAuth]; ok && val == "true" {
+	if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && val == "true" {
 		switch {
 		case componentExt != nil && componentExt.Batcher != nil:
 			upstreamPort = constants.InferenceServiceDefaultAgentPortStr

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -22,9 +22,6 @@ import (
 	"os"
 	"strings"
 
-	duckv1 "knative.dev/pkg/apis/duck/v1"
-	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
-
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -39,9 +36,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/kmp"
 	"knative.dev/pkg/network"
 	"knative.dev/pkg/system"
+	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/reconciler/route/config"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
+	isvcutils "github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/utils"
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/testing/protocmp"
 	istiov1beta1 "istio.io/api/networking/v1beta1"
@@ -676,7 +677,7 @@ func createIngress(isvc *v1beta1.InferenceService, useDefault bool, config *v1be
 		}
 	}
 	annotations := utils.Filter(isvc.Annotations, func(key string) bool {
-		return !utils.Includes(isvcConfig.ServiceAnnotationDisallowedList, key)
+		return !utils.Includes(isvcutils.FilterList(isvcConfig.ServiceAnnotationDisallowedList, constants.ODHKserveRawAuth), key)
 	})
 	desiredIngress := &istioclientv1beta1.VirtualService{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
@@ -21,21 +21,20 @@ import (
 	"fmt"
 	"strconv"
 
-	apierr "k8s.io/apimachinery/pkg/api/errors"
-	duckv1 "knative.dev/pkg/apis/duck/v1"
-
-	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	v1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
 	v1beta1utils "github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/utils"
 	"github.com/kserve/kserve/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/apis"
 	knapis "knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"knative.dev/pkg/network"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -60,6 +59,7 @@ func NewRawIngressReconciler(client client.Client,
 		isvcConfig:    isvcConfig,
 	}, nil
 }
+
 
 func (r *RawIngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
 	var err error
@@ -364,3 +364,5 @@ func createRawIngress(scheme *runtime.Scheme, isvc *v1beta1.InferenceService,
 func semanticIngressEquals(desired, existing *netv1.Ingress) bool {
 	return equality.Semantic.DeepEqual(desired.Spec, existing.Spec)
 }
+
+

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
@@ -169,7 +169,7 @@ func createDefaultSvc(componentMeta metav1.ObjectMeta, componentExt *v1beta1.Com
 		},
 	}
 
-	if val, ok := componentMeta.Labels[constants.ODHKserveRawAuth]; ok && val == "true" {
+	if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && val == "true" {
 		if service.ObjectMeta.Annotations == nil {
 			service.ObjectMeta.Annotations = make(map[string]string)
 		}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
@@ -169,7 +170,7 @@ func createDefaultSvc(componentMeta metav1.ObjectMeta, componentExt *v1beta1.Com
 		},
 	}
 
-	if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && val == "true" {
+	if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && strings.EqualFold(val, "true") {
 		if service.ObjectMeta.Annotations == nil {
 			service.ObjectMeta.Annotations = make(map[string]string)
 		}

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -518,3 +518,13 @@ func GetRouteURLIfExists(cli client.Client, metadata metav1.ObjectMeta, isvcName
 
 	return routeURL, nil
 }
+
+func FilterList(slice []string, element string) []string {
+	var result []string
+	for _, item := range slice {
+		if item != element {
+			result = append(result, item)
+		}
+	}
+	return result
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes : [RHOAIENG-20326](https://issues.redhat.com/browse/RHOAIENG-20326) 
- Changes the use of `security.opendatahub.io/enable-auth` from an label to an annotation to match with other uses of the same string 

**Feature/Issue validation/testing**:
- Test with https://github.com/opendatahub-io/odh-model-controller/pull/382 
- create raw isvcs with auth enabled using the annotation and verify isvc works as expected (in both cases where route is exposed and where it is not) 

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.