### PR TITLE
raw e2e test fixes 

### DIFF
--- a/config/overlays/test/configmap/inferenceservice-openshift-ci-raw.yaml
+++ b/config/overlays/test/configmap/inferenceservice-openshift-ci-raw.yaml
@@ -19,5 +19,5 @@ data:
         "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
         "urlScheme": "http",
         "disableIstioVirtualHost": false,
-        "disableIngressCreation": false
+        "disableIngressCreation": true
     }

--- a/config/overlays/test/configmap/inferenceservice-openshift-ci-raw.yaml
+++ b/config/overlays/test/configmap/inferenceservice-openshift-ci-raw.yaml
@@ -21,3 +21,7 @@ data:
         "disableIstioVirtualHost": false,
         "disableIngressCreation": true
     }
+    service: |-
+    {
+        "serviceClusterIPNone": false
+    }

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
@@ -19,8 +19,10 @@ package ingress
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 
-	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	v1beta1 "github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
 	v1beta1utils "github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/utils"
 	"github.com/kserve/kserve/pkg/utils"
@@ -32,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/apis"
+	knapis "knative.dev/pkg/apis"
 	duckv1 "knative.dev/pkg/apis/duck/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -55,6 +58,112 @@ func NewRawIngressReconciler(client client.Client,
 		ingressConfig: ingressConfig,
 		isvcConfig:    isvcConfig,
 	}, nil
