### PR TITLE
Resolve Resource Conflict In FVT Tests

### DIFF
--- a/test/e2e/predictor/test_scheduler_name.py
+++ b/test/e2e/predictor/test_scheduler_name.py
@@ -48,7 +48,7 @@ def get_pods(service_name: str) -> list[client.V1Pod]:
 @pytest.mark.asyncio(scope="session")
 async def test_scheduler_name(rest_v1_client):
     scheduler_name = "kserve-scheduler"
-    service_name = "isvc-sklearn"
+    service_name = "isvc-sklearn-scheduler"
     logger.info("Creating InferenceService %s", service_name)
 
     predictor = V1beta1PredictorSpec(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently https://github.com/openshift/release/pull/65538 is blocked by CI job failures due to flaky FVT tests in kserve. The test failure stems from conflicting inference services created in the `test_sklearn_kserve` and `test_scheduler_name` FVT tests. These tests create an ISVC with the same name and namespace, which can lead to `409` conflicts during test resource creation if the resource is not fully deleted by the time the next test executes.

FVT failure error:
```
FAILED predictor/test_sklearn.py::test_sklearn_kserve - RuntimeError: Exception when calling CustomObjectsApi->create_namespaced_custom_object:  (409) Reason: Conflict
HTTP response headers: HTTPHeaderDict({'Audit-Id': '3b4ee143-6409-4ddd-925d-2c2c7b5f8e34', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload', 'X-Kubernetes-Pf-Flowschema-Uid': '7ddd7e54-3584-4591-a9f5-0f8e9c5562b0', 'X-Kubernetes-Pf-Prioritylevel-Uid': '4b1d0366-e218-4254-9667-6dc137707860', 'Date': 'Thu, 19 Jun 2025 14:45:27 GMT', 'Content-Length': '299'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"object is being deleted: inferenceservices.serving.kserve.io \"isvc-sklearn\" already exists","reason":"AlreadyExists","details":{"name":"isvc-sklearn","group":"serving.kserve.io","kind":"inferenceservices"},"code":409}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Blocks [RHOAIENG-21641](https://issues.redhat.com/browse/RHOAIENG-21641)

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] Run FVT test suite

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test to use a new service name for InferenceService validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->