### PR TITLE
feat(test): custom matchers

### DIFF
--- a/pkg/testing/deployment_matchers.go
+++ b/pkg/testing/deployment_matchers.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/onsi/gomega/types"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+// HaveContainerImage returns a matcher that checks if a Deployment has a container with the specified image
+func HaveContainerImage(expectedImage string) types.GomegaMatcher {
+	return &haveContainerImageMatcher{
+		expectedImage: expectedImage,
+	}
+}
+
+type haveContainerImageMatcher struct {
+	expectedImage string
+	actualImages  []string
+	foundImage    bool
+}
+
+func (matcher *haveContainerImageMatcher) Match(actual any) (success bool, err error) {
+	var deployment *appsv1.Deployment
+	switch v := actual.(type) {
+	case *appsv1.Deployment:
+		if v == nil {
+			return false, errors.New("expected non-nil *appsv1.Deployment, but got nil")
+		}
+		deployment = v
+	case appsv1.Deployment:
+		deployment = &v
+	default:
+		return false, fmt.Errorf("expected *appsv1.Deployment or appsv1.Deployment, but got %T", actual)
+	}
+
+	containers := deployment.Spec.Template.Spec.Containers
+	matcher.actualImages = make([]string, len(containers))
+	for i, container := range containers {
+		matcher.actualImages[i] = container.Image
+		if container.Image == matcher.expectedImage {
+			matcher.foundImage = true
+		}
+	}
+
+	return matcher.foundImage, nil
+}
+
+func (matcher *haveContainerImageMatcher) FailureMessage(actual any) string {
+	if len(matcher.actualImages) == 0 {
+		return fmt.Sprintf("Expected %T to have container with image %q, but no containers were found",
+			actual, matcher.expectedImage)
+	}
+
+	return fmt.Sprintf("Expected %T to have container with image %q, but found container images: %v",
+		actual, matcher.expectedImage, matcher.actualImages)
+}
+
+func (matcher *haveContainerImageMatcher) NegatedFailureMessage(actual any) string {
+	return fmt.Sprintf("Expected %T to not have container with image %q, but it was found",
+		actual, matcher.expectedImage)
+}

