### PR TITLE
[Cherry pick v0.14] Stop and resume a model by adding a new annotation 

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service.go
+++ b/pkg/apis/serving/v1beta1/inference_service.go
@@ -17,11 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"strings"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/kserve/kserve/pkg/constants"
 )
 
 // InferenceServiceSpec is the top level type for this resource
@@ -121,16 +117,4 @@ type InferenceServiceList struct {
 
 func init() {
 	SchemeBuilder.Register(&InferenceService{}, &InferenceServiceList{})
-}
-
-func (isvc *InferenceService) GetForceStopRuntime() bool {
-	forceStopRuntime := false
-	if isvc == nil || isvc.Annotations == nil {
-		return forceStopRuntime
-	}
-	if val, exist := isvc.Annotations[constants.StopAnnotationKey]; exist {
-		forceStopRuntime = strings.EqualFold(val, "true")
-	}
-
-	return forceStopRuntime
 }

--- a/pkg/apis/serving/v1beta1/inference_service.go
+++ b/pkg/apis/serving/v1beta1/inference_service.go
@@ -17,7 +17,11 @@ limitations under the License.
 package v1beta1
 
 import (
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kserve/kserve/pkg/constants"
 )
 
 // InferenceServiceSpec is the top level type for this resource
@@ -117,4 +121,16 @@ type InferenceServiceList struct {
 
 func init() {
 	SchemeBuilder.Register(&InferenceService{}, &InferenceServiceList{})
+}
+
+func (isvc *InferenceService) GetForceStopRuntime() bool {
+	forceStopRuntime := false
+	if isvc == nil || isvc.Annotations == nil {
+		return forceStopRuntime
+	}
+	if val, exist := isvc.Annotations[constants.StopAnnotationKey]; exist {
+		forceStopRuntime = strings.EqualFold(val, "true")
+	}
+
+	return forceStopRuntime
 }

--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -123,6 +123,8 @@ const (
 	RoutesReady apis.ConditionType = "RoutesReady"
 	// LatestDeploymentReady is set when underlying configurations for all components have reported readiness.
 	LatestDeploymentReady apis.ConditionType = "LatestDeploymentReady"
+	// Stopped is set when the inference service has been stopped and all related objects are deleted
+	Stopped apis.ConditionType = "Stopped"
 )
 
 type ModelStatus struct {

--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -196,6 +196,9 @@ const (
 	FailedToLoad ModelState = "FailedToLoad"
 )
 
+// Stopped Inference Service reason
+const StoppedISVCReason = "Stopped"
+
 // FailureReason enum
 // +kubebuilder:validation:Enum=ModelLoadFailed;RuntimeUnhealthy;RuntimeDisabled;NoSupportingRuntime;RuntimeNotRecognized;InvalidPredictorSpec
 type FailureReason string

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -93,6 +93,7 @@ var (
 	InitialScaleAnnotationKey                   = KnativeAutoscalingAPIGroupName + "/initial-scale"
 	MinScaleAnnotationKey                       = KnativeAutoscalingAPIGroupName + "/min-scale"
 	MaxScaleAnnotationKey                       = KnativeAutoscalingAPIGroupName + "/max-scale"
+	StopAnnotationKey                           = KServeAPIGroupName + "/stop"
 	RollOutDurationAnnotationKey                = KnativeServingAPIGroupName + "/rollout-duration"
 	KnativeOpenshiftEnablePassthroughKey        = "serving.knative.openshift.io/enablePassthrough"
 	EnableMetricAggregation                     = KServeAPIGroupName + "/enable-metric-aggregation"

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -393,7 +393,9 @@ func (p *Predictor) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 		if err != nil {
 			return ctrl.Result{}, errors.Wrapf(err, "fails to reconcile predictor")
 		}
-		isvc.Status.PropagateRawStatus(v1beta1.PredictorComponent, deploymentList, r.URL)
+		if !utils.GetForceStopRuntime(isvc) {
+			isvc.Status.PropagateRawStatus(v1beta1.PredictorComponent, deploymentList, r.URL)
+		}
 	} else {
 		podLabelKey = constants.RevisionLabel
 		r, err := knative.NewKsvcReconciler(p.client, p.scheme, objectMeta, &isvc.Spec.Predictor.ComponentExtensionSpec,
@@ -410,46 +412,50 @@ func (p *Predictor) Reconcile(isvc *v1beta1.InferenceService) (ctrl.Result, erro
 		if err != nil {
 			return ctrl.Result{}, errors.Wrapf(err, "fails to reconcile predictor")
 		}
-		if !isvc.GetForceStopRuntime() {
+		if !utils.GetForceStopRuntime(isvc) {
 			isvc.Status.PropagateStatus(v1beta1.PredictorComponent, kstatus)
 		}
-		if isvc.GetForceStopRuntime() {
-			// Exit early if we have already set the status to stopped
-			existing_stopped_condition := isvc.Status.GetCondition(v1beta1.Stopped)
-			if existing_stopped_condition != nil && existing_stopped_condition.Status == v1.ConditionTrue {
-				return ctrl.Result{}, nil
-			}
+	}
 
-			deployMode := isvc.Status.DeploymentMode
-
-			// Clear all statuses
-			isvc.Status = v1beta1.InferenceServiceStatus{}
-
-			// Preserve the deployment mode value
-			isvc.Status.DeploymentMode = deployMode
-
-			// Set the ready condition
-			predictor_ready_condition := &apis.Condition{
-				Type:   v1beta1.PredictorReady,
-				Status: v1.ConditionFalse,
-			}
-			isvc.Status.SetCondition(v1beta1.PredictorReady, predictor_ready_condition)
-
-			// Add the stopped condition
-			stopped_condition := &apis.Condition{
-				Type:   v1beta1.Stopped,
-				Status: v1.ConditionTrue,
-			}
-			isvc.Status.SetCondition(v1beta1.Stopped, stopped_condition)
-
+	// Handle InferenceService status updates based on the force stop annotation.
+	// If true, transition the service to a stopped and unready state; otherwise, ensure it's not marked as stopped.
+	if utils.GetForceStopRuntime(isvc) {
+		// Exit early if we have already set the status to stopped
+		existingStoppedCondition := isvc.Status.GetCondition(v1beta1.Stopped)
+		if existingStoppedCondition != nil && existingStoppedCondition.Status == v1.ConditionTrue {
 			return ctrl.Result{}, nil
-		} else {
-			resume_condition := &apis.Condition{
-				Type:   v1beta1.Stopped,
-				Status: v1.ConditionFalse,
-			}
-			isvc.Status.SetCondition(v1beta1.Stopped, resume_condition)
 		}
+
+		deployMode := isvc.Status.DeploymentMode
+
+		// Clear all statuses
+		isvc.Status = v1beta1.InferenceServiceStatus{}
+
+		// Preserve the deployment mode value
+		isvc.Status.DeploymentMode = deployMode
+
+		// Set the ready condition
+		predictorReadyCondition := &apis.Condition{
+			Type:   v1beta1.PredictorReady,
+			Status: v1.ConditionFalse,
+			Reason: v1beta1.StoppedISVCReason,
+		}
+		isvc.Status.SetCondition(v1beta1.PredictorReady, predictorReadyCondition)
+
+		// Add the stopped condition
+		stoppedCondition := &apis.Condition{
+			Type:   v1beta1.Stopped,
+			Status: v1.ConditionTrue,
+		}
+		isvc.Status.SetCondition(v1beta1.Stopped, stoppedCondition)
+
+		return ctrl.Result{}, nil
+	} else {
+		resumeCondition := &apis.Condition{
+			Type:   v1beta1.Stopped,
+			Status: v1.ConditionFalse,
+		}
+		isvc.Status.SetCondition(v1beta1.Stopped, resumeCondition)
 	}
 
 	statusSpec := isvc.Status.Components[v1beta1.PredictorComponent]

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -238,8 +238,10 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if isvc.Spec.Explainer != nil {
 			componentList = append(componentList, v1beta1api.ExplainerComponent)
 		}
-		isvc.Status.PropagateCrossComponentStatus(componentList, v1beta1api.RoutesReady)
-		isvc.Status.PropagateCrossComponentStatus(componentList, v1beta1api.LatestDeploymentReady)
+		if !isvc.GetForceStopRuntime() {
+			isvc.Status.PropagateCrossComponentStatus(componentList, v1beta1api.RoutesReady)
+			isvc.Status.PropagateCrossComponentStatus(componentList, v1beta1api.LatestDeploymentReady)
+		}
 	}
 	// Reconcile ingress
 	ingressConfig, err := v1beta1api.NewIngressConfig(r.Clientset)

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -238,7 +238,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if isvc.Spec.Explainer != nil {
 			componentList = append(componentList, v1beta1api.ExplainerComponent)
 		}
-		if !isvc.GetForceStopRuntime() {
+		if !utils.GetForceStopRuntime(isvc) {
 			isvc.Status.PropagateCrossComponentStatus(componentList, v1beta1api.RoutesReady)
 			isvc.Status.PropagateCrossComponentStatus(componentList, v1beta1api.LatestDeploymentReady)
 		}

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -791,14 +791,14 @@ var _ = Describe("v1beta1 inference service controller", func() {
 		defaultIsvc := func(namespace string, name string, storageUri string) *v1beta1.InferenceService {
 			predictor := v1beta1.PredictorSpec{
 				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
-					MinReplicas: ptr.To(int32(1)),
+					MinReplicas: v1beta1.GetIntReference(1),
 					MaxReplicas: 3,
 				},
 				Tensorflow: &v1beta1.TFServingSpec{
 					PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
 						StorageURI:     &storageUri,
 						RuntimeVersion: proto.String("1.14.0"),
-						Container: corev1.Container{
+						Container: v1.Container{
 							Name:      constants.InferenceServiceContainerName,
 							Resources: defaultResource,
 						},
@@ -837,7 +837,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						},
 					},
 					ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
-						Containers: []corev1.Container{
+						Containers: []v1.Container{
 							{
 								Name:    constants.InferenceServiceContainerName,
 								Image:   "tensorflow/serving:1.14.0",
@@ -851,7 +851,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 								Resources: defaultResource,
 							},
 						},
-						ImagePullSecrets: []corev1.LocalObjectReference{
+						ImagePullSecrets: []v1.LocalObjectReference{
 							{Name: "sr-image-pull-secret"},
 						},
 					},
@@ -861,8 +861,8 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			return servingRuntime
 		}
 
-		createInferenceServiceConfigMap := func() *corev1.ConfigMap {
-			configMap := &corev1.ConfigMap{
+		createInferenceServiceConfigMap := func() *v1.ConfigMap {
+			configMap := &v1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      constants.InferenceServiceConfigMapName,
 					Namespace: constants.KServeNamespace,
@@ -947,7 +947,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Should(BeTrue())
 
 			// Check that the service is present
-			service := &corev1.Service{}
+			service := &v1.Service{}
 			Eventually(func() bool {
 				err := k8sClient.Get(context.TODO(), serviceKey, service)
 				return err == nil
@@ -959,7 +959,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
 				if err == nil {
 					stopped_cond := updatedIsvc.Status.GetCondition(v1beta1.Stopped)
-					if stopped_cond != nil && stopped_cond.Status == corev1.ConditionFalse {
+					if stopped_cond != nil && stopped_cond.Status == v1.ConditionFalse {
 						return true
 					}
 				}
@@ -973,7 +973,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					return false
 				}
 				readyCond := updatedIsvc.Status.GetCondition(v1beta1.PredictorReady)
-				return readyCond != nil && readyCond.Status == corev1.ConditionTrue
+				return readyCond != nil && readyCond.Status == v1.ConditionTrue
 			}, timeout, interval).Should(BeTrue(), "The predictor should be ready")
 
 			Eventually(func() bool {
@@ -982,7 +982,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					return false
 				}
 				readyCond := updatedIsvc.Status.GetCondition(v1beta1.IngressReady)
-				return readyCond != nil && readyCond.Status == corev1.ConditionTrue
+				return readyCond != nil && readyCond.Status == v1.ConditionTrue
 			}, timeout, interval).Should(BeTrue(), "The ingress should be ready")
 		})
 
@@ -1032,7 +1032,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Should(BeTrue(), "The virtual service should not be created")
 
 			// Check that the service was not created
-			service := &corev1.Service{}
+			service := &v1.Service{}
 			Consistently(func() bool {
 				err := k8sClient.Get(context.TODO(), serviceKey, service)
 				return apierr.IsNotFound(err)
@@ -1050,7 +1050,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
 				if err == nil {
 					stopped_cond := updatedIsvc.Status.GetCondition(v1beta1.Stopped)
-					if stopped_cond != nil && stopped_cond.Status == corev1.ConditionTrue {
+					if stopped_cond != nil && stopped_cond.Status == v1.ConditionTrue {
 						return true
 					}
 				}
@@ -1133,7 +1133,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Should(BeTrue())
 
 			// Check that the service is present
-			service := &corev1.Service{}
+			service := &v1.Service{}
 			Eventually(func() bool {
 				err := k8sClient.Get(context.TODO(), serviceKey, service)
 				return err == nil
@@ -1147,7 +1147,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					return false
 				}
 				readyCond := actualIsvc.Status.GetCondition(v1beta1.PredictorReady)
-				return readyCond != nil && readyCond.Status == corev1.ConditionTrue
+				return readyCond != nil && readyCond.Status == v1.ConditionTrue
 			}, timeout, interval).Should(BeTrue(), "The predictor should be ready before updating the annotation")
 
 			Eventually(func() bool {
@@ -1156,7 +1156,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					return false
 				}
 				readyCond := actualIsvc.Status.GetCondition(v1beta1.IngressReady)
-				return readyCond != nil && readyCond.Status == corev1.ConditionTrue
+				return readyCond != nil && readyCond.Status == v1.ConditionTrue
 			}, timeout, interval).Should(BeTrue(), "The ingress should be ready before updating the annotation")
 
 			// Stop the inference service
@@ -1195,7 +1195,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				err := k8sClient.Get(ctx, serviceKey, updatedStoppedIsvc)
 				if err == nil {
 					stopped_cond := updatedStoppedIsvc.Status.GetCondition(v1beta1.Stopped)
-					if stopped_cond != nil && stopped_cond.Status == corev1.ConditionTrue {
+					if stopped_cond != nil && stopped_cond.Status == v1.ConditionTrue {
 						return true
 					}
 				}
@@ -1249,7 +1249,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Should(BeTrue(), "The virtual service should not be created")
 
 			// Check that the service was not created
-			service := &corev1.Service{}
+			service := &v1.Service{}
 			Consistently(func() bool {
 				err := k8sClient.Get(context.TODO(), serviceKey, service)
 				return apierr.IsNotFound(err)
@@ -1267,7 +1267,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				err := k8sClient.Get(ctx, serviceKey, actualIsvc)
 				if err == nil {
 					stopped_cond := actualIsvc.Status.GetCondition(v1beta1.Stopped)
-					if stopped_cond != nil && stopped_cond.Status == corev1.ConditionTrue {
+					if stopped_cond != nil && stopped_cond.Status == v1.ConditionTrue {
 						return true
 					}
 				}
@@ -1326,7 +1326,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
 				if err == nil {
 					stopped_cond := updatedIsvc.Status.GetCondition(v1beta1.Stopped)
-					if stopped_cond != nil && stopped_cond.Status == corev1.ConditionFalse {
+					if stopped_cond != nil && stopped_cond.Status == v1.ConditionFalse {
 						return true
 					}
 				}
@@ -1340,7 +1340,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					return false
 				}
 				readyCond := actualIsvc.Status.GetCondition(v1beta1.PredictorReady)
-				return readyCond != nil && readyCond.Status == corev1.ConditionTrue
+				return readyCond != nil && readyCond.Status == v1.ConditionTrue
 			}, timeout, interval).Should(BeTrue(), "The predictor should be ready")
 
 			Eventually(func() bool {
@@ -1349,7 +1349,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					return false
 				}
 				readyCond := actualIsvc.Status.GetCondition(v1beta1.IngressReady)
-				return readyCond != nil && readyCond.Status == corev1.ConditionTrue
+				return readyCond != nil && readyCond.Status == v1.ConditionTrue
 			}, timeout, interval).Should(BeTrue(), "The ingress should be ready")
 		})
 	})

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -787,6 +787,573 @@ var _ = Describe("v1beta1 inference service controller", func() {
 		})
 	})
 
+	Context("When creating inference service with `serving.kserve.io/stop`", func() {
+		defaultIsvc := func(namespace string, name string, storageUri string) *v1beta1.InferenceService {
+			predictor := v1beta1.PredictorSpec{
+				ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+					MinReplicas: ptr.To(int32(1)),
+					MaxReplicas: 3,
+				},
+				Tensorflow: &v1beta1.TFServingSpec{
+					PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+						StorageURI:     &storageUri,
+						RuntimeVersion: proto.String("1.14.0"),
+						Container: corev1.Container{
+							Name:      constants.InferenceServiceContainerName,
+							Resources: defaultResource,
+						},
+					},
+				},
+			}
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode": "Serverless",
+					},
+				},
+
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: predictor,
+				},
+			}
+			return isvc
+		}
+
+		createServingRuntime := func(namespace string, name string) *v1alpha1.ServingRuntime {
+			// Define and create serving runtime
+			servingRuntime := &v1alpha1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.ServingRuntimeSpec{
+					SupportedModelFormats: []v1alpha1.SupportedModelFormat{
+						{
+							Name:       "tensorflow",
+							Version:    proto.String("1"),
+							AutoSelect: proto.Bool(true),
+						},
+					},
+					ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:    constants.InferenceServiceContainerName,
+								Image:   "tensorflow/serving:1.14.0",
+								Command: []string{"/usr/bin/tensorflow_model_server"},
+								Args: []string{
+									"--port=9000",
+									"--rest_api_port=8080",
+									"--model_base_path=/mnt/models",
+									"--rest_api_timeout_in_ms=60000",
+								},
+								Resources: defaultResource,
+							},
+						},
+						ImagePullSecrets: []corev1.LocalObjectReference{
+							{Name: "sr-image-pull-secret"},
+						},
+					},
+					Disabled: proto.Bool(false),
+				},
+			}
+			return servingRuntime
+		}
+
+		createInferenceServiceConfigMap := func() *corev1.ConfigMap {
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: configs,
+			}
+			return configMap
+		}
+
+		It("Should keep the knative service/virtualService/service when the annotation is set to false", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+
+			// Config map
+			configMap := createInferenceServiceConfigMap()
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, configMap)
+
+			// Serving runtime
+			serviceName := "stop-false-isvc"
+			serviceNamespace := "default"
+			expectedRequest := reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: serviceNamespace}}
+			serviceKey := expectedRequest.NamespacedName
+			storageUri := "s3://test/mnist/export"
+
+			servingRuntime := createServingRuntime(serviceKey.Namespace, "tf-serving")
+			Expect(k8sClient.Create(context.TODO(), servingRuntime)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, servingRuntime)
+
+			// Define InferenceService
+			isvc := defaultIsvc(serviceKey.Namespace, serviceKey.Name, storageUri)
+			isvc.Annotations[constants.StopAnnotationKey] = "false"
+			Expect(k8sClient.Create(context.TODO(), isvc)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, isvc)
+
+			// Knative service
+			actualService := &knservingv1.Service{}
+			predictorServiceKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace,
+			}
+			Eventually(func() bool {
+				err := k8sClient.Get(context.TODO(), predictorServiceKey, actualService)
+				return err == nil
+			}, 30*time.Second).Should(BeTrue())
+
+			// Add a url to the knative service so the services can be made
+			copiedKsvc := actualService.DeepCopy()
+			predictorUrl, _ := apis.ParseURL("http://" + constants.InferenceServiceHostName(constants.DefaultPredictorServiceName(serviceKey.Name), serviceKey.Namespace, domain))
+			copiedKsvc.Status.URL = predictorUrl
+			copiedKsvc.Status.Conditions = duckv1.Conditions{
+				{
+					Type:   knservingv1.ServiceConditionReady,
+					Status: "True",
+				},
+				{
+					Type:   knservingv1.ServiceConditionRoutesReady,
+					Status: "True",
+				},
+				{
+					Type:   knservingv1.ServiceConditionConfigurationsReady,
+					Status: "True",
+				},
+			}
+			copiedKsvc.Status.LatestCreatedRevisionName = "revision-v1"
+			copiedKsvc.Status.LatestReadyRevisionName = "revision-v1"
+			Expect(k8sClient.Status().Update(context.TODO(), copiedKsvc)).NotTo(HaveOccurred())
+
+			// Check that the ISVC was updated
+			updatedIsvc := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			// Check that the virtual service is present
+			virtualService := &istioclientv1beta1.VirtualService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(context.TODO(), serviceKey, virtualService)
+				return err == nil
+			}, timeout).
+				Should(BeTrue())
+
+			// Check that the service is present
+			service := &corev1.Service{}
+			Eventually(func() bool {
+				err := k8sClient.Get(context.TODO(), serviceKey, service)
+				return err == nil
+			}, timeout).
+				Should(BeTrue())
+
+			// Check that the stopped condition is false
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				if err == nil {
+					stopped_cond := updatedIsvc.Status.GetCondition(v1beta1.Stopped)
+					if stopped_cond != nil && stopped_cond.Status == corev1.ConditionFalse {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "The stopped condition should be set to false")
+
+			// Check that the inference service is ready
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				if err != nil {
+					return false
+				}
+				readyCond := updatedIsvc.Status.GetCondition(v1beta1.PredictorReady)
+				return readyCond != nil && readyCond.Status == corev1.ConditionTrue
+			}, timeout, interval).Should(BeTrue(), "The predictor should be ready")
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				if err != nil {
+					return false
+				}
+				readyCond := updatedIsvc.Status.GetCondition(v1beta1.IngressReady)
+				return readyCond != nil && readyCond.Status == corev1.ConditionTrue
+			}, timeout, interval).Should(BeTrue(), "The ingress should be ready")
+		})
+
+		It("Should delete the knative service/virtualService/service when the annotation is set to true", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+
+			// Config map
+			configMap := createInferenceServiceConfigMap()
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, configMap)
+
+			// Serving runtime
+			serviceName := "stop-true-isvc"
+			serviceNamespace := "default"
+			expectedRequest := reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: serviceNamespace}}
+			serviceKey := expectedRequest.NamespacedName
+			storageUri := "s3://test/mnist/export"
+
+			servingRuntime := createServingRuntime(serviceKey.Namespace, "tf-serving")
+			Expect(k8sClient.Create(context.TODO(), servingRuntime)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, servingRuntime)
+
+			// Define InferenceService
+			isvc := defaultIsvc(serviceKey.Namespace, serviceKey.Name, storageUri)
+			isvc.Annotations[constants.StopAnnotationKey] = "true"
+			Expect(k8sClient.Create(context.TODO(), isvc)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, isvc)
+
+			// Check that the KSVC does not exist
+			actualService := &knservingv1.Service{}
+			predictorServiceKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace,
+			}
+			Consistently(func() bool {
+				err := k8sClient.Get(context.TODO(), predictorServiceKey, actualService)
+				return apierr.IsNotFound(err)
+			}, timeout).Should(BeTrue(), "The ksvc should not be created")
+
+			// Check that the virtual service was not created
+			virtualService := &istioclientv1beta1.VirtualService{}
+			Consistently(func() bool {
+				err := k8sClient.Get(context.TODO(), serviceKey, virtualService)
+				return apierr.IsNotFound(err)
+			}, timeout).
+				Should(BeTrue(), "The virtual service should not be created")
+
+			// Check that the service was not created
+			service := &corev1.Service{}
+			Consistently(func() bool {
+				err := k8sClient.Get(context.TODO(), serviceKey, service)
+				return apierr.IsNotFound(err)
+			}, timeout).
+				Should(BeTrue(), "The service should not be created")
+
+			// Check that the ISVC status reflects that it is stopped
+			updatedIsvc := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				if err == nil {
+					stopped_cond := updatedIsvc.Status.GetCondition(v1beta1.Stopped)
+					if stopped_cond != nil && stopped_cond.Status == corev1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "The stopped condition should be set to true")
+		})
+
+		It("Should delete the knative service/virtualService/service when the annotation is updated to true on an existing ISVC", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+
+			// Config map
+			configMap := createInferenceServiceConfigMap()
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, configMap)
+
+			// Serving runtime
+			serviceName := "stop-edit-true-isvc"
+			serviceNamespace := "default"
+			expectedRequest := reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: serviceNamespace}}
+			serviceKey := expectedRequest.NamespacedName
+			storageUri := "s3://test/mnist/export"
+
+			servingRuntime := createServingRuntime(serviceKey.Namespace, "tf-serving")
+			Expect(k8sClient.Create(context.TODO(), servingRuntime)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, servingRuntime)
+
+			// Define InferenceService
+			isvc := defaultIsvc(serviceKey.Namespace, serviceKey.Name, storageUri)
+			isvc.Annotations[constants.StopAnnotationKey] = "false"
+			Expect(k8sClient.Create(context.TODO(), isvc)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, isvc)
+
+			// Knative service
+			actualService := &knservingv1.Service{}
+			predictorServiceKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace,
+			}
+			Eventually(func() bool {
+				err := k8sClient.Get(context.TODO(), predictorServiceKey, actualService)
+				return err == nil
+			}, timeout).
+				Should(BeTrue())
+
+			// Add a url to the knative service so the services can be made
+			copiedKsvc := actualService.DeepCopy()
+			predictorUrl, _ := apis.ParseURL("http://" + constants.InferenceServiceHostName(constants.DefaultPredictorServiceName(serviceKey.Name), serviceKey.Namespace, domain))
+			copiedKsvc.Status.URL = predictorUrl
+			copiedKsvc.Status.Conditions = duckv1.Conditions{
+				{
+					Type:   knservingv1.ServiceConditionReady,
+					Status: "True",
+				},
+				{
+					Type:   knservingv1.ServiceConditionRoutesReady,
+					Status: "True",
+				},
+				{
+					Type:   knservingv1.ServiceConditionConfigurationsReady,
+					Status: "True",
+				},
+			}
+			copiedKsvc.Status.LatestCreatedRevisionName = "revision-v1"
+			copiedKsvc.Status.LatestReadyRevisionName = "revision-v1"
+			Expect(k8sClient.Status().Update(context.TODO(), copiedKsvc)).NotTo(HaveOccurred())
+
+			actualIsvc := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, expectedRequest.NamespacedName, actualIsvc)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			// Check that the virtual service is present
+			virtualService := &istioclientv1beta1.VirtualService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(context.TODO(), serviceKey, virtualService)
+				return err == nil
+			}, timeout).
+				Should(BeTrue())
+
+			// Check that the service is present
+			service := &corev1.Service{}
+			Eventually(func() bool {
+				err := k8sClient.Get(context.TODO(), serviceKey, service)
+				return err == nil
+			}, timeout).
+				Should(BeTrue())
+
+			// Check that the inference service is ready
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, actualIsvc)
+				if err != nil {
+					return false
+				}
+				readyCond := actualIsvc.Status.GetCondition(v1beta1.PredictorReady)
+				return readyCond != nil && readyCond.Status == corev1.ConditionTrue
+			}, timeout, interval).Should(BeTrue(), "The predictor should be ready before updating the annotation")
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, actualIsvc)
+				if err != nil {
+					return false
+				}
+				readyCond := actualIsvc.Status.GetCondition(v1beta1.IngressReady)
+				return readyCond != nil && readyCond.Status == corev1.ConditionTrue
+			}, timeout, interval).Should(BeTrue(), "The ingress should be ready before updating the annotation")
+
+			// Stop the inference service
+			updatedIsvc := actualIsvc.DeepCopy()
+			updatedIsvc.Annotations[constants.StopAnnotationKey] = "true"
+			Expect(k8sClient.Update(ctx, updatedIsvc)).NotTo(HaveOccurred())
+
+			// Check that the KSVC was deleted
+			Eventually(func() bool {
+				err := k8sClient.Get(context.TODO(), predictorServiceKey, actualService)
+				return apierr.IsNotFound(err)
+			}, time.Second*30).Should(BeTrue(), "The ksvc should eventually be deleted")
+
+			// Check that the virtual service is deleted
+			Eventually(func() bool {
+				err := k8sClient.Get(context.TODO(), serviceKey, virtualService)
+				return apierr.IsNotFound(err)
+			}, timeout).
+				Should(BeTrue(), "The virtual service should be deleted")
+
+			// Check that the service is deleted
+			Eventually(func() bool {
+				err := k8sClient.Get(context.TODO(), serviceKey, service)
+				return apierr.IsNotFound(err)
+			}, timeout).
+				Should(BeTrue(), "The service should be deleted")
+
+			// Check that the ISVC status reflects that it is stopped
+			updatedStoppedIsvc := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedStoppedIsvc)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedStoppedIsvc)
+				if err == nil {
+					stopped_cond := updatedStoppedIsvc.Status.GetCondition(v1beta1.Stopped)
+					if stopped_cond != nil && stopped_cond.Status == corev1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "The stopped condition should be set to true")
+		})
+
+		It("Should create the knative service/virtualService/service when the annotation is updated to false on an existing ISVC that is stopped", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+
+			// Config map
+			configMap := createInferenceServiceConfigMap()
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, configMap)
+
+			// Serving runtime
+			serviceName := "stop-edit-false-isvc"
+			serviceNamespace := "default"
+			expectedRequest := reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: serviceNamespace}}
+			serviceKey := expectedRequest.NamespacedName
+			storageUri := "s3://test/mnist/export"
+
+			servingRuntime := createServingRuntime(serviceKey.Namespace, "tf-serving")
+			Expect(k8sClient.Create(context.TODO(), servingRuntime)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, servingRuntime)
+
+			// Define InferenceService
+			isvc := defaultIsvc(serviceKey.Namespace, serviceKey.Name, storageUri)
+			isvc.Annotations[constants.StopAnnotationKey] = "true"
+			Expect(k8sClient.Create(context.TODO(), isvc)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, isvc)
+
+			// Check that the KSVC does not exist
+			actualService := &knservingv1.Service{}
+			predictorServiceKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace,
+			}
+			Consistently(func() bool {
+				err := k8sClient.Get(context.TODO(), predictorServiceKey, actualService)
+				return apierr.IsNotFound(err)
+			}, timeout).Should(BeTrue(), "The ksvc should not be created")
+
+			// Check that the virtual service was not created
+			virtualService := &istioclientv1beta1.VirtualService{}
+			Consistently(func() bool {
+				err := k8sClient.Get(context.TODO(), serviceKey, virtualService)
+				return apierr.IsNotFound(err)
+			}, timeout).
+				Should(BeTrue(), "The virtual service should not be created")
+
+			// Check that the service was not created
+			service := &corev1.Service{}
+			Consistently(func() bool {
+				err := k8sClient.Get(context.TODO(), serviceKey, service)
+				return apierr.IsNotFound(err)
+			}, timeout).
+				Should(BeTrue(), "The service should not be created")
+
+			// Check that the ISVC status reflects that it is stopped
+			actualIsvc := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, actualIsvc)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, actualIsvc)
+				if err == nil {
+					stopped_cond := actualIsvc.Status.GetCondition(v1beta1.Stopped)
+					if stopped_cond != nil && stopped_cond.Status == corev1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "The stopped condition should be set to true")
+
+			// Resume the inference service
+			updatedIsvc := actualIsvc.DeepCopy()
+			updatedIsvc.Annotations[constants.StopAnnotationKey] = "false"
+			Expect(k8sClient.Update(ctx, updatedIsvc)).NotTo(HaveOccurred())
+
+			// Check that the knative service was created
+			Eventually(func() bool {
+				err := k8sClient.Get(context.TODO(), predictorServiceKey, actualService)
+				return err == nil
+			}, 30*time.Second).Should(BeTrue())
+
+			// Add a url to the knative service so the services can be made
+			copiedKsvc := actualService.DeepCopy()
+			predictorUrl, _ := apis.ParseURL("http://" + constants.InferenceServiceHostName(constants.DefaultPredictorServiceName(serviceKey.Name), serviceKey.Namespace, domain))
+			copiedKsvc.Status.URL = predictorUrl
+			copiedKsvc.Status.Conditions = duckv1.Conditions{
+				{
+					Type:   knservingv1.ServiceConditionReady,
+					Status: "True",
+				},
+				{
+					Type:   knservingv1.ServiceConditionRoutesReady,
+					Status: "True",
+				},
+				{
+					Type:   knservingv1.ServiceConditionConfigurationsReady,
+					Status: "True",
+				},
+			}
+			copiedKsvc.Status.LatestCreatedRevisionName = "revision-v1"
+			copiedKsvc.Status.LatestReadyRevisionName = "revision-v1"
+			Expect(k8sClient.Status().Update(context.TODO(), copiedKsvc)).NotTo(HaveOccurred())
+
+			// Check that the virtual service is present
+			Eventually(func() bool {
+				err := k8sClient.Get(context.TODO(), serviceKey, virtualService)
+				return err == nil
+			}, timeout).
+				Should(BeTrue())
+
+			// Check that the service is present
+			Eventually(func() bool {
+				err := k8sClient.Get(context.TODO(), serviceKey, service)
+				return err == nil
+			}, timeout).
+				Should(BeTrue())
+
+			// Check that the stopped condition is false
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				if err == nil {
+					stopped_cond := updatedIsvc.Status.GetCondition(v1beta1.Stopped)
+					if stopped_cond != nil && stopped_cond.Status == corev1.ConditionFalse {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "The stopped condition should be set to false")
+
+			// Check that the inference service is ready
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, actualIsvc)
+				if err != nil {
+					return false
+				}
+				readyCond := actualIsvc.Status.GetCondition(v1beta1.PredictorReady)
+				return readyCond != nil && readyCond.Status == corev1.ConditionTrue
+			}, timeout, interval).Should(BeTrue(), "The predictor should be ready")
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, actualIsvc)
+				if err != nil {
+					return false
+				}
+				readyCond := actualIsvc.Status.GetCondition(v1beta1.IngressReady)
+				return readyCond != nil && readyCond.Status == corev1.ConditionTrue
+			}, timeout, interval).Should(BeTrue(), "The ingress should be ready")
+		})
+	})
+
 	Context("Inference Service with transformer", func() {
 		It("Should create successfully", func() {
 			serviceName := "svc-with-transformer"

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -19,6 +19,7 @@ package inferenceservice
 import (
 	"context"
 	"fmt"
+	"maps"
 	"reflect"
 	"time"
 
@@ -415,6 +416,11 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						{
 							Type:   apis.ConditionReady,
 							Status: "True",
+						},
+						{
+							Type:     v1beta1.Stopped,
+							Status:   "False",
+							Severity: apis.ConditionSeverityInfo,
 						},
 					},
 				},
@@ -1385,6 +1391,819 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				Namespace: serviceKey.Namespace}
 			Consistently(func() error { return k8sClient.Get(context.TODO(), predictorIngressKey, actualIngress) }, timeout).
 				ShouldNot(Succeed())
+		})
+	})
+
+	Context("When creating inference service with raw kube predictor and `serving.kserve.io/stop`", func() {
+		configs := map[string]string{
+			"explainers": `{
+				"alibi": {
+					"image": "kserve/alibi-explainer",
+					"defaultImageVersion": "latest"
+				}
+			}`,
+			"ingress": `{
+				"enableGatewayApi": true,
+				"kserveIngressGateway": "kserve/kserve-ingress-gateway",
+				"ingressGateway": "knative-serving/knative-ingress-gateway",
+				"localGateway": "knative-serving/knative-local-gateway",
+				"localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local",
+				"additionalIngressDomains": ["additional.example.com"]
+			}`,
+			"storageInitializer": `{
+				"image" : "kserve/storage-initializer:latest",
+				"memoryRequest": "100Mi",
+				"memoryLimit": "1Gi",
+				"cpuRequest": "100m",
+				"cpuLimit": "1",
+				"CaBundleConfigMapName": "",
+				"caBundleVolumeMountPath": "/etc/ssl/custom-certs",
+				"enableDirectPvcVolumeMount": false
+			}`,
+		}
+
+		createInferenceServiceConfigMap := func() *v1.ConfigMap {
+			configMap := &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: maps.Clone(configs),
+			}
+			return configMap
+		}
+
+		createServingRuntime := func(namespace string, name string) *v1alpha1.ServingRuntime {
+			servingRuntime := &v1alpha1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+				Spec: v1alpha1.ServingRuntimeSpec{
+					SupportedModelFormats: []v1alpha1.SupportedModelFormat{
+						{
+							Name:       "tensorflow",
+							Version:    proto.String("1"),
+							AutoSelect: proto.Bool(true),
+						},
+					},
+					ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+						Containers: []v1.Container{
+							{
+								Name:    "kserve-container",
+								Image:   "tensorflow/serving:1.14.0",
+								Command: []string{"/usr/bin/tensorflow_model_server"},
+								Args: []string{
+									"--port=9000",
+									"--rest_api_port=8080",
+									"--model_base_path=/mnt/models",
+									"--rest_api_timeout_in_ms=60000",
+								},
+								Resources: defaultResource,
+							},
+						},
+					},
+					Disabled: proto.Bool(false),
+				},
+			}
+
+			return servingRuntime
+		}
+
+		defaultIsvc := func(serviceKey types.NamespacedName, storageUri string, autoscaler string, qty resource.Quantity) *v1beta1.InferenceService {
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceKey.Name,
+					Namespace: serviceKey.Namespace,
+					Annotations: map[string]string{
+						constants.DeploymentMode:  string(constants.RawDeployment),
+						constants.AutoscalerClass: autoscaler,
+					},
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: v1beta1.GetIntReference(1),
+							MaxReplicas: 3,
+						},
+						Tensorflow: &v1beta1.TFServingSpec{
+							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+								StorageURI:     &storageUri,
+								RuntimeVersion: proto.String("1.14.0"),
+								Container: v1.Container{
+									Name:      constants.InferenceServiceContainerName,
+									Resources: defaultResource,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			isvc.DefaultInferenceService(nil, nil, &v1beta1.SecurityConfig{AutoMountServiceAccountToken: false}, nil)
+			return isvc
+		}
+
+		It("Should keep the service/deployment/hpa created when the annotation is set to false", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+
+			// Config map
+			configMap := createInferenceServiceConfigMap()
+			Expect(k8sClient.Create(context.Background(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, configMap)
+
+			// Setup values
+			serviceName := "stop-false-isvc"
+			serviceNamespace := "default"
+			expectedRequest := reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: serviceNamespace}}
+			serviceKey := expectedRequest.NamespacedName
+			storageUri := "s3://test/mnist/export"
+			qty := resource.MustParse("10Gi")
+			predictorKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace,
+			}
+
+			// Serving runtime
+			servingRuntime := createServingRuntime(serviceKey.Namespace, "tf-serving-raw")
+			Expect(k8sClient.Create(context.Background(), servingRuntime)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, servingRuntime)
+
+			// Define InferenceService
+			isvc := defaultIsvc(serviceKey, storageUri, string(constants.AutoscalerClassHPA), qty)
+			isvc.Annotations[constants.StopAnnotationKey] = "false"
+			Expect(k8sClient.Create(context.Background(), isvc)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, isvc)
+
+			actualISVC := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, actualISVC)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			// Check the deployment
+			actualDeployment := &appsv1.Deployment{}
+			Eventually(func() error { return k8sClient.Get(context.Background(), predictorKey, actualDeployment) }, timeout).
+				Should(Succeed())
+
+			updatedDeployment := actualDeployment.DeepCopy()
+			updatedDeployment.Status.Conditions = []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentAvailable,
+					Status: v1.ConditionTrue,
+				},
+			}
+			Expect(k8sClient.Status().Update(context.TODO(), updatedDeployment)).NotTo(HaveOccurred())
+
+			// check the service
+			actualService := &v1.Service{}
+			Eventually(func() error { return k8sClient.Get(context.Background(), predictorKey, actualService) }, timeout).
+				Should(Succeed())
+
+			// check the HPA
+			actualHPA := &autoscalingv2.HorizontalPodAutoscaler{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, predictorKey, actualHPA)
+			}, timeout).Should(Succeed())
+
+			// Check that the ISVC was updated
+			updatedIsvc := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			// Check that the stopped condition is false
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				if err == nil {
+					stopped_cond := updatedIsvc.Status.GetCondition(v1beta1.Stopped)
+					if stopped_cond != nil && stopped_cond.Status == v1.ConditionFalse {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "The stopped condition should be set to false")
+
+			// Check that the inference service is ready
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				if err != nil {
+					return false
+				}
+				return updatedIsvc.Status.IsConditionReady(v1beta1.PredictorReady)
+			}, timeout, interval).Should(BeTrue(), "The predictor should be ready")
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				if err != nil {
+					return false
+				}
+				return updatedIsvc.Status.IsConditionReady(v1beta1.IngressReady)
+			}, timeout, interval).Should(BeTrue(), "The ingress should be ready")
+		})
+		It("Should keep the ingress/service/deployment/hpa created when gateway api is disabled and the annotation is set to false", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+
+			// Config map
+			configMap := createInferenceServiceConfigMap()
+			configMap.Data["ingress"] = `{
+				"enableGatewayAPI": false,
+				"ingressGateway": "knative-serving/knative-ingress-gateway",
+				"localGateway": "knative-serving/knative-local-gateway",
+				"localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local"
+			}`
+			configMap.Data["opentelemetryCollector"] = `{
+				"scrapeInterval": "5s",
+				"metricReceiverEndpoint": "keda-otel-scaler.keda.svc:4317",
+				"metricScalerEndpoint": "keda-otel-scaler.keda.svc:4318"
+			}`
+			Expect(k8sClient.Create(context.Background(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, configMap)
+
+			// Setup values
+			serviceName := "stop-false-ingress-isvc"
+			serviceNamespace := "default"
+			expectedRequest := reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: serviceNamespace}}
+			serviceKey := expectedRequest.NamespacedName
+			storageUri := "s3://test/mnist/export"
+			qty := resource.MustParse("10Gi")
+			predictorKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace,
+			}
+
+			// Serving runtime
+			servingRuntime := createServingRuntime(serviceKey.Namespace, "tf-serving-raw")
+			Expect(k8sClient.Create(context.Background(), servingRuntime)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, servingRuntime)
+
+			// Define InferenceService
+			isvc := defaultIsvc(serviceKey, storageUri, string(constants.AutoscalerClassHPA), qty)
+			isvc.Annotations[constants.StopAnnotationKey] = "false"
+			isvc.Annotations["sidecar.opentelemetry.io/inject"] = "true"
+			Expect(k8sClient.Create(context.Background(), isvc)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, isvc)
+
+			actualISVC := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, actualISVC)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			// Check the deployment
+			actualDeployment := &appsv1.Deployment{}
+			Eventually(func() error { return k8sClient.Get(context.Background(), predictorKey, actualDeployment) }, timeout).
+				Should(Succeed())
+
+			updatedDeployment := actualDeployment.DeepCopy()
+			updatedDeployment.Status.Conditions = []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentAvailable,
+					Status: v1.ConditionTrue,
+				},
+			}
+			Expect(k8sClient.Status().Update(context.TODO(), updatedDeployment)).NotTo(HaveOccurred())
+
+			// Check the service
+			actualService := &v1.Service{}
+			Eventually(func() error { return k8sClient.Get(context.Background(), predictorKey, actualService) }, timeout).
+				Should(Succeed())
+
+			// Check ingress
+			actualIngress := &netv1.Ingress{}
+			Eventually(func() error { return k8sClient.Get(context.TODO(), serviceKey, actualIngress) }, timeout).
+				Should(Succeed())
+
+			// check the HPA
+			actualHPA := &autoscalingv2.HorizontalPodAutoscaler{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, predictorKey, actualHPA)
+			}, timeout).Should(Succeed())
+
+			// Check that the ISVC was updated
+			updatedIsvc := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			// Check that the stopped condition is false
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				if err == nil {
+					stopped_cond := updatedIsvc.Status.GetCondition(v1beta1.Stopped)
+					if stopped_cond != nil && stopped_cond.Status == v1.ConditionFalse {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "The stopped condition should be set to false")
+
+			// Check that the inference service is ready
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				if err != nil {
+					return false
+				}
+				return updatedIsvc.Status.IsConditionReady(v1beta1.PredictorReady)
+			}, timeout, interval).Should(BeTrue(), "The predictor should be ready")
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				if err != nil {
+					return false
+				}
+				return updatedIsvc.Status.IsConditionReady(v1beta1.IngressReady)
+			}, timeout, interval).Should(BeTrue(), "The ingress should be ready")
+		})
+		It("Should not create the service/deployment/hpa when the annotation is set to true", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+
+			// Config map
+			configMap := createInferenceServiceConfigMap()
+			Expect(k8sClient.Create(context.Background(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, configMap)
+
+			// Setup values
+			serviceName := "stop-true-isvc"
+			serviceNamespace := "default"
+			expectedRequest := reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: serviceNamespace}}
+			serviceKey := expectedRequest.NamespacedName
+			storageUri := "s3://test/mnist/export"
+			qty := resource.MustParse("10Gi")
+			predictorKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace,
+			}
+
+			// Serving runtime
+			servingRuntime := createServingRuntime(serviceKey.Namespace, "tf-serving-raw")
+			Expect(k8sClient.Create(context.Background(), servingRuntime)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, servingRuntime)
+
+			// Define InferenceService
+			isvc := defaultIsvc(serviceKey, storageUri, string(constants.AutoscalerClassHPA), qty)
+			isvc.Annotations[constants.StopAnnotationKey] = "true"
+			Expect(k8sClient.Create(context.Background(), isvc)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, isvc)
+
+			actualISVC := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, actualISVC)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			// Check that the deployment was not created
+			actualDeployment := &appsv1.Deployment{}
+			Consistently(func() bool {
+				err := k8sClient.Get(context.Background(), predictorKey, actualDeployment)
+				return apierr.IsNotFound(err)
+			}, time.Second*10).Should(BeTrue(), "The deployment should not be created")
+
+			// check that the service was not created
+			actualService := &v1.Service{}
+			Consistently(func() bool {
+				err := k8sClient.Get(context.Background(), predictorKey, actualService)
+				return apierr.IsNotFound(err)
+			}, time.Second*10).Should(BeTrue(), "The service should not be created")
+
+			// check that the HPA was not created
+			existingHPA := &autoscalingv2.HorizontalPodAutoscaler{}
+			Consistently(func() bool {
+				err := k8sClient.Get(ctx, predictorKey, existingHPA)
+				return apierr.IsNotFound(err)
+			}, time.Second*10).Should(BeTrue(), "The HPA should not be created")
+
+			// Check that the ISVC was updated
+			updatedIsvc := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			// Check that the ISVC status reflects that it is stopped
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				if err == nil {
+					stopped_cond := updatedIsvc.Status.GetCondition(v1beta1.Stopped)
+					if stopped_cond != nil && stopped_cond.Status == v1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "The stopped condition should be set to true")
+		})
+
+		It("Should not create the ingress/service/deployment/hpa when gateway api is disabled and the annotation is set to true", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+
+			// Config map
+			configMap := createInferenceServiceConfigMap()
+			configMap.Data["ingress"] = `{
+				"enableGatewayAPI": false,
+				"ingressGateway": "knative-serving/knative-ingress-gateway",
+				"localGateway": "knative-serving/knative-local-gateway",
+				"localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local"
+			}`
+			configMap.Data["opentelemetryCollector"] = `{
+				"scrapeInterval": "5s",
+				"metricReceiverEndpoint": "keda-otel-scaler.keda.svc:4317",
+				"metricScalerEndpoint": "keda-otel-scaler.keda.svc:4318"
+			}`
+			Expect(k8sClient.Create(context.Background(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, configMap)
+
+			// Setup values
+			serviceName := "stop-true-ingress-isvc"
+			serviceNamespace := "default"
+			expectedRequest := reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: serviceNamespace}}
+			serviceKey := expectedRequest.NamespacedName
+			storageUri := "s3://test/mnist/export"
+			qty := resource.MustParse("10Gi")
+			predictorKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace,
+			}
+
+			// Serving runtime
+			servingRuntime := createServingRuntime(serviceKey.Namespace, "tf-serving-raw")
+			Expect(k8sClient.Create(context.Background(), servingRuntime)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, servingRuntime)
+
+			// Define InferenceService
+			isvc := defaultIsvc(serviceKey, storageUri, string(constants.AutoscalerClassHPA), qty)
+			isvc.Annotations[constants.StopAnnotationKey] = "true"
+			isvc.Annotations["sidecar.opentelemetry.io/inject"] = "true"
+
+			Expect(k8sClient.Create(context.Background(), isvc)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, isvc)
+
+			actualISVC := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, actualISVC)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			// Check that the deployment was not created
+			actualDeployment := &appsv1.Deployment{}
+			Consistently(func() bool {
+				err := k8sClient.Get(context.Background(), predictorKey, actualDeployment)
+				return apierr.IsNotFound(err)
+			}, time.Second*10).Should(BeTrue(), "The deployment should not be created")
+
+			// check that the service was not created
+			actualService := &v1.Service{}
+			Consistently(func() bool {
+				err := k8sClient.Get(context.Background(), predictorKey, actualService)
+				return apierr.IsNotFound(err)
+			}, time.Second*10).Should(BeTrue(), "The service should not be created")
+
+			// Check that the ingress was not created
+			actualIngress := &netv1.Ingress{}
+			Consistently(func() bool {
+				err := k8sClient.Get(context.TODO(), serviceKey, actualIngress)
+				return apierr.IsNotFound(err)
+			}, time.Second*10).Should(BeTrue(), "The ingress should not be created")
+
+			// check that the HPA was not created
+			existingHPA := &autoscalingv2.HorizontalPodAutoscaler{}
+			Consistently(func() bool {
+				err := k8sClient.Get(ctx, predictorKey, existingHPA)
+				return apierr.IsNotFound(err)
+			}, time.Second*10).Should(BeTrue(), "The HPA should not be created")
+
+			// Check that the ISVC was updated
+			updatedIsvc := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			// Check that the ISVC status reflects that it is stopped
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				if err == nil {
+					stopped_cond := updatedIsvc.Status.GetCondition(v1beta1.Stopped)
+					if stopped_cond != nil && stopped_cond.Status == v1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "The stopped condition should be set to true")
+		})
+
+		It("Should delete the service/deployment/hpa when the annotation is updated to true on an existing ISVC", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+
+			// Config map
+			configMap := createInferenceServiceConfigMap()
+			Expect(k8sClient.Create(context.Background(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, configMap)
+
+			// Setup values
+			serviceName := "stop-edit-true-isvc"
+			serviceNamespace := "default"
+			expectedRequest := reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: serviceNamespace}}
+			serviceKey := expectedRequest.NamespacedName
+			storageUri := "s3://test/mnist/export"
+			qty := resource.MustParse("10Gi")
+			predictorKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace,
+			}
+
+			// Serving runtime
+			servingRuntime := createServingRuntime(serviceKey.Namespace, "tf-serving-raw")
+			Expect(k8sClient.Create(context.Background(), servingRuntime)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, servingRuntime)
+
+			// Define InferenceService
+			isvc := defaultIsvc(serviceKey, storageUri, string(constants.AutoscalerClassHPA), qty)
+			isvc.Annotations[constants.StopAnnotationKey] = "false"
+			Expect(k8sClient.Create(context.Background(), isvc)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, isvc)
+
+			actualISVC := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, actualISVC)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			// Check the deployment
+			actualDeployment := &appsv1.Deployment{}
+			Eventually(func() error { return k8sClient.Get(context.Background(), predictorKey, actualDeployment) }, timeout).
+				Should(Succeed())
+
+			updatedDeployment := actualDeployment.DeepCopy()
+			updatedDeployment.Status.Conditions = []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentAvailable,
+					Status: v1.ConditionTrue,
+				},
+			}
+			Expect(k8sClient.Status().Update(context.TODO(), updatedDeployment)).NotTo(HaveOccurred())
+
+			// check the service
+			actualService := &v1.Service{}
+			Eventually(func() error { return k8sClient.Get(context.Background(), predictorKey, actualService) }, timeout).
+				Should(Succeed())
+
+			// check the HPA
+			actualHPA := &autoscalingv2.HorizontalPodAutoscaler{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, predictorKey, actualHPA)
+			}, timeout).Should(Succeed())
+
+			// Check that the ISVC was updated
+			updatedIsvc := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			// Check that the stopped condition is false
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				if err == nil {
+					stopped_cond := updatedIsvc.Status.GetCondition(v1beta1.Stopped)
+					if stopped_cond != nil && stopped_cond.Status == v1.ConditionFalse {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "The stopped condition should be set to false")
+
+			// Check that the inference service is ready
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				if err != nil {
+					return false
+				}
+				return updatedIsvc.Status.IsConditionReady(v1beta1.PredictorReady)
+			}, timeout, interval).Should(BeTrue(), "The predictor should be ready before updating the annotation")
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				if err != nil {
+					return false
+				}
+				return updatedIsvc.Status.IsConditionReady(v1beta1.IngressReady)
+			}, timeout, interval).Should(BeTrue(), "The ingress should be ready before updating the annotation")
+
+			// Stop the inference service
+			stoppedIsvc := updatedIsvc.DeepCopy()
+			stoppedIsvc.Annotations[constants.StopAnnotationKey] = "true"
+			Expect(k8sClient.Update(ctx, stoppedIsvc)).NotTo(HaveOccurred())
+
+			// Check that the deployment was deleted
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), predictorKey, actualDeployment)
+				return apierr.IsNotFound(err)
+			}, timeout).Should(BeTrue(), "The deployment should be deleted")
+
+			// check that the service was deleted
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), predictorKey, actualService)
+				return apierr.IsNotFound(err)
+			}, timeout).Should(BeTrue(), "The service should be deleted")
+
+			// check that the HPA was deleted
+			existingHPA := &autoscalingv2.HorizontalPodAutoscaler{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, predictorKey, existingHPA)
+				return apierr.IsNotFound(err)
+			}, timeout).Should(BeTrue(), "The HPA should be deleted")
+
+			// Check that the ISVC was updated
+			updatedStoppedIsvc := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedStoppedIsvc)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			// Check that the ISVC status reflects that it is stopped
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedStoppedIsvc)
+				if err == nil {
+					stopped_cond := updatedStoppedIsvc.Status.GetCondition(v1beta1.Stopped)
+					if stopped_cond != nil && stopped_cond.Status == v1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "The stopped condition should be set to true")
+		})
+
+		It("Should delete the ingress/service/deployment/hpa when gateway api is disabled and the annotation is updated to true on an existing ISVC", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+
+			// Config map
+			configMap := createInferenceServiceConfigMap()
+			configMap.Data["ingress"] = `{
+				"enableGatewayAPI": false,
+				"ingressGateway": "knative-serving/knative-ingress-gateway",
+				"localGateway": "knative-serving/knative-local-gateway",
+				"localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local"
+			}`
+			configMap.Data["opentelemetryCollector"] = `{
+				"scrapeInterval": "5s",
+				"metricReceiverEndpoint": "keda-otel-scaler.keda.svc:4317",
+				"metricScalerEndpoint": "keda-otel-scaler.keda.svc:4318"
+			}`
+			Expect(k8sClient.Create(context.Background(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, configMap)
+
+			// Setup values
+			serviceName := "stop-edit-ingress-isvc"
+			serviceNamespace := "default"
+			expectedRequest := reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: serviceNamespace}}
+			serviceKey := expectedRequest.NamespacedName
+			storageUri := "s3://test/mnist/export"
+			qty := resource.MustParse("10Gi")
+			predictorKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace,
+			}
+
+			// Serving runtime
+			servingRuntime := createServingRuntime(serviceKey.Namespace, "tf-serving-raw")
+			Expect(k8sClient.Create(context.Background(), servingRuntime)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, servingRuntime)
+
+			// Define InferenceService
+			isvc := defaultIsvc(serviceKey, storageUri, string(constants.AutoscalerClassHPA), qty)
+			isvc.Annotations[constants.StopAnnotationKey] = "false"
+			isvc.Annotations["sidecar.opentelemetry.io/inject"] = "true"
+			Expect(k8sClient.Create(context.Background(), isvc)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, isvc)
+
+			actualISVC := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, actualISVC)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			// Check the deployment
+			actualDeployment := &appsv1.Deployment{}
+			Eventually(func() error { return k8sClient.Get(context.Background(), predictorKey, actualDeployment) }, timeout).
+				Should(Succeed())
+
+			updatedDeployment := actualDeployment.DeepCopy()
+			updatedDeployment.Status.Conditions = []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentAvailable,
+					Status: v1.ConditionTrue,
+				},
+			}
+			Expect(k8sClient.Status().Update(context.TODO(), updatedDeployment)).NotTo(HaveOccurred())
+
+			// Check the service
+			actualService := &v1.Service{}
+			Eventually(func() error { return k8sClient.Get(context.Background(), predictorKey, actualService) }, timeout).
+				Should(Succeed())
+
+			// check the HPA
+			actualHPA := &autoscalingv2.HorizontalPodAutoscaler{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, predictorKey, actualHPA)
+			}, timeout).Should(Succeed())
+
+			// Check ingress
+			actualIngress := &netv1.Ingress{}
+			Eventually(func() error { return k8sClient.Get(context.TODO(), serviceKey, actualIngress) }, timeout).
+				Should(Succeed())
+
+			// Check that the ISVC was updated
+			updatedIsvc := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			// Check that the stopped condition is false
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				if err == nil {
+					stopped_cond := updatedIsvc.Status.GetCondition(v1beta1.Stopped)
+					if stopped_cond != nil && stopped_cond.Status == v1.ConditionFalse {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "The stopped condition should be set to false")
+
+			// Check that the inference service is ready
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				if err != nil {
+					return false
+				}
+				return updatedIsvc.Status.IsConditionReady(v1beta1.PredictorReady)
+			}, timeout, interval).Should(BeTrue(), "The predictor should be ready")
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedIsvc)
+				if err != nil {
+					return false
+				}
+				return updatedIsvc.Status.IsConditionReady(v1beta1.IngressReady)
+			}, timeout, interval).Should(BeTrue(), "The ingress should be ready")
+
+			// Stop the inference service
+			stoppedIsvc := updatedIsvc.DeepCopy()
+			stoppedIsvc.Annotations[constants.StopAnnotationKey] = "true"
+			Expect(k8sClient.Update(ctx, stoppedIsvc)).NotTo(HaveOccurred())
+
+			// Check that the deployment was deleted
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), predictorKey, actualDeployment)
+				return apierr.IsNotFound(err)
+			}, timeout).Should(BeTrue(), "The deployment should be deleted")
+
+			// check that the HPA was deleted
+			existingHPA := &autoscalingv2.HorizontalPodAutoscaler{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, predictorKey, existingHPA)
+				return apierr.IsNotFound(err)
+			}, timeout).Should(BeTrue(), "The HPA should be deleted")
+
+			// check that the service was deleted
+			Eventually(func() bool {
+				err := k8sClient.Get(context.Background(), predictorKey, actualService)
+				return apierr.IsNotFound(err)
+			}, timeout).Should(BeTrue(), "The service should be deleted")
+
+			// Check that the ingress was deleted
+			Eventually(func() bool {
+				err := k8sClient.Get(context.TODO(), serviceKey, actualIngress)
+				return apierr.IsNotFound(err)
+			}, timeout).Should(BeTrue(), "The ingress should be deleted")
+
+			// Check that the ISVC was updated
+			updatedStoppedIsvc := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedStoppedIsvc)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			// Check that the ISVC status reflects that it is stopped
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, updatedStoppedIsvc)
+				if err == nil {
+					stopped_cond := updatedStoppedIsvc.Status.GetCondition(v1beta1.Stopped)
+					if stopped_cond != nil && stopped_cond.Status == v1.ConditionTrue {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "The stopped condition should be set to true")
 		})
 	})
 
