### PR TITLE
Fix panic for invalid templates and add additional tests for MergeSpecs and ReplaceVariables

### DIFF
--- a/pkg/controller/llmisvc/config_merge.go
+++ b/pkg/controller/llmisvc/config_merge.go
@@ -137,12 +137,16 @@ func ReplaceVariables(llmSvc *v1alpha1.LLMInferenceService, llmSvcCfg *v1alpha1.
 		LLMInferenceService: llmSvc,
 		GlobalConfig:        reconcilerConfig,
 	}
-	if err := template.Must(template.New("config").
+	t, err := template.New("config").
 		Funcs(map[string]any{
 			"ChildName": kmeta.ChildName,
 		}).
 		Option("missingkey=error").
-		Parse(string(templateBytes))).Execute(buf, config); err != nil {
+		Parse(string(templateBytes))
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse template config: %w", err)
+	}
+	if err := t.Execute(buf, config); err != nil {
 		return nil, fmt.Errorf("failed to merge config: %w", err)
 	}
 

--- a/pkg/controller/llmisvc/config_merge_test.go
+++ b/pkg/controller/llmisvc/config_merge_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/apis"
 	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
@@ -744,6 +745,346 @@ func TestMergeSpecs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "merge LoRA adapters",
+			cfgs: []v1alpha1.LLMInferenceServiceSpec{
+				{
+					Model: v1alpha1.LLMModelSpec{
+						URI: apis.URL{Path: "base-model"},
+						LoRA: &v1alpha1.LoRASpec{
+							Adapters: []v1alpha1.ModelSpec{
+								{StorageURI: "s3://bucket/adapter1", Framework: "pytorch", Memory: resource.MustParse("1Gi")},
+							},
+						},
+					},
+				},
+				{
+					Model: v1alpha1.LLMModelSpec{
+						LoRA: &v1alpha1.LoRASpec{
+							Adapters: []v1alpha1.ModelSpec{
+								{StorageURI: "s3://bucket/adapter2", Framework: "pytorch", Memory: resource.MustParse("512Mi")},
+							},
+						},
+					},
+				},
+			},
+			want: v1alpha1.LLMInferenceServiceSpec{
+				Model: v1alpha1.LLMModelSpec{
+					URI: apis.URL{Path: "base-model"},
+					LoRA: &v1alpha1.LoRASpec{
+						Adapters: []v1alpha1.ModelSpec{
+							{StorageURI: "s3://bucket/adapter2", Framework: "pytorch", Memory: resource.MustParse("512Mi")},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "merge storage spec",
+			cfgs: []v1alpha1.LLMInferenceServiceSpec{
+				{
+					Model: v1alpha1.LLMModelSpec{
+						URI: apis.URL{Path: "model-uri"},
+						Storage: &v1alpha1.LLMStorageSpec{
+							Path:       ptr.To("/models/base"),
+							StorageKey: ptr.To("base-key"),
+							Parameters: &map[string]string{
+								"region": "us-east-1",
+								"bucket": "my-bucket",
+							},
+						},
+					},
+				},
+				{
+					Model: v1alpha1.LLMModelSpec{
+						Storage: &v1alpha1.LLMStorageSpec{
+							Path:       ptr.To("/models/override"),
+							StorageKey: ptr.To("override-key"),
+							Parameters: &map[string]string{
+								"region":     "us-west-2",
+								"encryption": "aes256",
+							},
+						},
+					},
+				},
+			},
+			want: v1alpha1.LLMInferenceServiceSpec{
+				Model: v1alpha1.LLMModelSpec{
+					URI: apis.URL{Path: "model-uri"},
+					Storage: &v1alpha1.LLMStorageSpec{
+						Path:       ptr.To("/models/override"),
+						StorageKey: ptr.To("override-key"),
+						Parameters: &map[string]string{
+							"region":     "us-west-2",
+							"bucket":     "my-bucket",
+							"encryption": "aes256",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "merge model criticality",
+			cfgs: []v1alpha1.LLMInferenceServiceSpec{
+				{
+					Model: v1alpha1.LLMModelSpec{
+						URI:         apis.URL{Path: "model-uri"},
+						Criticality: ptr.To(igwapi.Sheddable),
+					},
+				},
+				{
+					Model: v1alpha1.LLMModelSpec{
+						Criticality: ptr.To(igwapi.Critical),
+					},
+				},
+			},
+			want: v1alpha1.LLMInferenceServiceSpec{
+				Model: v1alpha1.LLMModelSpec{
+					URI:         apis.URL{Path: "model-uri"},
+					Criticality: ptr.To(igwapi.Critical),
+				},
+			},
+		},
+		{
+			name: "merge model URI",
+			cfgs: []v1alpha1.LLMInferenceServiceSpec{
+				{
+					Model: v1alpha1.LLMModelSpec{
+						URI: apis.URL{Scheme: "hf", Host: "hub.com", Path: "/model-a"},
+					},
+				},
+				{
+					Model: v1alpha1.LLMModelSpec{
+						URI: apis.URL{Scheme: "s3", Host: "bucket.com", Path: "/model-b"},
+					},
+				},
+			},
+			want: v1alpha1.LLMInferenceServiceSpec{
+				Model: v1alpha1.LLMModelSpec{
+					URI: apis.URL{Scheme: "s3", Host: "bucket.com", Path: "/model-b"},
+				},
+			},
+		},
+		{
+			name: "merge baseRefs",
+			cfgs: []v1alpha1.LLMInferenceServiceSpec{
+				{
+					BaseRefs: []corev1.LocalObjectReference{
+						{Name: "base-config-1"},
+						{Name: "base-config-2"},
+					},
+				},
+				{
+					BaseRefs: []corev1.LocalObjectReference{
+						{Name: "override-config-1"},
+					},
+				},
+			},
+			want: v1alpha1.LLMInferenceServiceSpec{
+				BaseRefs: []corev1.LocalObjectReference{
+					{Name: "override-config-1"},
+				},
+			},
+		},
+		{
+			name: "merge ingress spec",
+			cfgs: []v1alpha1.LLMInferenceServiceSpec{
+				{
+					Router: &v1alpha1.RouterSpec{
+						Ingress: &v1alpha1.IngressSpec{
+							Refs: []v1alpha1.UntypedObjectReference{
+								{Name: "base-ingress", Namespace: "base-ns"},
+							},
+						},
+					},
+				},
+				{
+					Router: &v1alpha1.RouterSpec{
+						Ingress: &v1alpha1.IngressSpec{
+							Refs: []v1alpha1.UntypedObjectReference{
+								{Name: "override-ingress", Namespace: "override-ns"},
+							},
+						},
+					},
+				},
+			},
+			want: v1alpha1.LLMInferenceServiceSpec{
+				Router: &v1alpha1.RouterSpec{
+					Ingress: &v1alpha1.IngressSpec{
+						Refs: []v1alpha1.UntypedObjectReference{
+							{Name: "override-ingress", Namespace: "override-ns"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "merge with nil pointer handling",
+			cfgs: []v1alpha1.LLMInferenceServiceSpec{
+				{
+					Model: v1alpha1.LLMModelSpec{
+						URI:  apis.URL{Path: "model-uri"},
+						Name: ptr.To("base-name"),
+					},
+					WorkloadSpec: v1alpha1.WorkloadSpec{
+						Replicas: ptr.To[int32](1),
+					},
+				},
+				{
+					Model: v1alpha1.LLMModelSpec{
+						Name: nil, // nil pointer should not override non-nil base
+					},
+					WorkloadSpec: v1alpha1.WorkloadSpec{
+						Replicas: ptr.To[int32](3),
+					},
+				},
+			},
+			want: v1alpha1.LLMInferenceServiceSpec{
+				Model: v1alpha1.LLMModelSpec{
+					URI:  apis.URL{Path: "model-uri"},
+					Name: ptr.To("base-name"), // Base value should be preserved
+				},
+				WorkloadSpec: v1alpha1.WorkloadSpec{
+					Replicas: ptr.To[int32](3),
+				},
+			},
+		},
+		{
+			name: "merge complex nested structures",
+			cfgs: []v1alpha1.LLMInferenceServiceSpec{
+				{
+					Model: v1alpha1.LLMModelSpec{
+						URI:         apis.URL{Path: "base-model"},
+						Name:        ptr.To("base-name"),
+						Criticality: ptr.To(igwapi.Sheddable),
+						LoRA: &v1alpha1.LoRASpec{
+							Adapters: []v1alpha1.ModelSpec{
+								{StorageURI: "base-adapter", Framework: "pytorch", Memory: resource.MustParse("1Gi")},
+							},
+						},
+						Storage: &v1alpha1.LLMStorageSpec{
+							Path:       ptr.To("/base/path"),
+							StorageKey: ptr.To("base-key"),
+						},
+					},
+					WorkloadSpec: v1alpha1.WorkloadSpec{
+						Replicas: ptr.To[int32](1),
+						Parallelism: &v1alpha1.ParallelismSpec{
+							Tensor: ptr.To[int64](2),
+						},
+					},
+					Router: &v1alpha1.RouterSpec{
+						Gateway: &v1alpha1.GatewaySpec{
+							Refs: []v1alpha1.UntypedObjectReference{{Name: "base-gw"}},
+						},
+					},
+				},
+				{
+					Model: v1alpha1.LLMModelSpec{
+						Name:        ptr.To("override-name"),
+						Criticality: ptr.To(igwapi.Critical),
+						LoRA: &v1alpha1.LoRASpec{
+							Adapters: []v1alpha1.ModelSpec{
+								{StorageURI: "override-adapter", Framework: "tensorflow", Memory: resource.MustParse("2Gi")},
+							},
+						},
+						Storage: &v1alpha1.LLMStorageSpec{
+							Path: ptr.To("/override/path"),
+							Parameters: &map[string]string{
+								"new-param": "new-value",
+							},
+						},
+					},
+					WorkloadSpec: v1alpha1.WorkloadSpec{
+						Replicas: ptr.To[int32](5),
+						Parallelism: &v1alpha1.ParallelismSpec{
+							Pipeline: ptr.To[int64](4),
+						},
+					},
+					Router: &v1alpha1.RouterSpec{
+						Route: &v1alpha1.GatewayRoutesSpec{
+							HTTP: &v1alpha1.HTTPRouteSpec{
+								Refs: []corev1.LocalObjectReference{{Name: "override-route"}},
+							},
+						},
+					},
+				},
+			},
+			want: v1alpha1.LLMInferenceServiceSpec{
+				Model: v1alpha1.LLMModelSpec{
+					URI:         apis.URL{Path: "base-model"}, // Base URI preserved
+					Name:        ptr.To("override-name"),      // Override name
+					Criticality: ptr.To(igwapi.Critical),
+					LoRA: &v1alpha1.LoRASpec{
+						Adapters: []v1alpha1.ModelSpec{
+							{StorageURI: "override-adapter", Framework: "tensorflow", Memory: resource.MustParse("2Gi")},
+						},
+					},
+					Storage: &v1alpha1.LLMStorageSpec{
+						Path:       ptr.To("/override/path"),
+						StorageKey: ptr.To("base-key"), // Base key preserved
+						Parameters: &map[string]string{
+							"new-param": "new-value",
+						},
+					},
+				},
+				WorkloadSpec: v1alpha1.WorkloadSpec{
+					Replicas: ptr.To[int32](5),
+					Parallelism: &v1alpha1.ParallelismSpec{
+						Tensor:   ptr.To[int64](2), // Base tensor preserved
+						Pipeline: ptr.To[int64](4), // Override pipeline
+					},
+				},
+				Router: &v1alpha1.RouterSpec{
+					Gateway: &v1alpha1.GatewaySpec{
+						Refs: []v1alpha1.UntypedObjectReference{{Name: "base-gw"}},
+					},
+					Route: &v1alpha1.GatewayRoutesSpec{
+						HTTP: &v1alpha1.HTTPRouteSpec{
+							Refs: []corev1.LocalObjectReference{{Name: "override-route"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "merge empty structures",
+			cfgs: []v1alpha1.LLMInferenceServiceSpec{
+				{
+					Model: v1alpha1.LLMModelSpec{},
+				},
+				{
+					Model: v1alpha1.LLMModelSpec{
+						URI: apis.URL{Path: "populated-model"},
+					},
+				},
+			},
+			want: v1alpha1.LLMInferenceServiceSpec{
+				Model: v1alpha1.LLMModelSpec{
+					URI: apis.URL{Path: "populated-model"},
+				},
+			},
+		},
+		{
+			name: "merge with zero values vs nil pointers",
+			cfgs: []v1alpha1.LLMInferenceServiceSpec{
+				{
+					WorkloadSpec: v1alpha1.WorkloadSpec{
+						Replicas: ptr.To[int32](0), // Zero value, but non-nil pointer
+					},
+				},
+				{
+					WorkloadSpec: v1alpha1.WorkloadSpec{
+						Replicas: nil, // Nil pointer should not override zero value
+					},
+				},
+			},
+			want: v1alpha1.LLMInferenceServiceSpec{
+				WorkloadSpec: v1alpha1.WorkloadSpec{
+					Replicas: ptr.To[int32](0), // Zero value should be preserved
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -764,6 +1105,7 @@ func TestReplaceVariables(t *testing.T) {
 		name    string
 		llmSvc  *v1alpha1.LLMInferenceService
 		cfg     *v1alpha1.LLMInferenceServiceConfig
+		extra   *llmisvc.Config
 		want    *v1alpha1.LLMInferenceServiceConfig
 		wantErr bool
 	}{
@@ -811,19 +1153,380 @@ func TestReplaceVariables(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "template with ChildName function",
+			cfg: &v1alpha1.LLMInferenceServiceConfig{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					WorkloadSpec: v1alpha1.WorkloadSpec{
+						Template: &corev1.PodSpec{
+							ServiceAccountName: "{{ ChildName .Name `-sa` }}",
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Env: []corev1.EnvVar{
+										{Name: "DEPLOYMENT_NAME", Value: "{{ ChildName .Name `-deployment` }}"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			llmSvc: &v1alpha1.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-llm",
+					Namespace: "test-ns",
+				},
+			},
+			want: &v1alpha1.LLMInferenceServiceConfig{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					WorkloadSpec: v1alpha1.WorkloadSpec{
+						Template: &corev1.PodSpec{
+							ServiceAccountName: "test-llm-sa",
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Env: []corev1.EnvVar{
+										{Name: "DEPLOYMENT_NAME", Value: "test-llm-deployment"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "template in model storage parameters",
+			cfg: &v1alpha1.LLMInferenceServiceConfig{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					Model: v1alpha1.LLMModelSpec{
+						URI: mustParseURL("s3://ai-team/models/llama-model"),
+						Storage: &v1alpha1.LLMStorageSpec{
+							Path: ptr.To("/models/{{ .Name }}"),
+							Parameters: &map[string]string{
+								"bucket":    "{{ .Namespace }}-models",
+								"model-id":  "{{ .Name }}",
+								"full-path": "{{ .Namespace }}/{{ .Name }}",
+							},
+						},
+					},
+				},
+			},
+			llmSvc: &v1alpha1.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "llama-model",
+					Namespace: "ai-team",
+				},
+			},
+			want: &v1alpha1.LLMInferenceServiceConfig{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					Model: v1alpha1.LLMModelSpec{
+						URI: mustParseURL("s3://ai-team/models/llama-model"),
+						Storage: &v1alpha1.LLMStorageSpec{
+							Path: ptr.To("/models/llama-model"),
+							Parameters: &map[string]string{
+								"bucket":    "ai-team-models",
+								"model-id":  "llama-model",
+								"full-path": "ai-team/llama-model",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "template in arrays",
+			cfg: &v1alpha1.LLMInferenceServiceConfig{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					WorkloadSpec: v1alpha1.WorkloadSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{
+										"--model-name={{ .Name }}",
+										"--namespace={{ .Namespace }}",
+										"--config-path=/config/{{ .Name }}.yaml",
+									},
+									Env: []corev1.EnvVar{
+										{Name: "MODEL_NAME", Value: "{{ .Name }}"},
+										{Name: "NAMESPACE", Value: "{{ .Namespace }}"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			llmSvc: &v1alpha1.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gpt-model",
+					Namespace: "ml-team",
+				},
+			},
+			want: &v1alpha1.LLMInferenceServiceConfig{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					WorkloadSpec: v1alpha1.WorkloadSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{
+										"--model-name=gpt-model",
+										"--namespace=ml-team",
+										"--config-path=/config/gpt-model.yaml",
+									},
+									Env: []corev1.EnvVar{
+										{Name: "MODEL_NAME", Value: "gpt-model"},
+										{Name: "NAMESPACE", Value: "ml-team"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "template with complex nested model spec",
+			cfg: &v1alpha1.LLMInferenceServiceConfig{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					Model: v1alpha1.LLMModelSpec{
+						Name: ptr.To("{{ .Spec.Model.Name }}"),
+					},
+					WorkloadSpec: v1alpha1.WorkloadSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{
+										"--served-model-name={{ .Spec.Model.Name }}",
+										"--model-path={{ .Spec.Model.URI.Host }}{{ .Spec.Model.URI.Path }}",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			llmSvc: &v1alpha1.LLMInferenceService{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					Model: v1alpha1.LLMModelSpec{
+						Name: ptr.To("meta-llama/Llama-3.2-3B-Instruct"),
+						URI:  mustParseURL("hf://meta-llama/Llama-3.2-3B-Instruct"),
+					},
+				},
+			},
+			want: &v1alpha1.LLMInferenceServiceConfig{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					Model: v1alpha1.LLMModelSpec{
+						Name: ptr.To("meta-llama/Llama-3.2-3B-Instruct"),
+					},
+					WorkloadSpec: v1alpha1.WorkloadSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{
+										"--served-model-name=meta-llama/Llama-3.2-3B-Instruct",
+										"--model-path=meta-llama/Llama-3.2-3B-Instruct",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "template with nil pointer access should not error if default value is provided",
+			cfg: &v1alpha1.LLMInferenceServiceConfig{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					Model: v1alpha1.LLMModelSpec{
+						Name: ptr.To(`{{ if .Spec.Model.Name }}{{ .Spec.Model.Name }}{{ else }}default-model{{ end }}`),
+					},
+				},
+			},
+			llmSvc: &v1alpha1.LLMInferenceService{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					Model: v1alpha1.LLMModelSpec{
+						Name: nil, // Nil pointer
+					},
+				},
+			},
+			want: &v1alpha1.LLMInferenceServiceConfig{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					Model: v1alpha1.LLMModelSpec{
+						Name: ptr.To("default-model"),
+					},
+				},
+			},
+		},
+		{
+			name: "template with router configurations",
+			cfg: &v1alpha1.LLMInferenceServiceConfig{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					Router: &v1alpha1.RouterSpec{
+						Route: &v1alpha1.GatewayRoutesSpec{
+							HTTP: &v1alpha1.HTTPRouteSpec{
+								Refs: []corev1.LocalObjectReference{
+									{Name: "{{ .Name }}-route"},
+								},
+							},
+						},
+						Gateway: &v1alpha1.GatewaySpec{
+							Refs: []v1alpha1.UntypedObjectReference{
+								{Name: "{{ .Name }}-gateway", Namespace: "{{ .Namespace }}"},
+							},
+						},
+					},
+				},
+			},
+			llmSvc: &v1alpha1.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "router-test",
+					Namespace: "routing-ns",
+				},
+			},
+			want: &v1alpha1.LLMInferenceServiceConfig{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					Router: &v1alpha1.RouterSpec{
+						Route: &v1alpha1.GatewayRoutesSpec{
+							HTTP: &v1alpha1.HTTPRouteSpec{
+								Refs: []corev1.LocalObjectReference{
+									{Name: "router-test-route"},
+								},
+							},
+						},
+						Gateway: &v1alpha1.GatewaySpec{
+							Refs: []v1alpha1.UntypedObjectReference{
+								{Name: "router-test-gateway", Namespace: "routing-ns"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "template with multiple variables in single string",
+			cfg: &v1alpha1.LLMInferenceServiceConfig{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					WorkloadSpec: v1alpha1.WorkloadSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Env: []corev1.EnvVar{
+										{Name: "FULL_NAME", Value: "{{ .Namespace }}/{{ .Name }}"},
+										{Name: "CONFIG_PATH", Value: "/config/{{ .Namespace }}-{{ .Name }}.yaml"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			llmSvc: &v1alpha1.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "multi-var",
+					Namespace: "test-ns",
+				},
+			},
+			want: &v1alpha1.LLMInferenceServiceConfig{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					WorkloadSpec: v1alpha1.WorkloadSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Env: []corev1.EnvVar{
+										{Name: "FULL_NAME", Value: "test-ns/multi-var"},
+										{Name: "CONFIG_PATH", Value: "/config/test-ns-multi-var.yaml"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "template with invalid syntax should error",
+			cfg: &v1alpha1.LLMInferenceServiceConfig{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					Model: v1alpha1.LLMModelSpec{
+						Name: ptr.To("{{ .Name"), // Invalid template syntax - missing closing brace
+					},
+				},
+			},
+			llmSvc: &v1alpha1.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "template with non-existent field should error",
+			cfg: &v1alpha1.LLMInferenceServiceConfig{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					Model: v1alpha1.LLMModelSpec{
+						Name: ptr.To("{{ .NonExistentField }}"),
+					},
+				},
+			},
+			llmSvc: &v1alpha1.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			},
+			wantErr: true,
+		},
+		{
+			name: "template in baseRefs",
+			cfg: &v1alpha1.LLMInferenceServiceConfig{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					BaseRefs: []corev1.LocalObjectReference{
+						{Name: "{{ .Name }}-base-config"},
+						{Name: "{{ .Namespace }}-shared-config"},
+					},
+				},
+			},
+			llmSvc: &v1alpha1.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "base-ref-test",
+					Namespace: "template-ns",
+				},
+			},
+			want: &v1alpha1.LLMInferenceServiceConfig{
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					BaseRefs: []corev1.LocalObjectReference{
+						{Name: "base-ref-test-base-config"},
+						{Name: "template-ns-shared-config"},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := llmisvc.ReplaceVariables(tt.llmSvc, tt.cfg, &llmisvc.Config{})
+			got, err := llmisvc.ReplaceVariables(tt.llmSvc, tt.cfg, tt.extra)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ReplaceVariables() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if diff := cmp.Diff(tt.want, got); diff != "" {
-				t.Errorf("ReplaceVariables() got = %#v, want %#v\nDiff:\n%s", got, tt.want, diff)
+			if !tt.wantErr {
+				if diff := cmp.Diff(tt.want, got); diff != "" {
+					t.Errorf("ReplaceVariables() got = %#v, want %#v\nDiff:\n%s", got, tt.want, diff)
+				}
 			}
 		})
 	}
+}
+
+func mustParseURL(s string) apis.URL {
+	u, err := apis.ParseURL(s)
+	if err != nil {
+		panic(err)
+	}
+	return *u
 }
 
 func TestAdditionalData(t *testing.T) {


### PR DESCRIPTION
The additional tests caught a panic for invalid templates, so now the ReplaceVariables doesn't panic and returns the error instead.

