### PR TITLE
Fix oauth-proxy should not be injected to InferenceGraph

### DIFF
--- a/pkg/controller/v1alpha1/inferencegraph/controller.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller.go
@@ -249,6 +249,7 @@ func (r *InferenceGraphReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 		hostname, err := routeReconciler.Reconcile(ctx, graph)
 		url.Host = hostname
+		url.Scheme = "https"
 		if err != nil {
 			return ctrl.Result{}, errors.Wrapf(err, "fails to reconcile Route for InferenceGraph")
 		}

--- a/pkg/controller/v1alpha1/inferencegraph/controller_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller_test.go
@@ -656,6 +656,10 @@ var _ = Describe("Inference Graph controller test", func() {
 				return true
 			}, timeout, interval).Should(BeTrue())
 
+			// ODH Svc checks
+			Expect(actualK8sServiceCreated.Spec.Ports[0].Port).To(Equal(int32(443)))
+			Expect(actualK8sServiceCreated.Spec.Ports[0].TargetPort.IntVal).To(Equal(int32(8080)))
+
 			//No KNative Service should get created in Raw deployment mode
 			actualKnServiceCreated := &knservingv1.Service{}
 			Eventually(func() bool {
@@ -706,6 +710,7 @@ var _ = Describe("Inference Graph controller test", func() {
 				k8sClient.Get(ctx, serviceKey, inferenceGraphSubmitted)
 				return inferenceGraphSubmitted.Status.URL.Host
 			}, timeout, interval).Should(Equal(osRoute.Status.Ingress[0].Host))
+			Expect(inferenceGraphSubmitted.Status.URL.Scheme).To(Equal("https"))
 		})
 
 		It("Should not create ingress when cluster-local visibility is configured", func() {
@@ -772,6 +777,7 @@ var _ = Describe("Inference Graph controller test", func() {
 				_ = k8sClient.Get(ctx, serviceKey, ig)
 				return ig.Status.URL.Host
 			}, timeout, interval).Should(Equal(fmt.Sprintf("%s.%s.svc.cluster.local", graphName, "default")))
+			Expect(ig.Status.URL.Scheme).To(Equal("https"))
 		})
 
 		It("Should reconfigure InferenceGraph as private when cluster-local visibility is configured", func() {
@@ -1010,7 +1016,7 @@ var _ = Describe("Inference Graph controller test", func() {
 				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: inferenceGraph.GetNamespace(), Name: inferenceGraph.GetName()}, &igDeployment)).To(Succeed())
 				g.Expect(igDeployment.Spec.Template.Spec.AutomountServiceAccountToken).To(Equal(proto.Bool(true)))
 				g.Expect(igDeployment.Spec.Template.Spec.ServiceAccountName).To(Equal(getServiceAccountNameForGraph(inferenceGraph)))
-				// g.Expect(igDeployment.Spec.Template.Spec.Containers).To(HaveLen(1)) // TODO: Restore in RHOAIENG-21300
+				g.Expect(igDeployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 				g.Expect(igDeployment.Spec.Template.Spec.Containers[0].Args).To(ContainElements("--enable-auth", "--inferencegraph-name", inferenceGraph.GetName()))
 			}, timeout, interval).Should(Succeed())
 		})

