### PR TITLE
chore(presets): simplifies template defaulting

### DIFF
--- a/config/llmisvc/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvc/config-llm-decode-worker-data-parallel.yaml
@@ -32,7 +32,7 @@ spec:
         args:
           - |-
 
-            START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ Default .Spec.Parallelism.DataLocal 1 }} ))
+            START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Parallelism.DataLocal 1 }} ))
             if [ "${LWS_WORKER_INDEX:-0}" -eq 0 ]; then
               #################
               # Leader-only launch
@@ -44,8 +44,8 @@ spec:
                 --disable-log-requests \
                 {{- if .Spec.Parallelism.Expert -}}--enable-expert-parallel \{{- end }}
                 {{- if .Spec.Parallelism.Tensor -}}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }} \{{- end }}
-                --data-parallel-size {{ Default .Spec.Parallelism.Data 1 }} \
-                --data-parallel-size-local {{ Default .Spec.Parallelism.DataLocal 1 }} \
+                --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
+                --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
                 --data-parallel-address $(LWS_LEADER_ADDRESS) \
                 --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
                 --data-parallel-start-rank $START_RANK \
@@ -60,8 +60,8 @@ spec:
                 --disable-log-requests \
                 {{- if .Spec.Parallelism.Expert }}--enable-expert-parallel \{{- end }}
                 {{- if .Spec.Parallelism.Tensor }}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }} \{{- end }}
-                --data-parallel-size {{ Default .Spec.Parallelism.Data 1 }} \
-                --data-parallel-size-local {{ Default .Spec.Parallelism.DataLocal 1 }} \
+                --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
+                --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
                 --data-parallel-address $(LWS_LEADER_ADDRESS) \
                 --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
                 --data-parallel-start-rank $START_RANK \

--- a/config/llmisvc/config-llm-prefill-worker-data-parallel.yaml
+++ b/config/llmisvc/config-llm-prefill-worker-data-parallel.yaml
@@ -20,7 +20,7 @@ spec:
           args:
             - |-
 
-              START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ Default .Spec.Prefill.Parallelism.DataLocal 1 }} ))
+              START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Prefill.Parallelism.DataLocal 1 }} ))
               if [ "${LWS_WORKER_INDEX:-0}" -eq 0 ]; then
                 #################
                 # Leader-only launch
@@ -32,8 +32,8 @@ spec:
                   --disable-log-requests \
                   {{- if .Spec.Prefill.Parallelism.Expert -}}--enable-expert-parallel \{{- end }}
                   {{- if .Spec.Prefill.Parallelism.Tensor -}}--tensor-parallel-size {{ .Spec.Prefill.Parallelism.Tensor }} \{{- end }}
-                  --data-parallel-size {{ Default .Spec.Prefill.Parallelism.Data 1 }} \
-                  --data-parallel-size-local {{ Default .Spec.Prefill.Parallelism.DataLocal 1 }} \
+                  --data-parallel-size {{ or .Spec.Prefill.Parallelism.Data 1 }} \
+                  --data-parallel-size-local {{ or .Spec.Prefill.Parallelism.DataLocal 1 }} \
                   --data-parallel-address $(LWS_LEADER_ADDRESS) \
                   --data-parallel-rpc-port {{ if .Spec.Prefill.Parallelism.DataRPCPort }}{{ .Spec.Prefill.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
                   --data-parallel-start-rank $START_RANK \
@@ -48,8 +48,8 @@ spec:
                   --disable-log-requests \
                   {{- if .Spec.Prefill.Parallelism.Expert -}}--enable-expert-parallel \{{- end }}
                   {{- if .Spec.Prefill.Parallelism.Tensor -}}--tensor-parallel-size {{ .Spec.Prefill.Parallelism.Tensor }} \{{- end }}
-                  --data-parallel-size {{ Default .Spec.Prefill.Parallelism.Data 1 }} \
-                  --data-parallel-size-local {{ Default .Spec.Prefill.Parallelism.DataLocal 1 }} \
+                  --data-parallel-size {{ or .Spec.Prefill.Parallelism.Data 1 }} \
+                  --data-parallel-size-local {{ or .Spec.Prefill.Parallelism.DataLocal 1 }} \
                   --data-parallel-address $(LWS_LEADER_ADDRESS) \
                   --data-parallel-rpc-port {{ if .Spec.Prefill.Parallelism.DataRPCPort }}{{ .Spec.Prefill.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
                   --data-parallel-start-rank $START_RANK \

--- a/config/llmisvc/config-llm-worker-data-parallel.yaml
+++ b/config/llmisvc/config-llm-worker-data-parallel.yaml
@@ -19,7 +19,7 @@ spec:
         args:
           - |-
 
-            START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ Default .Spec.Parallelism.DataLocal 1 }} ))
+            START_RANK=$(( ${LWS_WORKER_INDEX:-0} * {{ or .Spec.Parallelism.DataLocal 1 }} ))
             if [ "${LWS_WORKER_INDEX:-0}" -eq 0 ]; then
               #################
               # Leader-only launch
@@ -31,8 +31,8 @@ spec:
                 --disable-log-requests \
                 {{- if .Spec.Parallelism.Expert -}}--enable-expert-parallel \{{- end }}
                 {{- if .Spec.Parallelism.Tensor -}}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }} \{{- end }}
-                --data-parallel-size {{ Default .Spec.Parallelism.Data 1 }} \
-                --data-parallel-size-local {{ Default .Spec.Parallelism.DataLocal 1 }} \
+                --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
+                --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
                 --data-parallel-address $(LWS_LEADER_ADDRESS) \
                 --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
                 --data-parallel-start-rank $START_RANK \
@@ -47,8 +47,8 @@ spec:
                 --disable-log-requests \
                 {{- if .Spec.Parallelism.Expert }}--enable-expert-parallel \{{- end }}
                 {{- if .Spec.Parallelism.Tensor }}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }} \{{- end }}
-                --data-parallel-size {{ Default .Spec.Parallelism.Data 1 }} \
-                --data-parallel-size-local {{ Default .Spec.Parallelism.DataLocal 1 }} \
+                --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
+                --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
                 --data-parallel-address $(LWS_LEADER_ADDRESS) \
                 --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
                 --data-parallel-start-rank $START_RANK \

--- a/pkg/controller/llmisvc/config_merge.go
+++ b/pkg/controller/llmisvc/config_merge.go
@@ -169,12 +169,6 @@ func ReplaceVariables(llmSvc *v1alpha1.LLMInferenceService, llmSvcCfg *v1alpha1.
 	t, err := template.New("config").
 		Funcs(map[string]any{
 			"ChildName": kmeta.ChildName,
-			"Default": func(val, def interface{}) interface{} {
-				if val == nil {
-					return def
-				}
-				return val
-			},
 		}).
 		Option("missingkey=error").
 		Parse(string(templateBytes))


### PR DESCRIPTION
There is built-in `or` function for golang templates. We can use this one instead of custom func.

See: https://pkg.go.dev/text/template#hdr-Functions