### PR TITLE
Adding fvt tests and setup for s3 storage with tls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ istio-*
 test/scripts/openshift-ci/build*.log
 test/scripts/openshift-ci/setup*.log
 test/scripts/openshift-ci/run*.log
+
+# Generated Custom Certs
+test/scripts/openshift-ci/tls/certs

--- a/test/e2e/pytest.ini
+++ b/test/e2e/pytest.ini
@@ -18,3 +18,4 @@ markers =
     llm: e2e tests for huggingface runtime
     vllm: e2e tests for huggingface runtime with vllm-openvino backend
     modelcache: e2e tests for model caching
+    openshift_ci: e2e tests to be run only in openshift-ci

--- a/test/e2e/storagespec/test_s3_ssl_storagespec.py
+++ b/test/e2e/storagespec/test_s3_ssl_storagespec.py
@@ -1,0 +1,248 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import time
+from base64 import b64decode
+from kubernetes import client
+from kserve import (
+    constants,
+    KServeClient,
+    V1beta1InferenceService,
+    V1beta1InferenceServiceSpec,
+    V1beta1PredictorSpec,
+    V1beta1SKLearnSpec,
+    V1beta1StorageSpec,
+)
+from kubernetes.client import V1ResourceRequirements
+import pytest
+
+from ..common.utils import KSERVE_NAMESPACE, KSERVE_TEST_NAMESPACE
+
+invalid_cert = """
+-----BEGIN CERTIFICATE-----
+MIIFLTCCAxWgAwIBAgIUF4tP6T1S5H/Gt8BpjFsbXo7f0SYwDQYJKoZIhvcNAQEL
+BQAwJjEVMBMGA1UECgwMRXhhbXBsZSBJbmMuMQ0wCwYDVQQDDARyb290MB4XDTI0
+MDIxNjE5MTM0M1oXDTI1MDIxNTE5MTM0M1owJjEVMBMGA1UECgwMRXhhbXBsZSBJ
+bmMuMQ0wCwYDVQQDDARyb290MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKC
+AgEAnafLggtSuJDwmz6MNaeo2Wmjr6S4xuPYMrCcmclG8Z6qPYHGULTojjy+Du49
+xQ+Xf54kFICEndFEsi1/ms/OG7gT6D+yK/2qfHHJFDQiR1wpPGUPB39ICPRmKJZG
+u98dVGCULFw+ZKNJa9tQhbFU5GZUW/uHfu9S1CHr8TKjQ3C88+weiCZeP+0bOBNd
+ED+IgS7E5amLPhyZZOszN2TcGfIUZbhlshyjpEU3dBt7+X7eUCfCAEzlUnB//dTx
+PJI5LODjKAUeruCVzxqmPZVd8dcxoOLrO6GeRiLm9tWAVAuc91tMPlqBrx2gxOWC
+seWCc8MdwgneLhg7iaO3lgqCxT7UNJN6Vt0RJ4zHz5ix+9rPzNcVoSvPcFHsECFd
+Ia0Kw9BemDW+BElvfdcO4WKeKz5tqJeQJV4VNo5FhifquWHnDDwweZGnyHa+Ma0F
+nfDNu6EXz9PMaHwPGYYWUbooRiQ1jvokS+peEu4Co7IuT4N1kix3o17Otiboz9vJ
+ZktkMO4Q/8H8Mz9u/22t3/TyKgMYp4ng0JohGXU5jmoxGqd1hL0zkxjeakZXj1cz
+TyUzNq0TAYdjAc60DUGyO9zPqyppTMjNCAFJwWW3HDGdOpzmlx3q7G7DtqW38f9Z
+/wzQNrRzcrjSAlkoMh815U8KLe+46aQU8qKBNRVCWP+TyhsCAwEAAaNTMFEwHQYD
+VR0OBBYEFGx6yRBZRO69d5SLJb0HRbX8kdNgMB8GA1UdIwQYMBaAFGx6yRBZRO69
+d5SLJb0HRbX8kdNgMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggIB
+ADzivfSrSJE1lhmqJbJ2ZJaq59nyFu9/rNS9UfHYeiy8eBZEygVDWFIAxb8xmbwP
+brhGqCxlAW7Ydw/lwwGUndpP93LN9o93eVnEu7evEr4GflRt3++MCNUXjEbY5THV
+7XAU+Rm02lwejUJtk3L9Em0PUFiUp38vbLC0oZKAEOqNgGexPOlUI7+WW2kpEWTj
+eOmeEOOW2tKcy2pSId9TX6PtzEBIwuiGZLsD/vSQ1yXs0CZE96xqmRlPoQJ2fyBm
+ON/3QYs1o8Mns5tMf/hEWu4p7grHvIAIHHVc8Dyn2XlLiXTSWCgrcYn0HeMIXG+7
+yxIda8GBJYO2KZ/eLkg/dE2varrQ8JeapO6ozXS1MFYG4rTPEwSmLxjGyu3XD0sb
+jv5LBXm6oDvL8kfJO7uqKcizs2rx5HIjuQ6mEEunVlr9jlFlNzkO0rfoeECrtwuW
+jtAxrpGonBuGY4CcmjxpvSwaBDOAbZnZG7g5yRQQTA/lOBvgBfzFm6Xsdm/Vtnya
+UCOnFrN0vXLkrQVVrdZxxWhz9FN+SUXQyjsR3D+VpJUVWmw9pfiXi8F/JOpjORhe
+TbVunBmL9HUClHgUc2B0NSfNyqXSwo+Gp5Kg4iYIw4hJw2EPwilUFafcM8uVDktK
+5kwH30e7WUlkXz+j8p1UIuFM5kKHW/OwPBdLU/1Pl5ts
+-----END CERTIFICATE-----
+"""
+
+
+@pytest.mark.openshift_ci
+@pytest.mark.asyncio(scope="session")
+async def test_s3_tls_custom_cert_storagespec_kserve(rest_v1_client):
+    kserve_client = KServeClient(
+        config_file=os.environ.get("KUBECONFIG", "~/.kube/config")
+    )
+
+    # Mimic the RHOAI/ODH operators by creating the odh-trusted-ca-bundle configmap containing the custom cert
+    minio_tls_custom_certs = kserve_client.core_api.read_namespaced_secret(
+        "minio-tls-custom", KSERVE_NAMESPACE
+    ).data
+    odh_trusted_ca_configmap = client.V1ConfigMap(
+        api_version="v1",
+        kind="ConfigMap",
+        metadata=client.V1ObjectMeta(name="odh-trusted-ca-bundle"),
+        data={
+            "odh-ca-bundle.crt": b64decode(minio_tls_custom_certs["root.crt"]).decode()
+        },
+    )
+    kserve_client.core_api.create_namespaced_config_map(
+        namespace=KSERVE_TEST_NAMESPACE, body=odh_trusted_ca_configmap
+    )
+
+    # Validate that the model is successfully loaded when the custom cert is present
+    service_name = "isvc-sklearn-s3-tls-custom-pass"
+    predictor = V1beta1PredictorSpec(
+        min_replicas=1,
+        sklearn=V1beta1SKLearnSpec(
+            storage=V1beta1StorageSpec(
+                key="localTLSMinIOCustom",
+                path="sklearn",
+                parameters={"bucket": "example-models"},
+            ),
+            resources=V1ResourceRequirements(
+                requests={"cpu": "50m", "memory": "128Mi"},
+                limits={"cpu": "100m", "memory": "256Mi"},
+            ),
+        ),
+    )
+    isvc = V1beta1InferenceService(
+        api_version=constants.KSERVE_V1BETA1,
+        kind=constants.KSERVE_KIND_INFERENCESERVICE,
+        metadata=client.V1ObjectMeta(
+            name=service_name, namespace=KSERVE_TEST_NAMESPACE
+        ),
+        spec=V1beta1InferenceServiceSpec(predictor=predictor),
+    )
+    kserve_client.create(isvc)
+    check_model_transition_status(
+        kserve_client, service_name, KSERVE_TEST_NAMESPACE, "UpToDate"
+    )
+    kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
+
+    # Patch the odh-trusted-ca-bundle configmap to replace the custom cert with an invalid cert
+    odh_trusted_ca_configmap_patch = client.V1ConfigMap(
+        api_version="v1",
+        kind="ConfigMap",
+        metadata=client.V1ObjectMeta(name="odh-trusted-ca-bundle"),
+        data={"odh-ca-bundle.crt": invalid_cert},
+    )
+    kserve_client.core_api.patch_namespaced_config_map(
+        name="odh-trusted-ca-bundle",
+        namespace=KSERVE_TEST_NAMESPACE,
+        body=odh_trusted_ca_configmap_patch,
+    )
+
+    # Validate that the model fails to load when the custom cert is not present
+    service_name = "isvc-sklearn-s3-tls-custom-fail"
+    isvc.metadata.name = service_name
+    kserve_client.create(isvc)
+    check_model_transition_status(
+        kserve_client, service_name, KSERVE_TEST_NAMESPACE, "BlockedByFailedLoad"
+    )
+    kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
+
+    # Cleanup the configmap
+    kserve_client.core_api.delete_namespaced_config_map(
+        name="odh-trusted-ca-bundle", namespace=KSERVE_TEST_NAMESPACE
+    )
+
+
+@pytest.mark.openshift_ci
+@pytest.mark.asyncio(scope="session")
+async def test_s3_tls_serving_cert_storagespec_kserve(rest_v1_client):
+    kserve_client = KServeClient(
+        config_file=os.environ.get("KUBECONFIG", "~/.kube/config")
+    )
+
+    # Mimic the RHOAI/ODH operators by creating the odh-trusted-ca-bundle configmap containing the serving cert
+    minio_tls_serving_certs = kserve_client.core_api.read_namespaced_secret(
+        "minio-tls-serving", KSERVE_NAMESPACE
+    ).data
+    odhTrustedCAConfigmap = client.V1ConfigMap(
+        api_version="v1",
+        kind="ConfigMap",
+        metadata=client.V1ObjectMeta(name="odh-trusted-ca-bundle"),
+        data={
+            "odh-ca-bundle.crt": b64decode(minio_tls_serving_certs["tls.crt"]).decode()
+        },
+    )
+    kserve_client.core_api.create_namespaced_config_map(
+        namespace=KSERVE_TEST_NAMESPACE, body=odhTrustedCAConfigmap
+    )
+
+    # Validate that the model is successfully loaded when the serving cert is present
+    service_name = "isvc-sklearn-s3-tls-serving-pass"
+    predictor = V1beta1PredictorSpec(
+        min_replicas=1,
+        sklearn=V1beta1SKLearnSpec(
+            storage=V1beta1StorageSpec(
+                key="localTLSMinIOServing",
+                path="sklearn",
+                parameters={"bucket": "example-models"},
+            ),
+            resources=V1ResourceRequirements(
+                requests={"cpu": "50m", "memory": "128Mi"},
+                limits={"cpu": "100m", "memory": "256Mi"},
+            ),
+        ),
+    )
+    isvc = V1beta1InferenceService(
+        api_version=constants.KSERVE_V1BETA1,
+        kind=constants.KSERVE_KIND_INFERENCESERVICE,
+        metadata=client.V1ObjectMeta(
+            name=service_name, namespace=KSERVE_TEST_NAMESPACE
+        ),
+        spec=V1beta1InferenceServiceSpec(predictor=predictor),
+    )
+    kserve_client.create(isvc)
+    check_model_transition_status(
+        kserve_client, service_name, KSERVE_TEST_NAMESPACE, "UpToDate"
+    )
+    kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
+
+    # Patch the odh-trusted-ca-bundle configmap to replace the serving cert with an invalid cert
+    odhTrustedCAConfigmapPatch = client.V1ConfigMap(
+        api_version="v1",
+        kind="ConfigMap",
+        metadata=client.V1ObjectMeta(name="odh-trusted-ca-bundle"),
+        data={"odh-ca-bundle.crt": invalid_cert},
+    )
+    kserve_client.core_api.patch_namespaced_config_map(
+        name="odh-trusted-ca-bundle",
+        namespace=KSERVE_TEST_NAMESPACE,
+        body=odhTrustedCAConfigmapPatch,
+    )
+
+    # Validate that the model fails to load when the custom cert is not present
+    service_name = "isvc-sklearn-s3-tls-serving-fail"
+    isvc.metadata.name = service_name
+    kserve_client.create(isvc)
+    check_model_transition_status(
+        kserve_client, service_name, KSERVE_TEST_NAMESPACE, "BlockedByFailedLoad"
+    )
+    kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
+
+    # Cleanup the configmap
+    kserve_client.core_api.delete_namespaced_config_map(
+        name="odh-trusted-ca-bundle", namespace=KSERVE_TEST_NAMESPACE
+    )
+
+
+def check_model_transition_status(
+    kserve_client: KServeClient,
+    isvc_name: str,
+    isvc_namespace: str,
+    expected_status: str,
+    timeout_seconds: int = 600,
+    polling_interval: int = 10,
+):
+    for _ in range(round(timeout_seconds / polling_interval)):
+        time.sleep(polling_interval)
+        isvc = kserve_client.get(
+            name=isvc_name,
+            namespace=isvc_namespace,
+            version=constants.KSERVE_V1BETA1_VERSION,
+        )
+        if isvc["status"]["modelStatus"]["transitionStatus"] == expected_status:
+            return
+    raise RuntimeError(
+        f"InferenceService ({isvc_name}) has model transition status \
+            {isvc['status']['modelStatus']['transitionStatus']} after timeout, but expecting {expected_status}"
+    )

