### PR TITLE
disable autoMountServiceAccountToken: true globally 

### DIFF
--- a/config/overlays/odh/inferenceservice-config-patch.yaml
+++ b/config/overlays/odh/inferenceservice-config-patch.yaml
@@ -95,3 +95,8 @@ data:
         "security.opendatahub.io/enable-auth"
       ]
      }
+
+  security: |-
+    {
+      "autoMountServiceAccountToken": false
+    }

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -9143,6 +9143,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 								FSGroupChangePolicy: nil,
 								SeccompProfile:      nil,
 							},
+							// ODH override. See : https://issues.redhat.com/browse/RHOAIENG-19904
 							AutomountServiceAccountToken: proto.Bool(true),
 						},
 					},

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -9143,7 +9143,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 								FSGroupChangePolicy: nil,
 								SeccompProfile:      nil,
 							},
-							AutomountServiceAccountToken: proto.Bool(false),
+							AutomountServiceAccountToken: proto.Bool(true),
 						},
 					},
 					Strategy: appsv1.DeploymentStrategy{

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 
+	"google.golang.org/protobuf/proto"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/kubernetes"
 
@@ -269,6 +270,7 @@ func addOauthContainerToDeployment(clientset kubernetes.Interface, deployment *a
 		}
 		updatedPodSpec := deployment.Spec.Template.Spec.DeepCopy()
 		//	updatedPodSpec := podSpec.DeepCopy()
+		updatedPodSpec.AutomountServiceAccountToken = proto.Bool(true)
 		updatedPodSpec.Containers = append(updatedPodSpec.Containers, *oauthProxyContainer)
 		deployment.Spec.Template.Spec = *updatedPodSpec
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -270,6 +270,7 @@ func addOauthContainerToDeployment(clientset kubernetes.Interface, deployment *a
 		}
 		updatedPodSpec := deployment.Spec.Template.Spec.DeepCopy()
 		//	updatedPodSpec := podSpec.DeepCopy()
+		// ODH override. See : https://issues.redhat.com/browse/RHOAIENG-19904
 		updatedPodSpec.AutomountServiceAccountToken = proto.Bool(true)
 		updatedPodSpec.Containers = append(updatedPodSpec.Containers, *oauthProxyContainer)
 		deployment.Spec.Template.Spec = *updatedPodSpec


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes JIRA: https://issues.redhat.com/browse/RHOAIENG-19904 
- override upstream security config for ODH to set `autoMountServiceAccountToken: false` globally
- manually set `autoMountServiceAccountToken: true` while injecting oauth proxy to the deployment for raw isvcs as the token is needed in this case. 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

- create raw isvc with auth enabled and ensure inference works. 

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.