### PR TITLE
Add supportedArchitectures to component metadata

### DIFF
--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -2,3 +2,7 @@ releases:
   - name: KServe
     version: v0.14.0
     repoUrl: https://github.com/kserve/kserve/
+    supportedArchitectures:
+      - amd64
+      - ppc64le
+      - s390x


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the `supportedArchitectures` field to the `component_metadata.yaml` file for KServe.

The opendatahub-operator needs the `supportedArchitectures` field in order to implement Phase 1 of Power/Z support (see [this doc](https://docs.google.com/document/d/1lfHbLLzim9HG75jegjUsImRV5DsqqoyiZsjXxJAJJJI/edit?tab=t.0#heading=h.b5cm7cilc8uv) for more details).

**Which issue(s) this PR fixes**:
Fixes [RHOAIENG-19371](https://issues.redhat.com/browse/RHOAIENG-19371)

**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

**Feature/Issue validation/testing**:

There are no coding changes introduced in this PR, however the metadata has been indirectly tested as part of [this PR](https://github.com/opendatahub-io/opendatahub-operator/pull/1624) to the opendatahub-operator.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [N/A] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [N/A] Has code been commented, particularly in hard-to-understand areas?
- [N/A] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.