@@ -2859,6 +3678,11 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						{
 							Type:   apis.ConditionReady,
 							Status: "True",
+						},
+						{
+							Type:     v1beta1.Stopped,
+							Status:   "False",
+							Severity: apis.ConditionSeverityInfo,
 						},
 					},
 				},

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -839,6 +839,11 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							Type:   apis.ConditionReady,
 							Status: "True",
 						},
+						{
+							Type:     v1beta1.Stopped,
+							Status:   "False",
+							Severity: apis.ConditionSeverityInfo,
+						},
 					},
 				},
 				URL: &apis.URL{
@@ -1246,6 +1251,11 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						{
 							Type:   apis.ConditionReady,
 							Status: "True",
+						},
+						{
+							Type:     v1beta1.Stopped,
+							Status:   "False",
+							Severity: apis.ConditionSeverityInfo,
 						},
 					},
 				},
@@ -2732,6 +2742,11 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							Type:   apis.ConditionReady,
 							Status: "True",
 						},
+						{
+							Type:     v1beta1.Stopped,
+							Status:   "False",
+							Severity: apis.ConditionSeverityInfo,
+						},
 					},
 				},
 				URL: &apis.URL{
@@ -3166,6 +3181,11 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						{
 							Type:   apis.ConditionReady,
 							Status: "True",
+						},
+						{
+							Type:     v1beta1.Stopped,
+							Status:   "False",
+							Severity: apis.ConditionSeverityInfo,
 						},
 					},
 				},

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -89,10 +89,11 @@ func (ir *IngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
 		return errors.Wrapf(err, "fails to reconcile external name service")
 	}
 
