### PR TITLE
feat(webhook): introduces validation for configs

### DIFF
--- a/charts/kserve-resources/templates/webhookconfiguration.yaml
+++ b/charts/kserve-resources/templates/webhookconfiguration.yaml
@@ -218,3 +218,32 @@ webhooks:
           - DELETE
         resources:
           - localmodelcaches
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: llminferenceserviceconfig.serving.kserve.io
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/serving-cert
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: kserve-webhook-server-service
+        namespace: {{ .Release.Namespace }}
+        path: /validate-serving-kserve-io-v1alpha1-llminferenceserviceconfig
+    failurePolicy: Fail
+    sideEffects: None
+    name: llminferenceserviceconfigs.kserve-webhook-server.validator
+    rules:
+      - apiGroups:
+          - serving.kserve.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - llminferenceserviceconfigs

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"os"
 
+	llmisvcwebhook "github.com/kserve/kserve/pkg/controller/llmisvc/webhook"
+
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	istio_networking "istio.io/api/networking/v1alpha3"
@@ -358,6 +360,14 @@ func main() {
 		WithValidator(&localmodelcache.LocalModelCacheValidator{Client: mgr.GetClient()}).
 		Complete(); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "localmodelcache")
+		os.Exit(1)
+	}
+
+	llmConfigValidator := &llmisvcwebhook.LLMInferenceServiceConfigValidator{
+		ClientSet: clientSet,
+	}
+	if err = llmConfigValidator.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "llminferenceserviceconfig")
 		os.Exit(1)
 	}
 

--- a/config/default/llmisvcconfig_validatingwebhook_cainjection_patch.yaml
+++ b/config/default/llmisvcconfig_validatingwebhook_cainjection_patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: llminferenceserviceconfig.serving.kserve.io
+  annotations:
+    cert-manager.io/inject-ca-from: $(kserveNamespace)/serving-cert
+webhooks:
+  - name: llminferenceserviceconfig.kserve-webhook-server.validator

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -209,3 +209,30 @@ webhooks:
           - DELETE
         resources:
           - localmodelcaches
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: llminferenceserviceconfig.serving.kserve.io
+webhooks:
+  - clientConfig:
+      service:
+        name: $(webhookServiceName)
+        namespace: $(kserveNamespace)
+        path: /validate-serving-kserve-io-v1alpha1-llminferenceserviceconfig
+    failurePolicy: Fail
+    name: llminferenceserviceconfig.kserve-webhook-server.validator
+    sideEffects: None
+    admissionReviewVersions: [ "v1" ]
+    rules:
+      - apiGroups:
+          - serving.kserve.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - llminferenceserviceconfigs

--- a/pkg/controller/llmisvc/controller.go
+++ b/pkg/controller/llmisvc/controller.go
@@ -153,7 +153,7 @@ func (r *LLMInferenceServiceReconciler) reconcile(ctx context.Context, llmSvc *v
 	ctx = log.IntoContext(ctx, logger)
 
 	// TODO(ctrl): add watch on CfgMap with predicate and cache tuning to trigger reconcile when it changes
-	config, configErr := r.loadConfig(ctx)
+	config, configErr := LoadConfig(ctx, r.Clientset)
 	if configErr != nil {
 		return fmt.Errorf("failed to load ingress config: %w", configErr)
 	}
@@ -201,8 +201,8 @@ func (r *LLMInferenceServiceReconciler) updateStatus(ctx context.Context, desire
 	})
 }
 
-func (r *LLMInferenceServiceReconciler) loadConfig(ctx context.Context) (*Config, error) {
-	isvcConfigMap, errCfgMap := v1beta1.GetInferenceServiceConfigMap(ctx, r.Clientset) // Fetch directly from API Server
+func LoadConfig(ctx context.Context, clientset kubernetes.Interface) (*Config, error) {
+	isvcConfigMap, errCfgMap := v1beta1.GetInferenceServiceConfigMap(ctx, clientset) // Fetch directly from API Server
 	if errCfgMap != nil {
 		return nil, fmt.Errorf("failed to load InferenceServiceConfigMap: %w", errCfgMap)
 	}

--- a/pkg/controller/llmisvc/fixture/required_resources.go
+++ b/pkg/controller/llmisvc/fixture/required_resources.go
@@ -45,8 +45,8 @@ func RequiredResources(ctx context.Context, c client.Client, ns string) {
 		},
 	})).To(gomega.Succeed())
 
