### PR TITLE
chore(kustomize): consolidates webhook patching

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -21,186 +21,92 @@ resources:
 generatorOptions:
   disableNameSuffixHash: true
 
-
-
 replacements:
+# Replace webhook service name
 - source:
     fieldPath: metadata.name
     kind: Service
     name: kserve-webhook-server-service
     version: v1
   targets:
-  - fieldPaths:
-    - webhooks.*.clientConfig.service.name
-    select:
+  # All webhook configurations that need service name
+  - select:
       kind: MutatingWebhookConfiguration
-      name: inferenceservice.serving.kserve.io
-  - fieldPaths:
+    fieldPaths:
     - webhooks.*.clientConfig.service.name
-    select:
+  - select:
       kind: ValidatingWebhookConfiguration
-      name: inferenceservice.serving.kserve.io
-  - fieldPaths:
+    fieldPaths:
     - webhooks.*.clientConfig.service.name
-    select:
-      kind: ValidatingWebhookConfiguration
-      name: trainedmodel.serving.kserve.io
-  - fieldPaths:
-    - webhooks.*.clientConfig.service.name
-    select:
-      kind: ValidatingWebhookConfiguration
-      name: inferencegraph.serving.kserve.io
-  - fieldPaths:
-    - webhooks.*.clientConfig.service.name
-    select:
-      kind: ValidatingWebhookConfiguration
-      name: clusterservingruntime.serving.kserve.io
-  - fieldPaths:
-    - webhooks.*.clientConfig.service.name
-    select:
-      kind: ValidatingWebhookConfiguration
-      name: servingruntime.serving.kserve.io
-  - fieldPaths:
-      - webhooks.*.clientConfig.service.name
-    select:
-      kind: ValidatingWebhookConfiguration
-      name: localmodelcache.serving.kserve.io
-  - fieldPaths:
+  # Certificate service name
+  - select:
+      kind: Certificate
+      name: serving-cert
+      namespace: kserve
+    fieldPaths:
     - spec.commonName
     - spec.dnsNames.0
     options:
       delimiter: '.'
       index: 0
-    select:
-      kind: Certificate
-      name: serving-cert
-      namespace: kserve
-# Replace the namespace with the namespace of the controller manager.
+
+# Replace webhook service namespace and CA injection
 - source:
     fieldPath: metadata.namespace
     kind: Deployment
     name: kserve-controller-manager
     version: v1
   targets:
-  - fieldPaths:
-    - webhooks.*.clientConfig.service.namespace
-    select:
+  # All webhook configurations that need namespace
+  - select:
       kind: MutatingWebhookConfiguration
-      name: inferenceservice.serving.kserve.io
-  - fieldPaths:
+    fieldPaths:
     - webhooks.*.clientConfig.service.namespace
-    select:
+  - select:
       kind: ValidatingWebhookConfiguration
-      name: inferenceservice.serving.kserve.io
-  - fieldPaths:
+    fieldPaths:
     - webhooks.*.clientConfig.service.namespace
-    select:
-      kind: ValidatingWebhookConfiguration
-      name: trainedmodel.serving.kserve.io
-  - fieldPaths:
-    - webhooks.*.clientConfig.service.namespace
-    select:
-      kind: ValidatingWebhookConfiguration
-      name: inferencegraph.serving.kserve.io
-  - fieldPaths:
-    - webhooks.*.clientConfig.service.namespace
-    select:
-      kind: ValidatingWebhookConfiguration
-      name: clusterservingruntime.serving.kserve.io
-  - fieldPaths:
-    - webhooks.*.clientConfig.service.namespace
-    select:
-      kind: ValidatingWebhookConfiguration
-      name: servingruntime.serving.kserve.io
-  - fieldPaths:
-    - webhooks.*.clientConfig.service.namespace
-    select:
-      kind: ValidatingWebhookConfiguration
-      name: localmodelcache.serving.kserve.io
-  - fieldPaths:
+  # Certificate namespace
+  - select:
+      kind: Certificate
+      name: serving-cert
+      namespace: kserve
+    fieldPaths:
     - spec.commonName
     - spec.dnsNames.0
     options:
       delimiter: '.'
       index: 1
