### PR TITLE
Various reconcile fixes

### DIFF
--- a/pkg/controller/llmisvc/controller.go
+++ b/pkg/controller/llmisvc/controller.go
@@ -102,13 +102,13 @@ func (r *LLMInferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.
 	reconciler.PostProcessReconcile(ctx, resource, original)
 
 	if err := r.updateStatus(ctx, original, resource); err != nil {
-		return ctrl.Result{Requeue: true}, err
+		return ctrl.Result{}, err
 	}
 
 	if reconcileErr != nil {
 		logger.Error(reconcileErr, "Failed to reconcile LLMInferenceService")
 		r.Recorder.Eventf(original, corev1.EventTypeWarning, "Error", reconcileErr.Error())
-		return ctrl.Result{Requeue: true}, reconcileErr
+		return ctrl.Result{}, reconcileErr
 	}
 
 	logger.Info("Reconciliation completed successfully")
@@ -134,7 +134,7 @@ func (r *LLMInferenceServiceReconciler) ReconcileKind(ctx context.Context, llmSv
 	if err != nil {
 		return fmt.Errorf("failed to combine base-configurations: %w", err)
 	}
-	llmSvc = llmSvc.DeepCopy()
+	// We are only writing to status, so we can safely use the original object.
 	llmSvc.Spec = baseCfg.Spec
 
 	logger.Info("Reconciling with combined base configurations", "spec", llmSvc.Spec)

--- a/pkg/controller/llmisvc/workload.go
+++ b/pkg/controller/llmisvc/workload.go
@@ -72,6 +72,12 @@ func (r *LLMInferenceServiceReconciler) reconcileMainWorkload(ctx context.Contex
 
 func (r *LLMInferenceServiceReconciler) reconcileMainWorker(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {
 	expected := r.expectedMainWorker(ctx, llmSvc)
+	if llmSvc.Spec.Worker == nil {
+		if err := r.deleteDeployment(ctx, llmSvc, expected); client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("failed to delete worken deployment: %w", err)
+		}
+		return nil
+	}
 	return r.reconcileDeployment(ctx, llmSvc, expected)
 }
 

--- a/pkg/controller/llmisvc/workload_prefill.go
+++ b/pkg/controller/llmisvc/workload_prefill.go
@@ -59,8 +59,10 @@ func (r *LLMInferenceServiceReconciler) expectedPrefillMainDeployment(ctx contex
 				"app.kubernetes.io/name":      llmSvc.GetName(),
 				"app.kubernetes.io/part-of":   "llminferenceservice",
 			},
-		},
-		Spec: appsv1.DeploymentSpec{
+		}}
+
+	if llmSvc.Spec.Prefill != nil {
+		d.Spec = appsv1.DeploymentSpec{
 			Replicas: llmSvc.Spec.Prefill.Replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
@@ -78,10 +80,10 @@ func (r *LLMInferenceServiceReconciler) expectedPrefillMainDeployment(ctx contex
 					},
 				},
 			},
-		},
+		}
 	}
 
