### PR TITLE
feat(router): resolves model URLs

### DIFF
--- a/pkg/controller/llmisvc/DEV.md
+++ b/pkg/controller/llmisvc/DEV.md
@@ -96,7 +96,7 @@ curl $(kubectl get llmisvc -n $NS -o=jsonpath='{.items[0].status.addresses[0].ur
 ```
 
 > [!NOTE]
-> Actual address in KinD setup is considered local, hence the jsonpath dabove.
+> Actual address in KinD setup is considered local, hence the jsonpath above.
 
 you should see a similar output:
 

--- a/pkg/controller/llmisvc/DEV.md
+++ b/pkg/controller/llmisvc/DEV.md
@@ -1,5 +1,7 @@
 ### Local Dev
 
+#### Deploying LLMInferenceService controller locally
+
 > [!IMPORTANT]
 > If you are using quay.io make sure to change kserve binary img repos visibility to public!
 
@@ -11,6 +13,8 @@ go install sigs.k8s.io/cloud-provider-kind@latest
 cloud-provider-kind> /dev/null 2>&1 &
 
 make deploy-dev-llm -e KO_DOCKER_REPO=<YOUR_REPO>
+
+#### Creating simple CPU model
 
 NS=llm-test
 kubectl create namespace ${NS} || true
@@ -40,6 +44,8 @@ LLM_ISVC_NAME=$(cat $LLM_ISVC | yq .metadata.name)
 
 kubectl apply -n ${NS} -f $LLM_ISVC
 
+#### Validation
+
 LB_IP=$(k get svc/kserve-ingress-gateway-istio -n kserve -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')
 
 curl http://${LB_IP}/${NS}/${LLM_ISVC_NAME}/v1/completions  \
@@ -53,16 +59,52 @@ curl http://${LB_IP}/${NS}/${LLM_ISVC_NAME}/v1/completions  \
 You should see:
 
 ```shell
-curl http://${LB_IP}/${NS}/${LLM_ISVC_NAME}/v1/completions  \
+{
+  "id": "cmpl-f0601f1b-66cc-4f0c-bd0c-cc93c8afd9ec",
+  "object": "text_completion",
+  "created": 1751477229,
+  "model": "facebook/opt-125m",
+  "choices": [
+    {
+      "index": 0,
+      "text": " big place and I'd imagine it will stay that way. Until the US rel",
+      "logprobs": null,
+      "finish_reason": "length",
+      "stop_reason": null,
+      "prompt_logprobs": null
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 5,
+    "total_tokens": 21,
+    "completion_tokens": 16,
+    "prompt_tokens_details": null
+  },
+  "kv_transfer_params": null
+}
+```
+
+Or by using populated URLs from LLMInferenceService status:
+
+```shell
+curl $(kubectl get llmisvc -n $NS -o=jsonpath='{.items[0].status.addresses[0].url}')/v1/completions  \
     -H "Content-Type: application/json" \
     -d '{
         "model": "facebook/opt-125m",
         "prompt": "San Francisco is a"
     }' | jq
+```
+
+> [!NOTE]
+> Actual address in KinD setup is considered local, hence the jsonpath dabove.
+
+you should see a similar output:
+
+```shell
 {
-  "id": "cmpl-f0601f1b-66cc-4f0c-bd0c-cc93c8afd9ec",
+  "id": "cmpl-8482188a-d941-4d8a-96f8-c001e0e03624",
   "object": "text_completion",
-  "created": 1751477229,
+  "created": 1751543644,
   "model": "facebook/opt-125m",
   "choices": [
     {

--- a/pkg/controller/llmisvc/fixture/gwapi_builders.go
+++ b/pkg/controller/llmisvc/fixture/gwapi_builders.go
@@ -18,24 +18,26 @@ package fixture
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	v1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 type ObjectOption[T client.Object] func(T)
 
-type GatewayOption ObjectOption[*v1.Gateway]
+type GatewayOption ObjectOption[*gatewayapiv1.Gateway]
 
-func Gateway(name string, opts ...GatewayOption) *v1.Gateway {
-	gw := &v1.Gateway{
+func Gateway(name string, opts ...GatewayOption) *gatewayapiv1.Gateway {
+	gw := &gatewayapiv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: v1.GatewaySpec{
-			Listeners: []v1.Listener{},
+		Spec: gatewayapiv1.GatewaySpec{
+			Listeners:      []gatewayapiv1.Listener{},
+			Infrastructure: &gatewayapiv1.GatewayInfrastructure{},
 		},
-		Status: v1.GatewayStatus{
-			Addresses: []v1.GatewayStatusAddress{},
+		Status: gatewayapiv1.GatewayStatus{
+			Addresses: []gatewayapiv1.GatewayStatusAddress{},
 		},
 	}
 
@@ -53,22 +55,256 @@ func InNamespace[T client.Object](namespace string) func(T) {
 }
 
 func WithClassName(className string) GatewayOption {
-	return func(gw *v1.Gateway) {
-		gw.Spec.GatewayClassName = v1.ObjectName(className)
+	return func(gw *gatewayapiv1.Gateway) {
+		gw.Spec.GatewayClassName = gatewayapiv1.ObjectName(className)
 	}
 }
 
-func WithListener(protocol v1.ProtocolType) GatewayOption {
-	return func(gw *v1.Gateway) {
-		listener := v1.Listener{
+func WithInfrastructureLabels(key, value string) GatewayOption {
+	return func(gw *gatewayapiv1.Gateway) {
+		if gw.Spec.Infrastructure.Labels == nil {
+			gw.Spec.Infrastructure.Labels = make(map[gatewayapiv1.LabelKey]gatewayapiv1.LabelValue)
+		}
+		gw.Spec.Infrastructure.Labels[gatewayapiv1.LabelKey(key)] = gatewayapiv1.LabelValue(value)
+	}
+}
+
+func WithListener(protocol gatewayapiv1.ProtocolType) GatewayOption {
+	return func(gw *gatewayapiv1.Gateway) {
+		port := gatewayapiv1.PortNumber(80)
+		if protocol == gatewayapiv1.HTTPSProtocolType {
+			port = 443
+		}
+		listener := gatewayapiv1.Listener{
 			Protocol: protocol,
+			Port:     port,
 		}
 		gw.Spec.Listeners = append(gw.Spec.Listeners, listener)
 	}
 }
 
-func WithListeners(listeners ...v1.Listener) GatewayOption {
-	return func(gw *v1.Gateway) {
+func WithListeners(listeners ...gatewayapiv1.Listener) GatewayOption {
+	return func(gw *gatewayapiv1.Gateway) {
 		gw.Spec.Listeners = append(gw.Spec.Listeners, listeners...)
+	}
+}
+
+type (
+	HTTPRouteOption ObjectOption[*gatewayapiv1.HTTPRoute]
+	ParentRefOption func(*gatewayapiv1.ParentReference)
+)
+
+func HTTPRoute(name string, opts ...HTTPRouteOption) *gatewayapiv1.HTTPRoute {
+	route := &gatewayapiv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: gatewayapiv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayapiv1.CommonRouteSpec{
+				ParentRefs: []gatewayapiv1.ParentReference{},
+			},
+			Hostnames: []gatewayapiv1.Hostname{},
+			Rules:     []gatewayapiv1.HTTPRouteRule{},
+		},
+	}
+
+	for _, opt := range opts {
+		opt(route)
+	}
+
+	return route
+}
+
+func WithParentRef(ref gatewayapiv1.ParentReference) HTTPRouteOption {
+	return func(route *gatewayapiv1.HTTPRoute) {
+		route.Spec.CommonRouteSpec.ParentRefs = append(route.Spec.CommonRouteSpec.ParentRefs, ref)
+	}
+}
+
+func WithParentRefs(refs ...gatewayapiv1.ParentReference) HTTPRouteOption {
+	return func(route *gatewayapiv1.HTTPRoute) {
+		route.Spec.CommonRouteSpec.ParentRefs = refs
+	}
+}
+
+func WithHostnames(hostnames ...string) HTTPRouteOption {
+	return func(route *gatewayapiv1.HTTPRoute) {
+		route.Spec.Hostnames = make([]gatewayapiv1.Hostname, len(hostnames))
+		for i, hostname := range hostnames {
+			route.Spec.Hostnames[i] = gatewayapiv1.Hostname(hostname)
+		}
+	}
+}
+
+func WithAddresses(addresses ...string) GatewayOption {
+	return func(gw *gatewayapiv1.Gateway) {
+		gw.Status.Addresses = make([]gatewayapiv1.GatewayStatusAddress, len(addresses))
+		for i, address := range addresses {
+			gw.Status.Addresses[i] = gatewayapiv1.GatewayStatusAddress{
+				Value: address,
+				// Type is left as nil (defaults to IPAddressType behavior)
+			}
+		}
+	}
+}
+
+func WithHostnameAddresses(addresses ...string) GatewayOption {
+	return func(gw *gatewayapiv1.Gateway) {
+		gw.Status.Addresses = make([]gatewayapiv1.GatewayStatusAddress, len(addresses))
+		for i, address := range addresses {
+			gw.Status.Addresses[i] = gatewayapiv1.GatewayStatusAddress{
+				Type:  ptr.To(gatewayapiv1.HostnameAddressType),
+				Value: address,
+			}
+		}
+	}
+}
+
+func WithMixedAddresses(addresses ...gatewayapiv1.GatewayStatusAddress) GatewayOption {
+	return func(gw *gatewayapiv1.Gateway) {
+		gw.Status.Addresses = addresses
+	}
+}
+
+func IPAddress(value string) gatewayapiv1.GatewayStatusAddress {
+	return gatewayapiv1.GatewayStatusAddress{
+		Type:  ptr.To(gatewayapiv1.IPAddressType),
+		Value: value,
+	}
+}
+
+func HostnameAddress(value string) gatewayapiv1.GatewayStatusAddress {
+	return gatewayapiv1.GatewayStatusAddress{
+		Type:  ptr.To(gatewayapiv1.HostnameAddressType),
+		Value: value,
+	}
+}
+
+func WithPath(path string) HTTPRouteOption {
+	return func(route *gatewayapiv1.HTTPRoute) {
+		rule := gatewayapiv1.HTTPRouteRule{
+			Matches: []gatewayapiv1.HTTPRouteMatch{
+				{
+					Path: &gatewayapiv1.HTTPPathMatch{
+						Value: ptr.To(path),
+					},
+				},
+			},
+		}
+		route.Spec.Rules = append(route.Spec.Rules, rule)
+	}
+}
+
+func WithRules(rules ...gatewayapiv1.HTTPRouteRule) HTTPRouteOption {
+	return func(route *gatewayapiv1.HTTPRoute) {
+		route.Spec.Rules = rules
+	}
+}
+
+func GatewayRef(name string, opts ...ParentRefOption) gatewayapiv1.ParentReference {
+	ref := gatewayapiv1.ParentReference{
+		Name:  gatewayapiv1.ObjectName(name),
+		Group: ptr.To(gatewayapiv1.Group("gateway.networking.k8s.io")),
+		Kind:  ptr.To(gatewayapiv1.Kind("Gateway")),
+	}
+
+	for _, opt := range opts {
+		opt(&ref)
+	}
+
+	return ref
+}
+
+func RefInNamespace(namespace string) ParentRefOption {
+	return func(ref *gatewayapiv1.ParentReference) {
+		ref.Namespace = ptr.To(gatewayapiv1.Namespace(namespace))
+	}
+}
+
+func GatewayRefWithoutNamespace(name string) gatewayapiv1.ParentReference {
+	return gatewayapiv1.ParentReference{
+		Name:  gatewayapiv1.ObjectName(name),
+		Group: ptr.To(gatewayapiv1.Group("gateway.networking.k8s.io")),
+		Kind:  ptr.To(gatewayapiv1.Kind("Gateway")),
+		// Namespace intentionally omitted
+	}
+}
+
+func HTTPSGateway(name, namespace string, addresses ...string) *gatewayapiv1.Gateway {
+	return Gateway(name,
+		InNamespace[*gatewayapiv1.Gateway](namespace),
+		WithListener(gatewayapiv1.HTTPSProtocolType),
+		WithAddresses(addresses...),
+	)
+}
+
+func HTTPGateway(name, namespace string, addresses ...string) *gatewayapiv1.Gateway {
+	return Gateway(name,
+		InNamespace[*gatewayapiv1.Gateway](namespace),
+		WithListener(gatewayapiv1.HTTPProtocolType),
+		WithAddresses(addresses...),
+	)
+}
+
+type (
+	HTTPRouteRuleOption  func(*gatewayapiv1.HTTPRouteRule)
+	HTTPBackendRefOption func(*gatewayapiv1.HTTPBackendRef)
+)
+
+func WithHTTPRouteRule(rule gatewayapiv1.HTTPRouteRule) HTTPRouteOption {
+	return func(route *gatewayapiv1.HTTPRoute) {
+		route.Spec.Rules = append(route.Spec.Rules, rule)
+	}
+}
+
+func BuildHTTPRouteSpec(opts ...HTTPRouteOption) *gatewayapiv1.HTTPRouteSpec {
+	route := HTTPRoute("temp", opts...)
+	return &route.Spec
+}
+
+func InferenceServiceRef(name string, port int32, weight int32) gatewayapiv1.HTTPBackendRef {
+	return gatewayapiv1.HTTPBackendRef{
+		BackendRef: gatewayapiv1.BackendRef{
+			BackendObjectReference: gatewayapiv1.BackendObjectReference{
+				Group: ptr.To(gatewayapiv1.Group("serving.kserve.io")),
+				Kind:  ptr.To(gatewayapiv1.Kind("InferenceService")),
+				Name:  gatewayapiv1.ObjectName(name),
+				Port:  ptr.To(gatewayapiv1.PortNumber(port)),
+			},
+			Weight: ptr.To(weight),
+		},
+	}
+}
+
+func PathPrefixMatch(path string) gatewayapiv1.HTTPRouteMatch {
+	return gatewayapiv1.HTTPRouteMatch{
+		Path: &gatewayapiv1.HTTPPathMatch{
+			Type:  ptr.To(gatewayapiv1.PathMatchPathPrefix),
+			Value: ptr.To(path),
+		},
+	}
+}
+
+func HTTPRouteRuleWithBackendAndTimeouts(backendName string, backendPort int32, path string, backendTimeout, requestTimeout string) gatewayapiv1.HTTPRouteRule {
+	return gatewayapiv1.HTTPRouteRule{
+		BackendRefs: []gatewayapiv1.HTTPBackendRef{
+			InferenceServiceRef(backendName, backendPort, 1),
+		},
+		Matches: []gatewayapiv1.HTTPRouteMatch{
+			PathPrefixMatch(path),
+		},
+		Timeouts: &gatewayapiv1.HTTPRouteTimeouts{
+			BackendRequest: ptr.To(gatewayapiv1.Duration(backendTimeout)),
+			Request:        ptr.To(gatewayapiv1.Duration(requestTimeout)),
+		},
+	}
+}
+
+func GatewayParentRef(name, namespace string) gatewayapiv1.ParentReference {
+	return gatewayapiv1.ParentReference{
+		Group:     ptr.To(gatewayapiv1.Group("gateway.networking.k8s.io")),
+		Kind:      ptr.To(gatewayapiv1.Kind("Gateway")),
+		Name:      gatewayapiv1.ObjectName(name),
+		Namespace: ptr.To(gatewayapiv1.Namespace(namespace)),
 	}
 }

--- a/pkg/controller/llmisvc/fixture/required_resources.go
+++ b/pkg/controller/llmisvc/fixture/required_resources.go
@@ -47,14 +47,12 @@ func RequiredResources(ctx context.Context, c client.Client, ns string) {
 
 	SharedConfigPresets(ctx, c, ns)
 	InferenceServiceCfgMap(ctx, c, ns)
-	DefaultGateway(ctx, c, ns)
-}
 
-// DefaultGateway creates Gateway instance derived from charts/kserve-resources/templates/ingress_gateway.yaml
-func DefaultGateway(ctx context.Context, c client.Client, ns string) {
-	gw := Gateway("kserve-ingress-gateway",
+	gwName := "kserve-ingress-gateway"
+	defaultGateway := Gateway(gwName,
 		InNamespace[*gatewayapiv1.Gateway](ns),
 		WithClassName("istio"),
+		WithInfrastructureLabels("serving.kserve.io/gateway", gwName),
 		WithListeners(gatewayapiv1.Listener{
 			Name:     "http",
 			Port:     80,
@@ -67,13 +65,7 @@ func DefaultGateway(ctx context.Context, c client.Client, ns string) {
 		}),
 	)
 
-	gw.Spec.Infrastructure = &gatewayapiv1.GatewayInfrastructure{
-		Labels: map[gatewayapiv1.LabelKey]gatewayapiv1.LabelValue{
-			"serving.kserve.io/gateway": "kserve-ingress-gateway",
-		},
-	}
-
-	gomega.Expect(c.Create(ctx, gw)).To(gomega.Succeed())
+	gomega.Expect(c.Create(ctx, defaultGateway)).To(gomega.Succeed())
 }
 
 func InferenceServiceCfgMap(ctx context.Context, c client.Client, ns string) {

--- a/pkg/controller/llmisvc/router_discovery.go
+++ b/pkg/controller/llmisvc/router_discovery.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"slices"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"knative.dev/pkg/apis"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func DiscoverURLs(ctx context.Context, c client.Client, route *gatewayapi.HTTPRoute) ([]*apis.URL, error) {
+	var urls []*apis.URL
+
+	for _, parentRef := range route.Spec.ParentRefs {
+		ns := ptr.Deref((&parentRef).Namespace, gatewayapi.Namespace(route.Namespace))
+		gwNS, gwName := string(ns), string((&parentRef).Name)
+
+		gateway := &gatewayapi.Gateway{}
+		if err := c.Get(ctx, types.NamespacedName{Namespace: gwNS, Name: gwName}, gateway); err != nil {
+			return nil, fmt.Errorf("fetch Gateway %s/%s: %w", gwNS, gwName, err)
+		}
+
+		listener := selectListener(gateway, parentRef.SectionName)
+		scheme := extractSchemeFromListener(listener)
+		port := listener.Port
+
+		addresses := gateway.Status.Addresses
+		if len(addresses) == 0 {
+			return nil, &ExternalAddressNotFoundError{
+				GatewayNamespace: gateway.Namespace,
+				GatewayName:      gateway.Name,
+			}
+		}
+
+		hostnames := extractRouteHostnames(route)
+		if len(hostnames) == 0 {
+			hostnames = extractAddressValues(addresses)
+		}
+
+		path := extractRoutePath(route)
+
+		gatewayURLs, err := combineIntoURLs(hostnames, scheme, port, path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to combine URLs for Gateway %s/%s: %w", gwNS, gwName, err)
+		}
+
+		urls = append(urls, gatewayURLs...)
+	}
+
+	return urls, nil
+}
+
+func extractRoutePath(route *gatewayapi.HTTPRoute) string {
+	if len(route.Spec.Rules) > 0 && len(route.Spec.Rules[0].Matches) > 0 {
+		// TODO how do we deal with regexp
+		return ptr.Deref(route.Spec.Rules[0].Matches[0].Path.Value, "/")
+	}
+	return "/"
+}
+
+func selectListener(gateway *gatewayapi.Gateway, sectionName *gatewayapi.SectionName) *gatewayapi.Listener {
+	if sectionName != nil {
+		for _, listener := range gateway.Spec.Listeners {
+			if listener.Name == *sectionName {
+				return &listener
+			}
+		}
+	}
+
+	return &gateway.Spec.Listeners[0]
+}
+
+func extractSchemeFromListener(listener *gatewayapi.Listener) string {
+	if listener.Protocol == gatewayapi.HTTPSProtocolType {
+		return "https"
+	}
+	return "http"
+}
+
+func extractRouteHostnames(route *gatewayapi.HTTPRoute) []string {
+	var hostnames []string
+	for _, h := range route.Spec.Hostnames {
+		host := string(h)
+		if host != "" && host != "*" {
+			hostnames = append(hostnames, host)
+		}
+	}
+	return hostnames
+}
+
+func extractAddressValues(addresses []gatewayapi.GatewayStatusAddress) []string {
+	var values []string
+	for _, addr := range addresses {
+		if addr.Value != "" {
+			values = append(values, addr.Value)
+		}
+	}
+	return values
+}
+
+func combineIntoURLs(hostnames []string, scheme string, port gatewayapi.PortNumber, path string) ([]*apis.URL, error) {
+	urls := make([]*apis.URL, 0, len(hostnames))
+
+	sortedHostnames := make([]string, len(hostnames))
+	copy(sortedHostnames, hostnames)
+	slices.Sort(sortedHostnames)
+
+	for _, hostname := range sortedHostnames {
+		var urlStr string
+		if (scheme == "http" && port != 80) || (scheme == "https" && port != 443) {
+			urlStr = fmt.Sprintf("%s://%s%s", scheme, joinHostPort(hostname, &port), path)
+		} else {
+			urlStr = fmt.Sprintf("%s://%s%s", scheme, hostname, path)
+		}
+
+		url, err := apis.ParseURL(urlStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse URL %s: %w", urlStr, err)
+		}
+
+		urls = append(urls, url)
+	}
+
+	return urls, nil
+}
+
+func joinHostPort(host string, port *gatewayapi.PortNumber) string {
+	if port != nil && *port != 0 {
+		return net.JoinHostPort(host, fmt.Sprint(*port))
+	}
+	return host
+}
+
+type ExternalAddressNotFoundError struct {
+	GatewayNamespace string
+	GatewayName      string
+}
+
+func (e *ExternalAddressNotFoundError) Error() string {
+	return fmt.Sprintf("Gateway %s/%s has no external address found", e.GatewayNamespace, e.GatewayName)
+}
+
+func IgnoreExternalAddressNotFound(err error) error {
+	if IsExternalAddressNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+func IsExternalAddressNotFound(err error) bool {
+	var externalAddrNotFoundErr *ExternalAddressNotFoundError
+	return errors.As(err, &externalAddrNotFoundErr)
+}
+
+func filter[T any](s []T, predicateFn func(T) bool) []T {
+	out := make([]T, 0, len(s))
+	for _, x := range s {
+		if predicateFn(x) {
+			out = append(out, x)
+		}
+	}
+	return out
+}

--- a/pkg/controller/llmisvc/router_discovery_filter.go
+++ b/pkg/controller/llmisvc/router_discovery_filter.go
@@ -20,6 +20,8 @@ import (
 	"net"
 	"strings"
 
+	"knative.dev/pkg/network"
+
 	"knative.dev/pkg/apis"
 )
 
@@ -76,6 +78,12 @@ func isInternalIP(addr string) bool {
 func isInternalHostname(hostname string) bool {
 	hostname = strings.ToLower(hostname)
 
-	return hostname == "localhost" || strings.HasSuffix(hostname, ".local") ||
-		strings.HasSuffix(hostname, ".localhost") || strings.HasSuffix(hostname, ".internal")
+	localSuffixes := []string{network.GetClusterDomainName(), ".local", ".localhost", ".internal"}
+	for _, localSuffix := range localSuffixes {
+		if strings.HasSuffix(hostname, localSuffix) {
+			return true
+		}
+	}
+
+	return hostname == "localhost"
 }

--- a/pkg/controller/llmisvc/router_discovery_filter.go
+++ b/pkg/controller/llmisvc/router_discovery_filter.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"net"
+	"strings"
+
+	"knative.dev/pkg/apis"
+)
+
+type URLPredicateFn func(*apis.URL) bool
+
+func Filter(urls []*apis.URL, predicate URLPredicateFn) []*apis.URL {
+	if len(urls) == 0 {
+		return []*apis.URL{}
+	}
+
+	result := make([]*apis.URL, 0, len(urls))
+	for _, url := range urls {
+		if predicate(url) {
+			result = append(result, url)
+		}
+	}
+	return result
+}
+
+func IsInternalURL(url *apis.URL) bool {
+	host := url.Host
+
+	if colonIndex := strings.LastIndex(host, ":"); colonIndex != -1 {
+		host = host[:colonIndex]
+	}
+
+	if isInternalIP(host) {
+		return true
+	}
+
+	return isInternalHostname(host)
+}
+
+func IsExternalURL(url *apis.URL) bool {
+	return !IsInternalURL(url)
+}
+
+func FilterInternalURLs(urls []*apis.URL) []*apis.URL {
+	return Filter(urls, IsInternalURL)
+}
+
+func FilterExternalURLs(urls []*apis.URL) []*apis.URL {
+	return Filter(urls, IsExternalURL)
+}
+
+func isInternalIP(addr string) bool {
+	ip := net.ParseIP(addr)
+	if ip != nil && ip.IsPrivate() {
+		return true
+	}
+	return false
+}
+
+func isInternalHostname(hostname string) bool {
+	hostname = strings.ToLower(hostname)
+
+	return hostname == "localhost" || strings.HasSuffix(hostname, ".local") ||
+		strings.HasSuffix(hostname, ".localhost") || strings.HasSuffix(hostname, ".internal")
+}

--- a/pkg/controller/llmisvc/router_discovery_test.go
+++ b/pkg/controller/llmisvc/router_discovery_test.go
@@ -1,0 +1,780 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"knative.dev/pkg/apis"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1"
+
+	. "github.com/kserve/kserve/pkg/controller/llmisvc/fixture"
+
+	"github.com/kserve/kserve/pkg/controller/llmisvc"
+)
+
+func TestDiscoverURLs(t *testing.T) {
+	tests := []struct {
+		name               string
+		route              *gatewayapi.HTTPRoute
+		gateway            *gatewayapi.Gateway
+		additionalGateways []*gatewayapi.Gateway // Additional gateways for multiple parent refs test
+		expectedURLs       []string              // Always expect multiple URLs, single URL cases will have length 1
+		expectedErrorCheck func(error) bool
+	}{
+		{
+			name: "basic external address resolution",
+			route: HTTPRoute("test-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+			),
+			gateway:      HTTPGateway("test-gateway", "test-ns", "203.0.113.1"),
+			expectedURLs: []string{"http://203.0.113.1/"},
+		},
+		{
+			name: "address ordering consistency - same addresses different order",
+			route: HTTPRoute("consistency-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("consistency-gateway", RefInNamespace("test-ns"))),
+			),
+			gateway: Gateway("consistency-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListener(gatewayapi.HTTPProtocolType),
+				WithAddresses([]string{"203.0.113.200", "203.0.113.100"}...),
+			),
+			expectedURLs: []string{
+				"http://203.0.113.100/",
+				"http://203.0.113.200/",
+			},
+		},
+		{
+			name: "mixed internal and external addresses - deterministic selection",
+			route: HTTPRoute("mixed-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("mixed-gateway", RefInNamespace("test-ns"))),
+			),
+			gateway: Gateway("mixed-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListener(gatewayapi.HTTPProtocolType),
+				WithAddresses("192.168.1.10", "203.0.113.50", "10.0.0.20", "203.0.113.25"),
+			),
+			expectedURLs: []string{
+				"http://10.0.0.20/",
+				"http://192.168.1.10/",
+				"http://203.0.113.25/",
+				"http://203.0.113.50/",
+			},
+		},
+		{
+			name: "route hostname override",
+			route: HTTPRoute("hostname-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("hostname-gateway", RefInNamespace("test-ns"))),
+				WithHostnames("api.example.com"),
+			),
+			gateway: Gateway("hostname-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListener(gatewayapi.HTTPProtocolType),
+				WithAddresses([]string{"203.0.113.1"}...),
+			),
+			expectedURLs: []string{"http://api.example.com/"},
+		},
+		{
+			name: "route wildcard hostname - use gateway address",
+			route: HTTPRoute("wildcard-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("wildcard-gateway", RefInNamespace("test-ns"))),
+				WithHostnames("*"),
+			),
+			gateway: Gateway("wildcard-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListener(gatewayapi.HTTPProtocolType),
+				WithAddresses("203.0.113.100"),
+			),
+			expectedURLs: []string{"http://203.0.113.100/"},
+		},
+		{
+			name: "multiple hostnames - generates multiple URLs",
+			route: HTTPRoute("multi-hostname-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("multi-hostname-gateway", RefInNamespace("test-ns"))),
+				WithHostnames("*", "", "api.example.com", "alt.example.com"),
+			),
+			gateway: Gateway("multi-hostname-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListener(gatewayapi.HTTPProtocolType),
+				WithAddresses("203.0.113.1"),
+			),
+			expectedURLs: []string{
+				"http://alt.example.com/",
+				"http://api.example.com/",
+			},
+		},
+		{
+			name: "custom path extraction",
+			route: HTTPRoute("path-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("path-gateway", RefInNamespace("test-ns"))),
+				WithPath("/api/v1/models"),
+			),
+			gateway: Gateway("path-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListener(gatewayapi.HTTPProtocolType),
+				WithAddresses("203.0.113.1"),
+			),
+			expectedURLs: []string{"http://203.0.113.1/api/v1/models"},
+		},
+		{
+			name: "HTTPS scheme from gateway listener",
+			route: HTTPRoute("https-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("https-gateway", RefInNamespace("test-ns"))),
+			),
+			gateway:      HTTPSGateway("https-gateway", "test-ns", "203.0.113.1"),
+			expectedURLs: []string{"https://203.0.113.1/"},
+		},
+		{
+			name: "multiple parent refs - sorted selection",
+			route: HTTPRoute("multi-parent-route",
+				InNamespace[*gatewayapi.HTTPRoute]("default-ns"),
+				WithParentRefs(
+					GatewayRef("z-gateway", RefInNamespace("z-namespace")),
+					GatewayRef("a-gateway", RefInNamespace("a-namespace")),
+					GatewayRef("b-gateway", RefInNamespace("a-namespace")),
+				),
+			),
+			gateway: Gateway("a-gateway",
+				InNamespace[*gatewayapi.Gateway]("a-namespace"),
+				WithListener(gatewayapi.HTTPProtocolType),
+				WithAddresses([]string{"203.0.113.1"}...),
+			),
+			additionalGateways: []*gatewayapi.Gateway{
+				Gateway("z-gateway",
+					InNamespace[*gatewayapi.Gateway]("z-namespace"),
+					WithListener(gatewayapi.HTTPProtocolType),
+					WithAddresses("203.0.113.2"),
+				),
+				Gateway("b-gateway",
+					InNamespace[*gatewayapi.Gateway]("a-namespace"),
+					WithListener(gatewayapi.HTTPProtocolType),
+					WithAddresses("203.0.113.3"),
+				),
+			},
+			expectedURLs: []string{
+				"http://203.0.113.2/",
+				"http://203.0.113.1/",
+				"http://203.0.113.3/",
+			},
+		},
+		{
+			name: "parent ref without namespace - use route namespace",
+			route: HTTPRoute("no-ns-route",
+				InNamespace[*gatewayapi.HTTPRoute]("route-ns"),
+				WithParentRef(GatewayRefWithoutNamespace("no-ns-gateway")),
+			),
+			gateway: Gateway("no-ns-gateway",
+				InNamespace[*gatewayapi.Gateway]("route-ns"),
+				WithListener(gatewayapi.HTTPProtocolType),
+				WithAddresses("203.0.113.1"),
+			),
+			expectedURLs: []string{"http://203.0.113.1/"},
+		},
+		{
+			name: "no external addresses - custom ExternalAddressNotFoundError",
+			route: HTTPRoute("no-external-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("no-external-addresses-gateway", RefInNamespace("test-ns"))),
+			),
+			gateway: Gateway("no-external-addresses-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListener(gatewayapi.HTTPProtocolType),
+				WithAddresses("192.168.1.10", "10.0.0.20"),
+			),
+			expectedURLs: []string{
+				"http://10.0.0.20/",
+				"http://192.168.1.10/",
+			},
+		},
+		{
+			name: "gateway not found should cause not found error",
+			route: HTTPRoute("missing-gw-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("missing-gateway", RefInNamespace("test-ns"))),
+			),
+			expectedErrorCheck: apierrors.IsNotFound,
+		},
+		{
+			name: "empty route rules - default path",
+			route: HTTPRoute("empty-rules-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("empty-rules-gateway", RefInNamespace("test-ns"))),
+				WithRules(), // Empty rules
+			),
+			gateway: Gateway("empty-rules-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListener(gatewayapi.HTTPProtocolType),
+				WithAddresses("203.0.113.1"),
+			),
+			expectedURLs: []string{"http://203.0.113.1/"},
+		},
+		// Hostname address type tests
+		{
+			name: "hostname addresses - basic resolution",
+			route: HTTPRoute("hostname-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("hostname-gateway", RefInNamespace("test-ns"))),
+			),
+			gateway: Gateway("hostname-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListener(gatewayapi.HTTPProtocolType),
+				WithHostnameAddresses("api.example.com"),
+			),
+			expectedURLs: []string{"http://api.example.com/"},
+		},
+		{
+			name: "mixed hostname and IP addresses - deterministic selection",
+			route: HTTPRoute("mixed-types-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("mixed-types-gateway", RefInNamespace("test-ns"))),
+			),
+			gateway: Gateway("mixed-types-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListener(gatewayapi.HTTPProtocolType),
+				WithMixedAddresses(
+					HostnameAddress("z.example.com"),
+					IPAddress("203.0.113.1"),
+					HostnameAddress("api.example.com"),
+					IPAddress("198.51.100.1"),
+				),
+			),
+			expectedURLs: []string{
+				"http://198.51.100.1/",
+				"http://203.0.113.1/",
+				"http://api.example.com/",
+				"http://z.example.com/",
+			},
+		},
+		{
+			name: "hostname addresses with internal hostnames filtered",
+			route: HTTPRoute("internal-hostname-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("internal-hostname-gateway", RefInNamespace("test-ns"))),
+			),
+			gateway: Gateway("internal-hostname-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListener(gatewayapi.HTTPProtocolType),
+				WithMixedAddresses(
+					HostnameAddress("localhost"),
+					HostnameAddress("service.local"),
+					HostnameAddress("app.internal"),
+					HostnameAddress("api.example.com"),
+					HostnameAddress("backup.example.com"),
+				),
+			),
+			expectedURLs: []string{
+				"http://api.example.com/",
+				"http://app.internal/",
+				"http://backup.example.com/",
+				"http://localhost/",
+				"http://service.local/",
+			},
+		},
+		{
+			name: "only internal addresses (IP + hostnames) - ExternalAddressNotFoundError",
+			route: HTTPRoute("only-internal-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("only-internal-gateway", RefInNamespace("test-ns"))),
+			),
+			gateway: Gateway("only-internal-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListener(gatewayapi.HTTPProtocolType),
+				WithMixedAddresses(
+					IPAddress("192.168.1.10"),
+					IPAddress("10.0.0.20"),
+					HostnameAddress("localhost"),
+					HostnameAddress("app.local"),
+				),
+			),
+			expectedURLs: []string{
+				"http://10.0.0.20/",
+				"http://192.168.1.10/",
+				"http://app.local/",
+				"http://localhost/",
+			},
+		},
+		{
+			name: "backwards compatibility - nil Type defaults to IP behavior",
+			route: HTTPRoute("nil-type-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("nil-type-gateway", RefInNamespace("test-ns"))),
+			),
+			gateway: Gateway("nil-type-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListener(gatewayapi.HTTPProtocolType),
+				WithAddresses("203.0.113.1", "192.168.1.10"),
+			),
+			expectedURLs: []string{
+				"http://192.168.1.10/",
+				"http://203.0.113.1/",
+			},
+		},
+		{
+			name: "no addresses at all - ExternalAddressNotFoundError",
+			route: HTTPRoute("no-addresses-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("no-addresses-gateway", RefInNamespace("test-ns"))),
+			),
+			gateway: Gateway("no-addresses-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListener(gatewayapi.HTTPProtocolType),
+			),
+			expectedErrorCheck: llmisvc.IsExternalAddressNotFound,
+		},
+		{
+			name: "custom port handling - non-standard HTTP port",
+			route: HTTPRoute("custom-port-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("custom-port-gateway", RefInNamespace("test-ns"))),
+			),
+			gateway: Gateway("custom-port-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListeners(gatewayapi.Listener{
+					Protocol: gatewayapi.HTTPProtocolType,
+					Port:     8080,
+				}),
+				WithAddresses("203.0.113.1"),
+			),
+			expectedURLs: []string{"http://203.0.113.1:8080/"},
+		},
+		{
+			name: "custom port handling - non-standard HTTPS port",
+			route: HTTPRoute("custom-https-port-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("custom-https-port-gateway", RefInNamespace("test-ns"))),
+				WithHostnames("secure.example.com"),
+			),
+			gateway: Gateway("custom-https-port-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListeners(gatewayapi.Listener{
+					Protocol: gatewayapi.HTTPSProtocolType,
+					Port:     8443,
+				}),
+				WithAddresses("203.0.113.1"),
+			),
+			expectedURLs: []string{"https://secure.example.com:8443/"},
+		},
+		{
+			name: "standard ports omitted - HTTP port 80",
+			route: HTTPRoute("standard-http-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("standard-http-gateway", RefInNamespace("test-ns"))),
+			),
+			gateway: Gateway("standard-http-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListeners(gatewayapi.Listener{
+					Protocol: gatewayapi.HTTPProtocolType,
+					Port:     80,
+				}),
+				WithAddresses("203.0.113.1"),
+			),
+			expectedURLs: []string{"http://203.0.113.1/"},
+		},
+		{
+			name: "standard ports omitted - HTTPS port 443",
+			route: HTTPRoute("standard-https-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("standard-https-gateway", RefInNamespace("test-ns"))),
+				WithHostnames("secure.example.com"),
+			),
+			gateway: Gateway("standard-https-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListeners(gatewayapi.Listener{
+					Protocol: gatewayapi.HTTPSProtocolType,
+					Port:     443,
+				}),
+				WithAddresses("203.0.113.1"),
+			),
+			expectedURLs: []string{"https://secure.example.com/"},
+		},
+		{
+			name: "sectionName selects specific listener",
+			route: HTTPRoute("section-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(gatewayapi.ParentReference{
+					Name:        "multi-listener-gateway",
+					Namespace:   ptr.To(gatewayapi.Namespace("test-ns")),
+					SectionName: ptr.To(gatewayapi.SectionName("https-listener")),
+					Group:       ptr.To(gatewayapi.Group("gateway.networking.k8s.io")),
+					Kind:        ptr.To(gatewayapi.Kind("Gateway")),
+				}),
+				WithHostnames("secure.example.com"),
+			),
+			gateway: Gateway("multi-listener-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListeners(
+					gatewayapi.Listener{
+						Name:     "http-listener",
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     80,
+					},
+					gatewayapi.Listener{
+						Name:     "https-listener",
+						Protocol: gatewayapi.HTTPSProtocolType,
+						Port:     443,
+					},
+				),
+				WithAddresses("203.0.113.1"),
+			),
+			expectedURLs: []string{"https://secure.example.com/"},
+		},
+		{
+			name: "multiple hostnames and addresses - comprehensive URL generation",
+			route: HTTPRoute("comprehensive-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("comprehensive-gateway", RefInNamespace("test-ns"))),
+				WithHostnames("api.example.com", "backup.example.com", "primary.example.com"),
+			),
+			gateway: Gateway("comprehensive-gateway",
+				InNamespace[*gatewayapi.Gateway]("test-ns"),
+				WithListener(gatewayapi.HTTPProtocolType),
+				WithAddresses("203.0.113.1", "198.51.100.1"),
+			),
+			expectedURLs: []string{
+				"http://api.example.com/",
+				"http://backup.example.com/",
+				"http://primary.example.com/",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			ctx := t.Context()
+
+			scheme := runtime.NewScheme()
+			err := gatewayapi.Install(scheme)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			var objects []client.Object
+			if tt.gateway != nil {
+				objects = append(objects, tt.gateway)
+			}
+			if tt.route != nil {
+				objects = append(objects, tt.route)
+			}
+			for _, gw := range tt.additionalGateways {
+				objects = append(objects, gw)
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				Build()
+
+			urls, err := llmisvc.DiscoverURLs(ctx, fakeClient, tt.route)
+
+			if tt.expectedErrorCheck != nil {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(tt.expectedErrorCheck(err)).To(BeTrue(), "Error check function failed for error: %v", err)
+			} else {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(urls).To(HaveLen(len(tt.expectedURLs)))
+
+				// Convert to strings for easier comparison
+				var actualURLs []string
+				for _, url := range urls {
+					actualURLs = append(actualURLs, url.String())
+				}
+
+				g.Expect(actualURLs).To(Equal(tt.expectedURLs))
+			}
+		})
+	}
+}
+
+func TestFilterURLs(t *testing.T) {
+	convertToURLs := func(urls []string) ([]*apis.URL, error) {
+		var parsedURLs []*apis.URL
+		for _, urlStr := range urls {
+			url, err := apis.ParseURL(urlStr)
+			if err != nil {
+				return nil, err
+			}
+			parsedURLs = append(parsedURLs, url)
+		}
+
+		return parsedURLs, nil
+	}
+	t.Run("mixed internal and external URLs", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		inputURLs := []string{
+			"http://192.168.1.10/",
+			"http://api.example.com/",
+			"http://10.0.0.20/",
+			"https://secure.example.com/",
+			"http://localhost/",
+			"http://203.0.113.1/",
+		}
+		expectedInternal := []string{
+			"http://192.168.1.10/",
+			"http://10.0.0.20/",
+			"http://localhost/",
+		}
+		expectedExternal := []string{
+			"http://api.example.com/",
+			"https://secure.example.com/",
+			"http://203.0.113.1/",
+		}
+
+		parsedURLs, err := convertToURLs(inputURLs)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		internalURLs := llmisvc.FilterInternalURLs(parsedURLs)
+		actualInternal := make([]string, 0, len(internalURLs))
+		for _, url := range internalURLs {
+			actualInternal = append(actualInternal, url.String())
+		}
+		g.Expect(actualInternal).To(Equal(expectedInternal))
+
+		externalURLs := llmisvc.FilterExternalURLs(parsedURLs)
+		actualExternal := make([]string, 0, len(externalURLs))
+		for _, url := range externalURLs {
+			actualExternal = append(actualExternal, url.String())
+		}
+		g.Expect(actualExternal).To(Equal(expectedExternal))
+	})
+
+	t.Run("URLs with custom ports", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		inputURLs := []string{
+			"http://192.168.1.10:8080/",
+			"http://api.example.com:8080/",
+			"https://secure.example.com:8443/",
+			"http://localhost:3000/",
+		}
+		expectedInternal := []string{
+			"http://192.168.1.10:8080/",
+			"http://localhost:3000/",
+		}
+		expectedExternal := []string{
+			"http://api.example.com:8080/",
+			"https://secure.example.com:8443/",
+		}
+
+		parsedURLs, err := convertToURLs(inputURLs)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		internalURLs := llmisvc.FilterInternalURLs(parsedURLs)
+		actualInternal := make([]string, 0, len(internalURLs))
+		for _, url := range internalURLs {
+			actualInternal = append(actualInternal, url.String())
+		}
+		g.Expect(actualInternal).To(Equal(expectedInternal))
+
+		externalURLs := llmisvc.FilterExternalURLs(parsedURLs)
+		actualExternal := make([]string, 0, len(externalURLs))
+		for _, url := range externalURLs {
+			actualExternal = append(actualExternal, url.String())
+		}
+		g.Expect(actualExternal).To(Equal(expectedExternal))
+	})
+
+	t.Run("internal hostname types", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		inputURLs := []string{
+			"http://localhost/",
+			"http://service.local/",
+			"http://app.localhost/",
+			"http://backend.internal/",
+			"http://api.example.com/",
+		}
+		expectedInternal := []string{
+			"http://localhost/",
+			"http://service.local/",
+			"http://app.localhost/",
+			"http://backend.internal/",
+		}
+		expectedExternal := []string{
+			"http://api.example.com/",
+		}
+
+		parsedURLs, err := convertToURLs(inputURLs)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		internalURLs := llmisvc.FilterInternalURLs(parsedURLs)
+		actualInternal := make([]string, 0, len(internalURLs))
+		for _, url := range internalURLs {
+			actualInternal = append(actualInternal, url.String())
+		}
+		g.Expect(actualInternal).To(Equal(expectedInternal))
+
+		externalURLs := llmisvc.FilterExternalURLs(parsedURLs)
+		actualExternal := make([]string, 0, len(externalURLs))
+		for _, url := range externalURLs {
+			actualExternal = append(actualExternal, url.String())
+		}
+		g.Expect(actualExternal).To(Equal(expectedExternal))
+	})
+
+	t.Run("all internal URLs", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		inputURLs := []string{
+			"http://192.168.1.10/",
+			"http://10.0.0.20/",
+			"http://localhost/",
+		}
+		expectedInternal := []string{
+			"http://192.168.1.10/",
+			"http://10.0.0.20/",
+			"http://localhost/",
+		}
+		expectedExternal := []string{}
+
+		parsedURLs, err := convertToURLs(inputURLs)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		internalURLs := llmisvc.FilterInternalURLs(parsedURLs)
+		actualInternal := make([]string, 0, len(internalURLs))
+		for _, url := range internalURLs {
+			actualInternal = append(actualInternal, url.String())
+		}
+		g.Expect(actualInternal).To(Equal(expectedInternal))
+
+		externalURLs := llmisvc.FilterExternalURLs(parsedURLs)
+		actualExternal := make([]string, 0, len(externalURLs))
+		for _, url := range externalURLs {
+			actualExternal = append(actualExternal, url.String())
+		}
+		g.Expect(actualExternal).To(Equal(expectedExternal))
+	})
+
+	t.Run("all external URLs", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		inputURLs := []string{
+			"http://api.example.com/",
+			"https://secure.example.com/",
+			"http://203.0.113.1/",
+		}
+		expectedInternal := []string{}
+		expectedExternal := []string{
+			"http://api.example.com/",
+			"https://secure.example.com/",
+			"http://203.0.113.1/",
+		}
+
+		parsedURLs, err := convertToURLs(inputURLs)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		internalURLs := llmisvc.FilterInternalURLs(parsedURLs)
+		actualInternal := make([]string, 0, len(internalURLs))
+		for _, url := range internalURLs {
+			actualInternal = append(actualInternal, url.String())
+		}
+		g.Expect(actualInternal).To(Equal(expectedInternal))
+
+		externalURLs := llmisvc.FilterExternalURLs(parsedURLs)
+		actualExternal := make([]string, 0, len(externalURLs))
+		for _, url := range externalURLs {
+			actualExternal = append(actualExternal, url.String())
+		}
+		g.Expect(actualExternal).To(Equal(expectedExternal))
+	})
+
+	t.Run("empty URL slice", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		inputURLs := []string{}
+		expectedInternal := []string{}
+		expectedExternal := []string{}
+
+		parsedURLs, err := convertToURLs(inputURLs)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		internalURLs := llmisvc.FilterInternalURLs(parsedURLs)
+		actualInternal := make([]string, 0, len(internalURLs))
+		for _, url := range internalURLs {
+			actualInternal = append(actualInternal, url.String())
+		}
+		g.Expect(actualInternal).To(Equal(expectedInternal))
+
+		externalURLs := llmisvc.FilterExternalURLs(parsedURLs)
+		actualExternal := make([]string, 0, len(externalURLs))
+		for _, url := range externalURLs {
+			actualExternal = append(actualExternal, url.String())
+		}
+		g.Expect(actualExternal).To(Equal(expectedExternal))
+	})
+
+	t.Run("URLs with paths", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		inputURLs := []string{
+			"http://192.168.1.10/api/v1/models",
+			"http://api.example.com/api/v1/models",
+			"http://localhost:8080/health",
+		}
+		expectedInternal := []string{
+			"http://192.168.1.10/api/v1/models",
+			"http://localhost:8080/health",
+		}
+		expectedExternal := []string{
+			"http://api.example.com/api/v1/models",
+		}
+
+		parsedURLs, err := convertToURLs(inputURLs)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		internalURLs := llmisvc.FilterInternalURLs(parsedURLs)
+		actualInternal := make([]string, 0, len(internalURLs))
+		for _, url := range internalURLs {
+			actualInternal = append(actualInternal, url.String())
+		}
+		g.Expect(actualInternal).To(Equal(expectedInternal))
+
+		externalURLs := llmisvc.FilterExternalURLs(parsedURLs)
+		actualExternal := make([]string, 0, len(externalURLs))
+		for _, url := range externalURLs {
+			actualExternal = append(actualExternal, url.String())
+		}
+		g.Expect(actualExternal).To(Equal(expectedExternal))
+	})
+
+	t.Run("IsInternalURL and IsExternalURL are opposites", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		testURLs := []string{
+			"http://192.168.1.10/",
+			"http://api.example.com/",
+			"http://localhost/",
+			"https://secure.example.com:8443/",
+		}
+
+		for _, urlStr := range testURLs {
+			url, err := apis.ParseURL(urlStr)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			isInternal := llmisvc.IsInternalURL(url)
+			isExternal := llmisvc.IsExternalURL(url)
+
+			g.Expect(isInternal).To(Equal(!isExternal), "URL %s should be either internal or external, not both", urlStr)
+		}
+	})
+}


