### PR TITLE
chore(test): splits existing/non-existing well known configs

### DIFF
--- a/pkg/apis/serving/v1alpha1/v1alpha1.go
+++ b/pkg/apis/serving/v1alpha1/v1alpha1.go
@@ -42,6 +42,8 @@ var (
 
 	LLMInferenceServiceGVK = SchemeGroupVersion.WithKind("LLMInferenceService")
 
+	LLMInferenceServiceConfigGVK = SchemeGroupVersion.WithKind("LLMInferenceServiceConfig")
+
 	// AddToScheme is required by pkg/client/...
 	AddToScheme = SchemeBuilder.AddToScheme
 )

--- a/pkg/controller/llmisvc/config_merge.go
+++ b/pkg/controller/llmisvc/config_merge.go
@@ -52,15 +52,19 @@ const (
 	configRouterRouteName                   = configPrefix + "config-llm-router-route"
 )
 
-var WellKnownDefaultConfigs = sets.NewString(
-	configTemplateName,
-	configDecodeTemplateName,
+// FIXME move those presets to well-known when they're finally known :)
+var _ = sets.New[string](
+	configPrefillWorkerPipelineParallelName,
 	configDecodeWorkerPipelineParallelName,
 	configWorkerPipelineParallelName,
+)
+
+var WellKnownDefaultConfigs = sets.New[string](
+	configTemplateName,
+	configDecodeTemplateName,
 	configWorkerDataParallelName,
 	configDecodeWorkerDataParallelName,
 	configPrefillTemplateName,
-	configPrefillWorkerPipelineParallelName,
 	configPrefillWorkerDataParallelName,
 	configRouterSchedulerName,
 	configRouterRouteName,

--- a/pkg/controller/llmisvc/config_presets_test.go
+++ b/pkg/controller/llmisvc/config_presets_test.go
@@ -49,158 +49,140 @@ func TestPresetFiles(t *testing.T) {
 		IngressGatewayNamespace: "kserve",
 	}
 
-	tt := map[string][]struct {
-		name     string
-		llmSvc   *v1alpha1.LLMInferenceService
+	tt := map[string]struct {
 		expected *v1alpha1.LLMInferenceServiceConfig
 	}{
 		"config-llm-decode-worker-data-parallel.yaml": {
-			{
-				llmSvc: &v1alpha1.LLMInferenceService{
-					Spec: v1alpha1.LLMInferenceServiceSpec{
-						Model: v1alpha1.LLMModelSpec{
-							Name: ptr.To("llama"),
-						},
-						WorkloadSpec: v1alpha1.WorkloadSpec{
-							Parallelism: &v1alpha1.ParallelismSpec{
-								Data:      ptr.To[int32](4),
-								DataLocal: ptr.To[int32](2),
-								Tensor:    ptr.To[int32](1),
-								Expert:    true,
-							},
-						},
-					},
+			expected: &v1alpha1.LLMInferenceServiceConfig{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "serving.kserve.io/v1alpha1",
+					Kind:       "LLMInferenceServiceConfig",
 				},
-				expected: &v1alpha1.LLMInferenceServiceConfig{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: "serving.kserve.io/v1alpha1",
-						Kind:       "LLMInferenceServiceConfig",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "kserve-config-llm-decode-worker-data-parallel",
-					},
-					Spec: v1alpha1.LLMInferenceServiceSpec{
-						WorkloadSpec: v1alpha1.WorkloadSpec{
-							Worker: &corev1.PodSpec{
-								Volumes: []corev1.Volume{
-									{
-										Name: "home",
-										VolumeSource: corev1.VolumeSource{
-											EmptyDir: &corev1.EmptyDirVolumeSource{},
-										},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "kserve-config-llm-decode-worker-data-parallel",
+				},
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					WorkloadSpec: v1alpha1.WorkloadSpec{
+						Worker: &corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "home",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
-									{
-										Name: "dshm",
-										VolumeSource: corev1.VolumeSource{
-											EmptyDir: &corev1.EmptyDirVolumeSource{
-												Medium:    corev1.StorageMediumMemory,
-												SizeLimit: ptr.To(resource.MustParse("1Gi")),
-											},
-										},
-									},
-									{
-										Name: "model-cache",
-										VolumeSource: corev1.VolumeSource{
-											EmptyDir: &corev1.EmptyDirVolumeSource{},
+								},
+								{
+									Name: "dshm",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{
+											Medium:    corev1.StorageMediumMemory,
+											SizeLimit: ptr.To(resource.MustParse("1Gi")),
 										},
 									},
 								},
-								TerminationGracePeriodSeconds: ptr.To(int64(30)),
-								InitContainers: []corev1.Container{
-									{
-										Name:  "llm-d-routing-sidecar",
-										Image: "ghcr.io/llm-d/llm-d-routing-sidecar:0.0.6",
-										Args:  []string{"--port=8000", "--vllm-port=8001"},
-										Ports: []corev1.ContainerPort{
-											{
-												ContainerPort: 8000,
-												Protocol:      corev1.ProtocolTCP,
-											},
-										},
-										RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
-										TerminationMessagePath:   "/dev/termination-log",
-										TerminationMessagePolicy: "FallbackToLogsOnError",
-										ImagePullPolicy:          "IfNotPresent",
+								{
+									Name: "model-cache",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
-								Containers: []corev1.Container{
-									{
-										Name:    "main",
-										Image:   "ghcr.io/llm-d/llm-d:0.0.8",
-										Command: []string{"/bin/sh", "-c"},
-										Ports: []corev1.ContainerPort{
-											{
-												ContainerPort: 8001,
-												Protocol:      corev1.ProtocolTCP,
+							},
+							TerminationGracePeriodSeconds: ptr.To(int64(30)),
+							InitContainers: []corev1.Container{
+								{
+									Name:  "llm-d-routing-sidecar",
+									Image: "ghcr.io/llm-d/llm-d-routing-sidecar:0.0.6",
+									Args:  []string{"--port=8000", "--vllm-port=8001"},
+									Ports: []corev1.ContainerPort{
+										{
+											ContainerPort: 8000,
+											Protocol:      corev1.ProtocolTCP,
+										},
+									},
+									RestartPolicy:            ptr.To(corev1.ContainerRestartPolicyAlways),
+									TerminationMessagePath:   "/dev/termination-log",
+									TerminationMessagePolicy: "FallbackToLogsOnError",
+									ImagePullPolicy:          "IfNotPresent",
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Name:    "main",
+									Image:   "ghcr.io/llm-d/llm-d:0.0.8",
+									Command: []string{"/bin/sh", "-c"},
+									Ports: []corev1.ContainerPort{
+										{
+											ContainerPort: 8001,
+											Protocol:      corev1.ProtocolTCP,
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "home",
+											MountPath: "/home",
+										},
+										{
+											Name:      "dshm",
+											MountPath: "/dev/shm",
+										},
+										{
+											Name:      "model-cache",
+											MountPath: "/models",
+										},
+									},
+									LivenessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/health",
+												Port: intstr.FromInt32(8001),
 											},
 										},
-										VolumeMounts: []corev1.VolumeMount{
-											{
-												Name:      "home",
-												MountPath: "/home",
-											},
-											{
-												Name:      "dshm",
-												MountPath: "/dev/shm",
-											},
-											{
-												Name:      "model-cache",
-												MountPath: "/models",
+										InitialDelaySeconds: 120,
+										PeriodSeconds:       10,
+										TimeoutSeconds:      10,
+										FailureThreshold:    3,
+									},
+									ReadinessProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path: "/health",
+												Port: intstr.FromInt32(8001),
 											},
 										},
-										LivenessProbe: &corev1.Probe{
-											ProbeHandler: corev1.ProbeHandler{
-												HTTPGet: &corev1.HTTPGetAction{
-													Path: "/health",
-													Port: intstr.FromInt32(8001),
-												},
-											},
-											InitialDelaySeconds: 120,
-											PeriodSeconds:       10,
-											TimeoutSeconds:      10,
-											FailureThreshold:    3,
-										},
-										ReadinessProbe: &corev1.Probe{
-											ProbeHandler: corev1.ProbeHandler{
-												HTTPGet: &corev1.HTTPGetAction{
-													Path: "/health",
-													Port: intstr.FromInt32(8001),
-												},
-											},
-											InitialDelaySeconds: 10,
-											PeriodSeconds:       10,
-											TimeoutSeconds:      5,
-											FailureThreshold:    60,
-										},
-										SecurityContext: &corev1.SecurityContext{
-											AllowPrivilegeEscalation: ptr.To(false),
-											Capabilities: &corev1.Capabilities{
-												Add: []corev1.Capability{
-													"IPC_LOCK",
-													"SYS_RAWIO",
-												},
+										InitialDelaySeconds: 10,
+										PeriodSeconds:       10,
+										TimeoutSeconds:      5,
+										FailureThreshold:    60,
+									},
+									SecurityContext: &corev1.SecurityContext{
+										AllowPrivilegeEscalation: ptr.To(false),
+										Capabilities: &corev1.Capabilities{
+											Add: []corev1.Capability{
+												"IPC_LOCK",
+												"SYS_RAWIO",
 											},
 										},
-										Env: []corev1.EnvVar{
-											{
-												Name:  "HOME",
-												Value: "/home",
-											},
-											{
-												Name:  "VLLM_LOGGING_LEVEL",
-												Value: "INFO",
-											},
-											{
-												Name:  "HF_HUB_CACHE",
-												Value: "/models",
-											},
+									},
+									Env: []corev1.EnvVar{
+										{
+											Name:  "HOME",
+											Value: "/home",
 										},
-										TerminationMessagePath:   "/dev/termination-log",
-										TerminationMessagePolicy: "FallbackToLogsOnError",
-										ImagePullPolicy:          "IfNotPresent",
-										Stdin:                    true,
-										TTY:                      true,
-										Args: []string{`
+										{
+											Name:  "VLLM_LOGGING_LEVEL",
+											Value: "INFO",
+										},
+										{
+											Name:  "HF_HUB_CACHE",
+											Value: "/models",
+										},
+									},
+									TerminationMessagePath:   "/dev/termination-log",
+									TerminationMessagePolicy: "FallbackToLogsOnError",
+									ImagePullPolicy:          "IfNotPresent",
+									Stdin:                    true,
+									TTY:                      true,
+									Args: []string{`
 START_RANK=$(( ${LWS_WORKER_INDEX:-0} * 2 ))
 if [ "${LWS_WORKER_INDEX:-0}" -eq 0 ]; then
   #################
@@ -237,7 +219,6 @@ else
     --trust-remote-code \
     --headless
 fi`},
-									},
 								},
 							},
 						},
@@ -246,6 +227,8 @@ fi`},
 			},
 		},
 	}
+
+	remaining := llmisvc.WellKnownDefaultConfigs.Clone()
 
 	_ = filepath.Walk(presetsDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
@@ -268,37 +251,33 @@ fi`},
 
 			config := loadConfig(t, data, filePath)
 
-			// TODO Add the opposite check once PP configs are present so that we know that all WellKnownDefaultConfigs are present.
-			if !llmisvc.WellKnownDefaultConfigs.Has(config.ObjectMeta.Name) {
-				t.Fatalf("Expected %s to exist in WellKnownDefaultConfigs %#v", config.ObjectMeta.Name, llmisvc.WellKnownDefaultConfigs.List())
+			name := config.ObjectMeta.Name
+			if !llmisvc.WellKnownDefaultConfigs.Has(name) {
+				t.Fatalf("Expected %s to exist in WellKnownDefaultConfigs %#v", name, llmisvc.WellKnownDefaultConfigs)
 			}
+			// Remove from the tracked set
+			remaining = remaining.Delete(name)
 
-			_, err = llmisvc.ReplaceVariables(llmSvc, config, &kserveSystemConfig)
+			out, err := llmisvc.ReplaceVariables(llmSvc, config, &kserveSystemConfig)
 			if err != nil {
 				t.Errorf("ReplaceVariables() failed for %s: %v", filename, err)
 			}
 
-			for _, tc := range tt[filename] {
-				t.Run(tc.name, func(t *testing.T) {
-					t.Parallel()
-
-					out, err := llmisvc.ReplaceVariables(tc.llmSvc, config, &kserveSystemConfig)
-					if err != nil {
-						t.Errorf("ReplaceVariables() failed for %s: %v", filename, err)
-					}
-
-					if !equality.Semantic.DeepEqual(tc.expected, out) {
-						diff := cmp.Diff(tc.expected, out)
-						t.Errorf("ReplaceVariables() returned unexpected diff (-want +got):\n%s", diff)
-						diff = cmp.Diff(tc.expected.Spec.WorkloadSpec.Worker.Containers[0].Args, out.Spec.WorkloadSpec.Worker.Containers[0].Args)
-						t.Errorf("ReplaceVariables() returned unexpected diff (-want +got):\n%s", diff)
-					}
-				})
+			// Verify the actual Spec rendered if provided for the found file.
+			if tc, exist := tt[filename]; exist {
+				if !equality.Semantic.DeepEqual(tc.expected, out) {
+					diff := cmp.Diff(tc.expected, out)
+					t.Errorf("ReplaceVariables() returned unexpected diff (-want +got):\n%s", diff)
+				}
 			}
 		})
 
 		return nil
 	})
+
+	if remaining.Len() > 0 {
+		t.Errorf("Found %d remaining well-known-configs that are missing as manifest files: %#v", remaining.Len(), remaining)
+	}
 }
 
 func loadConfig(t *testing.T, data []byte, filePath string) *v1alpha1.LLMInferenceServiceConfig {
@@ -307,13 +286,21 @@ func loadConfig(t *testing.T, data []byte, filePath string) *v1alpha1.LLMInferen
 		t.Errorf("Failed to unmarshal YAML from %s: %v", filePath, err)
 		return nil
 	}
+	if err := yaml.Unmarshal(data, config); err != nil {
+		t.Errorf("Failed to unmarshal YAML from %s: %v", filePath, err)
+		return nil
+	}
 
-	if config.APIVersion != "serving.kserve.io/v1alpha1" {
-		t.Errorf("Expected APIVersion to be 'serving.kserve.io/v1alpha1', got %s", config.APIVersion)
+	expectedGroupVersion := v1alpha1.LLMInferenceServiceConfigGVK.GroupVersion().String()
+	if config.APIVersion != expectedGroupVersion {
+		t.Errorf("Expected APIVersion to be '%s', got '%s'", expectedGroupVersion, config.APIVersion)
 	}
-	if config.Kind != "LLMInferenceServiceConfig" {
-		t.Errorf("Expected Kind to be 'LLMInferenceServiceConfig', got %s", config.Kind)
+
+	expectedKind := v1alpha1.LLMInferenceServiceConfigGVK.Kind
+	if config.Kind != expectedKind {
+		t.Errorf("Expected Kind to be '%s', got %s", expectedKind, config.Kind)
 	}
+
 	if config.ObjectMeta.Name == "" {
 		t.Error("Expected ObjectMeta.Name to be set")
 	}


### PR DESCRIPTION
There are some presets that are not defined yet, namely:

- `configPrefillWorkerPipelineParallelName`
- `configDecodeWorkerPipelineParallelName`
- `configWorkerPipelineParallelName`

To ensure that our tests capture the diff between existing files (resources to be created in the cluster) and defined presets we rely on when merging specs in the code the set has been split to reflect it.

The test has been adjusted to check if there is a diff between existing files and defined constants in `config_merge.go` by keeping track of tested files.

In addition, the test logic has been simplified by removing duplicate loop over a map with expected preset content that verify actual modifications based on the provided template.

Split from #723