### PR TITLE
add flag to control tls behavior for kserve router

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -352,6 +352,7 @@ func readyHandler(w http.ResponseWriter, req *http.Request) {
 }
 
 var (
+	enableTlsFlag          = flag.Bool("enable-tls", false, "enable TLS for the router")
 	enableAuthFlag         = flag.Bool("enable-auth", false, "protect the inference graph with authorization")
 	graphName              = flag.String("inferencegraph-name", "", "the name of the associated inference graph Kubernetes resource")
 	jsonGraph              = flag.String("graph-json", "", "serialized json graph def")
@@ -547,7 +548,11 @@ func main() {
 	}
 
 	go func() {
-		err = server.ListenAndServe()
+		if *enableTlsFlag {
+			err = server.ListenAndServeTLS("/etc/tls/private/tls.crt", "/etc/tls/private/tls.key")
+		} else {
+			err = server.ListenAndServe()
+		}
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			log.Error(err, fmt.Sprintf("Failed to serve on address %v", server.Addr))
 			os.Exit(1)

--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
@@ -68,6 +68,7 @@ func createInferenceGraphPodSpec(graph *v1alpha1api.InferenceGraph, config *Rout
 				Name:  graph.ObjectMeta.Name,
 				Image: config.Image,
 				Args: []string{
+					"--enable-tls",
 					"--graph-json",
 					string(bytes),
 				},

--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig_test.go
@@ -152,6 +152,7 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 					Image: "kserve/router:v0.10.0",
 					Name:  "basic-ig",
 					Args: []string{
+						"--enable-tls",
 						"--graph-json",
 						"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.exmaple.com\"}]}},\"resources\":{}}",
 					},
@@ -186,6 +187,7 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 					Image: "kserve/router:v0.10.0",
 					Name:  "basic-ig",
 					Args: []string{
+						"--enable-tls",
 						"--graph-json",
 						"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.exmaple.com\"}]}},\"resources\":{}}",
 					},
@@ -226,6 +228,7 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 					Image: "kserve/router:v0.10.0",
 					Name:  "resource-ig",
 					Args: []string{
+						"--enable-tls",
 						"--graph-json",
 						"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.exmaple.com\"}]}},\"resources\":{\"limits\":{\"cpu\":\"100m\",\"memory\":\"500Mi\"},\"requests\":{\"cpu\":\"100m\",\"memory\":\"100Mi\"}}}",
 					},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://issues.redhat.com/browse/RHOAIENG-22471 
- add flag to control tls behavior in kserve router 

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- verify inferencegraphs can be created and used in Serverless mode. 

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.