### PR TITLE
Initialize Clientset for LLMInferenceService reconciler

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -275,6 +275,7 @@ func main() {
 		Client:        mgr.GetClient(),
 		EventRecorder: llmEventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: "LLMInferenceServiceController"}),
 		Config:        llmisvc.NewConfig(ingressConfig),
+		Clientset:     clientSet,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "v1beta1Controller", "InferenceService")
 		os.Exit(1)

--- a/pkg/controller/llmisvc/controller.go
+++ b/pkg/controller/llmisvc/controller.go
@@ -161,6 +161,7 @@ func (r *LLMInferenceServiceReconciler) loadIngressConfig(ctx context.Context, l
 			logger.Error(errConvert, fmt.Sprintf("Failed to convert InferenceServiceConfigMap to IngressConfig. Using existing values %+v", r.Config))
 			r.Eventf(original, corev1.EventTypeWarning, "Error", "Reconciliation failed: %v", errConvert.Error())
 		}
+		// TODO Guard Config with a mutex or atomic
 		r.Config = NewConfig(ingressConfig)
 	}
 }


### PR DESCRIPTION
Fix a panic in `controller/llmisvc.(*LLMInferenceServiceReconciler).loadIngressConfig`.