--- a/test/overlays/openshift-ci/kustomization.yaml
+++ b/test/overlays/openshift-ci/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- minio-tls-custom-cert
+- minio-tls-serving-cert

--- a/test/overlays/openshift-ci/minio-tls-custom-cert/kustomization.yaml
+++ b/test/overlays/openshift-ci/minio-tls-custom-cert/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- minio-tls-custom-deployment.yaml
+- minio-tls-custom-service.yaml
+- minio-tls-custom-artifact-secret.yaml

--- a/test/overlays/openshift-ci/minio-tls-custom-cert/minio-tls-custom-artifact-secret.yaml
+++ b/test/overlays/openshift-ci/minio-tls-custom-cert/minio-tls-custom-artifact-secret.yaml
@@ -1,0 +1,8 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: minio-tls-custom-artifact
+stringData:
+  accesskey: minio
+  secretkey: minio123
+

--- a/test/overlays/openshift-ci/minio-tls-custom-cert/minio-tls-custom-deployment.yaml
+++ b/test/overlays/openshift-ci/minio-tls-custom-cert/minio-tls-custom-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio-tls-custom
+  labels:
+    app: minio-tls-custom
+spec:
+  selector:
+    matchLabels:
+      app: minio-tls-custom
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: minio-tls-custom
+    spec:
+      containers:
+      - args:
+        - server
+        - /data
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-tls-custom-artifact
+              key: accesskey
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-tls-custom-artifact
+              key: secretkey
+        image: gcr.io/ml-pipeline/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance
+        name: minio-tls-custom
+        ports:
+        - containerPort: 9000
+        volumeMounts:
+        - mountPath: /data
+          name: data
+          subPath: minio
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      volumes:
+      - name: data
+        emptyDir: {}