-	SharedConfigPresets(ctx, c, ns)
 	InferenceServiceCfgMap(ctx, c, ns)
+	SharedConfigPresets(ctx, c, ns)
 
 	gwName := "kserve-ingress-gateway"
 	defaultGateway := Gateway(gwName,

--- a/pkg/controller/llmisvc/router_discovery_filter.go
+++ b/pkg/controller/llmisvc/router_discovery_filter.go
@@ -20,9 +20,8 @@ import (
 	"net"
 	"strings"
 
-	"knative.dev/pkg/network"
-
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/network"
 )
 
 type URLPredicateFn func(*apis.URL) bool

--- a/pkg/controller/llmisvc/webhook/config_validator.go
+++ b/pkg/controller/llmisvc/webhook/config_validator.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kserve/kserve/pkg/controller/llmisvc"
+	"github.com/kserve/kserve/pkg/utils"
+)
+
+// +kubebuilder:webhook:path=/validate-serving-kserve-io-v1alpha1-llminferenceserviceconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=serving.kserve.io,resources=llminferenceserviceconfigs,verbs=create;update,versions=v1alpha1,name=llminferenceserviceconfigs.kserve-webhook-server.validator,admissionReviewVersions=v1
+
+// LLMInferenceServiceConfigValidator is responsible for validating the LLMInferenceServiceConfig resource
+// when it is created, updated, or deleted.
+// +kubebuilder:object:generate=false
+type LLMInferenceServiceConfigValidator struct {
+	ClientSet kubernetes.Interface
+}
+
+var _ webhook.CustomValidator = &LLMInferenceServiceConfigValidator{}
+
+func (l *LLMInferenceServiceConfigValidator) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&v1alpha1.LLMInferenceServiceConfig{}).
+		WithValidator(l).
+		Complete()
+}
+
+func (l *LLMInferenceServiceConfigValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	warnings := admission.Warnings{}
+	llmSvcConfig, err := utils.Convert[*v1alpha1.LLMInferenceServiceConfig](obj)
+	if err != nil {
+		return warnings, err
+	}
+
+	return warnings, l.validate(ctx, llmSvcConfig)
+}
+
+func (l *LLMInferenceServiceConfigValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	logger := log.FromContext(ctx)
+	oldConfig, errOld := utils.Convert[*v1alpha1.LLMInferenceServiceConfig](oldObj)
+	if errOld != nil {
+		return admission.Warnings{}, errOld
+	}
+	newConfig, errNew := utils.Convert[*v1alpha1.LLMInferenceServiceConfig](newObj)
+	if errNew != nil {
+		return admission.Warnings{}, errNew
+	}
+
+	warnings := admission.Warnings{}
+	if llmisvc.WellKnownDefaultConfigs.Has(oldConfig.Name) && !equality.Semantic.DeepDerivative(oldConfig.Spec, newConfig.Spec) {
+		warning := fmt.Sprintf("updating well-known config %s/%s may have undesired consequences", oldConfig.Namespace, oldConfig.Name)
+		logger.Info(warning)
+		warnings = append(warnings, warning)
+	}
+
+	return warnings, l.validate(ctx, newConfig)
+}
+
+func (l *LLMInferenceServiceConfigValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	logger := log.FromContext(ctx)
+	config, err := utils.Convert[*v1alpha1.LLMInferenceServiceConfig](obj)
+	if err != nil {
+		return admission.Warnings{}, err
+	}
+
+	warnings := admission.Warnings{}
+	if llmisvc.WellKnownDefaultConfigs.Has(config.Name) {
+		warning := fmt.Sprintf("deleting well-known config %s/%s may have undesired consequences", config.Namespace, config.Name)
+		logger.Info(warning)
+		warnings = append(warnings, warning)
+	}
+
+	return warnings, nil
+}
+
+func (l *LLMInferenceServiceConfigValidator) validate(ctx context.Context, llmSvcConfig *v1alpha1.LLMInferenceServiceConfig) error {
+	logger := log.FromContext(ctx)
+	llmSvcConfig = llmSvcConfig.DeepCopy()
+
+	config, err := llmisvc.LoadConfig(ctx, l.ClientSet)
+	if err != nil {
+		logger.Error(err, "failed to load config")
+		return err
+	}
+
+	_, err = llmisvc.ReplaceVariables(llmisvc.LLMInferenceServiceSample(), llmSvcConfig, config)
+	if err != nil {
+		logger.Error(err, "failed to process the template")
+	}
+
+	return err
+}

