### PR TITLE
Fix issue with OCI support for multi-node/multi-gpu

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -531,7 +531,7 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 
 	deploymentAnnotations := annotations[constants.StorageInitializerSourceUriInternalAnnotationKey]
 	storageProtocol := strings.Split(deploymentAnnotations, "://")[0]
-	if storageProtocol == "pvc" {
+	if storageProtocol == "pvc" || storageProtocol == "oci" {
 		// Set the environment variable for "/mnt/models" to the MODEL_DIR when multiNodeEnabled is true.
 		if err := isvcutils.AddEnvVarToPodSpec(podSpec, constants.InferenceServiceContainerName, "MODEL_DIR", constants.DefaultModelLocalMountPath); err != nil {
 			return nil, errors.Wrapf(err, "failed to add MODEL_DIR environment to the container(%s)", constants.DefaultModelLocalMountPath)


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow setting the MODEL_DIR environment variable for OCI storage protocol.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Found as part of https://issues.redhat.com/browse/RHOAIENG-25713. This is because ODH configuration of the multi-node vLLM requires the MODEL_DIR environment variable to be set.

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