+}
+
+func (r *RawIngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
+	var err error
+	isInternal := false
+	// disable ingress creation if service is labelled with cluster local or kserve domain is cluster local
+	if val, ok := isvc.Labels[constants.NetworkVisibility]; ok && val == constants.ClusterLocalVisibility {
+		isInternal = true
+	}
+	if r.ingressConfig.IngressDomain == constants.ClusterLocalDomain {
+		isInternal = true
+	}
+	if !isInternal && !r.ingressConfig.DisableIngressCreation {
+		ingress, err := createRawIngress(r.scheme, isvc, r.ingressConfig, r.client, r.isvcConfig)
+		if ingress == nil {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		// reconcile ingress
+		existingIngress := &netv1.Ingress{}
+		err = r.client.Get(context.TODO(), types.NamespacedName{
+			Namespace: isvc.Namespace,
+			Name:      isvc.Name,
+		}, existingIngress)
+		if err != nil {
+			if apierr.IsNotFound(err) {
+				err = r.client.Create(context.TODO(), ingress)
+				log.Info("creating ingress", "ingressName", isvc.Name, "err", err)
+			} else {
+				return err
+			}
+		} else {
+			if !semanticIngressEquals(ingress, existingIngress) {
+				err = r.client.Update(context.TODO(), ingress)
+				log.Info("updating ingress", "ingressName", isvc.Name, "err", err)
+			}
+		}
+		if err != nil {
+			return err
+		}
+	}
+	authEnabled := false
+	if val, ok := isvc.Annotations[constants.ODHKserveRawAuth]; ok && strings.EqualFold(val, "true") {
+		authEnabled = true
+	}
+	isvc.Status.URL, err = createRawURLODH(r.client, isvc, authEnabled)
+	if err != nil {
+		return err
+	}
+	internalHost := getRawServiceHost(isvc, r.client)
+	url := &apis.URL{
+		Host:   internalHost,
+		Scheme: "http",
+		Path:   "",
+	}
+	if authEnabled {
+		internalHost += ":" + strconv.Itoa(constants.OauthProxyPort)
+		url.Host = internalHost
+		url.Scheme = "https"
+	}
+	isvc.Status.Address = &duckv1.Addressable{
+		URL: url,
+	}
+	isvc.Status.SetCondition(v1beta1.IngressReady, &apis.Condition{
+		Type:   v1beta1.IngressReady,
+		Status: corev1.ConditionTrue,
+	})
+	return nil
+}
+
+func createRawURLODH(client client.Client, isvc *v1beta1.InferenceService, authEnabled bool) (*knapis.URL, error) {
+	// upstream implementation
+	// var err error
+	// url := &knapis.URL{}
+	// url.Scheme = ingressConfig.UrlScheme
+	// url.Host, err = GenerateDomainName(isvc.Name, isvc.ObjectMeta, ingressConfig)
+	// if err != nil {
+	//	return nil, err
+	// }
+	// if authEnabled {
+	//	url.Host += ":" + strconv.Itoa(constants.OauthProxyPort)
+	// }
+	// return url, nil
+
+	// ODH changes
+	url := &knapis.URL{}
+	if val, ok := isvc.Labels[constants.NetworkVisibility]; ok && val == constants.ODHRouteEnabled {
+		var err error
+		url, err = v1beta1utils.GetRouteURLIfExists(client, isvc.ObjectMeta, isvc.Name)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		url = &apis.URL{
+			Host:   getRawServiceHost(isvc, client),
+			Scheme: "http",
+			Path:   "",
+		}
+		if authEnabled {
+			url.Host += ":" + strconv.Itoa(constants.OauthProxyPort)
+			url.Scheme = "https"
+		}
+	}
+	return url, nil
 }
 
 func generateRule(ingressHost string, componentName string, path string, port int32) netv1.IngressRule { //nolint:unparam
@@ -230,63 +339,4 @@ func createRawIngress(scheme *runtime.Scheme, isvc *v1beta1.InferenceService,
 
 func semanticIngressEquals(desired, existing *netv1.Ingress) bool {
 	return equality.Semantic.DeepEqual(desired.Spec, existing.Spec)
-}
-
-func (r *RawIngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
-	var err error
-	isInternal := false
-	// disable ingress creation if service is labelled with cluster local or kserve domain is cluster local
-	if val, ok := isvc.Labels[constants.NetworkVisibility]; ok && val == constants.ClusterLocalVisibility {
-		isInternal = true
-	}
-	if r.ingressConfig.IngressDomain == constants.ClusterLocalDomain {
-		isInternal = true
-	}
-	if !isInternal && !r.ingressConfig.DisableIngressCreation {
-		ingress, err := createRawIngress(r.scheme, isvc, r.ingressConfig, r.client, r.isvcConfig)
-		if ingress == nil {
-			return nil
-		}
-		if err != nil {
-			return err
-		}
-		// reconcile ingress
-		existingIngress := &netv1.Ingress{}
-		err = r.client.Get(context.TODO(), types.NamespacedName{
-			Namespace: isvc.Namespace,
-			Name:      isvc.Name,
-		}, existingIngress)
-		if err != nil {
-			if apierr.IsNotFound(err) {
-				err = r.client.Create(context.TODO(), ingress)
-				log.Info("creating ingress", "ingressName", isvc.Name, "err", err)
-			} else {
-				return err
-			}
-		} else {
-			if !semanticIngressEquals(ingress, existingIngress) {
-				err = r.client.Update(context.TODO(), ingress)
-				log.Info("updating ingress", "ingressName", isvc.Name, "err", err)
-			}
-		}
-		if err != nil {
-			return err
-		}
-	}
-	isvc.Status.URL, err = createRawURL(isvc, r.ingressConfig)
-	if err != nil {
-		return err
-	}
-	isvc.Status.Address = &duckv1.Addressable{
-		URL: &apis.URL{
-			Host:   getRawServiceHost(isvc, r.client),
-			Scheme: r.ingressConfig.UrlScheme,
-			Path:   "",
-		},
-	}
-	isvc.Status.SetCondition(v1beta1.IngressReady, &apis.Condition{
-		Type:   v1beta1.IngressReady,
-		Status: corev1.ConditionTrue,
-	})
-	return nil
 }

--- a/test/e2e/batcher/test_raw_batcher.py
+++ b/test/e2e/batcher/test_raw_batcher.py
@@ -39,6 +39,9 @@ async def test_batcher_raw(rest_v1_client, network_layer):
     annotations = dict()
     annotations["serving.kserve.io/deploymentMode"] = "RawDeployment"
 
+    labels = dict()
+    labels["networking.kserve.io/visibility"] = "exposed"
+
     predictor = V1beta1PredictorSpec(
         batcher=V1beta1Batcher(
             max_batch_size=32,
@@ -61,6 +64,7 @@ async def test_batcher_raw(rest_v1_client, network_layer):
             name=service_name,
             namespace=KSERVE_TEST_NAMESPACE,
             annotations=annotations,
+            labels=labels,
         ),
         spec=V1beta1InferenceServiceSpec(predictor=predictor),
     )

--- a/test/e2e/custom/test_custom_model_grpc.py
+++ b/test/e2e/custom/test_custom_model_grpc.py
@@ -374,6 +374,7 @@ async def test_predictor_rest_with_transformer_rest(rest_v2_client):
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
 
+@pytest.mark.skip(reason="Not testable in ODH at the moment")
 @pytest.mark.raw
 @pytest.mark.asyncio(scope="session")
 async def test_predictor_grpc_with_transformer_grpc_raw(network_layer):

--- a/test/e2e/explainer/test_art_explainer.py
+++ b/test/e2e/explainer/test_art_explainer.py
@@ -121,6 +121,7 @@ async def test_raw_tabular_explainer(rest_v1_client, network_layer):
             name=service_name,
             namespace=KSERVE_TEST_NAMESPACE,
             annotations={"serving.kserve.io/deploymentMode": "RawDeployment"},
+            labels={"networking.kserve.io/visibility": "exposed"},
         ),
         spec=V1beta1InferenceServiceSpec(
             predictor=V1beta1PredictorSpec(

--- a/test/e2e/graph/test_inference_graph.py
+++ b/test/e2e/graph/test_inference_graph.py
@@ -939,6 +939,8 @@ async def test_inference_graph_raw_mode(rest_v1_client, network_layer):
 
     annotations = dict()
     annotations["serving.kserve.io/deploymentMode"] = "RawDeployment"
+    labels = dict()
+    labels["networking.kserve.io/visibility"] = "exposed"
 
     sklearn_predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -957,6 +959,7 @@ async def test_inference_graph_raw_mode(rest_v1_client, network_layer):
             name=sklearn_name,
             namespace=KSERVE_TEST_NAMESPACE,
             annotations=annotations,
+            labels=labels,
         ),
         spec=V1beta1InferenceServiceSpec(predictor=sklearn_predictor),
     )
@@ -978,6 +981,7 @@ async def test_inference_graph_raw_mode(rest_v1_client, network_layer):
             name=xgb_name,
             namespace=KSERVE_TEST_NAMESPACE,
             annotations=annotations,
+            labels=labels,
         ),
         spec=V1beta1InferenceServiceSpec(predictor=xgb_predictor),
     )
