### PR TITLE
Revert "RHOAIENG-25750: Split syncable and static params"

### DIFF
--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -27,7 +27,6 @@ replacements:
 configMapGenerator:
 - envs:
   - params.env
-  - params-synced.env
   name: kserve-parameters
 
 generatorOptions:

--- a/config/overlays/odh/params-synced.env
+++ b/config/overlays/odh/params-synced.env
@@ -1,1 +1,0 @@
-oauth-proxy=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:bd49cfc8452b3d96467cc222db9487e120abc6cc5ba81349c6b3703706f36a08

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -2,3 +2,4 @@ kserve-controller=quay.io/opendatahub/kserve-controller:latest
 kserve-agent=quay.io/opendatahub/kserve-agent:latest
 kserve-router=quay.io/opendatahub/kserve-router:latest
 kserve-storage-initializer=quay.io/opendatahub/kserve-storage-initializer:latest
+oauth-proxy=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:bd49cfc8452b3d96467cc222db9487e120abc6cc5ba81349c6b3703706f36a08


### PR DESCRIPTION
Reverts opendatahub-io/kserve#640

It will be fixed once is in https://github.com/opendatahub-io/opendatahub-operator/pull/1984