### PR TITLE
Prevent External Route Changes To ISVCs From Creating New Revisions

### DIFF
--- a/config/overlays/odh/inferenceservice-config-patch.yaml
+++ b/config/overlays/odh/inferenceservice-config-patch.yaml
@@ -93,6 +93,6 @@ data:
         "internal.serving.kserve.io/storage-initializer-sourceuri",
         "kubectl.kubernetes.io/last-applied-configuration",
         "security.opendatahub.io/enable-auth",
-        "networking.knative.io/visibility"
+        "networking.knative.dev/visibility"
       ]
      }

--- a/config/overlays/odh/inferenceservice-config-patch.yaml
+++ b/config/overlays/odh/inferenceservice-config-patch.yaml
@@ -92,6 +92,7 @@ data:
         "autoscaling.knative.dev/max-scale",
         "internal.serving.kserve.io/storage-initializer-sourceuri",
         "kubectl.kubernetes.io/last-applied-configuration",
-        "security.opendatahub.io/enable-auth"
+        "security.opendatahub.io/enable-auth",
+        "networking.knative.io/visibility"
       ]
      }

--- a/hack/verify-doc-links.py
+++ b/hack/verify-doc-links.py
@@ -210,7 +210,6 @@ next_time_for_github_request = datetime.now()
 
 
 def wait_before_retry(url):
-    global next_time_for_github_request
     if "github.com" in url:
         if datetime.now() < next_time_for_github_request:
             sleep((next_time_for_github_request - datetime.now()).seconds + extra_wait)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -377,6 +377,7 @@ var (
 		StorageInitializerSourceUriInternalAnnotationKey,
 		"kubectl.kubernetes.io/last-applied-configuration",
 		"security.opendatahub.io/enable-auth",
+		"networking.knative.io/visibility",
 	}
 
 	RevisionTemplateLabelDisallowedList = []string{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -381,7 +381,6 @@ var (
 		StorageInitializerSourceUriInternalAnnotationKey,
 		"kubectl.kubernetes.io/last-applied-configuration",
 		"security.opendatahub.io/enable-auth",
-		VisibilityAnnotation,
 	}
 	// RevisionTemplateLabelDisallowedList is a list of labels that are not allowed to be propagated to Knative
 	// revisions, which prevents the reconciliation loop to be triggered if the labels is configured here are used.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -262,6 +262,7 @@ const (
 	KnativeLocalGateway   = "knative-serving/knative-local-gateway"
 	KnativeIngressGateway = "knative-serving/knative-ingress-gateway"
 	VisibilityLabel       = "networking.knative.dev/visibility"
+	VisibilityAnnotation  = "networking.knative.dev/visibility"
 )
 
 var (
@@ -380,7 +381,7 @@ var (
 		StorageInitializerSourceUriInternalAnnotationKey,
 		"kubectl.kubernetes.io/last-applied-configuration",
 		"security.opendatahub.io/enable-auth",
-		"networking.knative.io/visibility",
+		VisibilityAnnotation,
 	}
 	// RevisionTemplateLabelDisallowedList is a list of labels that are not allowed to be propagated to Knative
 	// revisions, which prevents the reconciliation loop to be triggered if the labels is configured here are used.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -262,7 +262,6 @@ const (
 	KnativeLocalGateway   = "knative-serving/knative-local-gateway"
 	KnativeIngressGateway = "knative-serving/knative-ingress-gateway"
 	VisibilityLabel       = "networking.knative.dev/visibility"
-	VisibilityAnnotation  = "networking.knative.dev/visibility"
 )
 
 var (

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -371,6 +371,9 @@ const (
 )
 
 var (
+	// ServiceAnnotationDisallowedList is a list of annotations that are not allowed to be propagated to Knative
+	// revisions, which prevents the reconciliation loop to be triggered if the annotations is
+	// configured here are used.
 	ServiceAnnotationDisallowedList = []string{
 		autoscaling.MinScaleAnnotationKey,
 		autoscaling.MaxScaleAnnotationKey,
@@ -379,7 +382,8 @@ var (
 		"security.opendatahub.io/enable-auth",
 		"networking.knative.io/visibility",
 	}
-
+	// RevisionTemplateLabelDisallowedList is a list of labels that are not allowed to be propagated to Knative
+	// revisions, which prevents the reconciliation loop to be triggered if the labels is configured here are used.
 	RevisionTemplateLabelDisallowedList = []string{
 		VisibilityLabel,
 	}

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -473,6 +473,102 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				return false
 			}, timeout, interval).Should(BeTrue())
 		})