--- a/pkg/controller/v1alpha1/inferencegraph/openshift_route_reconciler.go
+++ b/pkg/controller/v1alpha1/inferencegraph/openshift_route_reconciler.go
@@ -104,6 +104,9 @@ func (r *OpenShiftRouteReconciler) buildOpenShiftRoute(inferenceGraph *v1alpha1.
 			Port: &v1.RoutePort{
 				TargetPort: intstr.FromString(inferenceGraph.GetName()),
 			},
+			TLS: &v1.TLSConfig{
+				Termination: v1.TLSTerminationReencrypt,
+			},
 		},
 	}
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -94,9 +94,12 @@ func createRawDeploymentODH(clientset kubernetes.Interface, resourceType constan
 	headDeployment := deploymentList[0]
 	if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && strings.EqualFold(val, "true") {
 		enableAuth = true
-		err := addOauthContainerToDeployment(clientset, headDeployment, componentMeta, componentExt, podSpec)
-		if err != nil {
-			return nil, err
+
+		if resourceType != constants.InferenceGraphResource { // InferenceGraphs don't use oauth-proxy
+			err := addOauthContainerToDeployment(clientset, headDeployment, componentMeta, componentExt, podSpec)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	if (resourceType == constants.InferenceServiceResource && enableAuth) || resourceType == constants.InferenceGraphResource {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
@@ -85,7 +85,7 @@ func NewRawKubeReconciler(client client.Client,
 		client:     client,
 		scheme:     scheme,
 		Deployment: depl,
-		Service:    service.NewServiceReconciler(client, scheme, componentMeta, componentExt, podSpec, multiNodeEnabled, serviceConfig),
+		Service:    service.NewServiceReconciler(client, scheme, resourceType, componentMeta, componentExt, podSpec, multiNodeEnabled, serviceConfig),
 		Scaler:     as,
 		URL:        url,
 	}, nil

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
@@ -177,8 +177,7 @@ func createDefaultSvc(resourceType constants.ResourceType, componentMeta metav1.
 	service.ObjectMeta.Annotations[constants.OpenshiftServingCertAnnotation] = componentMeta.Name + constants.ServingCertSecretSuffix
 
 	if resourceType == constants.InferenceGraphResource {
-		port443 := int32(443)
-		servicePorts[0].Port = port443
+		servicePorts[0].Port = int32(443)
 	} else {
 		if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && strings.EqualFold(val, "true") {
 			httpsPort := corev1.ServicePort{

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
@@ -48,6 +48,7 @@ type ServiceReconciler struct {
 
 func NewServiceReconciler(client client.Client,
 	scheme *runtime.Scheme,
+	resourceType constants.ResourceType,
 	componentMeta metav1.ObjectMeta,
 	componentExt *v1beta1.ComponentExtensionSpec,
 	podSpec *corev1.PodSpec, multiNodeEnabled bool,
@@ -55,12 +56,12 @@ func NewServiceReconciler(client client.Client,
 	return &ServiceReconciler{
 		client:       client,
 		scheme:       scheme,
-		ServiceList:  createService(componentMeta, componentExt, podSpec, multiNodeEnabled, serviceConfig),
+		ServiceList:  createService(resourceType, componentMeta, componentExt, podSpec, multiNodeEnabled, serviceConfig),
 		componentExt: componentExt,
 	}
 }
 
-func createService(componentMeta metav1.ObjectMeta, componentExt *v1beta1.ComponentExtensionSpec,
+func createService(resourceType constants.ResourceType, componentMeta metav1.ObjectMeta, componentExt *v1beta1.ComponentExtensionSpec,
 	podSpec *corev1.PodSpec, multiNodeEnabled bool, serviceConfig *v1beta1.ServiceConfig) []*corev1.Service {
 	var svcList []*corev1.Service
 	var isWorkerContainer bool
@@ -75,11 +76,11 @@ func createService(componentMeta metav1.ObjectMeta, componentExt *v1beta1.Compon
 
 	if !multiNodeEnabled {
 		// If multiNodeEnabled is false, only defaultSvc will be created.
-		defaultSvc := createDefaultSvc(componentMeta, componentExt, podSpec, serviceConfig)
+		defaultSvc := createDefaultSvc(resourceType, componentMeta, componentExt, podSpec, serviceConfig)
 		svcList = append(svcList, defaultSvc)
 	} else if multiNodeEnabled && !isWorkerContainer {
 		// If multiNodeEnabled is true, both defaultSvc and headSvc will be created.
-		defaultSvc := createDefaultSvc(componentMeta, componentExt, podSpec, serviceConfig)
+		defaultSvc := createDefaultSvc(resourceType, componentMeta, componentExt, podSpec, serviceConfig)
 		svcList = append(svcList, defaultSvc)
 
 		headSvc := createHeadlessSvc(componentMeta)
@@ -89,7 +90,7 @@ func createService(componentMeta metav1.ObjectMeta, componentExt *v1beta1.Compon
 	return svcList
 }
 
-func createDefaultSvc(componentMeta metav1.ObjectMeta, componentExt *v1beta1.ComponentExtensionSpec,
+func createDefaultSvc(resourceType constants.ResourceType, componentMeta metav1.ObjectMeta, componentExt *v1beta1.ComponentExtensionSpec,
 	podSpec *corev1.PodSpec, serviceConfig *v1beta1.ServiceConfig) *corev1.Service {
 	var servicePorts []corev1.ServicePort
 
@@ -175,28 +176,33 @@ func createDefaultSvc(componentMeta metav1.ObjectMeta, componentExt *v1beta1.Com
 	}
 	service.ObjectMeta.Annotations[constants.OpenshiftServingCertAnnotation] = componentMeta.Name + constants.ServingCertSecretSuffix
 
-	if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && strings.EqualFold(val, "true") {
-		httpsPort := corev1.ServicePort{
-			Name: "https",
-			Port: constants.OauthProxyPort,
-			TargetPort: intstr.IntOrString{
-				Type:   intstr.String,
-				StrVal: "https",
-			},
-			Protocol: corev1.ProtocolTCP,
-		}
-		ports := service.Spec.Ports
-		replaced := false
-		for i, port := range ports {
-			if port.Port == constants.CommonDefaultHttpPort {
-				ports[i] = httpsPort
-				replaced = true
+	if resourceType == constants.InferenceGraphResource {
+		port443 := int32(443)
+		servicePorts[0].Port = port443
+	} else {
+		if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && strings.EqualFold(val, "true") {
+			httpsPort := corev1.ServicePort{
+				Name: "https",
+				Port: constants.OauthProxyPort,
+				TargetPort: intstr.IntOrString{
+					Type:   intstr.String,
+					StrVal: "https",
+				},
+				Protocol: corev1.ProtocolTCP,
 			}
+			ports := service.Spec.Ports
+			replaced := false
+			for i, port := range ports {
+				if port.Port == constants.CommonDefaultHttpPort {
+					ports[i] = httpsPort
+					replaced = true
+				}
+			}
+			if !replaced {
+				ports = append(ports, httpsPort)
+			}
+			service.Spec.Ports = ports
 		}
-		if !replaced {
-			ports = append(ports, httpsPort)
-		}
-		service.Spec.Ports = ports
 	}
 
 	if serviceConfig != nil && serviceConfig.ServiceClusterIPNone {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_test.go
@@ -224,7 +224,7 @@ func TestCreateDefaultDeployment(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := createService(tt.args.componentMeta, tt.args.componentExt, tt.args.podSpec, tt.args.multiNodeEnabled, emptyServiceConfig)
+			got := createService(constants.InferenceServiceResource, tt.args.componentMeta, tt.args.componentExt, tt.args.podSpec, tt.args.multiNodeEnabled, emptyServiceConfig)
 			for i, service := range got {
 				if diff := cmp.Diff(tt.expected[i], service); diff != "" {
 					t.Errorf("Test %q unexpected service (-want +got): %v", tt.name, diff)
@@ -282,7 +282,7 @@ func runTestServiceCreate(serviceConfig *v1beta1.ServiceConfig, expectedClusterI
 	componentExt := &v1beta1.ComponentExtensionSpec{}
 	podSpec := &corev1.PodSpec{}
 
-	service := createService(componentMeta, componentExt, podSpec, false, serviceConfig)
+	service := createService(constants.InferenceServiceResource, componentMeta, componentExt, podSpec, false, serviceConfig)
 	assert.Equal(t, componentMeta, service[0].ObjectMeta, "Expected ObjectMeta to be equal")
 	assert.Equal(t, map[string]string{"app": "isvc.test-service"}, service[0].Spec.Selector, "Expected Selector to be equal")
 	assert.Equal(t, expectedClusterIP, service[0].Spec.ClusterIP, "Expected ClusterIP to be equal")


### PR DESCRIPTION
**What this PR does / why we need it**:

InferenceGraphs do not require oauth-proxy for auth purposes. The auth validation is implemented in kserve-router. This is ensuring that oauth-proxy is not injected to InferenceGraph pods that are deployed in Raw mode.

Also, this is fixing some issues with the management of the related `Service` and `Route`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes https://issues.redhat.com/browse/RHOAIENG-21300

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

- Enable auth in an InferenceGraph in Raw mode. Validate that oauth-proxy container is not present.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?

