### PR TITLE
[RHOAIENG-27166] Fix flaky test failure with mc alias

### DIFF
--- a/test/scripts/openshift-ci/setup-e2e-tests.sh
+++ b/test/scripts/openshift-ci/setup-e2e-tests.sh
@@ -122,8 +122,34 @@ kustomize build $PROJECT_ROOT/test/scripts/openshift-ci |
   oc wait --for=condition=ready pod -l app=odh-model-controller -n kserve --timeout=300s
 
 echo "Add testing models to minio storage ..." # Reference: config/overlays/test/minio/minio-init-job.yaml
-oc expose service minio-service -n kserve && sleep 5
+
+# Wait for minio pod to be ready
+echo "Waiting for minio pod to be ready..."
+oc wait --for=condition=ready pod -l app=minio -n kserve --timeout=300s
+
+# Expose minio service and get route
+oc expose service minio-service -n kserve
 MINIO_ROUTE=$(oc get routes -n kserve minio-service -o jsonpath="{.spec.host}")
+
+# Wait for minio endpoint to be accessible
+echo "Waiting for minio endpoint to be accessible..."
+timeout=60
+counter=0
+while [ $counter -lt $timeout ]; do
+  if curl -f -s "http://$MINIO_ROUTE/minio/health/live" >/dev/null 2>&1; then
+    echo "Minio is ready!"
+    break
+  fi
+  echo "Waiting for minio to be ready... ($counter/$timeout)"
+  sleep 2
+  counter=$((counter + 2))
+done
+
+if [ $counter -ge $timeout ]; then
+  echo "Timeout waiting for minio to be ready"
+  exit 1
+fi
+
 mc alias set storage http://$MINIO_ROUTE minio minio123
 
 if ! mc ls storage/example-models >/dev/null 2>&1; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes the intermittent mc alias failure when running tests in openshift ci.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Run kserve fvt tests, verify there is no failure while setting up minio.


- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved reliability of MinIO setup by adding explicit readiness checks and health endpoint polling with progress feedback and timeouts, ensuring services are fully operational before proceeding in both standard and TLS configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->