### PR TITLE
[RHOAIENG-26152] created-fvt-test-for-knative-feature-schedulername

### DIFF
--- a/docs/odh/fvt-tests.md
+++ b/docs/odh/fvt-tests.md
@@ -81,21 +81,23 @@ export KSERVE_CONTROLLER_IMAGE=${KO_DOCKER_REPO}/kserve-controller:${TAG}
 
 4. Set environment variables
 
-   1. `$ export RUNNING_LOCAL=true`
-   2. For Graph tests:  
-      `$ export BUILD_GRAPH_IMAGES=true` will build images, false, to not build images, defaults to true  
-      `$ export QUAY_REPO=quay.io/<your_username>` to push images to quay  
-      `$ export BUILDER=podman` to use podman BUILDER=docker to use docker, defaults to docker  
-      `$ export ERROR_404_ISVC_IMAGE=$QUAY_REPO/kserve/error-404-isvc:latest`  
-      `$ export SUCCESS_200_ISVC_IMAGE=$QUAY_REPO/kserve/success-200-isvc:latest`
+**NOTE** To build kserve images `$ export BUILD_KSERVE_IMAGES=true`
 
-5. Run fvt tests
+1.  `$ export RUNNING_LOCAL=true`
+2.  For Graph tests:  
+    `$ export BUILD_GRAPH_IMAGES=true` will build images, false, to not build images, defaults to true  
+    `$ export QUAY_REPO=quay.io/<your_username>` to push images to quay  
+    `$ export BUILDER=podman` to use podman BUILDER=docker to use docker, defaults to docker  
+    `$ export ERROR_404_ISVC_IMAGE=$QUAY_REPO/kserve/error-404-isvc:latest`  
+    `$ export SUCCESS_200_ISVC_IMAGE=$QUAY_REPO/kserve/success-200-isvc:latest`
 
-   1. Run the e2e test script (includes setup commands inside)
+3.  Run fvt tests
 
-   $ cd ../../
+    1.  Run the e2e test script (includes setup commands inside)
 
-   $ ./test/scripts/openshift-ci/run-e2e-tests.sh \<marker\>
+    $ cd ../../
+
+    $ ./test/scripts/openshift-ci/run-e2e-tests.sh \<marker\>
 
 Ex: $ SETUP_E2E=true ./test/scripts/openshift-ci/run-e2e-tests.sh predictor
 

