### PR TITLE
[RHOAIENG-21272] Disabled HuggingFace CPU docker publish workflow for…

### DIFF
--- a/.github/workflows/huggingface-cpu-docker-publish.yml
+++ b/.github/workflows/huggingface-cpu-docker-publish.yml
@@ -13,7 +13,7 @@ on:
   pull_request:
 
 env:
-  IMAGE_NAME: huggingfaceserver 
+  IMAGE_NAME: huggingfaceserver
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/kserve-controller-docker-publish.yml
+++ b/.github/workflows/kserve-controller-docker-publish.yml
@@ -85,10 +85,10 @@ jobs:
           [[ "$VERSION" =~ ^release- ]] && VERSION=$(echo $VERSION | sed 's/^release-//')-latest
 
           TAGS=$IMAGE_ID:$VERSION
-          
+
           # If a vX.Y.Z release is being built, also update the vX.Y tag.
           [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && TAGS=$TAGS,$IMAGE_ID:$(echo $VERSION | sed 's/\(.*\)\.[[:digit:]]\+$/\1/')
-          
+
           echo CONTAINER_TAGS=$TAGS >> $GITHUB_ENV
 
       - name: Build and push

--- a/.github/workflows/kserve-localmodel-agent-docker-publish.yml
+++ b/.github/workflows/kserve-localmodel-agent-docker-publish.yml
@@ -42,9 +42,7 @@ jobs:
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/
   push:
-    # Ensure test job passes before pushing image.
     needs: test
-
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
 
@@ -58,15 +56,17 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to DockerHub
+      - name: Login to Quay
         uses: docker/login-action@v3
+
         with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: export version variable
         run: |
-          IMAGE_ID=kserve/$IMAGE_NAME
+          IMAGE_ID=quay.io/${{ vars.QUAY_OWNER }}/$IMAGE_NAME
 
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
@@ -79,17 +79,20 @@ jobs:
 
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
+          [[ "$VERSION" =~ ^release- ]] && VERSION=$(echo $VERSION | sed 's/^release-//')-latest
 
-          echo VERSION=$VERSION >> $GITHUB_ENV
-          echo IMAGE_ID=$IMAGE_ID >> $GITHUB_ENV
+          TAGS=$IMAGE_ID:$VERSION
+
+          # If a vX.Y.Z release is being built, also update the vX.Y tag.
+          [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && TAGS=$TAGS,$IMAGE_ID:$(echo $VERSION | sed 's/\(.*\)\.[[:digit:]]\+$/\1/')
+
+          echo CONTAINER_TAGS=$TAGS >> $GITHUB_ENV
 
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x
           context: .
-          file: localmodel-agent.Dockerfile
+          file: Dockerfile
           push: true
-          tags: ${{ env.IMAGE_ID }}:${{ env.VERSION }}
-          # https://github.com/docker/buildx/issues/1533
-          provenance: false
+          tags: ${{ env.CONTAINER_TAGS }}

--- a/.github/workflows/kserve-localmodel-controller-docker-publish.yml
+++ b/.github/workflows/kserve-localmodel-controller-docker-publish.yml
@@ -58,15 +58,17 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to DockerHub
+      - name: Login to Quay
         uses: docker/login-action@v3
+
         with:
-          username: ${{ secrets.DOCKER_USER }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: export version variable
         run: |
-          IMAGE_ID=kserve/$IMAGE_NAME
+          IMAGE_ID=quay.io/${{ vars.QUAY_OWNER }}/$IMAGE_NAME
 
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
@@ -79,17 +81,20 @@ jobs:
 
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
+          [[ "$VERSION" =~ ^release- ]] && VERSION=$(echo $VERSION | sed 's/^release-//')-latest
 
-          echo VERSION=$VERSION >> $GITHUB_ENV
-          echo IMAGE_ID=$IMAGE_ID >> $GITHUB_ENV
+          TAGS=$IMAGE_ID:$VERSION
+
+          # If a vX.Y.Z release is being built, also update the vX.Y tag.
+          [[ "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && TAGS=$TAGS,$IMAGE_ID:$(echo $VERSION | sed 's/\(.*\)\.[[:digit:]]\+$/\1/')
+
+          echo CONTAINER_TAGS=$TAGS >> $GITHUB_ENV
 
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64,linux/arm/v7,linux/arm64/v8,linux/ppc64le,linux/s390x
+          platforms: linux/amd64,linux/arm64/v8,linux/ppc64le,linux/s390x
           context: .
-          file: localmodel.Dockerfile
+          file: Dockerfile
           push: true
-          tags: ${{ env.IMAGE_ID }}:${{ env.VERSION }}
-          # https://github.com/docker/buildx/issues/1533
-          provenance: false
+          tags: ${{ env.CONTAINER_TAGS }}

--- a/hack/verify-doc-links.py
+++ b/hack/verify-doc-links.py
@@ -210,7 +210,6 @@ next_time_for_github_request = datetime.now()
 
 
 def wait_before_retry(url):
-    global next_time_for_github_request
     if "github.com" in url:
         if datetime.now() < next_time_for_github_request:
             sleep((next_time_for_github_request - datetime.now()).seconds + extra_wait)


### PR DESCRIPTION
… ODH.

Signed-off-by: Andres Llausas <allausas@redhat.com>

[RHOAIENG-21272] Disabled HuggingFace CPU docker publish workflow for ODH. Fixing kserve-localmodel.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixing post gitaction failures.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
[RHOAIENG-21272](https://issues.redhat.com//browse/RHOAIENG-21272)

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.