--- a/test/overlays/openshift-ci/minio-tls-custom-cert/minio-tls-custom-service.yaml
+++ b/test/overlays/openshift-ci/minio-tls-custom-cert/minio-tls-custom-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-tls-custom-service
+spec:
+  ports:
+  - name: https
+    port: 9000
+    protocol: TCP
+    targetPort: 9000
+  selector:
+    app: minio-tls-custom

--- a/test/overlays/openshift-ci/minio-tls-serving-cert/kustomization.yaml
+++ b/test/overlays/openshift-ci/minio-tls-serving-cert/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- minio-tls-serving-deployment.yaml
+- minio-tls-serving-service.yaml
+- minio-tls-serving-artifact-secret.yaml

--- a/test/overlays/openshift-ci/minio-tls-serving-cert/minio-tls-serving-artifact-secret.yaml
+++ b/test/overlays/openshift-ci/minio-tls-serving-cert/minio-tls-serving-artifact-secret.yaml
@@ -1,0 +1,8 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: minio-tls-serving-artifact
+stringData:
+  accesskey: minio
+  secretkey: minio123
+

--- a/test/overlays/openshift-ci/minio-tls-serving-cert/minio-tls-serving-deployment.yaml
+++ b/test/overlays/openshift-ci/minio-tls-serving-cert/minio-tls-serving-deployment.yaml
@@ -1,0 +1,62 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio-tls-serving
+  labels:
+    app: minio-tls-serving
+spec:
+  selector:
+    matchLabels:
+      app: minio-tls-serving
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: minio-tls-serving
+    spec:
+      containers:
+      - args:
+        - server
+        - /data
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-tls-serving-artifact
+              key: accesskey
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: minio-tls-serving-artifact
+              key: secretkey
+        image: gcr.io/ml-pipeline/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance
+        name: minio-tls-serving
+        ports:
+        - containerPort: 9000
+        volumeMounts:
+        - mountPath: .minio/certs
+          name: minio-tls-serving
+        - mountPath: /data
+          name: data
+          subPath: minio
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+      volumes:
+      - name: minio-tls-serving
+        projected:
+          defaultMode: 420
+          sources:
+          - secret:
+              items:
+              - key: tls.crt
+                path: public.crt
+              - key: tls.key
+                path: private.key
+              - key: tls.crt
+                path: CAs/root.crt
+              name: minio-tls-serving
+      - name: data
+        emptyDir: {}

