### PR TITLE
Fix kserve-router HTTP handlers configuration

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -537,14 +537,15 @@ func main() {
 		}
 	}
 
+	http.Handle("/", entrypointHandler)
 	http.HandleFunc(constants.RouterReadinessEndpoint, readyHandler)
 
 	server := &http.Server{
-		Addr:         ":8080",           // specify the address and port
-		Handler:      entrypointHandler, // specify your HTTP handler
-		ReadTimeout:  time.Minute,       // set the maximum duration for reading the entire request, including the body
-		WriteTimeout: time.Minute,       // set the maximum duration before timing out writes of the response
-		IdleTimeout:  3 * time.Minute,   // set the maximum amount of time to wait for the next request when keep-alives are enabled
+		Addr:         ":8080",         // specify the address and port
+		Handler:      nil,             // default server mux
+		ReadTimeout:  time.Minute,     // set the maximum duration for reading the entire request, including the body
+		WriteTimeout: time.Minute,     // set the maximum duration before timing out writes of the response
+		IdleTimeout:  3 * time.Minute, // set the maximum amount of time to wait for the next request when keep-alives are enabled
 	}
 
 	go func() {


### PR DESCRIPTION
There is a bug when setting up the kserve-router HTTP server endpoint handlers. Upstream project is using the default server mux, but when implementing auth we used a non-default handler.

When upstream introduced readiness probes, the code got mixed and the readiness probe endpoint is not taking effect. This commit fixes the configuration of the http server endpoints.