-	if llmSvc.Spec.Prefill.Template != nil {
+	if llmSvc.Spec.Prefill != nil && llmSvc.Spec.Prefill.Template != nil {
 		d.Spec.Template.Spec = *llmSvc.Spec.Prefill.Template.DeepCopy()
 	}
 

--- a/pkg/controller/llmisvc/workload_prefill.go
+++ b/pkg/controller/llmisvc/workload_prefill.go
@@ -59,7 +59,8 @@ func (r *LLMInferenceServiceReconciler) expectedPrefillMainDeployment(ctx contex
 				"app.kubernetes.io/name":      llmSvc.GetName(),
 				"app.kubernetes.io/part-of":   "llminferenceservice",
 			},
-		}}
+		},
+	}
 
 	if llmSvc.Spec.Prefill != nil {
 		d.Spec = appsv1.DeploymentSpec{

--- a/pkg/testing/status_matchers.go
+++ b/pkg/testing/status_matchers.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2023 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+
+	v1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/onsi/gomega/types"
+	"knative.dev/pkg/apis"
+)
+
+// HaveCondition returns a matcher that checks if a Status has a condition with the specified type and status
+func HaveCondition(conditionType string, expectedStatus string) types.GomegaMatcher {
+	return &haveConditionMatcher{
+		conditionType:  conditionType,
+		expectedStatus: expectedStatus,
+	}
+}
+
+type haveConditionMatcher struct {
+	conditionType    string
+	expectedStatus   string
+	actualConditions []apis.Condition
+	foundCondition   *apis.Condition
+}
+
+func (matcher *haveConditionMatcher) Match(actual any) (success bool, err error) {
+	conditions, err := matcher.extractConditions(actual)
+	if err != nil {
+		return false, err
+	}
+
+	matcher.actualConditions = conditions
+
+	for i := range conditions {
+		condition := &conditions[i]
+		if string(condition.Type) == matcher.conditionType {
+			matcher.foundCondition = condition
+			return string(condition.Status) == matcher.expectedStatus, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (matcher *haveConditionMatcher) extractConditions(actual any) (v1.Conditions, error) {
+	actualValue := reflect.ValueOf(actual)
+
+	if actualValue.Kind() == reflect.Ptr {
+		if actualValue.IsNil() {
+			return nil, errors.New("expected a non-nil pointer, but got nil")
+		}
+		actualValue = actualValue.Elem()
+	}
+
+	if actualValue.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("expected a struct or pointer to struct, but got %T", actual)
+	}
+
+	conditionsField := actualValue.FieldByName("Conditions")
+	if conditionsField.IsValid() && conditionsField.Kind() == reflect.Slice {
+		return matcher.convertToConditions(conditionsField)
+	}
+
+	statusField := actualValue.FieldByName("Status")
+	if statusField.IsValid() {
+		if statusField.Kind() == reflect.Struct {
+			conditionsField = statusField.FieldByName("Conditions")
+			if conditionsField.IsValid() && conditionsField.Kind() == reflect.Slice {
+				return matcher.convertToConditions(conditionsField)
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("could not find Conditions field in %T", actual)
+}
+
+func (matcher *haveConditionMatcher) convertToConditions(conditionsValue reflect.Value) (v1.Conditions, error) {
+	conditions, ok := conditionsValue.Interface().(v1.Conditions)
+	if !ok {
+		return nil, fmt.Errorf("expected v1.Conditions, but got %v", conditionsValue.Type())
+	}
+
+	return conditions, nil
+}
+
+func (matcher *haveConditionMatcher) FailureMessage(actual any) (message string) {
+	if matcher.foundCondition != nil {
+		return fmt.Sprintf("Expected %T to have condition %q with status %q, but found status %q",
+			actual, matcher.conditionType, matcher.expectedStatus, string(matcher.foundCondition.Status))
+	}
+
+	conditionTypes := make([]string, len(matcher.actualConditions))
+	for i, condition := range matcher.actualConditions {
+		conditionTypes[i] = string(condition.Type)
+	}
+
+	if len(conditionTypes) == 0 {
+		return fmt.Sprintf("Expected %T to have condition %q with status %q, but no conditions were found",
+			actual, matcher.conditionType, matcher.expectedStatus)
+	}
+
+	return fmt.Sprintf("Expected %T to have condition %q with status %q, but condition was not found. Available conditions: %v",
+		actual, matcher.conditionType, matcher.expectedStatus, conditionTypes)
+}
+
+func (matcher *haveConditionMatcher) NegatedFailureMessage(actual any) (message string) {
+	if matcher.foundCondition != nil {
+		return fmt.Sprintf("Expected %T to not have condition %q with status %q, but it was found",
+			actual, matcher.conditionType, matcher.expectedStatus)
+	}
+
+	return fmt.Sprintf("Expected %T to not have condition %q with status %q, and it was not found (which is correct)",
+		actual, matcher.conditionType, matcher.expectedStatus)
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Ideally this PR should go as "rebase" so we have all 3 commits in history

### fix(worker): deletes worker when not in spec

When `.Spec.Worker` is set to `nil` the existing deployment should be
deleted, instead of created or updated as it is right now.

With the single-node spec this leads to errors in the reconcile as
controller tries to create a worker deployment with empty
`.Spec.Template.Spec`.


###  fix(prefill): create full deployment resource only when .Spec.Prefill is set

If `.Spec.Prefill` is `nil` the expected deployment panics on setting
`.Replicas`. `.Spec` part is not needed in this case as empty
`.Spec.Prefill` results in deleting existing deployment.

### fix(conditions): do not use copy for reconcilation

We are going to write only to status so there's no need to copy.

With overwriting reference, we are losing sthe tatus calculation when we
exit to main reconcile