--- a/test/overlays/openshift-ci/minio-tls-serving-cert/minio-tls-serving-service.yaml
+++ b/test/overlays/openshift-ci/minio-tls-serving-cert/minio-tls-serving-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio-tls-serving-service
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: minio-tls-serving
+spec:
+  ports:
+  - name: https
+    port: 9000
+    protocol: TCP
+    targetPort: 9000
+  selector:
+    app: minio-tls-serving

--- a/test/scripts/openshift-ci/run-e2e-tests.sh
+++ b/test/scripts/openshift-ci/run-e2e-tests.sh
@@ -53,7 +53,7 @@ fi
 if [ "$SETUP_E2E" = "true" ]; then
   echo "Installing on cluster"
   pushd $PROJECT_ROOT >/dev/null
-  ./test/scripts/openshift-ci/setup-e2e-tests.sh "$1" | tee 2>&1 ./test/scripts/openshift-ci/setup-e2e-tests-$1.log
+  ./test/scripts/openshift-ci/setup-e2e-tests.sh "$1" | tee 2>&1 "./test/scripts/openshift-ci/setup-e2e-tests-${1// /-}.log"
   popd
 fi
 
@@ -65,6 +65,6 @@ echo "REQUESTS_CA_BUNDLE=$(cat ${REQUESTS_CA_BUNDLE})"
 
 echo "Run E2E tests: $1"
 pushd $PROJECT_ROOT >/dev/null
