### PR TITLE
Fix the tag replacement in params.env for the v0.15 branch 

### DIFF
--- a/.github/workflows/odh-create-release-tag.yml
+++ b/.github/workflows/odh-create-release-tag.yml
@@ -61,7 +61,7 @@ jobs:
               
       - name: Update params.env with new release version
         run: |     
-          sed -i 's|:latest|:${{ github.event.inputs.tag_name }}|gm' config/overlays/odh/params.env
+          sed -i 's|:v[0-9.]*\b-latest|:${{ github.event.inputs.tag_name }}|gm' config/overlays/odh/params.env
       - name: Commit changes
         run: |
           git config --global user.email "github-actions@github.com"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: The sed command in the release is looking for the tag "latest" in the params.env file. But the release branch uses the "v0.15-latest" tag. This is causing the tag to not be replaced with the odh release value

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.