### PR TITLE
Ability to configure Raw InferenceGraphs as private

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -117,6 +117,7 @@ rules:
   - routes
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/pkg/controller/v1alpha1/inferencegraph/controller.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller.go
@@ -19,7 +19,7 @@ limitations under the License.
 // +kubebuilder:rbac:groups=serving.knative.dev,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=serving.knative.dev,resources=services/finalizers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=serving.knative.dev,resources=services/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=create;get;update;patch;watch
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=create;get;update;patch;watch;delete
 // +kubebuilder:rbac:groups=route.openshift.io,resources=routes/status,verbs=get
 package inferencegraph
 

--- a/pkg/controller/v1alpha1/inferencegraph/controller_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller_test.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -695,6 +696,149 @@ var _ = Describe("Inference Graph controller test", func() {
 				k8sClient.Get(ctx, serviceKey, inferenceGraphSubmitted)
 				return inferenceGraphSubmitted.Status.URL.Host
 			}, timeout, interval).Should(Equal(osRoute.Status.Ingress[0].Host))
+		})
+
+		It("Should not create ingress when cluster-local visibility is configured", func() {
+			By("By creating a new InferenceGraph")
+			var configMap = &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: configs,
+			}
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer func() { _ = k8sClient.Delete(context.TODO(), configMap) }()
+			graphName := "igraw-private"
+			var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: graphName, Namespace: "default"}}
+			var serviceKey = expectedRequest.NamespacedName
+			ctx := context.Background()
+			ig := &v1alpha1.InferenceGraph{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceKey.Name,
+					Namespace: serviceKey.Namespace,
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode": string(constants.RawDeployment),
+					},
+					Labels: map[string]string{
+						constants.NetworkVisibility: constants.ClusterLocalVisibility,
+					},
+				},
+				Spec: v1alpha1.InferenceGraphSpec{
+					Nodes: map[string]v1alpha1.InferenceRouter{
+						v1alpha1.GraphRootNodeName: {
+							RouterType: v1alpha1.Sequence,
+							Steps: []v1alpha1.InferenceStep{
+								{
+									InferenceTarget: v1alpha1.InferenceTarget{
+										ServiceURL: "http://someservice.exmaple.com",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ig)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, ig) }()
+
+			// The OpenShift route must not be created
+			actualK8sDeploymentCreated := &appsv1.Deployment{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, serviceKey, actualK8sDeploymentCreated)
+			}, timeout, interval).Should(Succeed())
+			actualK8sDeploymentCreated.Status.Conditions = []appsv1.DeploymentCondition{
+				{Type: appsv1.DeploymentAvailable},
+			}
+			Expect(k8sClient.Status().Update(ctx, actualK8sDeploymentCreated)).Should(Succeed())
+			osRoute := osv1.Route{}
+			Consistently(func() error {
+				osRouteKey := types.NamespacedName{Name: ig.GetName() + "-route", Namespace: ig.GetNamespace()}
+				return k8sClient.Get(ctx, osRouteKey, &osRoute)
+			}, timeout, interval).Should(WithTransform(errors.IsNotFound, BeTrue()))
+
+			// The InferenceGraph should have a cluster-internal hostname
+			Eventually(func() string {
+				_ = k8sClient.Get(ctx, serviceKey, ig)
+				return ig.Status.URL.Host
+			}, timeout, interval).Should(Equal(fmt.Sprintf("%s.%s.svc.cluster.local", graphName, "default")))
+		})
+
+		It("Should reconfigure InferenceGraph as private when cluster-local visibility is configured", func() {
+			By("By creating a new InferenceGraph")
+			var configMap = &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: configs,
+			}
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer func() { _ = k8sClient.Delete(context.TODO(), configMap) }()
+			graphName := "igraw-exposed-to-private"
+			var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: graphName, Namespace: "default"}}
+			var serviceKey = expectedRequest.NamespacedName
+			ctx := context.Background()
+			ig := &v1alpha1.InferenceGraph{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceKey.Name,
+					Namespace: serviceKey.Namespace,
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode": string(constants.RawDeployment),
+					},
+				},
+				Spec: v1alpha1.InferenceGraphSpec{
+					Nodes: map[string]v1alpha1.InferenceRouter{
+						v1alpha1.GraphRootNodeName: {
+							RouterType: v1alpha1.Sequence,
+							Steps: []v1alpha1.InferenceStep{
+								{
+									InferenceTarget: v1alpha1.InferenceTarget{
+										ServiceURL: "http://someservice.exmaple.com",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, ig)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, ig) }()
+
+			// Wait the OpenShift route to be created
+			actualK8sDeploymentCreated := &appsv1.Deployment{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, serviceKey, actualK8sDeploymentCreated)
+			}, timeout, interval).Should(Succeed())
+			actualK8sDeploymentCreated.Status.Conditions = []appsv1.DeploymentCondition{
+				{Type: appsv1.DeploymentAvailable},
+			}
+			Expect(k8sClient.Status().Update(ctx, actualK8sDeploymentCreated)).Should(Succeed())
+			osRoute := osv1.Route{}
+			Eventually(func() error {
+				osRouteKey := types.NamespacedName{Name: ig.GetName() + "-route", Namespace: ig.GetNamespace()}
+				return k8sClient.Get(ctx, osRouteKey, &osRoute)
+			}, timeout, interval).Should(Succeed())
+
+			// Reconfigure as private
+			Expect(k8sClient.Get(ctx, serviceKey, ig)).Should(Succeed())
+			if ig.Labels == nil {
+				ig.Labels = map[string]string{}
+			}
+			ig.Labels[constants.NetworkVisibility] = constants.ClusterLocalVisibility
+			Expect(k8sClient.Update(ctx, ig)).Should(Succeed())
+
+			// The OpenShift route should be deleted
+			Eventually(func() error {
+				osRouteKey := types.NamespacedName{Name: ig.GetName() + "-route", Namespace: ig.GetNamespace()}
+				return k8sClient.Get(ctx, osRouteKey, &osRoute)
+			}).Should(WithTransform(errors.IsNotFound, BeTrue()))
+
+			// The InferenceGraph should have a cluster-internal hostname
+			Eventually(func() string {
+				_ = k8sClient.Get(ctx, serviceKey, ig)
+				return ig.Status.URL.Host
+			}, timeout, interval).Should(Equal(fmt.Sprintf("%s.%s.svc.cluster.local", graphName, "default")))
 		})
 	})
 

--- a/pkg/webhook/validation/inferenceservice/inferenceservice_webhook_test.go
+++ b/pkg/webhook/validation/inferenceservice/inferenceservice_webhook_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package inferenceservice
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds the possibility to use the `networking.kserve.io/visibility=cluster-local` label to configure an InferenceGraph in Raw mode as private (not exposed).


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

https://issues.redhat.com/browse/RHOAIENG-20324

**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
  - It will be done in the cherry-pick to `master` branch.

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

* Create InferenceGraph in Raw mode. Then, check that a route is created.
* Add the `networking.kserve.io/visibility=cluster-local` label to the InferenceGraph. Then, check that the route is removed.

- Logs

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
  - It will be done in the cherry-pick to `master` branch.
