### PR TITLE
Fix Raw InferenceGraph not connecting to ISVCs

### DIFF
--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
@@ -82,6 +82,30 @@ func createInferenceGraphPodSpec(graph *v1alpha1api.InferenceGraph, config *Rout
 						Drop: []v1.Capability{v1.Capability("ALL")},
 					},
 				},
+				VolumeMounts: []v1.VolumeMount{
+					{
+						Name:      "openshift-service-ca-bundle",
+						MountPath: "/etc/odh/openshift-service-ca-bundle",
+					},
+				},
+				Env: []v1.EnvVar{
+					{
+						Name:  "SSL_CERT_FILE",
+						Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
+					},
+				},
+			},
+		},
+		Volumes: []v1.Volume{
+			{
+				Name: "openshift-service-ca-bundle",
+				VolumeSource: v1.VolumeSource{
+					ConfigMap: &v1.ConfigMapVolumeSource{
+						LocalObjectReference: v1.LocalObjectReference{
+							Name: constants.OpenShiftServiceCaConfigMapName,
+						},
+					},
+				},
 			},
 		},
 		Affinity:                     graph.Spec.Affinity,
@@ -92,12 +116,12 @@ func createInferenceGraphPodSpec(graph *v1alpha1api.InferenceGraph, config *Rout
 	// Only adding this env variable "PROPAGATE_HEADERS" if router's headers config has the key "propagate"
 	value, exists := config.Headers["propagate"]
 	if exists {
-		podSpec.Containers[0].Env = []v1.EnvVar{
-			{
-				Name:  constants.RouterHeadersPropagateEnvVar,
-				Value: strings.Join(value, ","),
-			},
+		propagateEnv := v1.EnvVar{
+			Name:  constants.RouterHeadersPropagateEnvVar,
+			Value: strings.Join(value, ","),
 		}
+
+		podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, propagateEnv)
 	}
 
 	// If auth is enabled for the InferenceGraph:

--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig_test.go
@@ -173,6 +173,30 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 							Drop: []v1.Capability{v1.Capability("ALL")},
 						},
 					},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "openshift-service-ca-bundle",
+							MountPath: "/etc/odh/openshift-service-ca-bundle",
+						},
+					},
+					Env: []v1.EnvVar{
+						{
+							Name:  "SSL_CERT_FILE",
+							Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
+						},
+					},
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "openshift-service-ca-bundle",
+					VolumeSource: v1.VolumeSource{
+						ConfigMap: &v1.ConfigMapVolumeSource{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: constants.OpenShiftServiceCaConfigMapName,
+							},
+						},
+					},
 				},
 			},
 			AutomountServiceAccountToken: proto.Bool(false),
@@ -189,6 +213,10 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 						"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.exmaple.com\"}]}},\"resources\":{}}",
 					},
 					Env: []v1.EnvVar{
+						{
+							Name:  "SSL_CERT_FILE",
+							Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
+						},
 						{
 							Name:  "PROPAGATE_HEADERS",
 							Value: "Authorization,Intuit_tid",
@@ -211,6 +239,24 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 						AllowPrivilegeEscalation: proto.Bool(false),
 						Capabilities: &v1.Capabilities{
 							Drop: []v1.Capability{v1.Capability("ALL")},
+						},
+					},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "openshift-service-ca-bundle",
+							MountPath: "/etc/odh/openshift-service-ca-bundle",
+						},
+					},
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "openshift-service-ca-bundle",
+					VolumeSource: v1.VolumeSource{
+						ConfigMap: &v1.ConfigMapVolumeSource{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: constants.OpenShiftServiceCaConfigMapName,
+							},
 						},
 					},
 				},
@@ -245,6 +291,30 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 						AllowPrivilegeEscalation: proto.Bool(false),
 						Capabilities: &v1.Capabilities{
 							Drop: []v1.Capability{v1.Capability("ALL")},
+						},
+					},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "openshift-service-ca-bundle",
+							MountPath: "/etc/odh/openshift-service-ca-bundle",
+						},
+					},
+					Env: []v1.EnvVar{
+						{
+							Name:  "SSL_CERT_FILE",
+							Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
+						},
+					},
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "openshift-service-ca-bundle",
+					VolumeSource: v1.VolumeSource{
+						ConfigMap: &v1.ConfigMapVolumeSource{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: constants.OpenShiftServiceCaConfigMapName,
+							},
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

This is an ODH/OpenShift-specific fix. Since the InferenceServices can be protected under TLS, the InferenceGraph workload requires to trust OpenShift Serving certificates. This fixes kserve-contoller to properly configure the IG router workload to trust needed certificates so that connections succeed.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

This issue was found while working on https://issues.redhat.com/browse/RHOAIENG-24595.

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

- [x] Manual testing
- [x] Automated tests (still in WIP) in opendatahub-io/opendatahub-tests#285

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [N/A] Have you made corresponding changes to the documentation?

