### PR TITLE
fix(config): reworks config to be immutable

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -275,7 +275,6 @@ func main() {
 		Client:        mgr.GetClient(),
 		Clientset:     clientSet,
 		EventRecorder: llmEventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: "LLMInferenceServiceController"}),
-		Config:        llmisvc.NewConfig(ingressConfig),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "v1beta1Controller", "InferenceService")
 		os.Exit(1)

--- a/pkg/controller/llmisvc/config_merge.go
+++ b/pkg/controller/llmisvc/config_merge.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"text/template"
 
+	"github.com/kserve/kserve/pkg/constants"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -164,10 +166,10 @@ func (r *LLMInferenceServiceReconciler) getConfig(ctx context.Context, llmSvc *v
 	if err := r.Client.Get(ctx, client.ObjectKey{Name: name, Namespace: llmSvc.Namespace}, cfg); err != nil {
 		if apierrors.IsNotFound(err) {
 			cfg = &v1alpha1.LLMInferenceServiceConfig{}
-			if err := r.Client.Get(ctx, client.ObjectKey{Name: name, Namespace: r.Config.SystemNamespace}, cfg); err != nil {
+			if err := r.Client.Get(ctx, client.ObjectKey{Name: name, Namespace: constants.KServeNamespace}, cfg); err != nil {
 				// TODO: add available LLMInferenceServiceConfig in system namespace and llmSvc.Namespace namespace if not found
 
-				return nil, fmt.Errorf("failed to get LLMInferenceServiceConfig %q from namespaces [%q, %q]: %w", name, llmSvc.Namespace, r.Config.SystemNamespace, err)
+				return nil, fmt.Errorf("failed to get LLMInferenceServiceConfig %q from namespaces [%q, %q]: %w", name, llmSvc.Namespace, constants.KServeNamespace, err)
 			}
 			return cfg, nil
 		}

--- a/pkg/controller/llmisvc/suite_test.go
+++ b/pkg/controller/llmisvc/suite_test.go
@@ -66,11 +66,6 @@ var _ = SynchronizedBeforeSuite(func() {
 			Clientset: clientSet,
 			// TODO fix it to be set up similar to main.go, for now it's stub
 			EventRecorder: eventBroadcaster.NewRecorder(mgr.GetScheme(), corev1.EventSource{Component: "v1beta1Controllers"}),
-			Config: llmisvc.Config{
-				SystemNamespace:         systemNs,
-				IngressGatewayName:      "kserve-ingress-gateway",
-				IngressGatewayNamespace: "kserve",
-			},
 		}
 		return llmCtrl.SetupWithManager(mgr)
 	}


### PR DESCRIPTION
Previous implementation did not account for race conditions when multiple concurrent reconciles are taking place (when `MaxConcurrentReconciles` is set to > 1).

This PR reworks how config loading is handled by ensuring that each reconcile gets a consistent (local) instance of the configuration.

This eliminates relying on shared state  that could lead to inconsistencies and makes the code easier to reason about.
