### PR TITLE
feat(gw): uses default ingress gateway

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -33,6 +33,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/tools/record"
 	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -273,9 +274,7 @@ func main() {
 	if err = (&llmisvc.LLMInferenceServiceReconciler{
 		Client:        mgr.GetClient(),
 		EventRecorder: llmEventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: "LLMInferenceServiceController"}),
-		Config: llmisvc.ReconcilerConfig{
-			SystemNamespace: constants.KServeNamespace,
-		},
+		Config:        llmisvc.NewConfig(ingressConfig),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "v1beta1Controller", "InferenceService")
 		os.Exit(1)

--- a/config/llmisvc/config-llm-router-route.yaml
+++ b/config/llmisvc/config-llm-router-route.yaml
@@ -10,7 +10,10 @@ spec:
           parentRefs:
             - group: gateway.networking.k8s.io
               kind: Gateway
-              name: kserve-ingress-gateway
+              name: |-
+                {{ .Context.Config.IngressGatewayName }}
+              # With inherited namespace validation we cannot use {{ .Context.Config.IngressGatewayNamespace }}
+              # Need to disable validation on CRD level
               namespace: kserve
           rules:
             - backendRefs:

--- a/docs/samples/llmisvc/opt-125m/llm-inference-service-facebook-opt-125m-cpu.yaml
+++ b/docs/samples/llmisvc/opt-125m/llm-inference-service-facebook-opt-125m-cpu.yaml
@@ -9,6 +9,8 @@ spec:
   replicas: 1
   router:
     scheduler: {}
+    route: {}
+    gateway: {}
   template:
     containers:
       - name: main

--- a/docs/samples/llmisvc/opt-125m/llm-inference-service-pd-facebook-opt-125m-cpu.yaml
+++ b/docs/samples/llmisvc/opt-125m/llm-inference-service-pd-facebook-opt-125m-cpu.yaml
@@ -9,6 +9,8 @@ spec:
   replicas: 1
   router:
     scheduler: {}
+    route: {}
+    gateway: {}
   template:
     containers:
       - name: main

--- a/pkg/apis/serving/v1alpha1/llm_inference_service_types_func.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_types_func.go
@@ -20,6 +20,10 @@ func (in *GatewayRoutesSpec) IsManaged() bool {
 	return in != nil && in == &GatewayRoutesSpec{}
 }
 
+func (in *GatewaySpec) HasRefs() bool {
+	return in != nil && len(in.Refs) > 0
+}
+
 func (r *HTTPRouteSpec) HasRefs() bool {
 	return r != nil && len(r.Refs) > 0
 }

--- a/pkg/controller/llmisvc/config_presets_test.go
+++ b/pkg/controller/llmisvc/config_presets_test.go
@@ -36,10 +36,16 @@ import (
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 )
 