--- a/pkg/controller/llmisvc/webhook/webhook_test.go
+++ b/pkg/controller/llmisvc/webhook/webhook_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+var _ = Describe("Validating config configs", func() {
+	Context("validating new configs", func() {
+		It("should reject config with invalid template fields", func(ctx SpecContext) {
+			// given
+			preset := &v1alpha1.LLMInferenceServiceConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-template-fields",
+					Namespace: constants.KServeNamespace,
+				},
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					Model: v1alpha1.LLMModelSpec{
+						Name: ptr.To("{{ .NonExisting }}"),
+					},
+				},
+			}
+
+			// when
+			admissionError := envTest.Client.Create(ctx, preset)
+
+			// then
+			Expect(admissionError).To(HaveOccurred())
+			Expect(admissionError.Error()).To(ContainSubstring("can't evaluate field NonExisting in type struct"))
+		})
+
+		It("should reject updating config with wrong template syntax", func(ctx SpecContext) {
+			// given
+			preset := &v1alpha1.LLMInferenceServiceConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalid-template-fields",
+					Namespace: constants.KServeNamespace,
+				},
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					Model: v1alpha1.LLMModelSpec{
+						Name: ptr.To("{{ ChildName .ObjectMeta.Name `-inference-pool` }}"),
+					},
+				},
+			}
+			Expect(envTest.Client.Create(ctx, preset)).To(Succeed())
+
+			// when
+			preset.Spec.Model.Name = ptr.To("{{ ChildName .ObjectMeta.Name \"-inference-pool\" }}")
+			admissionError := envTest.Client.Update(ctx, preset)
+
+			// then
+			Expect(admissionError).To(HaveOccurred())
+			Expect(admissionError.Error()).To(ContainSubstring(`unexpected "\\" in operand`))
+		})
+	})
+})