@@ -1099,6 +1103,8 @@ async def test_inference_graph_raw_mode_with_hpa(rest_v1_client, network_layer):
     # annotations["serving.kserve.io/metric"] = 'rps'
     # annotations["serving.kserve.io/min-scale"] = '2'
     # annotations["serving.kserve.io/target"] = '30'
+    labels = dict()
+    labels["networking.kserve.io/visibility"] = "exposed"
 
     sklearn_predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -1117,6 +1123,7 @@ async def test_inference_graph_raw_mode_with_hpa(rest_v1_client, network_layer):
             name=sklearn_name,
             namespace=KSERVE_TEST_NAMESPACE,
             annotations=annotations,
+            labels=labels,
         ),
         spec=V1beta1InferenceServiceSpec(predictor=sklearn_predictor),
     )
@@ -1138,6 +1145,7 @@ async def test_inference_graph_raw_mode_with_hpa(rest_v1_client, network_layer):
             name=xgb_name,
             namespace=KSERVE_TEST_NAMESPACE,
             annotations=annotations,
+            labels=labels,
         ),
         spec=V1beta1InferenceServiceSpec(predictor=xgb_predictor),
     )

--- a/test/e2e/logger/test_raw_logger.py
+++ b/test/e2e/logger/test_raw_logger.py
@@ -114,7 +114,10 @@ def before(msg_dumper):
         api_version=constants.KSERVE_V1BETA1,
         kind=constants.KSERVE_KIND_INFERENCESERVICE,
         metadata=client.V1ObjectMeta(
-            name=msg_dumper, namespace=KSERVE_TEST_NAMESPACE, annotations=annotations, labels=labels
+            name=msg_dumper,
+            namespace=KSERVE_TEST_NAMESPACE,
+            annotations=annotations,
+            labels=labels,
         ),
         spec=V1beta1InferenceServiceSpec(predictor=predictor),
     )