+// TODO(webhook): re-use webhook logic to do  the spec merge and validation
 func TestPresetFiles(t *testing.T) {
 	presetsDir := filepath.Join(kservetesting.ProjectRoot(), "config", "llmisvc")
 
 	llmSvc := beefyLLMInferenceService()
+	kserveSystemConfig := llmisvc.Config{
+		SystemNamespace:         "kserve",
+		IngressGatewayName:      "kserve-ingress-gateway",
+		IngressGatewayNamespace: "kserve",
+	}
 
 	_ = filepath.Walk(presetsDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -76,7 +82,7 @@ func TestPresetFiles(t *testing.T) {
 				t.Error("Expected ObjectMeta.Name to be set")
 			}
 
-			_, err = llmisvc.ReplaceVariables(llmSvc, config)
+			_, err = llmisvc.ReplaceVariables(llmSvc, config, kserveSystemConfig)
 			if err != nil {
 				t.Errorf("ReplaceVariables() failed for %s: %v", filename, err)
 			}

--- a/pkg/controller/llmisvc/suite_test.go
+++ b/pkg/controller/llmisvc/suite_test.go
@@ -59,9 +59,7 @@ var _ = SynchronizedBeforeSuite(func() {
 	llmCtrlFunc := func(cfg *rest.Config, mgr ctrl.Manager) error {
 		eventBroadcaster := record.NewBroadcaster()
 		clientSet, err := kubernetes.NewForConfig(cfg)
-		if err != nil {
-			Expect(err).NotTo(HaveOccurred())
-		}
+		Expect(err).NotTo(HaveOccurred())
 
 		llmCtrl := llmisvc.LLMInferenceServiceReconciler{
 			Client:    mgr.GetClient(),

--- a/pkg/controller/llmisvc/suite_test.go
+++ b/pkg/controller/llmisvc/suite_test.go
@@ -21,6 +21,9 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
 	"github.com/kserve/kserve/pkg/constants"
 
 	corev1 "k8s.io/api/core/v1"
@@ -51,16 +54,24 @@ var _ = SynchronizedBeforeSuite(func() {
 	SetDefaultEventuallyPollingInterval(250 * time.Millisecond)
 
 	By("Setting up the test environment")
-	systemNs := "kserve"
+	systemNs := constants.KServeNamespace
 
-	llmCtrlFunc := func(mgr ctrl.Manager) error {
+	llmCtrlFunc := func(cfg *rest.Config, mgr ctrl.Manager) error {
 		eventBroadcaster := record.NewBroadcaster()
+		clientSet, err := kubernetes.NewForConfig(cfg)
+		if err != nil {
+			Expect(err).NotTo(HaveOccurred())
+		}
+
 		llmCtrl := llmisvc.LLMInferenceServiceReconciler{
-			Client: mgr.GetClient(),
+			Client:    mgr.GetClient(),
+			Clientset: clientSet,
 			// TODO fix it to be set up similar to main.go, for now it's stub
 			EventRecorder: eventBroadcaster.NewRecorder(mgr.GetScheme(), corev1.EventSource{Component: "v1beta1Controllers"}),
-			Config: llmisvc.ReconcilerConfig{
-				SystemNamespace: systemNs,
+			Config: llmisvc.Config{
+				SystemNamespace:         systemNs,
+				IngressGatewayName:      "kserve-ingress-gateway",
+				IngressGatewayNamespace: "kserve",
 			},
 		}
 		return llmCtrl.SetupWithManager(mgr)

--- a/pkg/testing/config.go
+++ b/pkg/testing/config.go
@@ -119,7 +119,7 @@ func (e *Config) Start(ctx context.Context) *Client {
 	gomega.Expect(errMgr).NotTo(gomega.HaveOccurred())
 
 	for _, setupFunc := range e.ctrlSetupFuncs {
-		errSetup := setupFunc(mgr)
+		errSetup := setupFunc(cfg, mgr)
 		gomega.Expect(errSetup).NotTo(gomega.HaveOccurred())
 	}
 

--- a/pkg/testing/types.go
+++ b/pkg/testing/types.go
@@ -18,9 +18,10 @@ package testing
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-type SetupWithManagerFunc func(mgr ctrl.Manager) error
+type SetupWithManagerFunc func(cfg *rest.Config, mgr ctrl.Manager) error
 
 type AddToSchemeFunc func(scheme *runtime.Scheme) error


### PR DESCRIPTION
With this change we can inject configuration from the config map.

There is no need for `.reconcileGateway` with the current approach - we either use default one with `.spec.router.gateway: {}` or we link routes to provided parent.

> [!IMPORTANT]
> We cannot template the namespace in the route preset, because the
validation on Namespace type rejects it for obvious reasons. We keep namespace hardcoded for the time being, but it can be changed by the user in the cluster.

```sh
kind create cluster -n "kserve-llm-d"

go install sigs.k8s.io/cloud-provider-kind@latest

cloud-provider-kind> /dev/null 2>&1 &

make deploy-dev-llm -e KO_DOCKER_REPO=<YOUR_REPO>

kubectl apply -n kserve -f - <<EOF
apiVersion: serving.kserve.io/v1alpha1
kind: LLMInferenceService
metadata:
  name: facebook-opt-125m-single
spec:
  model:
    uri: hf://facebook/opt-125m
    name: facebook/opt-125m
  replicas: 1
  router:
    scheduler: {}
    route: {}
    gateway: {}
  template:
    containers:
      - name: main
        image: quay.io/rh-aiservices-bu/vllm-cpu-openai-ubi9:0.3
EOF

LB_IP=$(k get svc/kserve-ingress-gateway-istio -n kserve -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')

curl http://${LB_IP}/v1/completions  \
    -H "Content-Type: application/json" \
    -d '{
        "model": "facebook/opt-125m",
        "prompt": "San Francisco is a"
    }'

```

> [!WARNING]
> curl will kill the model, but that's fine, not our problem yet ;)

> [!IMPORTANT]
> If you are using quay.io make sure to change kserve binary img repos
to public!