--- a/pkg/testing/ctrl.go
+++ b/pkg/testing/ctrl.go
@@ -17,62 +17,48 @@ limitations under the License.
 package testing
 
 import (
-	"context"
 	"path/filepath"
-
-	rbacv1 "k8s.io/api/rbac/v1"
-
-	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
-
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	otelv1beta1 "github.com/open-telemetry/opentelemetry-operator/apis/v1beta1"
 	istioclientv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 
+	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
 	gatewayapiv1 "sigs.k8s.io/gateway-api/apis/v1"
-
-	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
-// StartWithControllers starts the test environment with the provided controllers.
-// It automatically adds necessary CRDs and schemes.
-func StartWithControllers(ctrls ...SetupWithManagerFunc) (*Client, context.CancelFunc) {
-	// The context passed to Process 1, which is invoked before all parallel nodes are started by Ginkgo,
-	// is terminated when this function exits. As a result, this context is unsuitable for use with
-	// manager/controllers that need to be available for the entire duration of the test suite.
-	// To address this, a new cancellable context must be created to ensure it remains active
-	// throughout the whole test suite lifecycle.
-	ctx, cancel := context.WithCancel(context.Background())
+// NewEnvTest prepares k8s EnvTest with prereq
+func NewEnvTest(options ...Option) *Config {
+	testCRDs := WithCRDs(
+		filepath.Join(ProjectRoot(), "test", "crds"),
+	)
+	schemes := WithScheme(
+		// KServe Schemes
+		v1alpha1.AddToScheme,
+		v1beta1.AddToScheme,
+		// Kubernetes Schemes
+		corev1.AddToScheme,
+		rbacv1.AddToScheme,
+		appsv1.AddToScheme,
+		apiextv1.AddToScheme,
+		netv1.AddToScheme,
+		gatewayapiv1.Install,
+		igwapi.Install,
+		// Other Schemes
+		knservingv1.AddToScheme,
+		istioclientv1beta1.AddToScheme,
+		kedav1alpha1.AddToScheme,
+		otelv1beta1.AddToScheme,
+	)
 
-	return Configure(
-		WithCRDs(
-			filepath.Join(ProjectRoot(), "test", "crds"),
-		),
-		WithScheme(
-			// KServe Schemes
-			v1alpha1.AddToScheme,
-			v1beta1.AddToScheme,
-			// Kubernetes Schemes
-			corev1.AddToScheme,
-			rbacv1.AddToScheme,
-			appsv1.AddToScheme,
-			apiextv1.AddToScheme,
-			netv1.AddToScheme,
-			gatewayapiv1.Install,
-			igwapi.Install,
-			// Other Schemes
-			knservingv1.AddToScheme,
-			istioclientv1beta1.AddToScheme,
-			kedav1alpha1.AddToScheme,
-			otelv1beta1.AddToScheme,
-		),
-	).WithControllers(ctrls...).
-		Start(ctx), cancel
+	return Configure(append(options, testCRDs, schemes)...)
 }

--- a/pkg/testing/types.go
+++ b/pkg/testing/types.go
@@ -22,6 +22,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-type SetupWithManagerFunc func(cfg *rest.Config, mgr ctrl.Manager) error
-
-type AddToSchemeFunc func(scheme *runtime.Scheme) error
+type (
+	SetupFunc       func(cfg *rest.Config, mgr ctrl.Manager) error
+	AddToSchemeFunc func(scheme *runtime.Scheme) error
+)

--- a/test/webhooks/manifests.yaml
+++ b/test/webhooks/manifests.yaml
@@ -1,0 +1,26 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: llminferenceserviceconfig.serving.kserve.io
+webhooks:
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: kserve-webhook-server-service
+        namespace: kserve
+        path: /validate-serving-kserve-io-v1alpha1-llminferenceserviceconfig
+    failurePolicy: Fail
+    sideEffects: None
+    name: llminferenceserviceconfigs.kserve-webhook-server.validator
+    rules:
+      - apiGroups:
+          - serving.kserve.io
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        resources:
+          - llminferenceserviceconfigs

--- a/test/webhooks/service.yaml
+++ b/test/webhooks/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      # targetPort must match the port your webhook server actually listens on
+      # if you haven't overridden it in setup.Options.WebhookServer.Port, the default is 9443
+      targetPort: 9443
+  selector:
+    # your controller-manager (or webhook) usually carries these labels;
+    # swap them out for whatever you’re using in your Deployment/Pod spec
+    control-plane: controller-manager
+    app.kubernetes.io/name: kserve-controller-manager


### PR DESCRIPTION
This PR brings validating webhook for `LLMInferenceServiceConfig` kind.

It performs the  templating against a sample `LLMInferenceService` to verify if defined substitutions are correct.

### Considerations

- No validation of re-used structs (such as `HTTPRouteSpec`), this is deferred to respective webhook when the resource is created.  We deliberately patched CRDs to remove schema validators, as  `LLMInferenceServiceConfig` can have "not yet valid" values for fields like `Namespace` due to templating - see #712 .
- When updating well-known presets, a warning is emitted by validating webhook, but it is not blocking such operation. It is usually better to rely on RBAC rules or policy engines to guard deletions. We could reconcile well-known configs to bring them back to desired state, but that's another feature

Fixes [RHOAIENG-28534](https://issues.redhat.com//browse/RHOAIENG-28534)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a validating admission webhook for LLMInferenceServiceConfig resources, ensuring configuration validity during create, update, and delete operations.
  * Added warnings for modifications or deletions of well-known default configs to help prevent unintended changes.

* **Tests**
  * Added comprehensive tests to verify webhook validation logic, including rejection of invalid templates and syntax errors.
  * Enhanced test environment setup to support webhook testing with new manifests and service definitions.

* **Refactor**
  * Improved test environment and controller setup for better modularity and maintainability.
  * Streamlined configuration loading and environment management functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->