### PR TITLE
Remove extra step that printed the old tag

### DIFF
--- a/.github/workflows/odh-create-release-tag.yml
+++ b/.github/workflows/odh-create-release-tag.yml
@@ -22,8 +22,6 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: 0
       
-      - name: Get latest tag
-        id: get_tag
       - name: print tag
         id: print_tag
         run: | 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Gathering and printing the old tag was removed since the value wasn't being used. The removal introduced a formatting error in the workflow. This PR completely removes the step to fix the issue

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.