-	if isvc.GetForceStopRuntime() {
+	if utils.GetForceStopRuntime(isvc) {
 		isvc.Status.SetCondition(v1beta1.IngressReady, &apis.Condition{
 			Type:   v1beta1.IngressReady,
 			Status: corev1.ConditionFalse,
+			Reason: v1beta1.StoppedISVCReason,
 		})
 
 		return nil
@@ -296,7 +297,7 @@ func (ir *IngressReconciler) reconcileVirtualService(isvc *v1beta1.InferenceServ
 	existing := &istioclientv1beta1.VirtualService{}
 	getExistingErr := ir.client.Get(context.TODO(), types.NamespacedName{Name: isvc.Name, Namespace: isvc.Namespace}, existing)
 
-	if !isvc.GetForceStopRuntime() {
+	if !utils.GetForceStopRuntime(isvc) {
 		// When Istio virtual host is disabled, we return the underlying component url.
 		// When Istio virtual host is enabled. we return the url using inference service virtual host name and redirect to the corresponding transformer, predictor or explainer url.
 		if !disableIstioVirtualHost {
@@ -369,7 +370,7 @@ func (ir *IngressReconciler) reconcileExternalService(isvc *v1beta1.InferenceSer
 		return err
 	}
 
-	if !isvc.GetForceStopRuntime() {
+	if !utils.GetForceStopRuntime(isvc) {
 		// When Istio virtual host is disabled, we return the underlying component url.
 		// When Istio virtual host is enabled. we return the url using inference service virtual host name and redirect to the corresponding transformer, predictor or explainer url.
 		if !disableIstioVirtualHost {
@@ -406,7 +407,7 @@ func (ir *IngressReconciler) reconcileExternalService(isvc *v1beta1.InferenceSer
 		// Delete the service
 		if getExistingErr == nil {
 			// Make sure that we only delete services owned by the isvc
-			if existing.OwnerReferences[0].UID == isvc.UID {
+			if ctrl := metav1.GetControllerOf(existing); ctrl != nil && ctrl.UID == isvc.UID {
 				log.Info("The InferenceService ", isvc.Name, " is marked as stopped — delete its associated Service")
 				if err := ir.client.Delete(context.TODO(), existing); err != nil {
 					return err

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -340,7 +340,6 @@ func (ir *IngressReconciler) reconcileVirtualService(isvc *v1beta1.InferenceServ
 					return err
 				}
 			}
-
 		} else if !apierr.IsNotFound(getExistingErr) {
 			return getExistingErr
 		}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -78,57 +78,30 @@ func NewIngressReconciler(client client.Client, clientset kubernetes.Interface, 
 }
 
 func (ir *IngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
-	serviceHost := getServiceHost(isvc)
-	serviceUrl := getServiceUrl(isvc, ir.ingressConfig)
 	disableIstioVirtualHost := ir.ingressConfig.DisableIstioVirtualHost
-	if serviceHost == "" || serviceUrl == "" {
+
+	if err := ir.reconcileVirtualService(isvc); err != nil {
+		return errors.Wrapf(err, "fails to reconcile virtual service")
+	}
+
+	// Create external service which points to local gateway
+	if err := ir.reconcileExternalService(isvc, ir.ingressConfig); err != nil {
+		return errors.Wrapf(err, "fails to reconcile external name service")
+	}
+
+	if isvc.GetForceStopRuntime() {
+		isvc.Status.SetCondition(v1beta1.IngressReady, &apis.Condition{
+			Type:   v1beta1.IngressReady,
+			Status: corev1.ConditionFalse,
+		})
+
 		return nil
 	}
-	// When Istio virtual host is disabled, we return the underlying component url.
-	// When Istio virtual host is enabled. we return the url using inference service virtual host name and redirect to the corresponding transformer, predictor or explainer url.
-	if !disableIstioVirtualHost {
-		// Check if existing knative service name has default suffix
-		defaultNameExisting := &knservingv1.Service{}
-		useDefault := false
-		err := ir.client.Get(context.TODO(), types.NamespacedName{Name: constants.DefaultPredictorServiceName(isvc.Name), Namespace: isvc.Namespace}, defaultNameExisting)
-		if err == nil {
-			useDefault = true
-		}
-		domainList := getDomainList(ir.clientset)
-		desiredIngress := createIngress(isvc, useDefault, ir.ingressConfig, domainList, ir.isvcConfig)
-		if desiredIngress == nil {
-			return nil
-		}
 
-		// Create external service which points to local gateway
-		if err := ir.reconcileExternalService(isvc, ir.ingressConfig); err != nil {
-			return errors.Wrapf(err, "fails to reconcile external name service")
-		}
-
-		if err := controllerutil.SetControllerReference(isvc, desiredIngress, ir.scheme); err != nil {
-			return errors.Wrapf(err, "fails to set owner reference for ingress")
-		}
-
-		existing := &istioclientv1beta1.VirtualService{}
-		err = ir.client.Get(context.TODO(), types.NamespacedName{Name: desiredIngress.Name, Namespace: desiredIngress.Namespace}, existing)
-		if err != nil {
-			if apierr.IsNotFound(err) {
-				log.Info("Creating Ingress for isvc", "namespace", desiredIngress.Namespace, "name", desiredIngress.Name)
-				err = ir.client.Create(context.TODO(), desiredIngress)
-			}
-		} else {
-			if !routeSemanticEquals(desiredIngress, existing) {
-				deepCopy := existing.DeepCopy()
-				deepCopy.Spec = *desiredIngress.Spec.DeepCopy()
-				deepCopy.Annotations = desiredIngress.Annotations
-				deepCopy.Labels = desiredIngress.Labels
-				log.Info("Update Ingress for isvc", "namespace", desiredIngress.Namespace, "name", desiredIngress.Name)
-				err = ir.client.Update(context.TODO(), deepCopy)
-			}
-		}
-		if err != nil {
-			return errors.Wrapf(err, "fails to create or update ingress")
-		}
+	serviceHost := getServiceHost(isvc)
+	serviceUrl := getServiceUrl(isvc, ir.ingressConfig)
+	if serviceHost == "" || serviceUrl == "" {
+		return nil
 	}
 
 	if url, err := apis.ParseURL(serviceUrl); err == nil {
@@ -306,7 +279,78 @@ func getHostBasedServiceUrl(isvc *v1beta1.InferenceService, config *v1beta1.Ingr
 	}
 }
 
-func (r *IngressReconciler) reconcileExternalService(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig) error {
+func (ir *IngressReconciler) reconcileVirtualService(isvc *v1beta1.InferenceService) error {
+	disableIstioVirtualHost := ir.ingressConfig.DisableIstioVirtualHost
+
+	// Check if existing knative service name has default suffix
+	defaultNameExisting := &knservingv1.Service{}
+	useDefault := false
+	err := ir.client.Get(context.TODO(), types.NamespacedName{Name: constants.DefaultPredictorServiceName(isvc.Name), Namespace: isvc.Namespace}, defaultNameExisting)
+	if err == nil {
+		useDefault = true
+	}
+
+	domainList := getDomainList(ir.clientset)
+	desiredIngress := createIngress(isvc, useDefault, ir.ingressConfig, domainList, ir.isvcConfig) // actually the virtual service
+
+	existing := &istioclientv1beta1.VirtualService{}
+	getExistingErr := ir.client.Get(context.TODO(), types.NamespacedName{Name: isvc.Name, Namespace: isvc.Namespace}, existing)
+
+	if !isvc.GetForceStopRuntime() {
+		// When Istio virtual host is disabled, we return the underlying component url.
+		// When Istio virtual host is enabled. we return the url using inference service virtual host name and redirect to the corresponding transformer, predictor or explainer url.
+		if !disableIstioVirtualHost {
+			if desiredIngress == nil {
+				return nil
+			}
+
+			err = controllerutil.SetControllerReference(isvc, desiredIngress, ir.scheme)
+			if err != nil {
+				return errors.Wrapf(err, "fails to set owner reference for ingress")
+			}
+
+			if getExistingErr != nil {
+				if apierr.IsNotFound(getExistingErr) {
+					log.Info("Creating Ingress for isvc", "namespace", desiredIngress.Namespace, "name", desiredIngress.Name)
+					err = ir.client.Create(context.TODO(), desiredIngress)
+				}
+			} else {
+				if !routeSemanticEquals(desiredIngress, existing) {
+					deepCopy := existing.DeepCopy()
+					deepCopy.Spec = *desiredIngress.Spec.DeepCopy()
+					deepCopy.Annotations = desiredIngress.Annotations
+					deepCopy.Labels = desiredIngress.Labels
+					log.Info("Update Ingress for isvc", "namespace", desiredIngress.Namespace, "name", desiredIngress.Name)
+					err = ir.client.Update(context.TODO(), deepCopy)
+				}
+			}
+
+			if err != nil {
+				return errors.Wrapf(err, "fails to create or update ingress")
+			}
+		}
+	} else {
+		// Delete the virtualservice
+		if getExistingErr == nil {
+			// Make sure that we only delete virtual services owned by the isvc
+			if existing.OwnerReferences[0].UID == isvc.UID {
+				log.Info("The InferenceService ", isvc.Name, " is marked as stopped — delete its associated VirtualService")
+				if err := ir.client.Delete(context.TODO(), existing); err != nil {
+					return err
+				}
+			}
+
+		} else if !apierr.IsNotFound(getExistingErr) {
+			return getExistingErr
+		}
+	}
+
+	return nil
+}
+
+func (ir *IngressReconciler) reconcileExternalService(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig) error {
+	disableIstioVirtualHost := ir.ingressConfig.DisableIstioVirtualHost
+
 	desired := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      isvc.Name,
@@ -318,39 +362,59 @@ func (r *IngressReconciler) reconcileExternalService(isvc *v1beta1.InferenceServ
 			SessionAffinity: corev1.ServiceAffinityNone,
 		},
 	}
-	if err := controllerutil.SetControllerReference(isvc, desired, r.scheme); err != nil {
-		return err
-	}
-
-	// Create service if does not exist
 	existing := &corev1.Service{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
-	if err != nil {
-		if apierr.IsNotFound(err) {
-			log.Info("Creating external name service", "namespace", desired.Namespace, "name", desired.Name)
-			err = r.client.Create(context.TODO(), desired)
-		}
+	getExistingErr := ir.client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing)
+
+	if err := controllerutil.SetControllerReference(isvc, desired, ir.scheme); err != nil {
 		return err
 	}
 
-	// Return if no differences to reconcile.
-	if equality.Semantic.DeepEqual(desired, existing) {
-		return nil
-	}
+	if !isvc.GetForceStopRuntime() {
+		// When Istio virtual host is disabled, we return the underlying component url.
+		// When Istio virtual host is enabled. we return the url using inference service virtual host name and redirect to the corresponding transformer, predictor or explainer url.
+		if !disableIstioVirtualHost {
+			// Create service if does not exist
+			if getExistingErr != nil {
+				if apierr.IsNotFound(getExistingErr) {
+					log.Info("Creating external name service", "namespace", desired.Namespace, "name", desired.Name)
+					return ir.client.Create(context.TODO(), desired)
+				}
+				return getExistingErr
+			}
 
-	// Reconcile differences and update
-	diff, err := kmp.SafeDiff(desired.Spec, existing.Spec)
-	if err != nil {
-		return errors.Wrapf(err, "failed to diff external name service")
-	}
-	log.Info("Reconciling external service diff (-desired, +observed):", "diff", diff)
-	log.Info("Updating external service", "namespace", existing.Namespace, "name", existing.Name)
-	existing.Spec = desired.Spec
-	existing.ObjectMeta.Labels = desired.ObjectMeta.Labels
-	existing.ObjectMeta.Annotations = desired.ObjectMeta.Annotations
-	err = r.client.Update(context.TODO(), existing)
-	if err != nil {
-		return errors.Wrapf(err, "fails to update external name service")
+			// Return if no differences to reconcile.
+			if equality.Semantic.DeepEqual(desired, existing) {
+				return nil
+			}
+
+			// Reconcile differences and update
+			diff, err := kmp.SafeDiff(desired.Spec, existing.Spec)
+			if err != nil {
+				return errors.Wrapf(err, "failed to diff external name service")
+			}
+			log.Info("Reconciling external service diff (-desired, +observed):", "diff", diff)
+			log.Info("Updating external service", "namespace", existing.Namespace, "name", existing.Name)
+			existing.Spec = desired.Spec
+			existing.ObjectMeta.Labels = desired.ObjectMeta.Labels
+			existing.ObjectMeta.Annotations = desired.ObjectMeta.Annotations
+			err = ir.client.Update(context.TODO(), existing)
+			if err != nil {
+				return errors.Wrapf(err, "fails to update external name service")
+			}
+		}
+	} else {
+		// Delete the service
+		if getExistingErr == nil {
+			// Make sure that we only delete services owned by the isvc
+			if existing.OwnerReferences[0].UID == isvc.UID {
+				log.Info("The InferenceService ", isvc.Name, " is marked as stopped — delete its associated Service")
+				if err := ir.client.Delete(context.TODO(), existing); err != nil {
+					return err
+				}
+			}
+		} else if !apierr.IsNotFound(getExistingErr) {
+			return getExistingErr
+		}
 	}
 
 	return nil

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
@@ -231,7 +231,7 @@ func (r *KsvcReconciler) Reconcile() (*knservingv1.ServiceStatus, error) {
 		}
 
 		if forceStopRuntime {
-			log.Info("Stopping knative service", "namespace", existing.Namespace, "name", existing.Name)
+			log.Info("Deleting knative service", "namespace", existing.Namespace, "name", existing.Name)
 			if existing.GetDeletionTimestamp() == nil { // check if the ksvc was already deleted
 				err := r.client.Delete(context.TODO(), existing)
 				if err != nil {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
@@ -218,10 +219,26 @@ func (r *KsvcReconciler) Reconcile() (*knservingv1.ServiceStatus, error) {
 	desired := r.Service
 	existing := &knservingv1.Service{}
 
+	forceStopRuntime := false
+	if val, exist := desired.Spec.Template.Annotations[constants.StopAnnotationKey]; exist {
+		forceStopRuntime = strings.EqualFold(val, "true")
+	}
+
 	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		log.Info("Updating knative service", "namespace", desired.Namespace, "name", desired.Name)
 		if err := r.client.Get(context.TODO(), types.NamespacedName{Name: desired.Name, Namespace: desired.Namespace}, existing); err != nil {
 			return err
+		}
+
+		if forceStopRuntime {
+			log.Info("Stopping knative service", "namespace", existing.Namespace, "name", existing.Name)
+			if existing.GetDeletionTimestamp() == nil { // check if the ksvc was already deleted
+				err := r.client.Delete(context.TODO(), existing)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
 		}
 
 		// Set ResourceVersion which is required for update operation.
@@ -248,8 +265,12 @@ func (r *KsvcReconciler) Reconcile() (*knservingv1.ServiceStatus, error) {
 	if err != nil {
 		// Create service if it does not exist
 		if apierr.IsNotFound(err) {
-			log.Info("Creating knative service", "namespace", desired.Namespace, "name", desired.Name)
-			return &desired.Status, r.client.Create(context.TODO(), desired)
+			if !forceStopRuntime {
+				log.Info("Creating knative service", "namespace", desired.Namespace, "name", desired.Name)
+				return &desired.Status, r.client.Create(context.TODO(), desired)
+			}
+
+			return &desired.Status, nil
 		}
 		return &existing.Status, errors.Wrapf(err, "fails to reconcile knative service")
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -245,6 +245,29 @@ func GetEnvVarValue(envVars []v1.EnvVar, key string) (string, bool) {
 	return "", false // if key does not exist, return "", false
 }
 
+// Returns the value of the stop annotation
+// Defaults to false if the annotation is not present
+func GetForceStopRuntime(obj metav1.Object) bool {
+	forceStopRuntime := false
+	// Check that the object exists
+	if obj == nil {
+		return forceStopRuntime
+	}
+
+	// Check that the annotations exist
+	anns := obj.GetAnnotations()
+	if anns == nil {
+		return forceStopRuntime
+	}
+
+	// Determine the value of the stop annotation
+	if val, exist := anns[constants.StopAnnotationKey]; exist {
+		forceStopRuntime = strings.EqualFold(val, "true")
+	}
+
+	return forceStopRuntime
+}
+
 // IsUnknownGpuResourceType check if the provided gpu resource type is unknown one
 func IsUnknownGpuResourceType(resources v1.ResourceRequirements, customGpuResourceTypes string) bool {
 	basicResourceTypes := map[v1.ResourceName]struct{}{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Cherry picks https://github.com/kserve/kserve/pull/4337 and https://github.com/kserve/kserve/pull/4455
**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.