### PR TITLE
feat(envtest): loads bundled presets automatically

### DIFF
--- a/pkg/controller/llmisvc/controller_test.go
+++ b/pkg/controller/llmisvc/controller_test.go
@@ -19,21 +19,22 @@ package llmisvc_test
 import (
 	"context"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmeta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	. "github.com/kserve/kserve/pkg/testing"
-
-	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 )
 
 var _ = Describe("LLMInferenceService Controller", func() {
@@ -52,6 +53,9 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				envTest.DeleteAll(namespace)
 			}()
 
+			modelURL, err := apis.ParseURL("hf://facebook/opt-125m")
+			Expect(err).ToNot(HaveOccurred())
+
 			llmSvc := &v1alpha1.LLMInferenceService{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      svcName,
@@ -59,9 +63,26 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				},
 				Spec: v1alpha1.LLMInferenceServiceSpec{
 					Model: v1alpha1.LLMModelSpec{
-						URI: apis.URL{Path: "hf://facebook/opt-125m"},
+						URI: *modelURL,
 					},
 					WorkloadSpec: v1alpha1.WorkloadSpec{},
+					Router: &v1alpha1.RouterSpec{
+						Route: &v1alpha1.GatewayRoutesSpec{
+							HTTP: &v1alpha1.HTTPRouteSpec{
+								Refs: []corev1.LocalObjectReference{
+									{Name: "test-gateway"},
+								},
+							},
+						},
+						Gateway: &v1alpha1.GatewaySpec{
+							Refs: []v1alpha1.UntypedObjectReference{
+								{
+									Name:      "test-gateway",
+									Namespace: gatewayapi.Namespace(nsName),
+								},
+							},
+						},
+					},
 				},
 			}
 
@@ -73,18 +94,20 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 			// then
 			expectedDeployment := &appsv1.Deployment{}
-			Eventually(func() bool {
+			Eventually(func(g Gomega, ctx context.Context) error {
 				err := envTest.Get(ctx, types.NamespacedName{
 					Name:      "test-llm-kserve",
 					Namespace: nsName,
 				}, expectedDeployment)
 
-				return errors.IsNotFound(err)
-			}).Should(BeFalse())
+				g.Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+
+				return err
+			}).WithContext(ctx).Should(Succeed())
 
 			Expect(expectedDeployment.Spec.Replicas).To(Equal(ptr.To[int32](1)))
 			Expect(expectedDeployment.Spec.Template.Spec.Containers).To(HaveLen(1))
-			Expect(expectedDeployment.Spec.Template.Spec.Containers[0].Image).To(Equal("test-model:latest"))
+			Expect(expectedDeployment.Spec.Template.Spec.Containers[0].Image).To(Equal("facebook/opt-125m:latest"))
 
 			Expect(expectedDeployment.OwnerReferences).To(HaveLen(1))
 			Expect(expectedDeployment.OwnerReferences[0].Name).To(Equal(svcName))

--- a/pkg/controller/llmisvc/suite_test.go
+++ b/pkg/controller/llmisvc/suite_test.go
@@ -47,6 +47,8 @@ var _ = SynchronizedBeforeSuite(func() {
 	SetDefaultEventuallyPollingInterval(250 * time.Millisecond)
 
 	By("Setting up the test environment")
+	systemNs := "kserve"
+
 	llmCtrlFunc := func(mgr ctrl.Manager) error {
 		eventBroadcaster := record.NewBroadcaster()
 		llmCtrl := llmisvc.LLMInferenceServiceReconciler{
@@ -54,7 +56,7 @@ var _ = SynchronizedBeforeSuite(func() {
 			// TODO fix it to be set up similar to main.go, for now it's stub
 			Recorder: eventBroadcaster.NewRecorder(mgr.GetScheme(), corev1.EventSource{Component: "v1beta1Controllers"}),
 			Config: llmisvc.ReconcilerConfig{
-				SystemNamespace: "kserve",
+				SystemNamespace: systemNs,
 			},
 		}
 		return llmCtrl.SetupWithManager(mgr)
@@ -62,7 +64,7 @@ var _ = SynchronizedBeforeSuite(func() {
 
 	envTest, cancel = pkgtest.StartWithControllers(llmCtrlFunc)
 
-	sharedTestFixture(context.Background(), envTest.Client)
+	createRequiredResources(context.Background(), envTest.Client, systemNs)
 }, func() {})
 
 var _ = SynchronizedAfterSuite(func() {}, func() {

--- a/pkg/testing/ctrl.go
+++ b/pkg/testing/ctrl.go
@@ -51,7 +51,7 @@ func StartWithControllers(ctrls ...SetupWithManagerFunc) (*Client, context.Cance
 
 	return Configure(
 		WithCRDs(
-			filepath.Join(projectRoot(), "test", "crds"),
+			filepath.Join(ProjectRoot(), "test", "crds"),
 		),
 		WithScheme(
 			// KServe Schemes
@@ -73,8 +73,8 @@ func StartWithControllers(ctrls ...SetupWithManagerFunc) (*Client, context.Cance
 		Start(ctx), cancel
 }
 
-// projectRoot returns the root directory of the project by searching for the go.mod file up from where it is called.
-func projectRoot() string {
+// ProjectRoot returns the root directory of the project by searching for the go.mod file up from where it is called.
+func ProjectRoot() string {
 	rootDir := ""
 
 	currentDir, err := os.Getwd()


### PR DESCRIPTION
During test suite bootstrap well known config presets will be created in the cluster under test. They are automatically loaded from bundled kustomize manifests stored in the `config/llmisvc` folder. Every file prefixed with `config-` is treated as such.

This allows the controller to automatically use them when `LLMInferenceService` under test relies on them.
