### PR TITLE
Fix kserve-controller creating two InferenceGraph pods

### DIFF
--- a/pkg/controller/v1alpha1/inferencegraph/controller.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller.go
@@ -148,37 +148,6 @@ func (r *InferenceGraphReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		r.Log.Error(err, "Failed to find config map", "name", constants.InferenceServiceConfigMapName)
 		return reconcile.Result{}, err
 	}
-	routerConfig, err := getRouterConfigs(configMap)
-	if err != nil {
-		return reconcile.Result{}, err
-	}
-	// resolve service urls
-	for node, router := range graph.Spec.Nodes {
-		for i, route := range router.Steps {
-			isvc := v1beta1.InferenceService{}
-			if route.ServiceName != "" {
-				err := r.Client.Get(ctx, types.NamespacedName{Namespace: graph.Namespace, Name: route.ServiceName}, &isvc)
-				if err == nil {
-					if graph.Spec.Nodes[node].Steps[i].ServiceURL == "" {
-						serviceUrl, err := isvcutils.GetPredictorEndpoint(&isvc)
-						if err == nil {
-							graph.Spec.Nodes[node].Steps[i].ServiceURL = serviceUrl
-						} else {
-							r.Log.Info("inference service is not ready", "name", route.ServiceName)
-							return reconcile.Result{Requeue: true}, errors.Wrapf(err, "service %s is not ready", route.ServiceName)
-						}
-					}
-				} else {
-					r.Log.Info("inference service is not found", "name", route.ServiceName)
-					return reconcile.Result{Requeue: true}, errors.Wrapf(err, "Failed to find graph service %s", route.ServiceName)
-				}
-			}
-		}
-	}
-	deployConfig, err := v1beta1api.NewDeployConfig(r.Clientset)
-	if err != nil {
-		return reconcile.Result{}, errors.Wrapf(err, "fails to create DeployConfig")
-	}
 
 	// examine DeletionTimestamp to determine if object is under deletion
 	if graph.ObjectMeta.DeletionTimestamp.IsZero() {
@@ -213,6 +182,38 @@ func (r *InferenceGraphReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 		// Stop reconciliation as the item is being deleted
 		return ctrl.Result{}, nil
+	}
+
+	routerConfig, err := getRouterConfigs(configMap)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	// resolve service urls
+	for node, router := range graph.Spec.Nodes {
+		for i, route := range router.Steps {
+			isvc := v1beta1.InferenceService{}
+			if route.ServiceName != "" {
+				err := r.Client.Get(ctx, types.NamespacedName{Namespace: graph.Namespace, Name: route.ServiceName}, &isvc)
+				if err == nil {
+					if graph.Spec.Nodes[node].Steps[i].ServiceURL == "" {
+						serviceUrl, err := isvcutils.GetPredictorEndpoint(&isvc)
+						if err == nil {
+							graph.Spec.Nodes[node].Steps[i].ServiceURL = serviceUrl
+						} else {
+							r.Log.Info("inference service is not ready", "name", route.ServiceName)
+							return reconcile.Result{Requeue: true}, errors.Wrapf(err, "service %s is not ready", route.ServiceName)
+						}
+					}
+				} else {
+					r.Log.Info("inference service is not found", "name", route.ServiceName)
+					return reconcile.Result{Requeue: true}, errors.Wrapf(err, "Failed to find graph service %s", route.ServiceName)
+				}
+			}
+		}
+	}
+	deployConfig, err := v1beta1api.NewDeployConfig(r.Clientset)
+	if err != nil {
+		return reconcile.Result{}, errors.Wrapf(err, "fails to create DeployConfig")
 	}
 
 	deploymentMode := isvcutils.GetDeploymentMode(graph.Status.DeploymentMode, graph.ObjectMeta.Annotations, deployConfig)


### PR DESCRIPTION
**What this PR does / why we need it**:

A finalizer is being added on the InferenceGraph CRD for proper clean-up. Since the finalizer code is after resolving URLs of the involved InferenceServices, the `patch` operation over the IG resource would reset the in-memory IG struct object leading to a router-pod being created without the right command-line arguments. An immediate subsequent reconcile fixes the args, but a secondary pod is created.

Moving the configuration of the finalizer before resolving the ISVCs URLs fixes the double-pod creation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

N/A

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- N/A Has code been commented, particularly in hard-to-understand areas?
- N/A Have you made corresponding changes to the documentation?