-./test/scripts/gh-actions/run-e2e-tests.sh "$1" $PARALLELISM | tee 2>&1 ./test/scripts/openshift-ci/run-e2e-tests-$1.log
+./test/scripts/gh-actions/run-e2e-tests.sh "$1" $PARALLELISM | tee 2>&1 "./test/scripts/openshift-ci/run-e2e-tests-${1// /-}.log"
 popd
 cp ./test/e2e/conftest.py.bak ./test/e2e/conftest.py

--- a/test/scripts/openshift-ci/setup-e2e-tests.sh
+++ b/test/scripts/openshift-ci/setup-e2e-tests.sh
@@ -195,4 +195,8 @@ spec:
   - Egress
 EOF
 
+echo "Configuring minio tls"
+${PROJECT_ROOT}/test/scripts/openshift-ci/tls/setup-minio-tls-custom-cert.sh
+${PROJECT_ROOT}/test/scripts/openshift-ci/tls/setup-minio-tls-serving-cert.sh
+
 echo "Setup complete"

--- a/test/scripts/openshift-ci/teardown-e2e-setup.sh
+++ b/test/scripts/openshift-ci/teardown-e2e-setup.sh
@@ -67,13 +67,18 @@ if [ "$1" != "raw" ]; then
   oc delete namespace openshift-serverless --ignore-not-found
 fi
 
-echo "Installing KServe with Minio"
+echo "Deleting KServe with Minio"
 kustomize build $PROJECT_ROOT/config/overlays/test |
   sed "s|kserve/storage-initializer:latest|${STORAGE_INITIALIZER_IMAGE}|" |
   sed "s|kserve/agent:latest|${KSERVE_AGENT_IMAGE}|" |
   sed "s|kserve/router:latest|${KSERVE_ROUTER_IMAGE}|" |
   sed "s|kserve/kserve-controller:latest|${KSERVE_CONTROLLER_IMAGE}|" |
   oc delete --server-side=true -f -
+
+echo "Deleting TLS MinIO resources and generated certificates"
+kustomize build $PROJECT_ROOT/test/overlays/openshift-ci |
+  oc delete -n kserve -f -
+rm -rf $PROJECT_ROOT/test/scripts/openshift-ci/tls/certs
 
 # Install DSC/DSCI for test. (sometimes there is timing issue when it is under the same kustomization so it is separated)
 oc delete -f config/overlays/test/dsci.yaml

--- a/test/scripts/openshift-ci/tls/generate-custom-certs.sh
+++ b/test/scripts/openshift-ci/tls/generate-custom-certs.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a helper script to generate custom tls certificates.
+set -eu
+
+MY_PATH=$(dirname "$0")
+PROJECT_ROOT=$MY_PATH/../../../../
+TLS_DIR=$PROJECT_ROOT/test/scripts/openshift-ci/tls
+
+if [ ! -x "$(command -v openssl)" ]; then
+  echo "openssl not found"
+  exit 1
+fi
+
+echo "Generating Custom CA cert and secret"
+if ! [ -d $TLS_DIR/certs/custom ]; then
+    mkdir -p $TLS_DIR/certs/custom
+fi
+openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:4096 -subj "/O=Red Hat/CN=root" -keyout ${TLS_DIR}/certs/custom/root.key -out ${TLS_DIR}/certs/custom/root.crt 
+openssl req -nodes --newkey rsa:4096 -subj "/CN=custom/O=Red Hat" --keyout ${TLS_DIR}/certs/custom/custom.key -out ${TLS_DIR}/certs/custom/custom.csr -config ${TLS_DIR}/openssl-san.config
+openssl x509 -req -in ${TLS_DIR}/certs/custom/custom.csr -CA ${TLS_DIR}/certs/custom/root.crt -CAkey ${TLS_DIR}/certs/custom/root.key -CAcreateserial -out ${TLS_DIR}/certs/custom/custom.crt -days 365 -sha256 -extfile ${TLS_DIR}/openssl-san.config -extensions v3_req

