### PR TITLE
feat(presets): additional context in templating

### DIFF
--- a/pkg/controller/llmisvc/controller_test.go
+++ b/pkg/controller/llmisvc/controller_test.go
@@ -171,7 +171,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				}).WithContext(ctx).Should(Succeed())
 
 				Expect(expectedHTTPRoute).To(BeControllerBy(llmSvc))
-				Expect(expectedHTTPRoute).To(HaveGatewayRefs("kserve-ingress-gateway"))
+				Expect(expectedHTTPRoute).To(HaveGatewayRefs(gatewayapi.ParentReference{Name: "kserve-ingress-gateway"}))
 				Expect(expectedHTTPRoute).To(HaveBackendRefs(svcName + "-inference-pool"))
 			})
 
@@ -230,7 +230,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				}).WithContext(ctx).Should(Not(HaveOccurred()), "HTTPRoute should be created")
 
 				Expect(expectedHTTPRoute).To(BeControllerBy(llmSvc))
-				Expect(expectedHTTPRoute).To(HaveGatewayRefs("my-ingress-gateway"))
+				Expect(expectedHTTPRoute).To(HaveGatewayRefs(gatewayapi.ParentReference{Name: "my-ingress-gateway"}))
 				Expect(expectedHTTPRoute).To(HaveBackendRefs("my-inference-pool"))
 			})
 


### PR DESCRIPTION
This change allows to use arbitrary struct T in the preset templates by using `{{ .Context.T.Field }}`. This way we can inject KServe configurations such as `IngressConfig`. The templates will now fail on missing keys.

> [!IMPORTANT]
> The templates will now fail on missing keys.
> For simplicity struct is added by it's name without package prefix.
> Anonymous structs are not supported

In addition, copy-pasty bug in `HTTPRoute` matcher has been fixed.