--- a/python/kserve/poetry.lock
+++ b/python/kserve/poetry.lock
@@ -803,6 +803,23 @@ files = [
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
+name = "colorlog"
+version = "6.9.0"
+description = "Add colours to the output of Python's logging module."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "colorlog-6.9.0-py3-none-any.whl", hash = "sha256:5906e71acd67cb07a71e779c47c4bcb45fb8c2993eebe9e5adcd6a6f1b283eff"},
+    {file = "colorlog-6.9.0.tar.gz", hash = "sha256:bfba54a1b93b94f54e1f4fe48395725a3d92fd2a4af702f6bd70946bdc0c6ac2"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+development = ["black", "flake8", "mypy", "pytest", "types-colorama"]
+
+[[package]]
 name = "compressed-tensors"
 version = "0.9.3"
 description = "Library for utilization of compressed safetensors of neural network models"
@@ -4434,6 +4451,23 @@ files = [
 ]
 
 [[package]]
+name = "python-simple-logger"
+version = "2.0.13"
+description = "A simple logger for python"
+optional = false
+python-versions = "~=3.9"
+files = [
+    {file = "python_simple_logger-2.0.13.tar.gz", hash = "sha256:24f66784e48f6fa635de9d0d9738e41516adebfb930b4ee88b938ca06bbb18e9"},
+]
+
+[package.dependencies]
+colorlog = ">=6.7.0,<7"
+
+[package.extras]
+dev = ["ipdb (>=0.13.13)", "ipython (>=8.18.1)"]
+tests = ["pytest (>=8.3.5)", "pytest-cov (>=6.1.1)"]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 description = "World timezone definitions, modern and historical"
@@ -5354,6 +5388,19 @@ requests = ">=2.26.0"
 
 [package.extras]
 blobfile = ["blobfile (>=2)"]
+
+[[package]]
+name = "timeout-sampler"
+version = "1.0.3"
+description = "Timeout utility class to wait for any function output and interact with it in given time"
+optional = false
+python-versions = "<4.0,>=3.9"
+files = [
+    {file = "timeout_sampler-1.0.3.tar.gz", hash = "sha256:e07826c346fc591422fc94664c776c139341198edefde69d25732893c4f09188"},
+]
+
+[package.dependencies]
+python-simple-logger = ">=1.0.8"
 
 [[package]]
 name = "timing-asgi"
@@ -6431,4 +6478,4 @@ storage = ["azure-identity", "azure-storage-blob", "azure-storage-file-share", "
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "eea3b437e01ce0e3b957c4c37e183f25f9185f662d32895ce0241eeee84c1873"
+content-hash = "c069ef41c6a2480216480bbd802df54cea7b919330ac5aa01322aecbe36013dc"

--- a/python/kserve/pyproject.toml
+++ b/python/kserve/pyproject.toml
@@ -105,6 +105,7 @@ avro = "^1.11.0"
 tomlkit = "^0.12.0"
 jinja2 = "^3.1.4"
 grpcio-testing = "^1.60.0"
+timeout-sampler = "^1.0.0"
 
 [tool.poetry.group.dev]
 optional = true

--- a/test/e2e/predictor/test_scheduler_name.py
+++ b/test/e2e/predictor/test_scheduler_name.py
@@ -1,0 +1,104 @@
+# Copyright 2022 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+import pytest
+import logging
+from kubernetes import client
+
+from kubernetes.client import V1ResourceRequirements
+from kserve import KServeClient
+from kserve import constants
+from kserve import V1beta1PredictorSpec
+from kserve import V1beta1InferenceServiceSpec
+from kserve import V1beta1InferenceService
+from kserve.models.v1beta1_sk_learn_spec import V1beta1SKLearnSpec
+
+from ..common.utils import KSERVE_TEST_NAMESPACE
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
+
+
+def get_pods(service_name: str) -> list[client.V1Pod]:
+    pods = kserve_client.core_api.list_namespaced_pod(
+        KSERVE_TEST_NAMESPACE,
+        label_selector=f"serving.kserve.io/inferenceservice={service_name}",
+    )
+    return pods.items
+
+
+@pytest.mark.kserve_on_openshift
+@pytest.mark.asyncio(scope="session")
+async def test_scheduler_name(rest_v1_client):
+    scheduler_name = "kserve-scheduler"
+    service_name = "isvc-sklearn"
+    logger.info("Creating InferenceService %s", service_name)
+
+    predictor = V1beta1PredictorSpec(
+        scheduler_name=scheduler_name,  # This scheduler doesn't exist, but pods should still be created
+        min_replicas=1,
+        sklearn=V1beta1SKLearnSpec(
+            storage_uri="gs://kfserving-examples/models/sklearn/1.0/model",
+            resources=V1ResourceRequirements(
+                requests={"cpu": "50m", "memory": "128Mi"},
+                limits={"cpu": "100m", "memory": "256Mi"},
+            ),
+        ),
+    )
+
+    isvc = V1beta1InferenceService(
+        api_version=constants.KSERVE_V1BETA1,
+        kind=constants.KSERVE_KIND_INFERENCESERVICE,
+        metadata=client.V1ObjectMeta(
+            name=service_name,
+            namespace=KSERVE_TEST_NAMESPACE,
+            annotations={
+                "serving.kserve.io/autoscalerClass": "none"  # Adding autoscaler annotation
+            },
+        ),
+        spec=V1beta1InferenceServiceSpec(predictor=predictor),
+    )
+
+    kserve_client.create(isvc)
+    isvc = kserve_client.get(service_name, KSERVE_TEST_NAMESPACE)
+
+    assert (
+        isvc["spec"]["predictor"]["schedulerName"] == scheduler_name
+    ), f"Expected scheduler name '{scheduler_name}', got {isvc['spec']['predictor'].get('schedulerName')}"
+
+    try:
+        for pods in TimeoutSampler(
+            wait_timeout=30,
+            sleep=2,
+            func=lambda: get_pods(service_name),
+        ):
+            if len(pods) > 0:
+                break
+
+        pods = get_pods(service_name)
+        for pod in pods:
+            assert pod.spec.scheduler_name == scheduler_name, (
+                f"Pod {pod.metadata.name} scheduler name {pod.spec.scheduler_name} "
+                f"does not match expected value '{scheduler_name}'"
+            )
+            kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
+    except TimeoutExpiredError as e:
+        logger.error("Timeout waiting for pods to be created")
+        raise e

--- a/test/e2e/predictor/test_scheduler_name.py
+++ b/test/e2e/predictor/test_scheduler_name.py
@@ -98,7 +98,7 @@ async def test_scheduler_name(rest_v1_client):
                 f"Pod {pod.metadata.name} scheduler name {pod.spec.scheduler_name} "
                 f"does not match expected value '{scheduler_name}'"
             )
-            kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
+        kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
     except TimeoutExpiredError as e:
         logger.error("Timeout waiting for pods to be created")
         raise e

--- a/test/scripts/openshift-ci/deploy.serverless.sh
+++ b/test/scripts/openshift-ci/deploy.serverless.sh
@@ -116,6 +116,7 @@ spec:
       kubernetes.podspec-persistent-volume-claim: enabled
       kubernetes.podspec-persistent-volume-write: enabled
       kubernetes.podspec-tolerations: enabled
+      kubernetes.podspec-schedulername: enabled
     istio:
       local-gateway.knative-serving.knative-local-gateway: knative-local-gateway.istio-system.svc.cluster.local
   controller-custom-certs:


### PR DESCRIPTION
[RHOAIENG-26152](https://issues.redhat.com//browse/RHOAIENG-26152)-created-fvt-test-for-knative-feature-schedulername


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adding new FVT test for testing knative feature flag for schedulername for pods.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.
Created new test

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Run FVT tests with pytest marker kserve_on_openshift

- Logs
```

predictor/test_scheduler_name.py::test_scheduler_name 
[gw0] [100%] PASSED predictor/test_scheduler_name.py::test_scheduler_name 

=============================== warnings summary ===============================
<frozen importlib._bootstrap>:488
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: Type google._upb._message.MessageMapContainer uses PyType_Spec with a metaclass that has custom tp_new. This is deprecated and will no longer be allowed in Python 3.14.

<frozen importlib._bootstrap>:488
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: Type google._upb._message.ScalarMapContainer uses PyType_Spec with a metaclass that has custom tp_new. This is deprecated and will no longer be allowed in Python 3.14.

predictor/test_scheduler_name.py:49
  /home/allausas/workspace/github/forks/odh/kserve/test/e2e/predictor/test_scheduler_name.py:49: PytestUnknownMarkWarning: Unknown pytest.mark.andres_test - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.andres_test

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================== 1 passed, 3 skipped, 5 warnings in 4.18s ===================
```

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an end-to-end test to verify support for custom scheduler names in KServe InferenceService pods.

- **Documentation**
  - Improved clarity and organization of instructions for setting environment variables and running functional verification tests locally.

- **Chores**
  - Added the `timeout-sampler` dependency for testing.
  - Enabled the feature flag for custom scheduler names in OpenShift Serverless deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->