+		It("Should not propagate the networking.knative.io/visibility annotation", func() {
+			By("By including the annotation in the serviceAnnotationDisallowedList ")
+			// The inferenceService key is required in the inferenceservice-config configmap
+			// in order for the serviceAnnotationDisallowedList to be used.
+			configs["inferenceService"] = "{}"
+			defer delete(configs, "inferenceService")
+
+			// Create configmap
+			var configMap = &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: configs,
+			}
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), configMap)
+			// Create ServingRuntime
+			servingRuntime := &v1alpha1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tf-serving",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.ServingRuntimeSpec{
+					SupportedModelFormats: []v1alpha1.SupportedModelFormat{
+						{
+							Name:       "tensorflow",
+							Version:    proto.String("1"),
+							AutoSelect: proto.Bool(true),
+						},
+					},
+					ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+						Containers: []v1.Container{
+							{
+								Name:    constants.InferenceServiceContainerName,
+								Image:   "tensorflow/serving:1.14.0",
+								Command: []string{"/usr/bin/tensorflow_model_server"},
+								Args: []string{
+									"--port=9000",
+									"--rest_api_port=8080",
+									"--model_base_path=/mnt/models",
+									"--rest_api_timeout_in_ms=60000",
+								},
+								Resources: defaultResource,
+							},
+						},
+					},
+				},
+			}
+			k8sClient.Create(context.TODO(), servingRuntime)
+			defer k8sClient.Delete(context.TODO(), servingRuntime)
+			// Create InferenceService
+			serviceName := "visibility"
+			var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: "default"}}
+			var serviceKey = expectedRequest.NamespacedName
+			var storageUri = "s3://test/mnist/export"
+			ctx := context.Background()
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceKey.Name,
+					Namespace: serviceKey.Namespace,
+					Annotations: map[string]string{
+						"networking.knative.io/visibility": "test",
+					},
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: v1beta1.GetIntReference(1),
+							MaxReplicas: 3,
+						},
+						Tensorflow: &v1beta1.TFServingSpec{
+							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+								StorageURI:     &storageUri,
+								RuntimeVersion: proto.String("1.14.0"),
+								Container: v1.Container{
+									Name:      constants.InferenceServiceContainerName,
+									Resources: defaultResource,
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
+			defer k8sClient.Delete(ctx, isvc)
+
+			actualService := &knservingv1.Service{}
+			predictorServiceKey := types.NamespacedName{Name: constants.PredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace}
+			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorServiceKey, actualService) }, timeout).
+				Should(Succeed())
+
+			Expect("networking.knative.io/visibility").ShouldNot(BeKeyOf(actualService.Annotations))
+			Expect("networking.knative.io/visibility").ShouldNot(BeKeyOf(actualService.Spec.Template.Annotations))
+		})
 	})
 
 	Context("Inference Service with transformer", func() {

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -473,7 +473,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				return false
 			}, timeout, interval).Should(BeTrue())
 		})