### PR DESCRIPTION
This change brings URL resolution by looking up HTTPRoute->Gateways relationship.

If the public addresses are found, one is exposed in `.status.url`, besides that all resolved addresses are populated as `.status.addresses` slice.

> [!IMPORTANT]
>
> Local addresses local (i.e. services) will come as next PR

### How to test it

Following the `DEV.md` guide to deploy your LLMInferenceService, and then try:

```shell
curl $(kubectl get llmisvc -n $NS -o=jsonpath='{.items[0].status.addresses[0].url}')/v1/completions  \
    -H "Content-Type: application/json" \
    -d '{
        "model": "facebook/opt-125m",
        "prompt": "San Francisco is a"
    }' | jq
```

> [!NOTE]
> Actual address in KinD setup is considered local, hence the jsonpath
above.

you should see similar output:

```shell
{
  "id": "cmpl-8482188a-d941-4d8a-96f8-c001e0e03624",
  "object": "text_completion",
  "created": 1751543644,
  "model": "facebook/opt-125m",
  "choices": [
    {
      "index": 0,
      "text": " big place and I'd imagine it will stay that way. Until the US rel",
      "logprobs": null,
      "finish_reason": "length",
      "stop_reason": null,
      "prompt_logprobs": null
    }
  ],
  "usage": {
    "prompt_tokens": 5,
    "total_tokens": 21,
    "completion_tokens": 16,
    "prompt_tokens_details": null
  },
  "kv_transfer_params": null
}
```

> [!IMPORTANT]
> I have not tested it on real cluster yet, but I am working on it.

Fixes [RHOAIENG-28595](https://issues.redhat.com/browse/RHOAIENG-28595)
