### PR TITLE
Use Headless Services by default

### DIFF
--- a/pkg/apis/serving/v1beta1/configmap.go
+++ b/pkg/apis/serving/v1beta1/configmap.go
@@ -280,7 +280,7 @@ func NewServiceConfig(clientset kubernetes.Interface) (*ServiceConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-	serviceConfig := &ServiceConfig{}
+	serviceConfig := &ServiceConfig{ServiceClusterIPNone: true}
 	if service, ok := configMap.Data[ServiceConfigName]; ok {
 		err := json.Unmarshal([]byte(service), &serviceConfig)
 		if err != nil {

--- a/pkg/apis/serving/v1beta1/configmap_test.go
+++ b/pkg/apis/serving/v1beta1/configmap_test.go
@@ -48,7 +48,7 @@ var (
 		AdditionalDomain, AdditionalDomainExtra)
 	ServiceConfigData = fmt.Sprintf(`{
 		"serviceClusterIPNone" : %t
-	}`, true)
+	}`, false)
 
 	ISCVWithData = fmt.Sprintf(`{
 		"serviceAnnotationDisallowedList": ["%s","%s"],
@@ -134,6 +134,7 @@ func TestNewServiceConfig(t *testing.T) {
 	emp, err := NewServiceConfig(empty)
 	g.Expect(err).Should(gomega.BeNil())
 	g.Expect(emp).ShouldNot(gomega.BeNil())
+	g.Expect(emp.ServiceClusterIPNone).Should(gomega.BeTrue()) // In ODH the default is <true>
 
 	// with value
 	withTrue := fakeclientset.NewSimpleClientset(&v1.ConfigMap{
@@ -145,7 +146,7 @@ func TestNewServiceConfig(t *testing.T) {
 	wt, err := NewServiceConfig(withTrue)
 	g.Expect(err).Should(gomega.BeNil())
 	g.Expect(wt).ShouldNot(gomega.BeNil())
-	g.Expect(wt.ServiceClusterIPNone).Should(gomega.BeTrue())
+	g.Expect(wt.ServiceClusterIPNone).Should(gomega.BeFalse())
 
 	// no value, should be nil
 	noValue := fakeclientset.NewSimpleClientset(&v1.ConfigMap{
@@ -157,7 +158,7 @@ func TestNewServiceConfig(t *testing.T) {
 	nv, err := NewServiceConfig(noValue)
 	g.Expect(err).Should(gomega.BeNil())
 	g.Expect(nv).ShouldNot(gomega.BeNil())
-	g.Expect(nv.ServiceClusterIPNone).Should(gomega.BeFalse())
+	g.Expect(nv.ServiceClusterIPNone).Should(gomega.BeTrue()) // In ODH the default is <true>
 }
 
 func TestInferenceServiceDisallowedLists(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes a regression, because in ODH the Services had been headless for Raw deployment mode (see #288). Such default changed to headed services when the feasibility to configure the behavior was introduced, but despite the upstream project has always been using headed services, in ODH this  breaks backwards compatibility.

Thus, this restores the ODH default of using headless services for Raw deployment. Users can still use the inferenceservice-config ConfigMap to switch to headed Services.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

https://issues.redhat.com/browse/RHOAIENG-20543

**Type of changes**

- [x] Bug fix (non-breaking change which fixes an issue)

