### PR TITLE
Back-porting fixes for InferenceGraph 

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -609,8 +609,8 @@ func main() {
 		log.Info("This Router has authorization enabled")
 	}
 
-	http.Handle("/", entrypointHandler)
 	http.HandleFunc(constants.RouterReadinessEndpoint, readyHandler)
+	http.Handle("/", entrypointHandler)
 
 	server := &http.Server{
 		Addr:         ":8080",         // specify the address and port

--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
@@ -128,6 +128,9 @@ func createInferenceGraphPodSpec(graph *v1alpha1.InferenceGraph, config *RouterC
 		podSpec.ServiceAccountName = graph.GetName() + "-auth-verifier"
 	}
 
+	// In ODH, the readiness probe is using HTTPS
+	podSpec.Containers[0].ReadinessProbe.ProbeHandler.HTTPGet.Scheme = corev1.URISchemeHTTPS
+
 	return podSpec
 }
 

--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
@@ -83,6 +83,30 @@ func createInferenceGraphPodSpec(graph *v1alpha1.InferenceGraph, config *RouterC
 						Drop: []corev1.Capability{corev1.Capability("ALL")},
 					},
 				},
+				VolumeMounts: []corev1.VolumeMount{
+					{
+						Name:      "openshift-service-ca-bundle",
+						MountPath: "/etc/odh/openshift-service-ca-bundle",
+					},
+				},
+				Env: []corev1.EnvVar{
+					{
+						Name:  "SSL_CERT_FILE",
+						Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
+					},
+				},
+			},
+		},
+		Volumes: []corev1.Volume{
+			{
+				Name: "openshift-service-ca-bundle",
+				VolumeSource: corev1.VolumeSource{
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: constants.OpenShiftServiceCaConfigMapName,
+						},
+					},
+				},
 			},
 		},
 		Affinity:                     graph.Spec.Affinity,
@@ -98,12 +122,12 @@ func createInferenceGraphPodSpec(graph *v1alpha1.InferenceGraph, config *RouterC
 	// Only adding this env variable "PROPAGATE_HEADERS" if router's headers config has the key "propagate"
 	value, exists := config.Headers["propagate"]
 	if exists {
-		podSpec.Containers[0].Env = []corev1.EnvVar{
-			{
-				Name:  constants.RouterHeadersPropagateEnvVar,
-				Value: strings.Join(value, ","),
-			},
+		propagateEnv := corev1.EnvVar{
+			Name:  constants.RouterHeadersPropagateEnvVar,
+			Value: strings.Join(value, ","),
 		}
+
+		podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, propagateEnv)
 	}
 
 	// If auth is enabled for the InferenceGraph:

--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig_test.go
@@ -220,6 +220,30 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 							Drop: []corev1.Capability{corev1.Capability("ALL")},
 						},
 					},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "openshift-service-ca-bundle",
+							MountPath: "/etc/odh/openshift-service-ca-bundle",
+						},
+					},
+					Env: []v1.EnvVar{
+						{
+							Name:  "SSL_CERT_FILE",
+							Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
+						},
+					},
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "openshift-service-ca-bundle",
+					VolumeSource: v1.VolumeSource{
+						ConfigMap: &v1.ConfigMapVolumeSource{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: constants.OpenShiftServiceCaConfigMapName,
+							},
+						},
+					},
 				},
 			},
 			AutomountServiceAccountToken: proto.Bool(false),
@@ -237,6 +261,10 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 						"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.exmaple.com\"}]}},\"resources\":{}}",
 					},
 					Env: []corev1.EnvVar{
+						{
+							Name:  "SSL_CERT_FILE",
+							Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
+						},
 						{
 							Name:  "PROPAGATE_HEADERS",
 							Value: "Authorization,Intuit_tid",
@@ -260,6 +288,24 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 						AllowPrivilegeEscalation: proto.Bool(false),
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{corev1.Capability("ALL")},
+						},
+					},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "openshift-service-ca-bundle",
+							MountPath: "/etc/odh/openshift-service-ca-bundle",
+						},
+					},
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "openshift-service-ca-bundle",
+					VolumeSource: v1.VolumeSource{
+						ConfigMap: &v1.ConfigMapVolumeSource{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: constants.OpenShiftServiceCaConfigMapName,
+							},
 						},
 					},
 				},
@@ -296,6 +342,30 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 						AllowPrivilegeEscalation: proto.Bool(false),
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{corev1.Capability("ALL")},
+						},
+					},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "openshift-service-ca-bundle",
+							MountPath: "/etc/odh/openshift-service-ca-bundle",
+						},
+					},
+					Env: []v1.EnvVar{
+						{
+							Name:  "SSL_CERT_FILE",
+							Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
+						},
+					},
+				},
+			},
+			Volumes: []v1.Volume{
+				{
+					Name: "openshift-service-ca-bundle",
+					VolumeSource: v1.VolumeSource{
+						ConfigMap: &v1.ConfigMapVolumeSource{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: constants.OpenShiftServiceCaConfigMapName,
+							},
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is fixing InferenceGraph issues found while writing platform tests for [RHOAIENG-24595](https://issues.redhat.com/browse/RHOAIENG-24595).

* Pull request #581 is cherry-picked. These changes are missing in `master` and are required for Raw IGs to work correctly. Changes are to trust OpenShift Serving certificates.
* Commit fb72945f adapts the readiness probe of kserve-router. This readiness probe was recently added in `kserve/kserve`. Since in ODH project the kserve-router workload is secured with TLS, the readiness probe must be configured to use HTTPS. Also, when the IG is auth-protected, the readiness probe endpoint should stay unprotected.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixing under the scope of https://issues.redhat.com/browse/RHOAIENG-24595.

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

