### PR TITLE
test: ensures presets are valid

### DIFF
--- a/pkg/controller/llmisvc/config_merge_test.go
+++ b/pkg/controller/llmisvc/config_merge_test.go
@@ -14,10 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package llmisvc
+package llmisvc_test
 
 import (
 	"testing"
+
+	"github.com/kserve/kserve/pkg/controller/llmisvc"
 
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
@@ -740,7 +742,7 @@ func TestMergeSpecs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := MergeSpecs(tt.cfgs...)
+			got, err := llmisvc.MergeSpecs(tt.cfgs...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("MergeSpecs() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -807,7 +809,7 @@ func TestReplaceVariables(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ReplaceVariables(tt.llmSvc, tt.cfg)
+			got, err := llmisvc.ReplaceVariables(tt.llmSvc, tt.cfg)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ReplaceVariables() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/controller/llmisvc/config_presets_test.go
+++ b/pkg/controller/llmisvc/config_presets_test.go
@@ -1,0 +1,281 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/kserve/kserve/pkg/controller/llmisvc"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"knative.dev/pkg/apis"
+	"sigs.k8s.io/yaml"
+
+	kservetesting "github.com/kserve/kserve/pkg/testing"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+)
+
+func TestPresetFiles(t *testing.T) {
+	presetsDir := filepath.Join(kservetesting.ProjectRoot(), "config", "llmisvc")
+
+	llmSvc := beefyLLMInferenceService()
+
+	_ = filepath.Walk(presetsDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			t.Errorf("Failed to walk %s: %v", path, err)
+			return err
+		}
+
+		filename := info.Name()
+		if info.IsDir() || !strings.HasSuffix(filename, ".yaml") || !strings.HasPrefix(filename, "config-") {
+			return nil
+		}
+
+		t.Run(filename, func(t *testing.T) {
+			filePath := filepath.Join(presetsDir, filename)
+			data, err := os.ReadFile(filePath)
+			if err != nil {
+				t.Errorf("Failed to read file %s: %v", filePath, err)
+				return
+			}
+
+			config := &v1alpha1.LLMInferenceServiceConfig{}
+			if err := yaml.Unmarshal(data, config); err != nil {
+				t.Errorf("Failed to unmarshal YAML from %s: %v", filePath, err)
+				return
+			}
+
+			if config.APIVersion != "serving.kserve.io/v1alpha1" {
+				t.Errorf("Expected APIVersion to be 'serving.kserve.io/v1alpha1', got %s", config.APIVersion)
+			}
+			if config.Kind != "LLMInferenceServiceConfig" {
+				t.Errorf("Expected Kind to be 'LLMInferenceServiceConfig', got %s", config.Kind)
+			}
+			if config.ObjectMeta.Name == "" {
+				t.Error("Expected ObjectMeta.Name to be set")
+			}
+
+			_, err = llmisvc.ReplaceVariables(llmSvc, config)
+			if err != nil {
+				t.Errorf("ReplaceVariables() failed for %s: %v", filename, err)
+			}
+		})
+
+		return nil
+	})
+}
+
+func beefyLLMInferenceService() *v1alpha1.LLMInferenceService {
+	svcName := "test-llm-preset"
+	nsName := "test-llm-preset-test"
+	modelURL, _ := apis.ParseURL("hf://facebook/opt-125m")
+
+	return &v1alpha1.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svcName,
+			Namespace: nsName,
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      "llminferenceservice",
+				"app.kubernetes.io/instance":  svcName,
+				"app.kubernetes.io/component": "inference",
+			},
+			Annotations: map[string]string{
+				"serving.kserve.io/model-uri": modelURL.String(),
+			},
+		},
+		Spec: v1alpha1.LLMInferenceServiceSpec{
+			Model: v1alpha1.LLMModelSpec{
+				Name: ptr.To("facebook/opt-125m"),
+				URI:  *modelURL,
+				Storage: &v1alpha1.LLMStorageSpec{
+					Path: ptr.To("/models"),
+					Parameters: &map[string]string{
+						"storageUri": modelURL.String(),
+					},
+				},
+			},
+			WorkloadSpec: v1alpha1.WorkloadSpec{
+				Replicas: ptr.To[int32](2),
+				Parallelism: &v1alpha1.ParallelismSpec{
+					Tensor:   ptr.To[int64](2),
+					Pipeline: ptr.To[int64](1),
+				},
+				Template: &corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "kserve-container",
+							Image: "ghcr.io/llm-d/llm-d:0.0.8",
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: 8000,
+									Name:          "http",
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("2"),
+									corev1.ResourceMemory: resource.MustParse("4Gi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("4"),
+									corev1.ResourceMemory: resource.MustParse("8Gi"),
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "MODEL_NAME",
+									Value: "facebook/opt-125m",
+								},
+								{
+									Name:  "VLLM_LOGGING_LEVEL",
+									Value: "INFO",
+								},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						{
+							Key:      "nvidia.com/gpu",
+							Operator: corev1.TolerationOpExists,
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+					},
+					NodeSelector: map[string]string{
+						"node.kubernetes.io/instance-type": "gpu-node",
+					},
+				},
+				Worker: &corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "kserve-container",
+							Image: "ghcr.io/llm-d/llm-d:0.0.8",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("2Gi"),
+									"nvidia.com/gpu":      resource.MustParse("1"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("2"),
+									corev1.ResourceMemory: resource.MustParse("4Gi"),
+									"nvidia.com/gpu":      resource.MustParse("1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			Prefill: &v1alpha1.WorkloadSpec{
+				Replicas: ptr.To[int32](1),
+				Parallelism: &v1alpha1.ParallelismSpec{
+					Tensor:   ptr.To[int64](1),
+					Pipeline: ptr.To[int64](1),
+				},
+				Template: &corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "kserve-container",
+							Image: "ghcr.io/llm-d/llm-d:0.0.8",
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: 8000,
+									Name:          "http",
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("4"),
+									corev1.ResourceMemory: resource.MustParse("8Gi"),
+									"nvidia.com/gpu":      resource.MustParse("2"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("8"),
+									corev1.ResourceMemory: resource.MustParse("16Gi"),
+									"nvidia.com/gpu":      resource.MustParse("2"),
+								},
+							},
+						},
+					},
+				},
+			},
+			Router: &v1alpha1.RouterSpec{
+				Route: &v1alpha1.GatewayRoutesSpec{
+					HTTP: &v1alpha1.HTTPRouteSpec{
+						Refs: []corev1.LocalObjectReference{
+							{Name: "custom-http-route"},
+						},
+					},
+				},
+				Gateway: &v1alpha1.GatewaySpec{
+					Refs: []v1alpha1.UntypedObjectReference{
+						{
+							Name:      "kserve-ingress-gateway",
+							Namespace: "kserve",
+						},
+					},
+				},
+				Scheduler: &v1alpha1.SchedulerSpec{
+					Pool: &v1alpha1.InferencePoolSpec{
+						Ref: &corev1.LocalObjectReference{
+							Name: "custom-inference-pool",
+						},
+					},
+					Template: &corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "scheduler",
+								Image: "ghcr.io/llm-d/llm-d-inference-scheduler:0.0.4",
+								Ports: []corev1.ContainerPort{
+									{
+										ContainerPort: 9002,
+										Name:          "grpc",
+										Protocol:      corev1.ProtocolTCP,
+									},
+									{
+										ContainerPort: 9003,
+										Name:          "grpc-health",
+										Protocol:      corev1.ProtocolTCP,
+									},
+								},
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("256m"),
+										corev1.ResourceMemory: resource.MustParse("500Mi"),
+									},
+								},
+								Env: []corev1.EnvVar{
+									{Name: "ENABLE_LOAD_AWARE_SCORER", Value: "true"},
+									{Name: "POOL_NAME", Value: svcName + "-inference-pool"},
+									{Name: "POOL_NAMESPACE", Value: nsName},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
This PR is a follow-up to #686 that introduces smoke unit to ensures that all presets defined in `./config/llmisvc` are valid templates.

This not only prevents from wrong usage of quotes (see related PR) but also checks if golang templating is correct.

> [!IMPORTANT]
> Only files prefixed with `config-` are validated.