--- a/pkg/testing/httproute_matchers.go
+++ b/pkg/testing/httproute_matchers.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"errors"
+	"fmt"
+
+	"k8s.io/utils/ptr"
+
+	"github.com/onsi/gomega/types"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// extractHTTPRoute safely extracts HTTPRoute from either pointer or value type
+func extractHTTPRoute(actual any) (*gatewayapi.HTTPRoute, error) {
+	switch v := actual.(type) {
+	case *gatewayapi.HTTPRoute:
+		if v == nil {
+			return nil, errors.New("expected non-nil *gatewayapi.HTTPRoute, but got nil")
+		}
+		return v, nil
+	case gatewayapi.HTTPRoute:
+		return &v, nil
+	default:
+		return nil, fmt.Errorf("expected *gatewayapi.HTTPRoute or gatewayapi.HTTPRoute, but got %T", actual)
+	}
+}
+
+// HaveGatewayRefs returns a matcher that checks if an HTTPRoute has the specified gateway parent refs
+func HaveGatewayRefs(expectedGatewayNames ...string) types.GomegaMatcher {
+	return &haveGatewayRefsMatcher{
+		expectedGatewayNames: expectedGatewayNames,
+	}
+}
+
+type haveGatewayRefsMatcher struct {
+	expectedGatewayNames []string
+	actualParentRefs     []gatewayapi.ParentReference
+	actualGatewayNames   []string
+}
+
+func (matcher *haveGatewayRefsMatcher) Match(actual any) (success bool, err error) {
+	httpRoute, err := extractHTTPRoute(actual)
+	if err != nil {
+		return false, err
+	}
+
+	matcher.actualParentRefs = httpRoute.Spec.ParentRefs
+
+	actualNames := make([]string, 0, len(matcher.actualParentRefs))
+	for _, ref := range matcher.actualParentRefs {
+		if ptr.Deref(ref.Kind, "") == "Gateway" {
+			actualNames = append(actualNames, string(ref.Name))
+		}
+	}
+	matcher.actualGatewayNames = actualNames
+
+	if len(actualNames) != len(matcher.expectedGatewayNames) {
+		return false, nil
+	}
+
+	expectedSet := make(map[string]bool)
+	for _, name := range matcher.expectedGatewayNames {
+		expectedSet[name] = true
+	}
+
+	for _, name := range actualNames {
+		if !expectedSet[name] {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func (matcher *haveGatewayRefsMatcher) FailureMessage(actual any) string {
+	return fmt.Sprintf("Expected %T to have gateway refs %v, but found %v",
+		actual, matcher.expectedGatewayNames, matcher.actualGatewayNames)
+}
+
+func (matcher *haveGatewayRefsMatcher) NegatedFailureMessage(actual any) string {
+	return fmt.Sprintf("Expected %T to not have gateway refs %v, but they were found",
+		actual, matcher.expectedGatewayNames)
+}
+
+// HaveBackendRefs returns a matcher that checks if an HTTPRoute has the specified backend refs
+func HaveBackendRefs(expectedBackendNames ...string) types.GomegaMatcher {
+	return &haveBackendRefsMatcher{
+		expectedBackendNames: expectedBackendNames,
+	}
+}
+
+type haveBackendRefsMatcher struct {
+	expectedBackendNames []string
+	actualBackendNames   []string
+}
+
+func (matcher *haveBackendRefsMatcher) Match(actual any) (success bool, err error) {
+	httpRoute, err := extractHTTPRoute(actual)
+	if err != nil {
+		return false, err
+	}
+
+	var backendNames []string
+	for _, rule := range httpRoute.Spec.Rules {
+		for _, backendRef := range rule.BackendRefs {
+			backendNames = append(backendNames, string(backendRef.Name))
+		}
+	}
+	matcher.actualBackendNames = backendNames
+
+	if len(backendNames) != len(matcher.expectedBackendNames) {
+		return false, nil
+	}
+
+	expectedSet := make(map[string]bool)
+	for _, name := range matcher.expectedBackendNames {
+		expectedSet[name] = true
+	}
+
+	for _, name := range backendNames {
+		if !expectedSet[name] {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func (matcher *haveBackendRefsMatcher) FailureMessage(actual any) string {
+	return fmt.Sprintf("Expected %T to have backend refs %v, but found %v",
+		actual, matcher.expectedBackendNames, matcher.actualBackendNames)
+}
+
+func (matcher *haveBackendRefsMatcher) NegatedFailureMessage(actual any) string {
+	return fmt.Sprintf("Expected %T to not have backend refs %v, but they were found",
+		actual, matcher.expectedBackendNames)
+}
+
+// HaveGatewayRefsInNamespace returns a matcher that checks if an HTTPRoute has the specified gateway parent refs in the given namespace
+func HaveGatewayRefsInNamespace(namespace string, expectedGatewayNames ...string) types.GomegaMatcher {
+	return &haveGatewayRefsInNamespaceMatcher{
+		expectedNamespace:    namespace,
+		expectedGatewayNames: expectedGatewayNames,
+	}
+}
+
+type haveGatewayRefsInNamespaceMatcher struct {
+	expectedNamespace    string
+	expectedGatewayNames []string
+	actualParentRefs     []gatewayapi.ParentReference
+	actualGatewayNames   []string
+}
+
+func (matcher *haveGatewayRefsInNamespaceMatcher) Match(actual any) (success bool, err error) {
+	httpRoute, err := extractHTTPRoute(actual)
+	if err != nil {
+		return false, err
+	}
+
+	matcher.actualParentRefs = httpRoute.Spec.ParentRefs
+
+	actualNames := make([]string, 0, len(matcher.actualParentRefs))
+	for _, ref := range matcher.actualParentRefs {
+		// Only consider Gateway kind refs in the specified namespace
+		if ptr.Deref(ref.Kind, "") == "Gateway" && ptr.Deref(ref.Namespace, "") == gatewayapi.Namespace(matcher.expectedNamespace) {
+			actualNames = append(actualNames, string(ref.Name))
+		}
+	}
+	matcher.actualGatewayNames = actualNames
+
+	if len(actualNames) != len(matcher.expectedGatewayNames) {
+		return false, nil
+	}
+
+	expectedSet := make(map[string]bool)
+	for _, name := range matcher.expectedGatewayNames {
+		expectedSet[name] = true
+	}
+
+	for _, name := range actualNames {
+		if !expectedSet[name] {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func (matcher *haveGatewayRefsInNamespaceMatcher) FailureMessage(actual any) string {
+	return fmt.Sprintf("Expected %T to have gateway refs %v in namespace %q, but found %v",
+		actual, matcher.expectedGatewayNames, matcher.expectedNamespace, matcher.actualGatewayNames)
+}
+
+func (matcher *haveGatewayRefsInNamespaceMatcher) NegatedFailureMessage(actual any) string {
+	return fmt.Sprintf("Expected %T to not have gateway refs %v in namespace %q, but they were found",
+		actual, matcher.expectedGatewayNames, matcher.expectedNamespace)
+}

--- a/pkg/testing/meta_matchers.go
+++ b/pkg/testing/meta_matchers.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// BeOwnedBy returns a matcher that checks if a Kubernetes object is owned by the specified owner
+func BeOwnedBy(expectedOwner any) types.GomegaMatcher {
+	return &beOwnedByMatcher{
+		expectedOwner: expectedOwner,
+	}
+}
+
+type beOwnedByMatcher struct {
+	expectedOwner    any
+	expectedName     string
+	expectedKind     string
+	actualOwnerRefs  []metav1.OwnerReference
+	matchingOwnerRef *metav1.OwnerReference
+}
+
+func (matcher *beOwnedByMatcher) Match(actual any) (success bool, err error) {
+	// Ensure actual is a Kubernetes object
+	actualObj, ok := actual.(metav1.Object)
+	if !ok {
+		return false, fmt.Errorf("expected a Kubernetes object implementing metav1.Object, but got %T", actual)
+	}
+
+	// Extract expected owner name and kind
+	expectedOwnerObj, ok := matcher.expectedOwner.(metav1.Object)
+	if !ok {
+		return false, fmt.Errorf("expected owner to be a Kubernetes object implementing metav1.Object, but got %T", matcher.expectedOwner)
+	}
+
+	matcher.expectedName = expectedOwnerObj.GetName()
+
+	// Extract kind from the runtime object
+	if runtimeObj, ok := matcher.expectedOwner.(runtime.Object); ok {
+		gvk := runtimeObj.GetObjectKind().GroupVersionKind()
+		if gvk.Kind != "" {
+			matcher.expectedKind = gvk.Kind
+		} else {
+			// Fall back to type name if Kind is not set
+			matcher.expectedKind = fmt.Sprintf("%T", matcher.expectedOwner)
+			// Remove package path and pointer indicator if present
+			if len(matcher.expectedKind) > 0 && matcher.expectedKind[0] == '*' {
+				matcher.expectedKind = matcher.expectedKind[1:]
+			}
+			if idx := len(matcher.expectedKind) - 1; idx >= 0 {
+				for i := idx; i >= 0; i-- {
+					if matcher.expectedKind[i] == '.' {
+						matcher.expectedKind = matcher.expectedKind[i+1:]
+						break
+					}
+				}
+			}
+		}
+	} else {
+		return false, fmt.Errorf("expected owner to implement runtime.Object for kind extraction, but got %T", matcher.expectedOwner)
+	}
+
+	// Extract actual owner references
+	matcher.actualOwnerRefs = actualObj.GetOwnerReferences()
+
+	// Check if any owner reference matches
+	for i := range matcher.actualOwnerRefs {
+		ownerRef := &matcher.actualOwnerRefs[i]
+		if ownerRef.Name == matcher.expectedName && ownerRef.Kind == matcher.expectedKind {
+			matcher.matchingOwnerRef = ownerRef
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func (matcher *beOwnedByMatcher) FailureMessage(actual any) string {
+	if len(matcher.actualOwnerRefs) == 0 {
+		return fmt.Sprintf("Expected %T to be owned by %q (Kind: %q), but no owner references were found",
+			actual, matcher.expectedName, matcher.expectedKind)
+	}
+
+	ownerInfo := make([]string, len(matcher.actualOwnerRefs))
+	for i, ref := range matcher.actualOwnerRefs {
+		ownerInfo[i] = fmt.Sprintf("%s/%s", ref.Kind, ref.Name)
+	}
+
+	return fmt.Sprintf("Expected %T to be owned by %q (Kind: %q), but found owner references: %v",
+		actual, matcher.expectedName, matcher.expectedKind, ownerInfo)
+}
+
+func (matcher *beOwnedByMatcher) NegatedFailureMessage(actual any) string {
+	return fmt.Sprintf("Expected %T to not be owned by %q (Kind: %q), but it was found in owner references",
+		actual, matcher.expectedName, matcher.expectedKind)
+}
+
+// BeControllerBy returns a matcher that checks if a Kubernetes object is owned AND controlled by the specified owner
+func BeControllerBy(expectedOwner any) types.GomegaMatcher {
+	return &beControllerByMatcher{
+		expectedOwner:  expectedOwner,
+		ownedByMatcher: BeOwnedBy(expectedOwner).(*beOwnedByMatcher),
+	}
+}
+
+type beControllerByMatcher struct {
+	expectedOwner    any
+	ownedByMatcher   *beOwnedByMatcher
+	controllerStatus string
+}
+
+func (matcher *beControllerByMatcher) Match(actual any) (success bool, err error) {
+	owned, err := matcher.ownedByMatcher.Match(actual)
+	if err != nil {
+		return false, err
+	}
+
+	if !owned {
+		return false, nil
+	}
+
+	if matcher.ownedByMatcher.matchingOwnerRef.Controller == nil {
+		matcher.controllerStatus = "nil"
+		return false, nil
+	}
+
+	isController := *matcher.ownedByMatcher.matchingOwnerRef.Controller
+	matcher.controllerStatus = strconv.FormatBool(isController)
+
+	return isController, nil
+}
+
+func (matcher *beControllerByMatcher) FailureMessage(actual any) string {
+	owned, _ := matcher.ownedByMatcher.Match(actual)
+	if !owned {
+		return fmt.Sprintf("Expected %T to be controlled by %q, but %s",
+			actual, matcher.ownedByMatcher.expectedName,
+			matcher.ownedByMatcher.FailureMessage(actual)[len("Expected"):])
+	}
+
+	return fmt.Sprintf("Expected %T to be controlled by %q (Kind: %q), but controller field is %s",
+		actual, matcher.ownedByMatcher.expectedName, matcher.ownedByMatcher.expectedKind, matcher.controllerStatus)
+}
+
+func (matcher *beControllerByMatcher) NegatedFailureMessage(actual any) string {
+	return fmt.Sprintf("Expected %T to not be controlled by %q (Kind: %q), but it was found as a controller",
+		actual, matcher.ownedByMatcher.expectedName, matcher.ownedByMatcher.expectedKind)
+}

--- a/pkg/testing/status_matchers.go
+++ b/pkg/testing/status_matchers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The KServe Authors.
+Copyright 2025 The KServe Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
> [!NOTE]
> This is a stacked PR from my ongoing router work.
> I want to keep them small and focused.

This PR brings a few additional custom Gomega matchers that simplify asserting properties of k8s resources under tests.

- Meta matcher to check proper owner references and are controller by
- Deployment-specific assertions
- HTTPRoute assertions, specifically for checking refs (gateway and backend)

For example:

```golang
Expect(httpRoute).To(BeControllerBy(llmSvc))
Expect(httpRoute).To(HaveGatewayRefs("my-ingress-gateway"))
Expect(httpRoute).To(HaveBackendRefs("my-inference-pool"))
```
