### PR TITLE
modify e2e setup script to allow specifying odh-model-controller image

### DIFF
--- a/test/scripts/openshift-ci/setup-e2e-tests.sh
+++ b/test/scripts/openshift-ci/setup-e2e-tests.sh
@@ -27,6 +27,7 @@ set -o pipefail
 : "${KSERVE_AGENT_IMAGE:=quay.io/opendatahub/kserve-agent:latest}"
 : "${KSERVE_ROUTER_IMAGE:=quay.io/opendatahub/kserve-router:latest}"
 : "${STORAGE_INITIALIZER_IMAGE:=quay.io/opendatahub/kserve-storage-initializer:latest}"
+: "${ODH_MODEL_CONTROLLER_IMAGE:=quay.io/opendatahub/odh-model-controller:latest}"
 
 echo "SKLEARN_IMAGE=$SKLEARN_IMAGE"
 echo "KSERVE_CONTROLLER_IMAGE=$KSERVE_CONTROLLER_IMAGE"
@@ -112,7 +113,9 @@ if [ "$1" != "raw" ]; then
     sed "s/{{ .ControlPlane.Namespace }}/istio-system/g" |
     oc create -f -
 
-  oc apply -k $PROJECT_ROOT/test/scripts/openshift-ci
+  kustomize build $PROJECT_ROOT/test/scripts/openshift-ci |
+    sed "s|quay.io/opendatahub/odh-model-controller:fast|${ODH_MODEL_CONTROLLER_IMAGE}|" |
+    oc apply -n kserve -f -
   oc wait --for=condition=ready pod -l app=odh-model-controller -n kserve --timeout=300s
 fi
 

--- a/test/scripts/openshift-ci/setup-e2e-tests.sh
+++ b/test/scripts/openshift-ci/setup-e2e-tests.sh
@@ -27,7 +27,7 @@ set -o pipefail
 : "${KSERVE_AGENT_IMAGE:=quay.io/opendatahub/kserve-agent:latest}"
 : "${KSERVE_ROUTER_IMAGE:=quay.io/opendatahub/kserve-router:latest}"
 : "${STORAGE_INITIALIZER_IMAGE:=quay.io/opendatahub/kserve-storage-initializer:latest}"
-: "${ODH_MODEL_CONTROLLER_IMAGE:=quay.io/opendatahub/odh-model-controller:latest}"
+: "${ODH_MODEL_CONTROLLER_IMAGE:=quay.io/opendatahub/odh-model-controller:fast}"
 
 echo "SKLEARN_IMAGE=$SKLEARN_IMAGE"
 echo "KSERVE_CONTROLLER_IMAGE=$KSERVE_CONTROLLER_IMAGE"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/RHOAIENG-10406 
- allows specifying odh-model-controller image for e2e test setup such that the same script can be re-used for running kserve e2e tests on odh-model-controller PRs via openshift-ci 

**Feature/Issue validation/testing**:

- prereq: fresh cluster
- `ODH_MODEL_CONTROLLER_IMAGE=quay.io/vedantm/odh-model-controller:latest` 
- `./test/scripts/openshift-ci/setup-e2e-tests.sh`
- deployed `odh-model-controller` in namespace `kserve` should use the image `quay.io/vedantm/odh-model-controller:latest`

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.