-    select:
-      kind: Certificate
-      name: serving-cert
-      namespace: kserve
-  - fieldPaths:
-    - metadata.annotations.[cert-manager.io/inject-ca-from]
-    options:
-      delimiter: '/'
-      index: 0
-    select:
+  # CA injection annotations for all webhook configurations
+  - select:
       kind: CustomResourceDefinition
       name: inferenceservices.serving.kserve.io
-  - fieldPaths:
+    fieldPaths:
     - metadata.annotations.[cert-manager.io/inject-ca-from]
     options:
       delimiter: '/'
       index: 0
-    select:
+  - select:
       kind: MutatingWebhookConfiguration
-      name: inferenceservice.serving.kserve.io
-  - fieldPaths:
+    fieldPaths:
     - metadata.annotations.[cert-manager.io/inject-ca-from]
     options:
       delimiter: '/'
       index: 0
-    select:
+  - select:
       kind: ValidatingWebhookConfiguration
-      name: inferenceservice.serving.kserve.io
-  - fieldPaths:
+    fieldPaths:
     - metadata.annotations.[cert-manager.io/inject-ca-from]
     options:
       delimiter: '/'
       index: 0
-    select:
-      kind: ValidatingWebhookConfiguration
-      name: trainedmodel.serving.kserve.io
-  - fieldPaths:
-    - metadata.annotations.[cert-manager.io/inject-ca-from]
-    options:
-      delimiter: '/'
-      index: 0
-    select:
-      kind: ValidatingWebhookConfiguration
-      name: inferencegraph.serving.kserve.io
-  - fieldPaths:
-    - metadata.annotations.[cert-manager.io/inject-ca-from]
-    options:
-      delimiter: '/'
-      index: 0
-    select:
-      kind: ValidatingWebhookConfiguration
-      name: clusterservingruntime.serving.kserve.io
-  - fieldPaths:
-    - metadata.annotations.[cert-manager.io/inject-ca-from]
-    options:
-      delimiter: '/'
-      index: 0
-    select:
-      kind: ValidatingWebhookConfiguration
-      name: servingruntime.serving.kserve.io
-  - fieldPaths:
-      - metadata.annotations.[cert-manager.io/inject-ca-from]
-    options:
-      delimiter: '/'
-      index: 0
-    select:
-      kind: ValidatingWebhookConfiguration
-      name: localmodelcache.serving.kserve.io
 
-    # Protect the /metrics endpoint by putting it behind auth.
-    # Only one of manager_auth_proxy_patch.yaml and
-    # manager_prometheus_metrics_patch.yaml should be enabled.
-    # If you want your controller-manager to expose the /metrics
-    # endpoint w/o any authn/z, uncomment the following line and
-    # comment manager_auth_proxy_patch.yaml.
-    # Only one of manager_auth_proxy_patch.yaml and
-    # manager_prometheus_metrics_patch.yaml should be enabled.
-    #- manager_prometheus_metrics_patch.yaml
+# Protect the /metrics endpoint by putting it behind auth.
+# Only one of manager_auth_proxy_patch.yaml and
+# manager_prometheus_metrics_patch.yaml should be enabled.
+# If you want your controller-manager to expose the /metrics
+# endpoint w/o any authn/z, uncomment the following line and
+# comment manager_auth_proxy_patch.yaml.
 patches:
 - path: manager_image_patch.yaml
 - path: manager_auth_proxy_patch.yaml


### PR DESCRIPTION
This PR simplifies how `kustomization.yaml` defines patching of webhooks. The old approach was redundant with nearly indentical replacements repeated for each webhook patch.

Multiple replacements has been merged into single select blocks for all webhooks, so you only define the substitution once per resource type or category and include patch file. There's no need for copy-paste anymore.

Split from #723