@@ -128,7 +131,10 @@ async def base_test(msg_dumper, service_name, predictor, rest_v1_client, network
         api_version=constants.KSERVE_V1BETA1,
         kind=constants.KSERVE_KIND_INFERENCESERVICE,
         metadata=client.V1ObjectMeta(
-            name=service_name, namespace=KSERVE_TEST_NAMESPACE, annotations=annotations, labels=labels
+            name=service_name,
+            namespace=KSERVE_TEST_NAMESPACE,
+            annotations=annotations,
+            labels=labels,
         ),
         spec=V1beta1InferenceServiceSpec(predictor=predictor),
     )

--- a/test/e2e/logger/test_raw_logger.py
+++ b/test/e2e/logger/test_raw_logger.py
@@ -34,6 +34,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE
 
 kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
 annotations = {"serving.kserve.io/deploymentMode": "RawDeployment"}
+labels = {"networking.kserve.io/visibility": "exposed"}
 
 
 @pytest.mark.raw
@@ -113,7 +114,7 @@ def before(msg_dumper):
         api_version=constants.KSERVE_V1BETA1,
         kind=constants.KSERVE_KIND_INFERENCESERVICE,
         metadata=client.V1ObjectMeta(
-            name=msg_dumper, namespace=KSERVE_TEST_NAMESPACE, annotations=annotations
+            name=msg_dumper, namespace=KSERVE_TEST_NAMESPACE, annotations=annotations, labels=labels
         ),
         spec=V1beta1InferenceServiceSpec(predictor=predictor),
     )
@@ -127,7 +128,7 @@ async def base_test(msg_dumper, service_name, predictor, rest_v1_client, network
         api_version=constants.KSERVE_V1BETA1,
         kind=constants.KSERVE_KIND_INFERENCESERVICE,
         metadata=client.V1ObjectMeta(
-            name=service_name, namespace=KSERVE_TEST_NAMESPACE, annotations=annotations
+            name=service_name, namespace=KSERVE_TEST_NAMESPACE, annotations=annotations, labels=labels
         ),
         spec=V1beta1InferenceServiceSpec(predictor=predictor),
     )

--- a/test/e2e/predictor/test_autoscaling.py
+++ b/test/e2e/predictor/test_autoscaling.py
@@ -201,7 +201,10 @@ async def test_sklearn_scale_raw(rest_v1_client, network_layer):
         api_version=constants.KSERVE_V1BETA1,
         kind=constants.KSERVE_KIND_INFERENCESERVICE,
         metadata=client.V1ObjectMeta(
-            name=service_name, namespace=KSERVE_TEST_NAMESPACE, annotations=annotations, labels=labels
+            name=service_name,
+            namespace=KSERVE_TEST_NAMESPACE,
+            annotations=annotations,
+            labels=labels,
         ),
         spec=V1beta1InferenceServiceSpec(predictor=predictor),
     )
