### PR TITLE
chore(config): injects `llmisvc.Config` struct in the templates

### DIFF
--- a/config/llmisvc/config-llm-router-route.yaml
+++ b/config/llmisvc/config-llm-router-route.yaml
@@ -11,8 +11,8 @@ spec:
             - group: gateway.networking.k8s.io
               kind: Gateway
               name: |-
-                {{ .Context.Config.IngressGatewayName }}
-              # With inherited namespace validation we cannot use {{ .Context.Config.IngressGatewayNamespace }}
+                {{ .GlobalConfig.IngressGatewayName }}
+              # With inherited namespace validation we cannot use {{ .GlobalConfig.IngressGatewayNamespace }}
               # Need to disable validation on CRD level
               namespace: kserve
           rules:

--- a/pkg/controller/llmisvc/config_presets_test.go
+++ b/pkg/controller/llmisvc/config_presets_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 )
 
-// TODO(webhook): re-use webhook logic to do  the spec merge and validation
+// TODO(webhook): re-use webhook logic to do the spec merge and validation
 func TestPresetFiles(t *testing.T) {
 	presetsDir := filepath.Join(kservetesting.ProjectRoot(), "config", "llmisvc")
 
@@ -82,7 +82,7 @@ func TestPresetFiles(t *testing.T) {
 				t.Error("Expected ObjectMeta.Name to be set")
 			}
 
-			_, err = llmisvc.ReplaceVariables(llmSvc, config, kserveSystemConfig)
+			_, err = llmisvc.ReplaceVariables(llmSvc, config, &kserveSystemConfig)
 			if err != nil {
 				t.Errorf("ReplaceVariables() failed for %s: %v", filename, err)
 			}

--- a/pkg/controller/llmisvc/controller.go
+++ b/pkg/controller/llmisvc/controller.go
@@ -190,7 +190,7 @@ func (r *LLMInferenceServiceReconciler) reconcile(ctx context.Context, llmSvc *v
 	logger := log.FromContext(ctx).WithName("reconcile")
 	ctx = log.IntoContext(ctx, logger)
 
-	baseCfg, err := r.combineBaseRefsConfig(ctx, llmSvc, r.Config)
+	baseCfg, err := r.combineBaseRefsConfig(ctx, llmSvc, &r.Config)
 	if err != nil {
 		llmSvc.MarkPresetsCombinedNotReady("CombineBaseError", err.Error())
 		return fmt.Errorf("failed to combine base-configurations: %w", err)


### PR DESCRIPTION
Replaces previously introduced `extra` context (#700) with actual type that can be used in the templating of `LLMInferenceServiceConfig`. The fields of injected `llmisvc.Config` struct can accessed through `{{ .GlobalConfig }}`. This promotes well-known values and makes validation easier.

Discussion on [related PR](https://github.com/opendatahub-io/kserve/pull/700#discussion_r2171225230) that led to this change.