--- a/test/scripts/openshift-ci/tls/openssl-san.config
+++ b/test/scripts/openshift-ci/tls/openssl-san.config
@@ -1,0 +1,8 @@
+[ req ]
+distinguished_name = req
+[v3_req]
+keyUsage = keyEncipherment, dataEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = minio-tls-custom-service.kserve.svc

--- a/test/scripts/openshift-ci/tls/setup-minio-tls-custom-cert.sh
+++ b/test/scripts/openshift-ci/tls/setup-minio-tls-custom-cert.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a helper script to create and configure the resources needed
+# for minio storage to have tls enabled with a custom certificate.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+MY_PATH=$(dirname "$0")
+PROJECT_ROOT=$MY_PATH/../../../../
+TLS_DIR=$PROJECT_ROOT/test/scripts/openshift-ci/tls
+
+# If Kustomize is not installed, install it
+if ! command -v kustomize &>/dev/null; then
+  echo "Installing Kustomize"
+  curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- 5.0.1 $HOME/.local/bin
+fi
+
+# If minio CLI is not installed, install it
+if ! command -v mc &>/dev/null; then
+  echo "Installing MinIO CLI"
+  curl https://dl.min.io/client/mc/release/linux-amd64/mc --create-dirs -o $HOME/.local/bin/mc
+  chmod +x $HOME/.local/bin/mc
+fi
+
+# Create kserve namespace if it does not already exist
+if oc get namespace kserve > /dev/null 2>&1; then
+    echo "Namespace kserve exists."
+else
+    cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: kserve
+EOF
+fi
+
+# Required for idempotency
+if oc get deployment minio-tls-custom -n kserve > /dev/null 2>&1; then
+    echo "Cleaning up existing minio-tls-custom deployment"
+    oc delete deployment minio-tls-custom -n kserve
+fi
+
+# Create tls minio resources
+kustomize build $PROJECT_ROOT/test/overlays/openshift-ci/minio-tls-custom-cert |
+  oc apply -n kserve --server-side=true -f -
+
+echo "Configuring MinIO for TLS with custom certificate and adding models to storage ..."
+# Create custom certs
+${PROJECT_ROOT}/test/scripts/openshift-ci/tls/generate-custom-certs.sh
+# Generate secret to store the custom certs. If the secret already exists, replace it.
+if oc get secret minio-tls-custom -n kserve > /dev/null 2>&1; then
+    oc delete secret minio-tls-custom -n kserve
+fi
+oc create secret generic minio-tls-custom --from-file=${TLS_DIR}/certs/custom/root.crt  --from-file=${TLS_DIR}/certs/custom/custom.crt --from-file=${TLS_DIR}/certs/custom/custom.key -n kserve
+# Mount certificates to minio-tls-custom container
+oc patch deployment minio-tls-custom -n kserve -p '{"spec":{"template":{"spec":{"containers":[{"name":"minio-tls-custom","volumeMounts":[{"mountPath":".minio/certs","name":"minio-tls-custom"}]}], "volumes":[{"name":"minio-tls-custom","projected":{"defaultMode":420,"sources":[{"secret":{"name":"minio-tls-custom","items":[{"key":"custom.crt","path":"public.crt"},{"key":"custom.key", "path":"private.key"},{"key":"root.crt","path":"CAs/root.crt"}]}}]}}]}}}}'
+# Expose the route with tls enabled
+oc expose service minio-tls-custom-service -n kserve && sleep 5
+CUSTOM_ROOT_CERT="$(awk '{printf "%s\\n", $0}' ${TLS_DIR}/certs/custom/root.crt)"
+oc patch route minio-tls-custom-service -n kserve -p "{\"spec\":{\"tls\":{\"termination\":\"reencrypt\",\"destinationCACertificate\":\"${CUSTOM_ROOT_CERT}\"}}}" && sleep 5
+MINIO_TLS_CUSTOM_ROUTE=$(oc get routes -n kserve minio-tls-custom-service -o jsonpath="{.spec.host}")
+# Upload the model
+mc alias set storage-tls-custom https://$MINIO_TLS_CUSTOM_ROUTE minio minio123
+if ! mc ls storage-tls-custom/example-models >/dev/null 2>&1; then
+  mc mb storage-tls-custom/example-models
+else
+  echo "Bucket 'example-models' already exists."
+fi
+if [[ $(mc ls storage-tls-custom/example-models/sklearn/model.joblib |wc -l) == "1" ]]; then
+  echo "Test model exists"
+else
+  echo "Copy test model"
+  curl -L https://storage.googleapis.com/kfserving-examples/models/sklearn/1.0/model/model.joblib -o /tmp/sklearn-model.joblib
+  mc cp /tmp/sklearn-model.joblib storage-tls-custom/example-models/sklearn/model.joblib
+fi
+# Delete the route after upload
+oc delete route -n kserve minio-tls-custom-service
+
+# Create kserve-ci-e2e-test namespace if it does not already exist
+if oc get namespace kserve-ci-e2e-test > /dev/null 2>&1; then
+    echo "Namespace kserve-ci-e2e-test exists."
+else
+    cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: kserve-ci-e2e-test
+EOF
+fi
+
+echo "Adding localTLSMinIOCustom configuration to storage-config secret"
+# Creating/Updating storage-config secret with ca created ca bundle
+LOCAL_TLS_MINIO_CUSTOM="{\"type\": \"s3\",\"access_key_id\":\"minio\",\"secret_access_key\":\"minio123\",\"endpoint_url\":\"https://minio-tls-custom-service.kserve.svc:9000\",\"bucket\":\"mlpipeline\",\"region\":\"us-south\",\"cabundle_configmap\":\"odh-kserve-custom-ca-bundle\",\"anonymous\":\"False\"}" 
+LOCAL_TLS_MINIO_CUSTOM_BASE64=$(echo ${LOCAL_TLS_MINIO_CUSTOM} | base64 -w 0)
+if oc get secret storage-config -n kserve-ci-e2e-test > /dev/null 2>&1; then
+    oc patch secret storage-config -n kserve-ci-e2e-test -p "{\"data\":{\"localTLSMinIOCustom\":\"${LOCAL_TLS_MINIO_CUSTOM_BASE64}\"}}"
+else
+    oc create secret generic storage-config --from-literal=localTLSMinIOCustom="${LOCAL_TLS_MINIO_CUSTOM}" -n kserve-ci-e2e-test
+fi