-		It("Should not propagate the networking.knative.io/visibility annotation", func() {
+		It("Should not propagate the networking.knative.dev/visibility annotation", func() {
 			By("By including the annotation in the serviceAnnotationDisallowedList ")
 			// The inferenceService key is required in the inferenceservice-config configmap
 			// in order for the serviceAnnotationDisallowedList to be used.
@@ -535,7 +535,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					Name:      serviceKey.Name,
 					Namespace: serviceKey.Namespace,
 					Annotations: map[string]string{
-						"networking.knative.io/visibility": "test",
+						constants.VisibilityAnnotation: "test",
 					},
 				},
 				Spec: v1beta1.InferenceServiceSpec{
@@ -566,8 +566,8 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			Eventually(func() error { return k8sClient.Get(context.TODO(), predictorServiceKey, actualService) }, timeout).
 				Should(Succeed())
 
-			Expect("networking.knative.io/visibility").ShouldNot(BeKeyOf(actualService.Annotations))
-			Expect("networking.knative.io/visibility").ShouldNot(BeKeyOf(actualService.Spec.Template.Annotations))
+			Expect(constants.VisibilityAnnotation).ShouldNot(BeKeyOf(actualService.Annotations))
+			Expect(constants.VisibilityAnnotation).ShouldNot(BeKeyOf(actualService.Spec.Template.Annotations))
 		})
 	})
 

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -95,7 +95,8 @@ var _ = Describe("v1beta1 inference service controller", func() {
 		When("the annotation is a member of the serviceAnnotationDisallowedList in the inferenceservice-config configmap", func() {
 			It("should not be propagated to any knative revisions", func() {
 				// Add the annotation to the inferenceservice-config inferenceService serviceAnnotationDisallowedList
-				configs["inferenceService"] = fmt.Sprintf("{\"serviceAnnotationDisallowedList\": [\"%s\"]}", constants.VisibilityAnnotation)
+				sampleAnnotation := "test.dev/testing"
+				configs["inferenceService"] = fmt.Sprintf("{\"serviceAnnotationDisallowedList\": [\"%s\"]}", sampleAnnotation)
 				defer delete(configs, "inferenceService")
 
 				// Create configmap
@@ -120,7 +121,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						Name:      serviceKey.Name,
 						Namespace: serviceKey.Namespace,
 						Annotations: map[string]string{
-							constants.VisibilityAnnotation: "test",
+							sampleAnnotation: "test",
 						},
 					},
 					Spec: v1beta1.InferenceServiceSpec{
@@ -151,8 +152,8 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Eventually(func() error { return k8sClient.Get(context.TODO(), predictorServiceKey, actualService) }, timeout).
 					Should(Succeed())
 
-				Expect(constants.VisibilityAnnotation).ShouldNot(BeKeyOf(actualService.Annotations))
-				Expect(constants.VisibilityAnnotation).ShouldNot(BeKeyOf(actualService.Spec.Template.Annotations))
+				Expect(sampleAnnotation).ShouldNot(BeKeyOf(actualService.Annotations))
+				Expect(sampleAnnotation).ShouldNot(BeKeyOf(actualService.Spec.Template.Annotations))
 			})
 		})
 	})

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -475,9 +475,8 @@ var _ = Describe("v1beta1 inference service controller", func() {
 		})
 		It("Should not propagate the networking.knative.dev/visibility annotation", func() {
 			By("By including the annotation in the serviceAnnotationDisallowedList ")
-			// The inferenceService key is required in the inferenceservice-config configmap
-			// in order for the serviceAnnotationDisallowedList to be used.
-			configs["inferenceService"] = "{}"
+			// Add the annotation to the inferenceservice-config inferenceService serviceAnnotationDisallowedList
+			configs["inferenceService"] = "{\"serviceAnnotationDisallowedList\": [\"networking.knative.dev/visibility\"]}"
 			defer delete(configs, "inferenceService")
 
 			// Create configmap


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When an ISVC has changes made to its external route configuration, a new knative revision is created. This behavior is not acceptable to users due to external route management being a different layer than model serving. The expected behavior is that any change enabling/disabling some feature that is not related to serving a model should not create a new revision.

This pull request adds the `networking.knative.io/visibility` annotation to the ServiceAnnotationDisallowedList for ISVCs. This annotation is used to enable/disable the external route for an ISVC. Any annotations that are a member of the ServiceAnnotationDisakkiwedList are prevented from being propagated to knative revisions, which prevents the reconciliation loop from being triggered when these annotations are used. Therefore, when the `networking.knative.io/visibility`  is configured as a member of this list, no new knative revisions will be configured on changes to this annotation in an ISVC.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
[RHOAIENG-18967](https://issues.redhat.com/browse/RHOAIENG-18967)

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

Steps to test:
1. Install ODH in an openshift cluster
2. Create a DSCI and DSC with the default configurations
3. Create a Data Science Project
4. Create an ISVC within the project
5. Edit the `inferenceservice-config` configmap and ensure the `inferenceService` key exists and contains at least the following data:
`     inferenceService: |-
      {
        "serviceAnnotationDisallowedList": [
          "networking.knative.io/visibility"  
        ]
       }
`

OR apply the updated overlay from the root of this repo with command:
 `oc apply -f ./config/overlays/odh/inferenceservice-config-patch.yaml`

6. Edit the ISVC to change change the `networking.knative.io/visibility` annotation. No new revision should be created

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
2. Please confirm that the serviceAnnotationDisallowedList does not need to be updated anywhere else

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.