### PR TITLE
Improve Model Load Status Check in  s3-TLS FVT Tests

### DIFF
--- a/test/e2e/storagespec/test_s3_tls_storagespec.py
+++ b/test/e2e/storagespec/test_s3_tls_storagespec.py
@@ -66,7 +66,7 @@ TbVunBmL9HUClHgUc2B0NSfNyqXSwo+Gp5Kg4iYIw4hJw2EPwilUFafcM8uVDktK
 
 @pytest.mark.kserve_on_openshift
 @pytest.mark.asyncio(scope="session")
-async def test_s3_tls_custom_cert_storagespec_kserve(rest_v1_client):
+async def test_s3_tls_custom_cert_storagespec_kserve():
     kserve_client = KServeClient(
         config_file=os.environ.get("KUBECONFIG", "~/.kube/config")
     )
@@ -149,7 +149,7 @@ async def test_s3_tls_custom_cert_storagespec_kserve(rest_v1_client):
 
 @pytest.mark.kserve_on_openshift
 @pytest.mark.asyncio(scope="session")
-async def test_s3_tls_serving_cert_storagespec_kserve(rest_v1_client):
+async def test_s3_tls_serving_cert_storagespec_kserve():
     kserve_client = KServeClient(
         config_file=os.environ.get("KUBECONFIG", "~/.kube/config")
     )

--- a/test/e2e/storagespec/test_s3_tls_storagespec.py
+++ b/test/e2e/storagespec/test_s3_tls_storagespec.py
@@ -25,6 +25,7 @@ from kserve import (
     V1beta1StorageSpec,
 )
 from kubernetes.client import V1ResourceRequirements
+from typing import Optional
 import pytest
 
 from ..common.utils import KSERVE_NAMESPACE, KSERVE_TEST_NAMESPACE
@@ -235,7 +236,7 @@ def check_model_status(
     isvc_name: str,
     isvc_namespace: str,
     expected_status: str,
-    expected_failure_message: str | None = None,
+    expected_failure_message: Optional[str] = None,
     timeout_seconds: int = 600,
     polling_interval: int = 10,
 ):

--- a/test/e2e/storagespec/test_s3_tls_storagespec.py
+++ b/test/e2e/storagespec/test_s3_tls_storagespec.py
@@ -260,13 +260,18 @@ def check_model_status(
         ):
             return
 
+    actual_status = isvc["status"]["modelStatus"]["transitionStatus"]
     if expected_failure_message is not None:
+        actual_failure_message = (
+            isvc["status"]["modelStatus"].get("lastFailureInfo", {}).get("message", "")
+        )
         raise RuntimeError(
-            f"Expected inferenceservice {isvc_name} to have model transition status '{expected_status}' and last failure info \
-                '{expected_failure_message}' after timeout, but got model transition status '{isvc['status']['modelStatus']['transitionStatus']}' \
-                    and last failure info '{isvc['status']['modelStatus'].get('lastFailureInfo', {}).get('message', '')}'"
+            f"Expected inferenceservice {isvc_name} to have model transition status '{expected_status}' "
+            f"and last failure info '{expected_failure_message}' after timeout, "
+            f"but got model transition status '{actual_status}' "
+            f"and last failure info '{actual_failure_message}'"
         )
     raise RuntimeError(
-        f"Expected inferenceservice {isvc_name} to have model transition status '{expected_status}' after timeout, but got \
-            '{isvc['status']['modelStatus']['transitionStatus']}'"
+        f"Expected inferenceservice {isvc_name} to have model transition status '{expected_status}' "
+        f"after timeout, but got '{actual_status}'"
     )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
[RHOAIENG-27527](https://issues.redhat.com/browse/RHOAIENG-27527)

This PR improves the model load status check performed in the s3 TLS FVT tests by adding an optional check to validate the last failure message in addition to the transition status of the model. This allows us to confidently determine the exact reason a model is failing to load, which in the case of the s3 TLS tests would be due to certificate verification failure.

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- Run the following command from the root of the repo to validate the tests are executing successfully:
```
SETUP_E2E=true ./test/scripts/openshift-ci/run-e2e-tests.sh kserve_on_openshift
```

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved validation of SSL certificate errors in S3 TLS storage tests.
  * Enhanced status and error message checks for inference service failures due to TLS issues.
  * Improved error diagnostics when expected failure messages do not match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->