@@ -256,8 +259,10 @@ async def test_sklearn_rolling_update():
             name=service_name,
             namespace=KSERVE_TEST_NAMESPACE,
             annotations=annotations,
-            labels={"serving.kserve.io/test": "rolling-update",
-                    "networking.kserve.io/visibility": "exposed"},
+            labels={
+                "serving.kserve.io/test": "rolling-update",
+                "networking.kserve.io/visibility": "exposed",
+            },
         ),
         spec=V1beta1InferenceServiceSpec(predictor=predictor),
     )

--- a/test/e2e/predictor/test_autoscaling.py
+++ b/test/e2e/predictor/test_autoscaling.py
@@ -194,11 +194,14 @@ async def test_sklearn_scale_raw(rest_v1_client, network_layer):
     annotations = dict()
     annotations["serving.kserve.io/deploymentMode"] = "RawDeployment"
 
+    labels = dict()
+    labels["networking.kserve.io/visibility"] = "exposed"
+
     isvc = V1beta1InferenceService(
         api_version=constants.KSERVE_V1BETA1,
         kind=constants.KSERVE_KIND_INFERENCESERVICE,
         metadata=client.V1ObjectMeta(
-            name=service_name, namespace=KSERVE_TEST_NAMESPACE, annotations=annotations
+            name=service_name, namespace=KSERVE_TEST_NAMESPACE, annotations=annotations, labels=labels
         ),
         spec=V1beta1InferenceServiceSpec(predictor=predictor),
     )
@@ -253,7 +256,8 @@ async def test_sklearn_rolling_update():
             name=service_name,
             namespace=KSERVE_TEST_NAMESPACE,
             annotations=annotations,
-            labels={"serving.kserve.io/test": "rolling-update"},
+            labels={"serving.kserve.io/test": "rolling-update",
+                    "networking.kserve.io/visibility": "exposed"},
         ),
         spec=V1beta1InferenceServiceSpec(predictor=predictor),
     )

--- a/test/e2e/predictor/test_raw_deployment.py
+++ b/test/e2e/predictor/test_raw_deployment.py
@@ -47,6 +47,8 @@ async def test_raw_deployment_kserve(rest_v1_client, network_layer):
     service_name = "raw-sklearn-" + suffix
     annotations = dict()
     annotations["serving.kserve.io/deploymentMode"] = "RawDeployment"
+    labels = dict()
+    labels["networking.kserve.io/visibility"] = "exposed"
 
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -66,6 +68,7 @@ async def test_raw_deployment_kserve(rest_v1_client, network_layer):
             name=service_name,
             namespace=KSERVE_TEST_NAMESPACE,
             annotations=annotations,
+            labels=labels,
         ),
         spec=V1beta1InferenceServiceSpec(predictor=predictor),
     )
@@ -92,6 +95,8 @@ async def test_raw_deployment_runtime_kserve(rest_v1_client, network_layer):
     service_name = "raw-sklearn-runtime-" + suffix
     annotations = dict()
     annotations["serving.kserve.io/deploymentMode"] = "RawDeployment"
+    labels = dict()
+    labels["networking.kserve.io/visibility"] = "exposed"
 
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -114,6 +119,7 @@ async def test_raw_deployment_runtime_kserve(rest_v1_client, network_layer):
             name=service_name,
             namespace=KSERVE_TEST_NAMESPACE,
             annotations=annotations,
+            labels=labels,
         ),
         spec=V1beta1InferenceServiceSpec(predictor=predictor),
     )


### PR DESCRIPTION
**What this PR does / why we need it**:
- fix raw e2e tests to work with ODH 
- restore some midstream rawdeployment code changes that were lost during syncs from upstream 
- disable gatewayapi unit tests as they are flaky right now, and ODH hasn't adopted gateway api yet. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/RHOAIENG-20368 
tests re-enabled in CI in https://github.com/openshift/release/pull/63837 

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.