### PR TITLE
[RHOAIENG-19717] Pod now has correct imagepull secret when updated in raw deployment

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -19,6 +19,7 @@ package inferenceservice
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"time"
 
 	apierr "k8s.io/apimachinery/pkg/api/errors"
@@ -3180,6 +3181,143 @@ var _ = Describe("v1beta1 inference service controller", func() {
 
 			// Verify deployments details
 			verifyTensorParallelSizeDeployments(actualDefaultDeployment, actualWorkerDeployment, "3", constants.NvidiaGPUResourceType)
+		})
+	})
+	Context("When creating an inference service with modelcar and raw deployment", func() {
+		It("Should only have the ImagePullSecrets that are specified in the InferenceService", func() {
+			By("Updating an InferenceService with a new ImagePullSecret and checking the deployment")
+			var configMap = &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: configs,
+			}
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), configMap)
+
+			servingRuntime := &v1alpha1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vllm-runtime",
+					Namespace: constants.KServeNamespace,
+				},
+				Spec: v1alpha1.ServingRuntimeSpec{
+					SupportedModelFormats: []v1alpha1.SupportedModelFormat{
+						{
+							AutoSelect: proto.Bool(true),
+							Name:       "vLLM",
+						},
+					},
+					ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+						Containers: []v1.Container{
+							{
+								Name:    constants.InferenceServiceContainerName,
+								Image:   "kserve/vllm:latest",
+								Command: []string{"bash", "-c"},
+								Args: []string{
+									"python2 -m vllm --model_name=${MODEL_NAME} --model_dir=${MODEL} --tensor-parallel-size=${TENSOR_PARALLEL_SIZE} --pipeline-parallel-size=${PIPELINE_PARALLEL_SIZE}",
+								},
+								Resources: defaultResource,
+							},
+						},
+					},
+					Disabled: proto.Bool(false),
+				},
+			}
+
+			k8sClient.Create(context.TODO(), servingRuntime)
+			defer k8sClient.Delete(context.TODO(), servingRuntime)
+			serviceName := "modelcar-raw-deployment"
+			var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: constants.KServeNamespace}}
+			var serviceKey = expectedRequest.NamespacedName
+			var storageUri = "oci://test/mnist/export"
+			ctx := context.Background()
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceKey.Name,
+					Namespace: serviceKey.Namespace,
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode":              "RawDeployment",
+						"serving.kserve.io/autoscalerClass":             "hpa",
+						"serving.kserve.io/metrics":                     "cpu",
+						"serving.kserve.io/targetUtilizationPercentage": "75",
+					},
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: v1beta1.GetIntReference(1),
+							MaxReplicas: 2,
+						},
+						PodSpec: v1beta1.PodSpec{
+							ImagePullSecrets: []v1.LocalObjectReference{
+								{Name: "isvc-image-pull-secret"},
+							},
+						},
+						Model: &v1beta1.ModelSpec{
+							ModelFormat: v1beta1.ModelFormat{
+								Name: "vLLM",
+							},
+							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+								StorageURI:     &storageUri,
+								RuntimeVersion: proto.String("0.14.0"),
+								Container: v1.Container{
+									Name: constants.InferenceServiceContainerName,
+									Resources: v1.ResourceRequirements{
+										Limits: v1.ResourceList{
+											constants.NvidiaGPUResourceType: resource.MustParse("1"),
+										},
+										Requests: v1.ResourceList{
+											constants.NvidiaGPUResourceType: resource.MustParse("1"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			isvc.DefaultInferenceService(nil, nil, &v1beta1.SecurityConfig{AutoMountServiceAccountToken: false}, nil)
+			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
+			defer k8sClient.Delete(ctx, isvc)
+
+			inferenceService := &v1beta1.InferenceService{}
+
+			Eventually(func() bool {
+				return k8sClient.Get(ctx, serviceKey, inferenceService) == nil
+			}, timeout, interval).Should(BeTrue())
+
+			actualDeployment := &appsv1.Deployment{}
+			predictorDeploymentKey := types.NamespacedName{Name: constants.PredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace}
+			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorDeploymentKey, actualDeployment) }, timeout, interval).
+				Should(Succeed())
+
+			Expect(actualDeployment.Spec.Template.Spec.ImagePullSecrets).To(HaveLen(1))
+			Expect(actualDeployment.Spec.Template.Spec.ImagePullSecrets[0].Name).To(Equal("isvc-image-pull-secret"))
+
+			Expect(k8sClient.Get(ctx, serviceKey, inferenceService)).Should(Succeed())
+			updateForInferenceService := inferenceService.DeepCopy()
+			updateForInferenceService.Spec.Predictor.PodSpec.ImagePullSecrets = []v1.LocalObjectReference{
+				{Name: "new-image-pull-secret"},
+			}
+			expectedImagePullSecrets := updateForInferenceService.Spec.Predictor.PodSpec.ImagePullSecrets
+			Eventually(func() error {
+				return k8sClient.Update(ctx, updateForInferenceService)
+			}, timeout, interval).Should(Succeed())
+
+			updatedDeployment := &appsv1.Deployment{}
+			Eventually(func() (bool, error) {
+				if err := k8sClient.Get(ctx, predictorDeploymentKey, updatedDeployment); err != nil {
+					return false, err
+				}
+				if len(updatedDeployment.Spec.Template.Spec.ImagePullSecrets) != 1 {
+					return false, nil
+				}
+				return reflect.DeepEqual(updatedDeployment.Spec.Template.Spec.ImagePullSecrets, expectedImagePullSecrets), nil
+			}, timeout, interval).Should(BeTrue())
+
 		})
 	})
 })

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -21,6 +21,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -571,11 +572,6 @@ func (r *DeploymentReconciler) Reconcile() ([]*appsv1.Deployment, error) {
 			// get the current deployment
 			_ = r.client.Get(context.TODO(), types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, originalDeployment)
 			// we need to remove the Replicas field from the deployment spec
-			originalDeployment.Spec.Replicas = nil
-			curJson, err := json.Marshal(originalDeployment)
-			if err != nil {
-				return nil, err
-			}
 
 			// Check if there are any envs to remove
 			// If there, its value will be set to "delete" so we can update the patchBytes with
@@ -602,9 +598,30 @@ func (r *DeploymentReconciler) Reconcile() ([]*appsv1.Deployment, error) {
 				deployment.Spec.Template.Spec.Containers[i].Env = envs
 			}
 
+			originalDeployment.Spec.Replicas = nil
+			curJson, err := json.Marshal(originalDeployment)
+			if err != nil {
+				return nil, err
+			}
 			// To avoid the conflict between HPA and Deployment,
 			// we need to remove the Replicas field from the deployment spec
 			deployment.Spec.Replicas = nil
+
+			imagePullSecretsDesired := deployment.Spec.Template.Spec.ImagePullSecrets
+			originalDeploymentPullSecrets := originalDeployment.Spec.Template.Spec.ImagePullSecrets
+			imagePullSecretsToRemove := []string{}
+			for _, secret := range originalDeploymentPullSecrets {
+				found := false
+				for _, desiredSecret := range imagePullSecretsDesired {
+					if secret.Name == desiredSecret.Name {
+						found = true
+						break
+					}
+				}
+				if !found {
+					imagePullSecretsToRemove = append(imagePullSecretsToRemove, secret.Name)
+				}
+			}
 
 			modJson, err := json.Marshal(deployment)
 			if err != nil {
@@ -617,10 +634,60 @@ func (r *DeploymentReconciler) Reconcile() ([]*appsv1.Deployment, error) {
 				return nil, err
 			}
 
-			// override the envs that needs to be removed with  "$patch": "delete"
+			// Patch the deployment object with the strategic merge patch
 			patchByte = []byte(strings.ReplaceAll(string(patchByte), "\"value\":\""+utils.PLACEHOLDER_FOR_DELETION+"\"", "\"$patch\":\"delete\""))
 
-			// Patch the deployment object with the strategic merge patch
+			// The strategic merge patch does not remove items from list just by removing it from the patch,
+			// to delete lists items using strategic merge patch, the $patch delete pattern is used.
+			// Example:
+			// imagePullSecrets:
+			//   - "name": "pull-secret-1",
+			//     "$patch": "delete"
+			if len(imagePullSecretsToRemove) > 0 {
+				patchJson := map[string]interface{}{}
+				err = json.Unmarshal(patchByte, &patchJson)
+				if err != nil {
+					return nil, err
+				}
+				spec, ok := patchJson["spec"].(map[string]interface{})
+				if !ok {
+					return nil, errors.New("spec not found")
+				}
+				template, ok := spec["template"].(map[string]interface{})
+				if !ok {
+					return nil, errors.New("template not found")
+				}
+				specTemplate, ok := template["spec"].(map[string]interface{})
+				if !ok {
+					return nil, errors.New("template.spec not found")
+				}
+
+				// Ensure imagePullSecrets is a slice, defaulting to an empty slice if nil.
+				ipsField, exists := specTemplate["imagePullSecrets"]
+				var imagePullSecrets []interface{}
+				if exists && ipsField != nil {
+					var ok bool
+					imagePullSecrets, ok = ipsField.([]interface{})
+					if !ok {
+						return nil, errors.New("imagePullSecrets is not the expected type")
+					}
+				} else {
+					imagePullSecrets = []interface{}{}
+				}
+
+				for _, secret := range imagePullSecretsToRemove {
+					for _, secretMap := range imagePullSecrets {
+						if secretMap.(map[string]interface{})["name"] == secret {
+							secretMap.(map[string]interface{})["$patch"] = "delete"
+						}
+					}
+				}
+				patchJson["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["imagePullSecrets"] = imagePullSecrets
+				patchByte, err = json.Marshal(patchJson)
+				if err != nil {
+					return nil, err
+				}
+			}
 			opErr = r.client.Patch(context.TODO(), deployment, kclient.RawPatch(types.StrategicMergePatchType, patchByte))
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This issue was found while using Modelcars feature. For Modelcars, users may prefer using a private container registry to store their models. When using a private registry, it is required to provide a pull secret in the InferenceService so that the cluster can pull the model container.

At any time, and for any reason, users may require to replace/update the pull secret. This operation is done on the InferenceService. It is observed that when replacing the pull secret, the old one won't be removed in the updated deployment.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
[RHOAIENG-19717](https://issues.redhat.com//browse/RHOAIENG-19717)
**Type of changes**
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Test A
1. Created the following Inference Service

```
apiVersion: serving.kserve.io/v1beta1
kind: InferenceService
metadata:
  name: sample-isvc-using-oci
  namespace: oci-model-example
  annotations:
    serving.kserve.io/deploymentMode: RawDeployment
spec:
  predictor:
    imagePullSecrets:
    - name: pull-secret-one
    model:
      runtime: vllm-runtime # This is the name of the ServingRuntime resource
      modelFormat:
        name: vLLM
      storageUri: oci://quay.io/rh-ee-allausas/huggingface:latest
      args:
        - --dtype=half
      resources:
        limits:
          nvidia.com/gpu: 1
        requests:
          nvidia.com/gpu: 1
```
    
 2. Check the imagePullSecret from the pod that gets created     
 2. Edit the Inference Service and change the imagePullSecret
 3. Check the imagePullSecret from the new pod that gets created and verify that it matches

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [X] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [X] Has code been commented, particularly in hard-to-understand areas?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.