### PR TITLE
Add optional go1.22 image and profile to utilize it

### DIFF
--- a/dev_tools/README.md
+++ b/dev_tools/README.md
@@ -47,6 +47,7 @@ For regular development you usually run `devspace use context`, then `devspace u
 - `devspace use namespace` change what namepsace you want to deploy your container into e.g. `devspace use namespace opendatahub` for this project
 - `devspace dev` main command used to start up the devspace container
 - `devspace run-pipeline ${pipeline_name}` to run a specific pipeline e.g. `debug` pipeline that was configured for this project
+**NOTE:** The default image uses go1.24. If you need to use go1.22, you can run with the flag `--profile go1.22` ex: `$ devspace run-pipeline debug --profile go1.22` 
 
 [More Cleanup Commands](https://www.devspace.sh/docs/getting-started/cleanup)
 

--- a/dev_tools/devspace.yaml
+++ b/dev_tools/devspace.yaml
@@ -18,9 +18,6 @@ pipelines:
     run: |-
       run_pipelines dev
       code --folder-uri vscode-remote://ssh-remote+app.kserve.devspace/app
-    dev:
-      app:
-        devImage: quay.io/vedantm/golang:1.22-odh-kserve-debug
 
 images:
   app:
@@ -79,3 +76,11 @@ commands:
     command: |-
       echo 'This is a cross-platform, shared command that can be used to codify any kind of dev task.'
       echo 'Anyone using this project can invoke it via "devspace run migrate-db"'
+
+profiles:
+  - name: go1.22 
+    patches: # Use patches to modify the base configuration
+      - op: replace
+        path: dev.app.devImage
+        value: quay.io/vedantm/golang:1.22-odh-kserve-debug 
+


### PR DESCRIPTION

**What this PR does / why we need it**:
Fixes formatting error in the devspace yaml and adds the ability to run with go1.22 instead of go 1.24 by default. 

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.