--- a/test/scripts/openshift-ci/tls/setup-minio-tls-serving-cert.sh
+++ b/test/scripts/openshift-ci/tls/setup-minio-tls-serving-cert.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is a helper script to create and configure the resources needed
+# for minio storage to have tls enabled with an openshift serving certificate.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+MY_PATH=$(dirname "$0")
+PROJECT_ROOT=$MY_PATH/../../../../
+TLS_DIR=$PROJECT_ROOT/test/scripts/openshift-ci/tls
+
+# If Kustomize is not installed, install it
+if ! command -v kustomize &>/dev/null; then
+  echo "Installing Kustomize"
+  curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s -- 5.0.1 $HOME/.local/bin
+fi
+
+# If minio CLI is not installed, install it
+if ! command -v mc &>/dev/null; then
+  echo "Installing MinIO CLI"
+  curl https://dl.min.io/client/mc/release/linux-amd64/mc --create-dirs -o $HOME/.local/bin/mc
+  chmod +x $HOME/.local/bin/mc
+fi
+
+# Create kserve namespace if it does not already exist
+if oc get namespace kserve > /dev/null 2>&1; then
+    echo "Namespace kserve exists."
+else
+    cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: kserve
+EOF
+fi
+
+# Create tls minio resources
+kustomize build $PROJECT_ROOT/test/overlays/openshift-ci/minio-tls-serving-cert |
+  oc apply -n kserve --server-side=true -f - && sleep 5
+
+echo "Configuring MinIO for TLS with Openshift serving certificate and adding models to storage"
+# Add openshift generated serving certificates to certs directory
+if ! [ -d $TLS_DIR/certs/serving ]; then
+    mkdir -p $TLS_DIR/certs/serving
+fi
+(oc get secret minio-tls-serving -n kserve -o json | jq -r '.data."tls.crt"' | base64 -d) > $TLS_DIR/certs/serving/tls.crt
+(oc get secret minio-tls-serving -n kserve -o json | jq -r '.data."tls.key"' | base64 -d) > $TLS_DIR/certs/serving/tls.key
+# Expose the route with tls enabled
+oc expose service minio-tls-serving-service -n kserve && sleep 5
+SERVING_ROOT_CERT="$(awk '{printf "%s\\n", $0}' ${TLS_DIR}/certs/serving/tls.crt)"
+oc patch route minio-tls-serving-service -n kserve -p "{\"spec\":{\"tls\":{\"termination\":\"reencrypt\",\"destinationCACertificate\":\"${SERVING_ROOT_CERT}\"}}}" && sleep 5
+MINIO_TLS_SERVING_ROUTE=$(oc get routes -n kserve minio-tls-serving-service -o jsonpath="{.spec.host}")
+# Upload the model
+mc alias set storage-tls-serving https://$MINIO_TLS_SERVING_ROUTE minio minio123
+if ! mc ls storage-tls-serving/example-models >/dev/null 2>&1; then
+  mc mb storage-tls-serving/example-models
+else
+  echo "Bucket 'example-models' already exists."
+fi
+if [[ $(mc ls storage-tls-serving/example-models/sklearn/model.joblib |wc -l) == "1" ]]; then
+  echo "Test model exists"
+else
+  echo "Copy test model"
+  curl -L https://storage.googleapis.com/kfserving-examples/models/sklearn/1.0/model/model.joblib -o /tmp/sklearn-model.joblib
+  mc cp /tmp/sklearn-model.joblib storage-tls-serving/example-models/sklearn/model.joblib
+fi
+# Delete the route after upload
+oc delete route -n kserve minio-tls-serving-service
+
+# Create kserve-ci-e2e-test namespace if it does not already exist
+if oc get namespace kserve-ci-e2e-test > /dev/null 2>&1; then
+    echo "Namespace kserve-ci-e2e-test exists."
+else
+    cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+    name: kserve-ci-e2e-test
+EOF
+fi
+
+echo "Adding localTLSMinIOServing configuration to storage-config secret"
+# Creating/Updating storage-config secret with ca created ca bundle
+LOCAL_TLS_MINIO_SERVING="{\"type\": \"s3\",\"access_key_id\":\"minio\",\"secret_access_key\":\"minio123\",\"endpoint_url\":\"https://minio-tls-serving-service.kserve.svc:9000\",\"bucket\":\"mlpipeline\",\"region\":\"us-south\",\"cabundle_configmap\":\"odh-kserve-custom-ca-bundle\",\"anonymous\":\"False\"}" 
+LOCAL_TLS_MINIO_SERVING_BASE64=$(echo ${LOCAL_TLS_MINIO_SERVING} | base64 -w 0)
+if oc get secret storage-config -n kserve-ci-e2e-test > /dev/null 2>&1; then
+    oc patch secret storage-config -n kserve-ci-e2e-test -p "{\"data\":{\"localTLSMinIOServing\":\"${LOCAL_TLS_MINIO_SERVING_BASE64}\"}}"
+else
+    oc create secret generic storage-config --from-literal=localTLSMinIOServing="${LOCAL_TLS_MINIO_SERVING}" -n kserve-ci-e2e-test
+fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
[RHOAIENG-21641](https://issues.redhat.com/browse/RHOAIENG-21641)
This PR adds two new pytests under the `test/e2e/storage_spec` directory that cover an inference services ability to download a model from s3 storage with TLS enabled. The following scenarios are validated:
1. When s3 storage is configured with a custom certificate, an ISVC can download the model from s3 storage successfully if the custom ca bundle is present in the `odh-kserve-custom-ca-bundle` configmap.
2. When s3 storage is configured with a custom certificate, an ISVC fails to download the model from s3 storage if the custom ca bundle is not present in the `odh-kserve-custom-ca-bundle` configmap.
3. When s3 storage is configured with an Openshift serving certificate, an ISVC can download the model from s3 storage successfully if the serving ca bundle is present in the `odh-kserve-custom-ca-bundle` configmap.
4. When s3 storage is configured with an Openshift serving certificate, an ISVC fails to download the model from s3 storage if the serving ca bundle is not present in the `odh-kserve-custom-ca-bundle` configmap.

Given that the RHOAI/ODH operator are not running for the openshift-ci tests, the `odh-kserve-custom-ca-bundle`  is generated by the odh-model-controller after manually creating a `odh-trusted-ca-bundle` configmap.

In order for these tests to execute successfully some additional setup is required to create and enable the MinIO TLS related resources. The necessary resource manifests have been added to the `test/overlays/openshift-ci/` directory. Additionally, 3 scripts have been added to create and configure these resources:
1. `generate-custom-certs.sh` => creates custom certificates to be utilized for testing
2. `setup-minio-tls-custom-cert.sh` => creates a MinIO service with TLS enabled utilizing a custom certificate.
3. `setup-minio-tls-serving-cert.sh` => creates a MinIO service with TLS enabled utilizing an Openshift serving certificate.

**NOTE**
Given that these tests have a hard requirement on the odh-model-controller running, they should only be executed when tests are run via openshift-ci. To avoid running these tests in other setups, a new `openshift_ci` pytest marker has been added.

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- Run the following command to setup and execute the tests: 
    `SETUP_E2E=true ./test/scripts/openshift-ci/run-e2e-tests.sh openshift_ci`


**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.