### PR TITLE
fix(scheduler): creates missing endpoint picker service

### DIFF
--- a/test/overlays/llm-istio-experimental/istio_base.yaml
+++ b/test/overlays/llm-istio-experimental/istio_base.yaml
@@ -16,8 +16,8 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "istio-base"
     app.kubernetes.io/part-of: "istio"
-    app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: base-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
 ---
 # Source: base/templates/crds.yaml
 # TODO enableCRDTemplates is now defaulted to true as we
@@ -36,8 +36,8 @@ metadata:
     app.kubernetes.io/instance: istio-base
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
+    helm.sh/chart: base-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
   name: wasmplugins.extensions.istio.io
 spec:
   group: extensions.istio.io
@@ -72,10 +72,11 @@ spec:
                 description: |-
                   Specifies the failure behavior for the plugin due to fatal errors.
 
-                  Valid Options: FAIL_CLOSE, FAIL_OPEN
+                  Valid Options: FAIL_CLOSE, FAIL_OPEN, FAIL_RELOAD
                 enum:
                 - FAIL_CLOSE
                 - FAIL_OPEN
+                - FAIL_RELOAD
                 type: string
               imagePullPolicy:
                 description: |-
@@ -402,8 +403,8 @@ metadata:
     app.kubernetes.io/instance: istio-base
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
+    helm.sh/chart: base-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
   name: destinationrules.networking.istio.io
 spec:
   group: networking.istio.io
@@ -424,11 +425,11 @@ spec:
       jsonPath: .spec.host
       name: Host
       type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time
-        when this object was created. It is not guaranteed to be set in happens-before
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
         order across separate operations. Clients may not set this value. It is represented
         in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
-        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+        lists. For more information, see [Kubernetes API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -535,10 +536,6 @@ spec:
                                 idleTimeout:
                                   description: The idle timeout for TCP connections.
                                   type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
                                 maxConnectionDuration:
                                   description: The maximum duration of a connection.
                                   type: string
@@ -901,10 +898,6 @@ spec:
                                       idleTimeout:
                                         description: The idle timeout for TCP connections.
                                         type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
                                       maxConnectionDuration:
                                         description: The maximum duration of a connection.
                                         type: string
@@ -1281,6 +1274,26 @@ spec:
                               - V2
                               type: string
                           type: object
+                        retryBudget:
+                          description: Specifies a limit on concurrent retries in
+                            relation to the number of active requests.
+                          properties:
+                            minRetryConcurrency:
+                              description: Specifies the minimum retry concurrency
+                                allowed for the retry budget.
+                              maximum: 4294967295
+                              minimum: 0
+                              type: integer
+                            percent:
+                              description: Specifies the limit on concurrent retries
+                                as a percentage of the sum of active requests and
+                                active pending requests.
+                              format: double
+                              maximum: 100
+                              minimum: 0
+                              nullable: true
+                              type: number
+                          type: object
                         tls:
                           description: TLS related settings for connections to the
                             upstream service.
@@ -1429,9 +1442,6 @@ spec:
                           idleTimeout:
                             description: The idle timeout for TCP connections.
                             type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
                           maxConnectionDuration:
                             description: The maximum duration of a connection.
                             type: string
@@ -1785,10 +1795,6 @@ spec:
                                 idleTimeout:
                                   description: The idle timeout for TCP connections.
                                   type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
                                 maxConnectionDuration:
                                   description: The maximum duration of a connection.
                                   type: string
@@ -2154,3833 +2160,25 @@ spec:
                         - V2
                         type: string
                     type: object
-                  tls:
-                    description: TLS related settings for connections to the upstream
-                      service.
+                  retryBudget:
+                    description: Specifies a limit on concurrent retries in relation
+                      to the number of active requests.
                     properties:
-                      caCertificates:
-                        description: 'OPTIONAL: The path to the file containing certificate
-                          authority certificates to use in verifying a presented server
-                          certificate.'
-                        type: string
-                      caCrl:
-                        description: 'OPTIONAL: The path to the file containing the
-                          certificate revocation list (CRL) to use in verifying a
-                          presented server certificate.'
-                        type: string
-                      clientCertificate:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        type: string
-                      credentialName:
-                        description: The name of the secret that holds the TLS certs
-                          for the client including the CA certificates.
-                        type: string
-                      insecureSkipVerify:
-                        description: '`insecureSkipVerify` specifies whether the proxy
-                          should skip verifying the CA signature and SAN for the server
-                          certificate corresponding to the host.'
-                        nullable: true
-                        type: boolean
-                      mode:
-                        description: |-
-                          Indicates whether connections to this port should be secured using TLS.
-
-                          Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
-                        enum:
-                        - DISABLE
-                        - SIMPLE
-                        - MUTUAL
-                        - ISTIO_MUTUAL
-                        type: string
-                      privateKey:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        type: string
-                      sni:
-                        description: SNI string to present to the server during TLS
-                          handshake.
-                        type: string
-                      subjectAltNames:
-                        description: A list of alternate names to verify the subject
-                          identity in the certificate.
-                        items:
-                          type: string
-                        type: array
-                    type: object
-                  tunnel:
-                    description: Configuration of tunneling TCP over other transport
-                      or application layers for the host configured in the DestinationRule.
-                    properties:
-                      protocol:
-                        description: Specifies which protocol to use for tunneling
-                          the downstream connection.
-                        type: string
-                      targetHost:
-                        description: Specifies a host to which the downstream connection
-                          is tunneled.
-                        type: string
-                      targetPort:
-                        description: Specifies a port to which the downstream connection
-                          is tunneled.
+                      minRetryConcurrency:
+                        description: Specifies the minimum retry concurrency allowed
+                          for the retry budget.
                         maximum: 4294967295
                         minimum: 0
                         type: integer
-                    required:
-                    - targetHost
-                    - targetPort
-                    type: object
-                type: object
-              workloadSelector:
-                description: Criteria used to select the specific set of pods/VMs
-                  on which this `DestinationRule` configuration should be applied.
-                properties:
-                  matchLabels:
-                    additionalProperties:
-                      maxLength: 63
-                      type: string
-                      x-kubernetes-validations:
-                      - message: wildcard not allowed in label value match
-                        rule: '!self.contains("*")'
-                    description: One or more labels that indicate a specific set of
-                      pods/VMs on which a policy should be applied.
-                    maxProperties: 4096
-                    type: object
-                    x-kubernetes-validations:
-                    - message: wildcard not allowed in label key match
-                      rule: self.all(key, !key.contains("*"))
-                    - message: key must not be empty
-                      rule: self.all(key, key.size() != 0)
-                type: object
-            required:
-            - host
-            type: object
-          status:
-            properties:
-              conditions:
-                description: Current service state of the resource.
-                items:
-                  properties:
-                    lastProbeTime:
-                      description: Last time we probed the condition.
-                      format: date-time
-                      type: string
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
-                      format: date-time
-                      type: string
-                    message:
-                      description: Human-readable message indicating details about
-                        last transition.
-                      type: string
-                    observedGeneration:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      description: Resource Generation to which the Condition refers.
-                      x-kubernetes-int-or-string: true
-                    reason:
-                      description: Unique, one-word, CamelCase reason for the condition's
-                        last transition.
-                      type: string
-                    status:
-                      description: Status is the status of the condition.
-                      type: string
-                    type:
-                      description: Type is the type of the condition.
-                      type: string
-                  type: object
-                type: array
-              observedGeneration:
-                anyOf:
-                - type: integer
-                - type: string
-                x-kubernetes-int-or-string: true
-              validationMessages:
-                description: Includes any errors or warnings detected by Istio's analyzers.
-                items:
-                  properties:
-                    documentationUrl:
-                      description: A url pointing to the Istio documentation for this
-                        specific error type.
-                      type: string
-                    level:
-                      description: |-
-                        Represents how severe a message is.
-
-                        Valid Options: UNKNOWN, ERROR, WARNING, INFO
-                      enum:
-                      - UNKNOWN
-                      - ERROR
-                      - WARNING
-                      - INFO
-                      type: string
-                    type:
-                      properties:
-                        code:
-                          description: A 7 character code matching `^IST[0-9]{4}$`
-                            intended to uniquely identify the message type.
-                          type: string
-                        name:
-                          description: A human-readable name for the message type.
-                          type: string
-                      type: object
-                  type: object
-                type: array
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - description: The name of a service from the service registry
-      jsonPath: .spec.host
-      name: Host
-      type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time
-        when this object was created. It is not guaranteed to be set in happens-before
-        order across separate operations. Clients may not set this value. It is represented
-        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
-        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha3
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting load balancing, outlier detection,
-              etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
-            properties:
-              exportTo:
-                description: A list of namespaces to which this destination rule is
-                  exported.
-                items:
-                  type: string
-                type: array
-              host:
-                description: The name of a service from the service registry.
-                type: string
-              subsets:
-                description: One or more named sets that represent individual versions
-                  of a service.
-                items:
-                  properties:
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels apply a filter over the endpoints of a service
-                        in the service registry.
-                      type: object
-                    name:
-                      description: Name of the subset.
-                      type: string
-                    trafficPolicy:
-                      description: Traffic policies that apply to this subset.
-                      properties:
-                        connectionPool:
-                          properties:
-                            http:
-                              description: HTTP connection pool settings.
-                              properties:
-                                h2UpgradePolicy:
-                                  description: |-
-                                    Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-
-                                    Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
-                                  enum:
-                                  - DEFAULT
-                                  - DO_NOT_UPGRADE
-                                  - UPGRADE
-                                  type: string
-                                http1MaxPendingRequests:
-                                  description: Maximum number of requests that will
-                                    be queued while waiting for a ready connection
-                                    pool connection.
-                                  format: int32
-                                  type: integer
-                                http2MaxRequests:
-                                  description: Maximum number of active requests to
-                                    a destination.
-                                  format: int32
-                                  type: integer
-                                idleTimeout:
-                                  description: The idle timeout for upstream connection
-                                    pool connections.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConcurrentStreams:
-                                  description: The maximum number of concurrent streams
-                                    allowed for a peer on one HTTP/2 connection.
-                                  format: int32
-                                  type: integer
-                                maxRequestsPerConnection:
-                                  description: Maximum number of requests per connection
-                                    to a backend.
-                                  format: int32
-                                  type: integer
-                                maxRetries:
-                                  description: Maximum number of retries that can
-                                    be outstanding to all hosts in a cluster at a
-                                    given time.
-                                  format: int32
-                                  type: integer
-                                useClientProtocol:
-                                  description: If set to true, client protocol will
-                                    be preserved while initiating connection to backend.
-                                  type: boolean
-                              type: object
-                            tcp:
-                              description: Settings common to both HTTP and TCP upstream
-                                connections.
-                              properties:
-                                connectTimeout:
-                                  description: TCP connection timeout.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                idleTimeout:
-                                  description: The idle timeout for TCP connections.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConnectionDuration:
-                                  description: The maximum duration of a connection.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConnections:
-                                  description: Maximum number of HTTP1 /TCP connections
-                                    to a destination host.
-                                  format: int32
-                                  type: integer
-                                tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on the
-                                    socket to enable TCP Keepalives.
-                                  properties:
-                                    interval:
-                                      description: The time duration between keep-alive
-                                        probes.
-                                      type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
-                                    probes:
-                                      description: Maximum number of keepalive probes
-                                        to send without response before deciding the
-                                        connection is dead.
-                                      maximum: 4294967295
-                                      minimum: 0
-                                      type: integer
-                                    time:
-                                      description: The time duration a connection
-                                        needs to be idle before keep-alive probes
-                                        start being sent.
-                                      type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
-                                  type: object
-                              type: object
-                          type: object
-                        loadBalancer:
-                          description: Settings controlling the load balancer algorithms.
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - simple
-                              - required:
-                                - consistentHash
-                          - required:
-                            - simple
-                          - required:
-                            - consistentHash
-                          properties:
-                            consistentHash:
-                              allOf:
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - ringHash
-                                    - required:
-                                      - maglev
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                              properties:
-                                httpCookie:
-                                  description: Hash based on HTTP cookie.
-                                  properties:
-                                    name:
-                                      description: Name of the cookie.
-                                      type: string
-                                    path:
-                                      description: Path to set for the cookie.
-                                      type: string
-                                    ttl:
-                                      description: Lifetime of the cookie.
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                httpHeaderName:
-                                  description: Hash based on a specific HTTP header.
-                                  type: string
-                                httpQueryParameterName:
-                                  description: Hash based on a specific HTTP query
-                                    parameter.
-                                  type: string
-                                maglev:
-                                  description: The Maglev load balancer implements
-                                    consistent hashing to backend hosts.
-                                  properties:
-                                    tableSize:
-                                      description: The table size for Maglev hashing.
-                                      minimum: 0
-                                      type: integer
-                                  type: object
-                                minimumRingSize:
-                                  description: Deprecated.
-                                  minimum: 0
-                                  type: integer
-                                ringHash:
-                                  description: The ring/modulo hash load balancer
-                                    implements consistent hashing to backend hosts.
-                                  properties:
-                                    minimumRingSize:
-                                      description: The minimum number of virtual nodes
-                                        to use for the hash ring.
-                                      minimum: 0
-                                      type: integer
-                                  type: object
-                                useSourceIp:
-                                  description: Hash based on the source IP address.
-                                  type: boolean
-                              type: object
-                            localityLbSetting:
-                              properties:
-                                distribute:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating locality, '/' separated,
-                                          e.g.
-                                        type: string
-                                      to:
-                                        additionalProperties:
-                                          maximum: 4294967295
-                                          minimum: 0
-                                          type: integer
-                                        description: Map of upstream localities to
-                                          traffic distribution weights.
-                                        type: object
-                                    type: object
-                                  type: array
-                                enabled:
-                                  description: Enable locality load balancing.
-                                  nullable: true
-                                  type: boolean
-                                failover:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating region.
-                                        type: string
-                                      to:
-                                        description: Destination region the traffic
-                                          will fail over to when endpoints in the
-                                          'from' region becomes unhealthy.
-                                        type: string
-                                    type: object
-                                  type: array
-                                failoverPriority:
-                                  description: failoverPriority is an ordered list
-                                    of labels used to sort endpoints to do priority
-                                    based load balancing.
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            simple:
-                              description: |2-
-
-
-                                Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
-                              enum:
-                              - UNSPECIFIED
-                              - LEAST_CONN
-                              - RANDOM
-                              - PASSTHROUGH
-                              - ROUND_ROBIN
-                              - LEAST_REQUEST
-                              type: string
-                            warmup:
-                              description: Represents the warmup configuration of
-                                Service.
-                              properties:
-                                aggression:
-                                  description: This parameter controls the speed of
-                                    traffic increase over the warmup duration.
-                                  format: double
-                                  minimum: 1
-                                  nullable: true
-                                  type: number
-                                duration:
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                minimumPercent:
-                                  format: double
-                                  maximum: 100
-                                  minimum: 0
-                                  nullable: true
-                                  type: number
-                              required:
-                              - duration
-                              type: object
-                            warmupDurationSecs:
-                              description: 'Deprecated: use `warmup` instead.'
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                          type: object
-                        outlierDetection:
-                          properties:
-                            baseEjectionTime:
-                              description: Minimum ejection duration.
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                            consecutive5xxErrors:
-                              description: Number of 5xx errors before a host is ejected
-                                from the connection pool.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            consecutiveErrors:
-                              format: int32
-                              type: integer
-                            consecutiveGatewayErrors:
-                              description: Number of gateway errors before a host
-                                is ejected from the connection pool.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            consecutiveLocalOriginFailures:
-                              description: The number of consecutive locally originated
-                                failures before ejection occurs.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            interval:
-                              description: Time interval between ejection sweep analysis.
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                            maxEjectionPercent:
-                              description: Maximum % of hosts in the load balancing
-                                pool for the upstream service that can be ejected.
-                              format: int32
-                              type: integer
-                            minHealthPercent:
-                              description: Outlier detection will be enabled as long
-                                as the associated load balancing pool has at least
-                                `minHealthPercent` hosts in healthy mode.
-                              format: int32
-                              type: integer
-                            splitExternalLocalOriginErrors:
-                              description: Determines whether to distinguish local
-                                origin failures from external errors.
-                              type: boolean
-                          type: object
-                        portLevelSettings:
-                          description: Traffic policies specific to individual ports.
-                          items:
-                            properties:
-                              connectionPool:
-                                properties:
-                                  http:
-                                    description: HTTP connection pool settings.
-                                    properties:
-                                      h2UpgradePolicy:
-                                        description: |-
-                                          Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-
-                                          Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
-                                        enum:
-                                        - DEFAULT
-                                        - DO_NOT_UPGRADE
-                                        - UPGRADE
-                                        type: string
-                                      http1MaxPendingRequests:
-                                        description: Maximum number of requests that
-                                          will be queued while waiting for a ready
-                                          connection pool connection.
-                                        format: int32
-                                        type: integer
-                                      http2MaxRequests:
-                                        description: Maximum number of active requests
-                                          to a destination.
-                                        format: int32
-                                        type: integer
-                                      idleTimeout:
-                                        description: The idle timeout for upstream
-                                          connection pool connections.
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      maxConcurrentStreams:
-                                        description: The maximum number of concurrent
-                                          streams allowed for a peer on one HTTP/2
-                                          connection.
-                                        format: int32
-                                        type: integer
-                                      maxRequestsPerConnection:
-                                        description: Maximum number of requests per
-                                          connection to a backend.
-                                        format: int32
-                                        type: integer
-                                      maxRetries:
-                                        description: Maximum number of retries that
-                                          can be outstanding to all hosts in a cluster
-                                          at a given time.
-                                        format: int32
-                                        type: integer
-                                      useClientProtocol:
-                                        description: If set to true, client protocol
-                                          will be preserved while initiating connection
-                                          to backend.
-                                        type: boolean
-                                    type: object
-                                  tcp:
-                                    description: Settings common to both HTTP and
-                                      TCP upstream connections.
-                                    properties:
-                                      connectTimeout:
-                                        description: TCP connection timeout.
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      idleTimeout:
-                                        description: The idle timeout for TCP connections.
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      maxConnectionDuration:
-                                        description: The maximum duration of a connection.
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      maxConnections:
-                                        description: Maximum number of HTTP1 /TCP
-                                          connections to a destination host.
-                                        format: int32
-                                        type: integer
-                                      tcpKeepalive:
-                                        description: If set then set SO_KEEPALIVE
-                                          on the socket to enable TCP Keepalives.
-                                        properties:
-                                          interval:
-                                            description: The time duration between
-                                              keep-alive probes.
-                                            type: string
-                                            x-kubernetes-validations:
-                                            - message: must be a valid duration greater
-                                                than 1ms
-                                              rule: duration(self) >= duration('1ms')
-                                          probes:
-                                            description: Maximum number of keepalive
-                                              probes to send without response before
-                                              deciding the connection is dead.
-                                            maximum: 4294967295
-                                            minimum: 0
-                                            type: integer
-                                          time:
-                                            description: The time duration a connection
-                                              needs to be idle before keep-alive probes
-                                              start being sent.
-                                            type: string
-                                            x-kubernetes-validations:
-                                            - message: must be a valid duration greater
-                                                than 1ms
-                                              rule: duration(self) >= duration('1ms')
-                                        type: object
-                                    type: object
-                                type: object
-                              loadBalancer:
-                                description: Settings controlling the load balancer
-                                  algorithms.
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - simple
-                                    - required:
-                                      - consistentHash
-                                - required:
-                                  - simple
-                                - required:
-                                  - consistentHash
-                                properties:
-                                  consistentHash:
-                                    allOf:
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - ringHash
-                                          - required:
-                                            - maglev
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                    properties:
-                                      httpCookie:
-                                        description: Hash based on HTTP cookie.
-                                        properties:
-                                          name:
-                                            description: Name of the cookie.
-                                            type: string
-                                          path:
-                                            description: Path to set for the cookie.
-                                            type: string
-                                          ttl:
-                                            description: Lifetime of the cookie.
-                                            type: string
-                                        required:
-                                        - name
-                                        type: object
-                                      httpHeaderName:
-                                        description: Hash based on a specific HTTP
-                                          header.
-                                        type: string
-                                      httpQueryParameterName:
-                                        description: Hash based on a specific HTTP
-                                          query parameter.
-                                        type: string
-                                      maglev:
-                                        description: The Maglev load balancer implements
-                                          consistent hashing to backend hosts.
-                                        properties:
-                                          tableSize:
-                                            description: The table size for Maglev
-                                              hashing.
-                                            minimum: 0
-                                            type: integer
-                                        type: object
-                                      minimumRingSize:
-                                        description: Deprecated.
-                                        minimum: 0
-                                        type: integer
-                                      ringHash:
-                                        description: The ring/modulo hash load balancer
-                                          implements consistent hashing to backend
-                                          hosts.
-                                        properties:
-                                          minimumRingSize:
-                                            description: The minimum number of virtual
-                                              nodes to use for the hash ring.
-                                            minimum: 0
-                                            type: integer
-                                        type: object
-                                      useSourceIp:
-                                        description: Hash based on the source IP address.
-                                        type: boolean
-                                    type: object
-                                  localityLbSetting:
-                                    properties:
-                                      distribute:
-                                        description: 'Optional: only one of distribute,
-                                          failover or failoverPriority can be set.'
-                                        items:
-                                          properties:
-                                            from:
-                                              description: Originating locality, '/'
-                                                separated, e.g.
-                                              type: string
-                                            to:
-                                              additionalProperties:
-                                                maximum: 4294967295
-                                                minimum: 0
-                                                type: integer
-                                              description: Map of upstream localities
-                                                to traffic distribution weights.
-                                              type: object
-                                          type: object
-                                        type: array
-                                      enabled:
-                                        description: Enable locality load balancing.
-                                        nullable: true
-                                        type: boolean
-                                      failover:
-                                        description: 'Optional: only one of distribute,
-                                          failover or failoverPriority can be set.'
-                                        items:
-                                          properties:
-                                            from:
-                                              description: Originating region.
-                                              type: string
-                                            to:
-                                              description: Destination region the
-                                                traffic will fail over to when endpoints
-                                                in the 'from' region becomes unhealthy.
-                                              type: string
-                                          type: object
-                                        type: array
-                                      failoverPriority:
-                                        description: failoverPriority is an ordered
-                                          list of labels used to sort endpoints to
-                                          do priority based load balancing.
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  simple:
-                                    description: |2-
-
-
-                                      Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
-                                    enum:
-                                    - UNSPECIFIED
-                                    - LEAST_CONN
-                                    - RANDOM
-                                    - PASSTHROUGH
-                                    - ROUND_ROBIN
-                                    - LEAST_REQUEST
-                                    type: string
-                                  warmup:
-                                    description: Represents the warmup configuration
-                                      of Service.
-                                    properties:
-                                      aggression:
-                                        description: This parameter controls the speed
-                                          of traffic increase over the warmup duration.
-                                        format: double
-                                        minimum: 1
-                                        nullable: true
-                                        type: number
-                                      duration:
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      minimumPercent:
-                                        format: double
-                                        maximum: 100
-                                        minimum: 0
-                                        nullable: true
-                                        type: number
-                                    required:
-                                    - duration
-                                    type: object
-                                  warmupDurationSecs:
-                                    description: 'Deprecated: use `warmup` instead.'
-                                    type: string
-                                    x-kubernetes-validations:
-                                    - message: must be a valid duration greater than
-                                        1ms
-                                      rule: duration(self) >= duration('1ms')
-                                type: object
-                              outlierDetection:
-                                properties:
-                                  baseEjectionTime:
-                                    description: Minimum ejection duration.
-                                    type: string
-                                    x-kubernetes-validations:
-                                    - message: must be a valid duration greater than
-                                        1ms
-                                      rule: duration(self) >= duration('1ms')
-                                  consecutive5xxErrors:
-                                    description: Number of 5xx errors before a host
-                                      is ejected from the connection pool.
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    nullable: true
-                                    type: integer
-                                  consecutiveErrors:
-                                    format: int32
-                                    type: integer
-                                  consecutiveGatewayErrors:
-                                    description: Number of gateway errors before a
-                                      host is ejected from the connection pool.
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    nullable: true
-                                    type: integer
-                                  consecutiveLocalOriginFailures:
-                                    description: The number of consecutive locally
-                                      originated failures before ejection occurs.
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    nullable: true
-                                    type: integer
-                                  interval:
-                                    description: Time interval between ejection sweep
-                                      analysis.
-                                    type: string
-                                    x-kubernetes-validations:
-                                    - message: must be a valid duration greater than
-                                        1ms
-                                      rule: duration(self) >= duration('1ms')
-                                  maxEjectionPercent:
-                                    description: Maximum % of hosts in the load balancing
-                                      pool for the upstream service that can be ejected.
-                                    format: int32
-                                    type: integer
-                                  minHealthPercent:
-                                    description: Outlier detection will be enabled
-                                      as long as the associated load balancing pool
-                                      has at least `minHealthPercent` hosts in healthy
-                                      mode.
-                                    format: int32
-                                    type: integer
-                                  splitExternalLocalOriginErrors:
-                                    description: Determines whether to distinguish
-                                      local origin failures from external errors.
-                                    type: boolean
-                                type: object
-                              port:
-                                description: Specifies the number of a port on the
-                                  destination service on which this policy is being
-                                  applied.
-                                properties:
-                                  number:
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    type: integer
-                                type: object
-                              tls:
-                                description: TLS related settings for connections
-                                  to the upstream service.
-                                properties:
-                                  caCertificates:
-                                    description: 'OPTIONAL: The path to the file containing
-                                      certificate authority certificates to use in
-                                      verifying a presented server certificate.'
-                                    type: string
-                                  caCrl:
-                                    description: 'OPTIONAL: The path to the file containing
-                                      the certificate revocation list (CRL) to use
-                                      in verifying a presented server certificate.'
-                                    type: string
-                                  clientCertificate:
-                                    description: REQUIRED if mode is `MUTUAL`.
-                                    type: string
-                                  credentialName:
-                                    description: The name of the secret that holds
-                                      the TLS certs for the client including the CA
-                                      certificates.
-                                    type: string
-                                  insecureSkipVerify:
-                                    description: '`insecureSkipVerify` specifies whether
-                                      the proxy should skip verifying the CA signature
-                                      and SAN for the server certificate corresponding
-                                      to the host.'
-                                    nullable: true
-                                    type: boolean
-                                  mode:
-                                    description: |-
-                                      Indicates whether connections to this port should be secured using TLS.
-
-                                      Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
-                                    enum:
-                                    - DISABLE
-                                    - SIMPLE
-                                    - MUTUAL
-                                    - ISTIO_MUTUAL
-                                    type: string
-                                  privateKey:
-                                    description: REQUIRED if mode is `MUTUAL`.
-                                    type: string
-                                  sni:
-                                    description: SNI string to present to the server
-                                      during TLS handshake.
-                                    type: string
-                                  subjectAltNames:
-                                    description: A list of alternate names to verify
-                                      the subject identity in the certificate.
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                            type: object
-                          maxItems: 4096
-                          type: array
-                        proxyProtocol:
-                          description: The upstream PROXY protocol settings.
-                          properties:
-                            version:
-                              description: |-
-                                The PROXY protocol version to use.
-
-                                Valid Options: V1, V2
-                              enum:
-                              - V1
-                              - V2
-                              type: string
-                          type: object
-                        tls:
-                          description: TLS related settings for connections to the
-                            upstream service.
-                          properties:
-                            caCertificates:
-                              description: 'OPTIONAL: The path to the file containing
-                                certificate authority certificates to use in verifying
-                                a presented server certificate.'
-                              type: string
-                            caCrl:
-                              description: 'OPTIONAL: The path to the file containing
-                                the certificate revocation list (CRL) to use in verifying
-                                a presented server certificate.'
-                              type: string
-                            clientCertificate:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            credentialName:
-                              description: The name of the secret that holds the TLS
-                                certs for the client including the CA certificates.
-                              type: string
-                            insecureSkipVerify:
-                              description: '`insecureSkipVerify` specifies whether
-                                the proxy should skip verifying the CA signature and
-                                SAN for the server certificate corresponding to the
-                                host.'
-                              nullable: true
-                              type: boolean
-                            mode:
-                              description: |-
-                                Indicates whether connections to this port should be secured using TLS.
-
-                                Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
-                              enum:
-                              - DISABLE
-                              - SIMPLE
-                              - MUTUAL
-                              - ISTIO_MUTUAL
-                              type: string
-                            privateKey:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            sni:
-                              description: SNI string to present to the server during
-                                TLS handshake.
-                              type: string
-                            subjectAltNames:
-                              description: A list of alternate names to verify the
-                                subject identity in the certificate.
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        tunnel:
-                          description: Configuration of tunneling TCP over other transport
-                            or application layers for the host configured in the DestinationRule.
-                          properties:
-                            protocol:
-                              description: Specifies which protocol to use for tunneling
-                                the downstream connection.
-                              type: string
-                            targetHost:
-                              description: Specifies a host to which the downstream
-                                connection is tunneled.
-                              type: string
-                            targetPort:
-                              description: Specifies a port to which the downstream
-                                connection is tunneled.
-                              maximum: 4294967295
-                              minimum: 0
-                              type: integer
-                          required:
-                          - targetHost
-                          - targetPort
-                          type: object
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
-              trafficPolicy:
-                description: Traffic policies to apply (load balancing policy, connection
-                  pool sizes, outlier detection).
-                properties:
-                  connectionPool:
-                    properties:
-                      http:
-                        description: HTTP connection pool settings.
-                        properties:
-                          h2UpgradePolicy:
-                            description: |-
-                              Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-
-                              Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
-                            enum:
-                            - DEFAULT
-                            - DO_NOT_UPGRADE
-                            - UPGRADE
-                            type: string
-                          http1MaxPendingRequests:
-                            description: Maximum number of requests that will be queued
-                              while waiting for a ready connection pool connection.
-                            format: int32
-                            type: integer
-                          http2MaxRequests:
-                            description: Maximum number of active requests to a destination.
-                            format: int32
-                            type: integer
-                          idleTimeout:
-                            description: The idle timeout for upstream connection
-                              pool connections.
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          maxConcurrentStreams:
-                            description: The maximum number of concurrent streams
-                              allowed for a peer on one HTTP/2 connection.
-                            format: int32
-                            type: integer
-                          maxRequestsPerConnection:
-                            description: Maximum number of requests per connection
-                              to a backend.
-                            format: int32
-                            type: integer
-                          maxRetries:
-                            description: Maximum number of retries that can be outstanding
-                              to all hosts in a cluster at a given time.
-                            format: int32
-                            type: integer
-                          useClientProtocol:
-                            description: If set to true, client protocol will be preserved
-                              while initiating connection to backend.
-                            type: boolean
-                        type: object
-                      tcp:
-                        description: Settings common to both HTTP and TCP upstream
-                          connections.
-                        properties:
-                          connectTimeout:
-                            description: TCP connection timeout.
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          idleTimeout:
-                            description: The idle timeout for TCP connections.
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          maxConnectionDuration:
-                            description: The maximum duration of a connection.
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          maxConnections:
-                            description: Maximum number of HTTP1 /TCP connections
-                              to a destination host.
-                            format: int32
-                            type: integer
-                          tcpKeepalive:
-                            description: If set then set SO_KEEPALIVE on the socket
-                              to enable TCP Keepalives.
-                            properties:
-                              interval:
-                                description: The time duration between keep-alive
-                                  probes.
-                                type: string
-                                x-kubernetes-validations:
-                                - message: must be a valid duration greater than 1ms
-                                  rule: duration(self) >= duration('1ms')
-                              probes:
-                                description: Maximum number of keepalive probes to
-                                  send without response before deciding the connection
-                                  is dead.
-                                maximum: 4294967295
-                                minimum: 0
-                                type: integer
-                              time:
-                                description: The time duration a connection needs
-                                  to be idle before keep-alive probes start being
-                                  sent.
-                                type: string
-                                x-kubernetes-validations:
-                                - message: must be a valid duration greater than 1ms
-                                  rule: duration(self) >= duration('1ms')
-                            type: object
-                        type: object
-                    type: object
-                  loadBalancer:
-                    description: Settings controlling the load balancer algorithms.
-                    oneOf:
-                    - not:
-                        anyOf:
-                        - required:
-                          - simple
-                        - required:
-                          - consistentHash
-                    - required:
-                      - simple
-                    - required:
-                      - consistentHash
-                    properties:
-                      consistentHash:
-                        allOf:
-                        - oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - httpHeaderName
-                              - required:
-                                - httpCookie
-                              - required:
-                                - useSourceIp
-                              - required:
-                                - httpQueryParameterName
-                          - required:
-                            - httpHeaderName
-                          - required:
-                            - httpCookie
-                          - required:
-                            - useSourceIp
-                          - required:
-                            - httpQueryParameterName
-                        - oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - ringHash
-                              - required:
-                                - maglev
-                          - required:
-                            - ringHash
-                          - required:
-                            - maglev
-                        properties:
-                          httpCookie:
-                            description: Hash based on HTTP cookie.
-                            properties:
-                              name:
-                                description: Name of the cookie.
-                                type: string
-                              path:
-                                description: Path to set for the cookie.
-                                type: string
-                              ttl:
-                                description: Lifetime of the cookie.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          httpHeaderName:
-                            description: Hash based on a specific HTTP header.
-                            type: string
-                          httpQueryParameterName:
-                            description: Hash based on a specific HTTP query parameter.
-                            type: string
-                          maglev:
-                            description: The Maglev load balancer implements consistent
-                              hashing to backend hosts.
-                            properties:
-                              tableSize:
-                                description: The table size for Maglev hashing.
-                                minimum: 0
-                                type: integer
-                            type: object
-                          minimumRingSize:
-                            description: Deprecated.
-                            minimum: 0
-                            type: integer
-                          ringHash:
-                            description: The ring/modulo hash load balancer implements
-                              consistent hashing to backend hosts.
-                            properties:
-                              minimumRingSize:
-                                description: The minimum number of virtual nodes to
-                                  use for the hash ring.
-                                minimum: 0
-                                type: integer
-                            type: object
-                          useSourceIp:
-                            description: Hash based on the source IP address.
-                            type: boolean
-                        type: object
-                      localityLbSetting:
-                        properties:
-                          distribute:
-                            description: 'Optional: only one of distribute, failover
-                              or failoverPriority can be set.'
-                            items:
-                              properties:
-                                from:
-                                  description: Originating locality, '/' separated,
-                                    e.g.
-                                  type: string
-                                to:
-                                  additionalProperties:
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    type: integer
-                                  description: Map of upstream localities to traffic
-                                    distribution weights.
-                                  type: object
-                              type: object
-                            type: array
-                          enabled:
-                            description: Enable locality load balancing.
-                            nullable: true
-                            type: boolean
-                          failover:
-                            description: 'Optional: only one of distribute, failover
-                              or failoverPriority can be set.'
-                            items:
-                              properties:
-                                from:
-                                  description: Originating region.
-                                  type: string
-                                to:
-                                  description: Destination region the traffic will
-                                    fail over to when endpoints in the 'from' region
-                                    becomes unhealthy.
-                                  type: string
-                              type: object
-                            type: array
-                          failoverPriority:
-                            description: failoverPriority is an ordered list of labels
-                              used to sort endpoints to do priority based load balancing.
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      simple:
-                        description: |2-
-
-
-                          Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
-                        enum:
-                        - UNSPECIFIED
-                        - LEAST_CONN
-                        - RANDOM
-                        - PASSTHROUGH
-                        - ROUND_ROBIN
-                        - LEAST_REQUEST
-                        type: string
-                      warmup:
-                        description: Represents the warmup configuration of Service.
-                        properties:
-                          aggression:
-                            description: This parameter controls the speed of traffic
-                              increase over the warmup duration.
-                            format: double
-                            minimum: 1
-                            nullable: true
-                            type: number
-                          duration:
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          minimumPercent:
-                            format: double
-                            maximum: 100
-                            minimum: 0
-                            nullable: true
-                            type: number
-                        required:
-                        - duration
-                        type: object
-                      warmupDurationSecs:
-                        description: 'Deprecated: use `warmup` instead.'
-                        type: string
-                        x-kubernetes-validations:
-                        - message: must be a valid duration greater than 1ms
-                          rule: duration(self) >= duration('1ms')
-                    type: object
-                  outlierDetection:
-                    properties:
-                      baseEjectionTime:
-                        description: Minimum ejection duration.
-                        type: string
-                        x-kubernetes-validations:
-                        - message: must be a valid duration greater than 1ms
-                          rule: duration(self) >= duration('1ms')
-                      consecutive5xxErrors:
-                        description: Number of 5xx errors before a host is ejected
-                          from the connection pool.
-                        maximum: 4294967295
+                      percent:
+                        description: Specifies the limit on concurrent retries as
+                          a percentage of the sum of active requests and active pending
+                          requests.
+                        format: double
+                        maximum: 100
                         minimum: 0
                         nullable: true
-                        type: integer
-                      consecutiveErrors:
-                        format: int32
-                        type: integer
-                      consecutiveGatewayErrors:
-                        description: Number of gateway errors before a host is ejected
-                          from the connection pool.
-                        maximum: 4294967295
-                        minimum: 0
-                        nullable: true
-                        type: integer
-                      consecutiveLocalOriginFailures:
-                        description: The number of consecutive locally originated
-                          failures before ejection occurs.
-                        maximum: 4294967295
-                        minimum: 0
-                        nullable: true
-                        type: integer
-                      interval:
-                        description: Time interval between ejection sweep analysis.
-                        type: string
-                        x-kubernetes-validations:
-                        - message: must be a valid duration greater than 1ms
-                          rule: duration(self) >= duration('1ms')
-                      maxEjectionPercent:
-                        description: Maximum % of hosts in the load balancing pool
-                          for the upstream service that can be ejected.
-                        format: int32
-                        type: integer
-                      minHealthPercent:
-                        description: Outlier detection will be enabled as long as
-                          the associated load balancing pool has at least `minHealthPercent`
-                          hosts in healthy mode.
-                        format: int32
-                        type: integer
-                      splitExternalLocalOriginErrors:
-                        description: Determines whether to distinguish local origin
-                          failures from external errors.
-                        type: boolean
-                    type: object
-                  portLevelSettings:
-                    description: Traffic policies specific to individual ports.
-                    items:
-                      properties:
-                        connectionPool:
-                          properties:
-                            http:
-                              description: HTTP connection pool settings.
-                              properties:
-                                h2UpgradePolicy:
-                                  description: |-
-                                    Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-
-                                    Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
-                                  enum:
-                                  - DEFAULT
-                                  - DO_NOT_UPGRADE
-                                  - UPGRADE
-                                  type: string
-                                http1MaxPendingRequests:
-                                  description: Maximum number of requests that will
-                                    be queued while waiting for a ready connection
-                                    pool connection.
-                                  format: int32
-                                  type: integer
-                                http2MaxRequests:
-                                  description: Maximum number of active requests to
-                                    a destination.
-                                  format: int32
-                                  type: integer
-                                idleTimeout:
-                                  description: The idle timeout for upstream connection
-                                    pool connections.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConcurrentStreams:
-                                  description: The maximum number of concurrent streams
-                                    allowed for a peer on one HTTP/2 connection.
-                                  format: int32
-                                  type: integer
-                                maxRequestsPerConnection:
-                                  description: Maximum number of requests per connection
-                                    to a backend.
-                                  format: int32
-                                  type: integer
-                                maxRetries:
-                                  description: Maximum number of retries that can
-                                    be outstanding to all hosts in a cluster at a
-                                    given time.
-                                  format: int32
-                                  type: integer
-                                useClientProtocol:
-                                  description: If set to true, client protocol will
-                                    be preserved while initiating connection to backend.
-                                  type: boolean
-                              type: object
-                            tcp:
-                              description: Settings common to both HTTP and TCP upstream
-                                connections.
-                              properties:
-                                connectTimeout:
-                                  description: TCP connection timeout.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                idleTimeout:
-                                  description: The idle timeout for TCP connections.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConnectionDuration:
-                                  description: The maximum duration of a connection.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConnections:
-                                  description: Maximum number of HTTP1 /TCP connections
-                                    to a destination host.
-                                  format: int32
-                                  type: integer
-                                tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on the
-                                    socket to enable TCP Keepalives.
-                                  properties:
-                                    interval:
-                                      description: The time duration between keep-alive
-                                        probes.
-                                      type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
-                                    probes:
-                                      description: Maximum number of keepalive probes
-                                        to send without response before deciding the
-                                        connection is dead.
-                                      maximum: 4294967295
-                                      minimum: 0
-                                      type: integer
-                                    time:
-                                      description: The time duration a connection
-                                        needs to be idle before keep-alive probes
-                                        start being sent.
-                                      type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
-                                  type: object
-                              type: object
-                          type: object
-                        loadBalancer:
-                          description: Settings controlling the load balancer algorithms.
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - simple
-                              - required:
-                                - consistentHash
-                          - required:
-                            - simple
-                          - required:
-                            - consistentHash
-                          properties:
-                            consistentHash:
-                              allOf:
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - ringHash
-                                    - required:
-                                      - maglev
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                              properties:
-                                httpCookie:
-                                  description: Hash based on HTTP cookie.
-                                  properties:
-                                    name:
-                                      description: Name of the cookie.
-                                      type: string
-                                    path:
-                                      description: Path to set for the cookie.
-                                      type: string
-                                    ttl:
-                                      description: Lifetime of the cookie.
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                httpHeaderName:
-                                  description: Hash based on a specific HTTP header.
-                                  type: string
-                                httpQueryParameterName:
-                                  description: Hash based on a specific HTTP query
-                                    parameter.
-                                  type: string
-                                maglev:
-                                  description: The Maglev load balancer implements
-                                    consistent hashing to backend hosts.
-                                  properties:
-                                    tableSize:
-                                      description: The table size for Maglev hashing.
-                                      minimum: 0
-                                      type: integer
-                                  type: object
-                                minimumRingSize:
-                                  description: Deprecated.
-                                  minimum: 0
-                                  type: integer
-                                ringHash:
-                                  description: The ring/modulo hash load balancer
-                                    implements consistent hashing to backend hosts.
-                                  properties:
-                                    minimumRingSize:
-                                      description: The minimum number of virtual nodes
-                                        to use for the hash ring.
-                                      minimum: 0
-                                      type: integer
-                                  type: object
-                                useSourceIp:
-                                  description: Hash based on the source IP address.
-                                  type: boolean
-                              type: object
-                            localityLbSetting:
-                              properties:
-                                distribute:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating locality, '/' separated,
-                                          e.g.
-                                        type: string
-                                      to:
-                                        additionalProperties:
-                                          maximum: 4294967295
-                                          minimum: 0
-                                          type: integer
-                                        description: Map of upstream localities to
-                                          traffic distribution weights.
-                                        type: object
-                                    type: object
-                                  type: array
-                                enabled:
-                                  description: Enable locality load balancing.
-                                  nullable: true
-                                  type: boolean
-                                failover:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating region.
-                                        type: string
-                                      to:
-                                        description: Destination region the traffic
-                                          will fail over to when endpoints in the
-                                          'from' region becomes unhealthy.
-                                        type: string
-                                    type: object
-                                  type: array
-                                failoverPriority:
-                                  description: failoverPriority is an ordered list
-                                    of labels used to sort endpoints to do priority
-                                    based load balancing.
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            simple:
-                              description: |2-
-
-
-                                Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
-                              enum:
-                              - UNSPECIFIED
-                              - LEAST_CONN
-                              - RANDOM
-                              - PASSTHROUGH
-                              - ROUND_ROBIN
-                              - LEAST_REQUEST
-                              type: string
-                            warmup:
-                              description: Represents the warmup configuration of
-                                Service.
-                              properties:
-                                aggression:
-                                  description: This parameter controls the speed of
-                                    traffic increase over the warmup duration.
-                                  format: double
-                                  minimum: 1
-                                  nullable: true
-                                  type: number
-                                duration:
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                minimumPercent:
-                                  format: double
-                                  maximum: 100
-                                  minimum: 0
-                                  nullable: true
-                                  type: number
-                              required:
-                              - duration
-                              type: object
-                            warmupDurationSecs:
-                              description: 'Deprecated: use `warmup` instead.'
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                          type: object
-                        outlierDetection:
-                          properties:
-                            baseEjectionTime:
-                              description: Minimum ejection duration.
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                            consecutive5xxErrors:
-                              description: Number of 5xx errors before a host is ejected
-                                from the connection pool.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            consecutiveErrors:
-                              format: int32
-                              type: integer
-                            consecutiveGatewayErrors:
-                              description: Number of gateway errors before a host
-                                is ejected from the connection pool.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            consecutiveLocalOriginFailures:
-                              description: The number of consecutive locally originated
-                                failures before ejection occurs.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            interval:
-                              description: Time interval between ejection sweep analysis.
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                            maxEjectionPercent:
-                              description: Maximum % of hosts in the load balancing
-                                pool for the upstream service that can be ejected.
-                              format: int32
-                              type: integer
-                            minHealthPercent:
-                              description: Outlier detection will be enabled as long
-                                as the associated load balancing pool has at least
-                                `minHealthPercent` hosts in healthy mode.
-                              format: int32
-                              type: integer
-                            splitExternalLocalOriginErrors:
-                              description: Determines whether to distinguish local
-                                origin failures from external errors.
-                              type: boolean
-                          type: object
-                        port:
-                          description: Specifies the number of a port on the destination
-                            service on which this policy is being applied.
-                          properties:
-                            number:
-                              maximum: 4294967295
-                              minimum: 0
-                              type: integer
-                          type: object
-                        tls:
-                          description: TLS related settings for connections to the
-                            upstream service.
-                          properties:
-                            caCertificates:
-                              description: 'OPTIONAL: The path to the file containing
-                                certificate authority certificates to use in verifying
-                                a presented server certificate.'
-                              type: string
-                            caCrl:
-                              description: 'OPTIONAL: The path to the file containing
-                                the certificate revocation list (CRL) to use in verifying
-                                a presented server certificate.'
-                              type: string
-                            clientCertificate:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            credentialName:
-                              description: The name of the secret that holds the TLS
-                                certs for the client including the CA certificates.
-                              type: string
-                            insecureSkipVerify:
-                              description: '`insecureSkipVerify` specifies whether
-                                the proxy should skip verifying the CA signature and
-                                SAN for the server certificate corresponding to the
-                                host.'
-                              nullable: true
-                              type: boolean
-                            mode:
-                              description: |-
-                                Indicates whether connections to this port should be secured using TLS.
-
-                                Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
-                              enum:
-                              - DISABLE
-                              - SIMPLE
-                              - MUTUAL
-                              - ISTIO_MUTUAL
-                              type: string
-                            privateKey:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            sni:
-                              description: SNI string to present to the server during
-                                TLS handshake.
-                              type: string
-                            subjectAltNames:
-                              description: A list of alternate names to verify the
-                                subject identity in the certificate.
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                      type: object
-                    maxItems: 4096
-                    type: array
-                  proxyProtocol:
-                    description: The upstream PROXY protocol settings.
-                    properties:
-                      version:
-                        description: |-
-                          The PROXY protocol version to use.
-
-                          Valid Options: V1, V2
-                        enum:
-                        - V1
-                        - V2
-                        type: string
-                    type: object
-                  tls:
-                    description: TLS related settings for connections to the upstream
-                      service.
-                    properties:
-                      caCertificates:
-                        description: 'OPTIONAL: The path to the file containing certificate
-                          authority certificates to use in verifying a presented server
-                          certificate.'
-                        type: string
-                      caCrl:
-                        description: 'OPTIONAL: The path to the file containing the
-                          certificate revocation list (CRL) to use in verifying a
-                          presented server certificate.'
-                        type: string
-                      clientCertificate:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        type: string
-                      credentialName:
-                        description: The name of the secret that holds the TLS certs
-                          for the client including the CA certificates.
-                        type: string
-                      insecureSkipVerify:
-                        description: '`insecureSkipVerify` specifies whether the proxy
-                          should skip verifying the CA signature and SAN for the server
-                          certificate corresponding to the host.'
-                        nullable: true
-                        type: boolean
-                      mode:
-                        description: |-
-                          Indicates whether connections to this port should be secured using TLS.
-
-                          Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
-                        enum:
-                        - DISABLE
-                        - SIMPLE
-                        - MUTUAL
-                        - ISTIO_MUTUAL
-                        type: string
-                      privateKey:
-                        description: REQUIRED if mode is `MUTUAL`.
-                        type: string
-                      sni:
-                        description: SNI string to present to the server during TLS
-                          handshake.
-                        type: string
-                      subjectAltNames:
-                        description: A list of alternate names to verify the subject
-                          identity in the certificate.
-                        items:
-                          type: string
-                        type: array
-                    type: object
-                  tunnel:
-                    description: Configuration of tunneling TCP over other transport
-                      or application layers for the host configured in the DestinationRule.
-                    properties:
-                      protocol:
-                        description: Specifies which protocol to use for tunneling
-                          the downstream connection.
-                        type: string
-                      targetHost:
-                        description: Specifies a host to which the downstream connection
-                          is tunneled.
-                        type: string
-                      targetPort:
-                        description: Specifies a port to which the downstream connection
-                          is tunneled.
-                        maximum: 4294967295
-                        minimum: 0
-                        type: integer
-                    required:
-                    - targetHost
-                    - targetPort
-                    type: object
-                type: object
-              workloadSelector:
-                description: Criteria used to select the specific set of pods/VMs
-                  on which this `DestinationRule` configuration should be applied.
-                properties:
-                  matchLabels:
-                    additionalProperties:
-                      maxLength: 63
-                      type: string
-                      x-kubernetes-validations:
-                      - message: wildcard not allowed in label value match
-                        rule: '!self.contains("*")'
-                    description: One or more labels that indicate a specific set of
-                      pods/VMs on which a policy should be applied.
-                    maxProperties: 4096
-                    type: object
-                    x-kubernetes-validations:
-                    - message: wildcard not allowed in label key match
-                      rule: self.all(key, !key.contains("*"))
-                    - message: key must not be empty
-                      rule: self.all(key, key.size() != 0)
-                type: object
-            required:
-            - host
-            type: object
-          status:
-            properties:
-              conditions:
-                description: Current service state of the resource.
-                items:
-                  properties:
-                    lastProbeTime:
-                      description: Last time we probed the condition.
-                      format: date-time
-                      type: string
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
-                      format: date-time
-                      type: string
-                    message:
-                      description: Human-readable message indicating details about
-                        last transition.
-                      type: string
-                    observedGeneration:
-                      anyOf:
-                      - type: integer
-                      - type: string
-                      description: Resource Generation to which the Condition refers.
-                      x-kubernetes-int-or-string: true
-                    reason:
-                      description: Unique, one-word, CamelCase reason for the condition's
-                        last transition.
-                      type: string
-                    status:
-                      description: Status is the status of the condition.
-                      type: string
-                    type:
-                      description: Type is the type of the condition.
-                      type: string
-                  type: object
-                type: array
-              observedGeneration:
-                anyOf:
-                - type: integer
-                - type: string
-                x-kubernetes-int-or-string: true
-              validationMessages:
-                description: Includes any errors or warnings detected by Istio's analyzers.
-                items:
-                  properties:
-                    documentationUrl:
-                      description: A url pointing to the Istio documentation for this
-                        specific error type.
-                      type: string
-                    level:
-                      description: |-
-                        Represents how severe a message is.
-
-                        Valid Options: UNKNOWN, ERROR, WARNING, INFO
-                      enum:
-                      - UNKNOWN
-                      - ERROR
-                      - WARNING
-                      - INFO
-                      type: string
-                    type:
-                      properties:
-                        code:
-                          description: A 7 character code matching `^IST[0-9]{4}$`
-                            intended to uniquely identify the message type.
-                          type: string
-                        name:
-                          description: A human-readable name for the message type.
-                          type: string
-                      type: object
-                  type: object
-                type: array
-            type: object
-            x-kubernetes-preserve-unknown-fields: true
-        type: object
-    served: true
-    storage: false
-    subresources:
-      status: {}
-  - additionalPrinterColumns:
-    - description: The name of a service from the service registry
-      jsonPath: .spec.host
-      name: Host
-      type: string
-    - description: 'CreationTimestamp is a timestamp representing the server time
-        when this object was created. It is not guaranteed to be set in happens-before
-        order across separate operations. Clients may not set this value. It is represented
-        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
-        lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-      jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1beta1
-    schema:
-      openAPIV3Schema:
-        properties:
-          spec:
-            description: 'Configuration affecting load balancing, outlier detection,
-              etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
-            properties:
-              exportTo:
-                description: A list of namespaces to which this destination rule is
-                  exported.
-                items:
-                  type: string
-                type: array
-              host:
-                description: The name of a service from the service registry.
-                type: string
-              subsets:
-                description: One or more named sets that represent individual versions
-                  of a service.
-                items:
-                  properties:
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels apply a filter over the endpoints of a service
-                        in the service registry.
-                      type: object
-                    name:
-                      description: Name of the subset.
-                      type: string
-                    trafficPolicy:
-                      description: Traffic policies that apply to this subset.
-                      properties:
-                        connectionPool:
-                          properties:
-                            http:
-                              description: HTTP connection pool settings.
-                              properties:
-                                h2UpgradePolicy:
-                                  description: |-
-                                    Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-
-                                    Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
-                                  enum:
-                                  - DEFAULT
-                                  - DO_NOT_UPGRADE
-                                  - UPGRADE
-                                  type: string
-                                http1MaxPendingRequests:
-                                  description: Maximum number of requests that will
-                                    be queued while waiting for a ready connection
-                                    pool connection.
-                                  format: int32
-                                  type: integer
-                                http2MaxRequests:
-                                  description: Maximum number of active requests to
-                                    a destination.
-                                  format: int32
-                                  type: integer
-                                idleTimeout:
-                                  description: The idle timeout for upstream connection
-                                    pool connections.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConcurrentStreams:
-                                  description: The maximum number of concurrent streams
-                                    allowed for a peer on one HTTP/2 connection.
-                                  format: int32
-                                  type: integer
-                                maxRequestsPerConnection:
-                                  description: Maximum number of requests per connection
-                                    to a backend.
-                                  format: int32
-                                  type: integer
-                                maxRetries:
-                                  description: Maximum number of retries that can
-                                    be outstanding to all hosts in a cluster at a
-                                    given time.
-                                  format: int32
-                                  type: integer
-                                useClientProtocol:
-                                  description: If set to true, client protocol will
-                                    be preserved while initiating connection to backend.
-                                  type: boolean
-                              type: object
-                            tcp:
-                              description: Settings common to both HTTP and TCP upstream
-                                connections.
-                              properties:
-                                connectTimeout:
-                                  description: TCP connection timeout.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                idleTimeout:
-                                  description: The idle timeout for TCP connections.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConnectionDuration:
-                                  description: The maximum duration of a connection.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConnections:
-                                  description: Maximum number of HTTP1 /TCP connections
-                                    to a destination host.
-                                  format: int32
-                                  type: integer
-                                tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on the
-                                    socket to enable TCP Keepalives.
-                                  properties:
-                                    interval:
-                                      description: The time duration between keep-alive
-                                        probes.
-                                      type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
-                                    probes:
-                                      description: Maximum number of keepalive probes
-                                        to send without response before deciding the
-                                        connection is dead.
-                                      maximum: 4294967295
-                                      minimum: 0
-                                      type: integer
-                                    time:
-                                      description: The time duration a connection
-                                        needs to be idle before keep-alive probes
-                                        start being sent.
-                                      type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
-                                  type: object
-                              type: object
-                          type: object
-                        loadBalancer:
-                          description: Settings controlling the load balancer algorithms.
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - simple
-                              - required:
-                                - consistentHash
-                          - required:
-                            - simple
-                          - required:
-                            - consistentHash
-                          properties:
-                            consistentHash:
-                              allOf:
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - ringHash
-                                    - required:
-                                      - maglev
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                              properties:
-                                httpCookie:
-                                  description: Hash based on HTTP cookie.
-                                  properties:
-                                    name:
-                                      description: Name of the cookie.
-                                      type: string
-                                    path:
-                                      description: Path to set for the cookie.
-                                      type: string
-                                    ttl:
-                                      description: Lifetime of the cookie.
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                httpHeaderName:
-                                  description: Hash based on a specific HTTP header.
-                                  type: string
-                                httpQueryParameterName:
-                                  description: Hash based on a specific HTTP query
-                                    parameter.
-                                  type: string
-                                maglev:
-                                  description: The Maglev load balancer implements
-                                    consistent hashing to backend hosts.
-                                  properties:
-                                    tableSize:
-                                      description: The table size for Maglev hashing.
-                                      minimum: 0
-                                      type: integer
-                                  type: object
-                                minimumRingSize:
-                                  description: Deprecated.
-                                  minimum: 0
-                                  type: integer
-                                ringHash:
-                                  description: The ring/modulo hash load balancer
-                                    implements consistent hashing to backend hosts.
-                                  properties:
-                                    minimumRingSize:
-                                      description: The minimum number of virtual nodes
-                                        to use for the hash ring.
-                                      minimum: 0
-                                      type: integer
-                                  type: object
-                                useSourceIp:
-                                  description: Hash based on the source IP address.
-                                  type: boolean
-                              type: object
-                            localityLbSetting:
-                              properties:
-                                distribute:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating locality, '/' separated,
-                                          e.g.
-                                        type: string
-                                      to:
-                                        additionalProperties:
-                                          maximum: 4294967295
-                                          minimum: 0
-                                          type: integer
-                                        description: Map of upstream localities to
-                                          traffic distribution weights.
-                                        type: object
-                                    type: object
-                                  type: array
-                                enabled:
-                                  description: Enable locality load balancing.
-                                  nullable: true
-                                  type: boolean
-                                failover:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating region.
-                                        type: string
-                                      to:
-                                        description: Destination region the traffic
-                                          will fail over to when endpoints in the
-                                          'from' region becomes unhealthy.
-                                        type: string
-                                    type: object
-                                  type: array
-                                failoverPriority:
-                                  description: failoverPriority is an ordered list
-                                    of labels used to sort endpoints to do priority
-                                    based load balancing.
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            simple:
-                              description: |2-
-
-
-                                Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
-                              enum:
-                              - UNSPECIFIED
-                              - LEAST_CONN
-                              - RANDOM
-                              - PASSTHROUGH
-                              - ROUND_ROBIN
-                              - LEAST_REQUEST
-                              type: string
-                            warmup:
-                              description: Represents the warmup configuration of
-                                Service.
-                              properties:
-                                aggression:
-                                  description: This parameter controls the speed of
-                                    traffic increase over the warmup duration.
-                                  format: double
-                                  minimum: 1
-                                  nullable: true
-                                  type: number
-                                duration:
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                minimumPercent:
-                                  format: double
-                                  maximum: 100
-                                  minimum: 0
-                                  nullable: true
-                                  type: number
-                              required:
-                              - duration
-                              type: object
-                            warmupDurationSecs:
-                              description: 'Deprecated: use `warmup` instead.'
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                          type: object
-                        outlierDetection:
-                          properties:
-                            baseEjectionTime:
-                              description: Minimum ejection duration.
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                            consecutive5xxErrors:
-                              description: Number of 5xx errors before a host is ejected
-                                from the connection pool.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            consecutiveErrors:
-                              format: int32
-                              type: integer
-                            consecutiveGatewayErrors:
-                              description: Number of gateway errors before a host
-                                is ejected from the connection pool.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            consecutiveLocalOriginFailures:
-                              description: The number of consecutive locally originated
-                                failures before ejection occurs.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            interval:
-                              description: Time interval between ejection sweep analysis.
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                            maxEjectionPercent:
-                              description: Maximum % of hosts in the load balancing
-                                pool for the upstream service that can be ejected.
-                              format: int32
-                              type: integer
-                            minHealthPercent:
-                              description: Outlier detection will be enabled as long
-                                as the associated load balancing pool has at least
-                                `minHealthPercent` hosts in healthy mode.
-                              format: int32
-                              type: integer
-                            splitExternalLocalOriginErrors:
-                              description: Determines whether to distinguish local
-                                origin failures from external errors.
-                              type: boolean
-                          type: object
-                        portLevelSettings:
-                          description: Traffic policies specific to individual ports.
-                          items:
-                            properties:
-                              connectionPool:
-                                properties:
-                                  http:
-                                    description: HTTP connection pool settings.
-                                    properties:
-                                      h2UpgradePolicy:
-                                        description: |-
-                                          Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-
-                                          Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
-                                        enum:
-                                        - DEFAULT
-                                        - DO_NOT_UPGRADE
-                                        - UPGRADE
-                                        type: string
-                                      http1MaxPendingRequests:
-                                        description: Maximum number of requests that
-                                          will be queued while waiting for a ready
-                                          connection pool connection.
-                                        format: int32
-                                        type: integer
-                                      http2MaxRequests:
-                                        description: Maximum number of active requests
-                                          to a destination.
-                                        format: int32
-                                        type: integer
-                                      idleTimeout:
-                                        description: The idle timeout for upstream
-                                          connection pool connections.
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      maxConcurrentStreams:
-                                        description: The maximum number of concurrent
-                                          streams allowed for a peer on one HTTP/2
-                                          connection.
-                                        format: int32
-                                        type: integer
-                                      maxRequestsPerConnection:
-                                        description: Maximum number of requests per
-                                          connection to a backend.
-                                        format: int32
-                                        type: integer
-                                      maxRetries:
-                                        description: Maximum number of retries that
-                                          can be outstanding to all hosts in a cluster
-                                          at a given time.
-                                        format: int32
-                                        type: integer
-                                      useClientProtocol:
-                                        description: If set to true, client protocol
-                                          will be preserved while initiating connection
-                                          to backend.
-                                        type: boolean
-                                    type: object
-                                  tcp:
-                                    description: Settings common to both HTTP and
-                                      TCP upstream connections.
-                                    properties:
-                                      connectTimeout:
-                                        description: TCP connection timeout.
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      idleTimeout:
-                                        description: The idle timeout for TCP connections.
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      maxConnectionDuration:
-                                        description: The maximum duration of a connection.
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      maxConnections:
-                                        description: Maximum number of HTTP1 /TCP
-                                          connections to a destination host.
-                                        format: int32
-                                        type: integer
-                                      tcpKeepalive:
-                                        description: If set then set SO_KEEPALIVE
-                                          on the socket to enable TCP Keepalives.
-                                        properties:
-                                          interval:
-                                            description: The time duration between
-                                              keep-alive probes.
-                                            type: string
-                                            x-kubernetes-validations:
-                                            - message: must be a valid duration greater
-                                                than 1ms
-                                              rule: duration(self) >= duration('1ms')
-                                          probes:
-                                            description: Maximum number of keepalive
-                                              probes to send without response before
-                                              deciding the connection is dead.
-                                            maximum: 4294967295
-                                            minimum: 0
-                                            type: integer
-                                          time:
-                                            description: The time duration a connection
-                                              needs to be idle before keep-alive probes
-                                              start being sent.
-                                            type: string
-                                            x-kubernetes-validations:
-                                            - message: must be a valid duration greater
-                                                than 1ms
-                                              rule: duration(self) >= duration('1ms')
-                                        type: object
-                                    type: object
-                                type: object
-                              loadBalancer:
-                                description: Settings controlling the load balancer
-                                  algorithms.
-                                oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - simple
-                                    - required:
-                                      - consistentHash
-                                - required:
-                                  - simple
-                                - required:
-                                  - consistentHash
-                                properties:
-                                  consistentHash:
-                                    allOf:
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - httpHeaderName
-                                          - required:
-                                            - httpCookie
-                                          - required:
-                                            - useSourceIp
-                                          - required:
-                                            - httpQueryParameterName
-                                      - required:
-                                        - httpHeaderName
-                                      - required:
-                                        - httpCookie
-                                      - required:
-                                        - useSourceIp
-                                      - required:
-                                        - httpQueryParameterName
-                                    - oneOf:
-                                      - not:
-                                          anyOf:
-                                          - required:
-                                            - ringHash
-                                          - required:
-                                            - maglev
-                                      - required:
-                                        - ringHash
-                                      - required:
-                                        - maglev
-                                    properties:
-                                      httpCookie:
-                                        description: Hash based on HTTP cookie.
-                                        properties:
-                                          name:
-                                            description: Name of the cookie.
-                                            type: string
-                                          path:
-                                            description: Path to set for the cookie.
-                                            type: string
-                                          ttl:
-                                            description: Lifetime of the cookie.
-                                            type: string
-                                        required:
-                                        - name
-                                        type: object
-                                      httpHeaderName:
-                                        description: Hash based on a specific HTTP
-                                          header.
-                                        type: string
-                                      httpQueryParameterName:
-                                        description: Hash based on a specific HTTP
-                                          query parameter.
-                                        type: string
-                                      maglev:
-                                        description: The Maglev load balancer implements
-                                          consistent hashing to backend hosts.
-                                        properties:
-                                          tableSize:
-                                            description: The table size for Maglev
-                                              hashing.
-                                            minimum: 0
-                                            type: integer
-                                        type: object
-                                      minimumRingSize:
-                                        description: Deprecated.
-                                        minimum: 0
-                                        type: integer
-                                      ringHash:
-                                        description: The ring/modulo hash load balancer
-                                          implements consistent hashing to backend
-                                          hosts.
-                                        properties:
-                                          minimumRingSize:
-                                            description: The minimum number of virtual
-                                              nodes to use for the hash ring.
-                                            minimum: 0
-                                            type: integer
-                                        type: object
-                                      useSourceIp:
-                                        description: Hash based on the source IP address.
-                                        type: boolean
-                                    type: object
-                                  localityLbSetting:
-                                    properties:
-                                      distribute:
-                                        description: 'Optional: only one of distribute,
-                                          failover or failoverPriority can be set.'
-                                        items:
-                                          properties:
-                                            from:
-                                              description: Originating locality, '/'
-                                                separated, e.g.
-                                              type: string
-                                            to:
-                                              additionalProperties:
-                                                maximum: 4294967295
-                                                minimum: 0
-                                                type: integer
-                                              description: Map of upstream localities
-                                                to traffic distribution weights.
-                                              type: object
-                                          type: object
-                                        type: array
-                                      enabled:
-                                        description: Enable locality load balancing.
-                                        nullable: true
-                                        type: boolean
-                                      failover:
-                                        description: 'Optional: only one of distribute,
-                                          failover or failoverPriority can be set.'
-                                        items:
-                                          properties:
-                                            from:
-                                              description: Originating region.
-                                              type: string
-                                            to:
-                                              description: Destination region the
-                                                traffic will fail over to when endpoints
-                                                in the 'from' region becomes unhealthy.
-                                              type: string
-                                          type: object
-                                        type: array
-                                      failoverPriority:
-                                        description: failoverPriority is an ordered
-                                          list of labels used to sort endpoints to
-                                          do priority based load balancing.
-                                        items:
-                                          type: string
-                                        type: array
-                                    type: object
-                                  simple:
-                                    description: |2-
-
-
-                                      Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
-                                    enum:
-                                    - UNSPECIFIED
-                                    - LEAST_CONN
-                                    - RANDOM
-                                    - PASSTHROUGH
-                                    - ROUND_ROBIN
-                                    - LEAST_REQUEST
-                                    type: string
-                                  warmup:
-                                    description: Represents the warmup configuration
-                                      of Service.
-                                    properties:
-                                      aggression:
-                                        description: This parameter controls the speed
-                                          of traffic increase over the warmup duration.
-                                        format: double
-                                        minimum: 1
-                                        nullable: true
-                                        type: number
-                                      duration:
-                                        type: string
-                                        x-kubernetes-validations:
-                                        - message: must be a valid duration greater
-                                            than 1ms
-                                          rule: duration(self) >= duration('1ms')
-                                      minimumPercent:
-                                        format: double
-                                        maximum: 100
-                                        minimum: 0
-                                        nullable: true
-                                        type: number
-                                    required:
-                                    - duration
-                                    type: object
-                                  warmupDurationSecs:
-                                    description: 'Deprecated: use `warmup` instead.'
-                                    type: string
-                                    x-kubernetes-validations:
-                                    - message: must be a valid duration greater than
-                                        1ms
-                                      rule: duration(self) >= duration('1ms')
-                                type: object
-                              outlierDetection:
-                                properties:
-                                  baseEjectionTime:
-                                    description: Minimum ejection duration.
-                                    type: string
-                                    x-kubernetes-validations:
-                                    - message: must be a valid duration greater than
-                                        1ms
-                                      rule: duration(self) >= duration('1ms')
-                                  consecutive5xxErrors:
-                                    description: Number of 5xx errors before a host
-                                      is ejected from the connection pool.
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    nullable: true
-                                    type: integer
-                                  consecutiveErrors:
-                                    format: int32
-                                    type: integer
-                                  consecutiveGatewayErrors:
-                                    description: Number of gateway errors before a
-                                      host is ejected from the connection pool.
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    nullable: true
-                                    type: integer
-                                  consecutiveLocalOriginFailures:
-                                    description: The number of consecutive locally
-                                      originated failures before ejection occurs.
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    nullable: true
-                                    type: integer
-                                  interval:
-                                    description: Time interval between ejection sweep
-                                      analysis.
-                                    type: string
-                                    x-kubernetes-validations:
-                                    - message: must be a valid duration greater than
-                                        1ms
-                                      rule: duration(self) >= duration('1ms')
-                                  maxEjectionPercent:
-                                    description: Maximum % of hosts in the load balancing
-                                      pool for the upstream service that can be ejected.
-                                    format: int32
-                                    type: integer
-                                  minHealthPercent:
-                                    description: Outlier detection will be enabled
-                                      as long as the associated load balancing pool
-                                      has at least `minHealthPercent` hosts in healthy
-                                      mode.
-                                    format: int32
-                                    type: integer
-                                  splitExternalLocalOriginErrors:
-                                    description: Determines whether to distinguish
-                                      local origin failures from external errors.
-                                    type: boolean
-                                type: object
-                              port:
-                                description: Specifies the number of a port on the
-                                  destination service on which this policy is being
-                                  applied.
-                                properties:
-                                  number:
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    type: integer
-                                type: object
-                              tls:
-                                description: TLS related settings for connections
-                                  to the upstream service.
-                                properties:
-                                  caCertificates:
-                                    description: 'OPTIONAL: The path to the file containing
-                                      certificate authority certificates to use in
-                                      verifying a presented server certificate.'
-                                    type: string
-                                  caCrl:
-                                    description: 'OPTIONAL: The path to the file containing
-                                      the certificate revocation list (CRL) to use
-                                      in verifying a presented server certificate.'
-                                    type: string
-                                  clientCertificate:
-                                    description: REQUIRED if mode is `MUTUAL`.
-                                    type: string
-                                  credentialName:
-                                    description: The name of the secret that holds
-                                      the TLS certs for the client including the CA
-                                      certificates.
-                                    type: string
-                                  insecureSkipVerify:
-                                    description: '`insecureSkipVerify` specifies whether
-                                      the proxy should skip verifying the CA signature
-                                      and SAN for the server certificate corresponding
-                                      to the host.'
-                                    nullable: true
-                                    type: boolean
-                                  mode:
-                                    description: |-
-                                      Indicates whether connections to this port should be secured using TLS.
-
-                                      Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
-                                    enum:
-                                    - DISABLE
-                                    - SIMPLE
-                                    - MUTUAL
-                                    - ISTIO_MUTUAL
-                                    type: string
-                                  privateKey:
-                                    description: REQUIRED if mode is `MUTUAL`.
-                                    type: string
-                                  sni:
-                                    description: SNI string to present to the server
-                                      during TLS handshake.
-                                    type: string
-                                  subjectAltNames:
-                                    description: A list of alternate names to verify
-                                      the subject identity in the certificate.
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                            type: object
-                          maxItems: 4096
-                          type: array
-                        proxyProtocol:
-                          description: The upstream PROXY protocol settings.
-                          properties:
-                            version:
-                              description: |-
-                                The PROXY protocol version to use.
-
-                                Valid Options: V1, V2
-                              enum:
-                              - V1
-                              - V2
-                              type: string
-                          type: object
-                        tls:
-                          description: TLS related settings for connections to the
-                            upstream service.
-                          properties:
-                            caCertificates:
-                              description: 'OPTIONAL: The path to the file containing
-                                certificate authority certificates to use in verifying
-                                a presented server certificate.'
-                              type: string
-                            caCrl:
-                              description: 'OPTIONAL: The path to the file containing
-                                the certificate revocation list (CRL) to use in verifying
-                                a presented server certificate.'
-                              type: string
-                            clientCertificate:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            credentialName:
-                              description: The name of the secret that holds the TLS
-                                certs for the client including the CA certificates.
-                              type: string
-                            insecureSkipVerify:
-                              description: '`insecureSkipVerify` specifies whether
-                                the proxy should skip verifying the CA signature and
-                                SAN for the server certificate corresponding to the
-                                host.'
-                              nullable: true
-                              type: boolean
-                            mode:
-                              description: |-
-                                Indicates whether connections to this port should be secured using TLS.
-
-                                Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
-                              enum:
-                              - DISABLE
-                              - SIMPLE
-                              - MUTUAL
-                              - ISTIO_MUTUAL
-                              type: string
-                            privateKey:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            sni:
-                              description: SNI string to present to the server during
-                                TLS handshake.
-                              type: string
-                            subjectAltNames:
-                              description: A list of alternate names to verify the
-                                subject identity in the certificate.
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                        tunnel:
-                          description: Configuration of tunneling TCP over other transport
-                            or application layers for the host configured in the DestinationRule.
-                          properties:
-                            protocol:
-                              description: Specifies which protocol to use for tunneling
-                                the downstream connection.
-                              type: string
-                            targetHost:
-                              description: Specifies a host to which the downstream
-                                connection is tunneled.
-                              type: string
-                            targetPort:
-                              description: Specifies a port to which the downstream
-                                connection is tunneled.
-                              maximum: 4294967295
-                              minimum: 0
-                              type: integer
-                          required:
-                          - targetHost
-                          - targetPort
-                          type: object
-                      type: object
-                  required:
-                  - name
-                  type: object
-                type: array
-              trafficPolicy:
-                description: Traffic policies to apply (load balancing policy, connection
-                  pool sizes, outlier detection).
-                properties:
-                  connectionPool:
-                    properties:
-                      http:
-                        description: HTTP connection pool settings.
-                        properties:
-                          h2UpgradePolicy:
-                            description: |-
-                              Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-
-                              Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
-                            enum:
-                            - DEFAULT
-                            - DO_NOT_UPGRADE
-                            - UPGRADE
-                            type: string
-                          http1MaxPendingRequests:
-                            description: Maximum number of requests that will be queued
-                              while waiting for a ready connection pool connection.
-                            format: int32
-                            type: integer
-                          http2MaxRequests:
-                            description: Maximum number of active requests to a destination.
-                            format: int32
-                            type: integer
-                          idleTimeout:
-                            description: The idle timeout for upstream connection
-                              pool connections.
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          maxConcurrentStreams:
-                            description: The maximum number of concurrent streams
-                              allowed for a peer on one HTTP/2 connection.
-                            format: int32
-                            type: integer
-                          maxRequestsPerConnection:
-                            description: Maximum number of requests per connection
-                              to a backend.
-                            format: int32
-                            type: integer
-                          maxRetries:
-                            description: Maximum number of retries that can be outstanding
-                              to all hosts in a cluster at a given time.
-                            format: int32
-                            type: integer
-                          useClientProtocol:
-                            description: If set to true, client protocol will be preserved
-                              while initiating connection to backend.
-                            type: boolean
-                        type: object
-                      tcp:
-                        description: Settings common to both HTTP and TCP upstream
-                          connections.
-                        properties:
-                          connectTimeout:
-                            description: TCP connection timeout.
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          idleTimeout:
-                            description: The idle timeout for TCP connections.
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          maxConnectionDuration:
-                            description: The maximum duration of a connection.
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          maxConnections:
-                            description: Maximum number of HTTP1 /TCP connections
-                              to a destination host.
-                            format: int32
-                            type: integer
-                          tcpKeepalive:
-                            description: If set then set SO_KEEPALIVE on the socket
-                              to enable TCP Keepalives.
-                            properties:
-                              interval:
-                                description: The time duration between keep-alive
-                                  probes.
-                                type: string
-                                x-kubernetes-validations:
-                                - message: must be a valid duration greater than 1ms
-                                  rule: duration(self) >= duration('1ms')
-                              probes:
-                                description: Maximum number of keepalive probes to
-                                  send without response before deciding the connection
-                                  is dead.
-                                maximum: 4294967295
-                                minimum: 0
-                                type: integer
-                              time:
-                                description: The time duration a connection needs
-                                  to be idle before keep-alive probes start being
-                                  sent.
-                                type: string
-                                x-kubernetes-validations:
-                                - message: must be a valid duration greater than 1ms
-                                  rule: duration(self) >= duration('1ms')
-                            type: object
-                        type: object
-                    type: object
-                  loadBalancer:
-                    description: Settings controlling the load balancer algorithms.
-                    oneOf:
-                    - not:
-                        anyOf:
-                        - required:
-                          - simple
-                        - required:
-                          - consistentHash
-                    - required:
-                      - simple
-                    - required:
-                      - consistentHash
-                    properties:
-                      consistentHash:
-                        allOf:
-                        - oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - httpHeaderName
-                              - required:
-                                - httpCookie
-                              - required:
-                                - useSourceIp
-                              - required:
-                                - httpQueryParameterName
-                          - required:
-                            - httpHeaderName
-                          - required:
-                            - httpCookie
-                          - required:
-                            - useSourceIp
-                          - required:
-                            - httpQueryParameterName
-                        - oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - ringHash
-                              - required:
-                                - maglev
-                          - required:
-                            - ringHash
-                          - required:
-                            - maglev
-                        properties:
-                          httpCookie:
-                            description: Hash based on HTTP cookie.
-                            properties:
-                              name:
-                                description: Name of the cookie.
-                                type: string
-                              path:
-                                description: Path to set for the cookie.
-                                type: string
-                              ttl:
-                                description: Lifetime of the cookie.
-                                type: string
-                            required:
-                            - name
-                            type: object
-                          httpHeaderName:
-                            description: Hash based on a specific HTTP header.
-                            type: string
-                          httpQueryParameterName:
-                            description: Hash based on a specific HTTP query parameter.
-                            type: string
-                          maglev:
-                            description: The Maglev load balancer implements consistent
-                              hashing to backend hosts.
-                            properties:
-                              tableSize:
-                                description: The table size for Maglev hashing.
-                                minimum: 0
-                                type: integer
-                            type: object
-                          minimumRingSize:
-                            description: Deprecated.
-                            minimum: 0
-                            type: integer
-                          ringHash:
-                            description: The ring/modulo hash load balancer implements
-                              consistent hashing to backend hosts.
-                            properties:
-                              minimumRingSize:
-                                description: The minimum number of virtual nodes to
-                                  use for the hash ring.
-                                minimum: 0
-                                type: integer
-                            type: object
-                          useSourceIp:
-                            description: Hash based on the source IP address.
-                            type: boolean
-                        type: object
-                      localityLbSetting:
-                        properties:
-                          distribute:
-                            description: 'Optional: only one of distribute, failover
-                              or failoverPriority can be set.'
-                            items:
-                              properties:
-                                from:
-                                  description: Originating locality, '/' separated,
-                                    e.g.
-                                  type: string
-                                to:
-                                  additionalProperties:
-                                    maximum: 4294967295
-                                    minimum: 0
-                                    type: integer
-                                  description: Map of upstream localities to traffic
-                                    distribution weights.
-                                  type: object
-                              type: object
-                            type: array
-                          enabled:
-                            description: Enable locality load balancing.
-                            nullable: true
-                            type: boolean
-                          failover:
-                            description: 'Optional: only one of distribute, failover
-                              or failoverPriority can be set.'
-                            items:
-                              properties:
-                                from:
-                                  description: Originating region.
-                                  type: string
-                                to:
-                                  description: Destination region the traffic will
-                                    fail over to when endpoints in the 'from' region
-                                    becomes unhealthy.
-                                  type: string
-                              type: object
-                            type: array
-                          failoverPriority:
-                            description: failoverPriority is an ordered list of labels
-                              used to sort endpoints to do priority based load balancing.
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      simple:
-                        description: |2-
-
-
-                          Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
-                        enum:
-                        - UNSPECIFIED
-                        - LEAST_CONN
-                        - RANDOM
-                        - PASSTHROUGH
-                        - ROUND_ROBIN
-                        - LEAST_REQUEST
-                        type: string
-                      warmup:
-                        description: Represents the warmup configuration of Service.
-                        properties:
-                          aggression:
-                            description: This parameter controls the speed of traffic
-                              increase over the warmup duration.
-                            format: double
-                            minimum: 1
-                            nullable: true
-                            type: number
-                          duration:
-                            type: string
-                            x-kubernetes-validations:
-                            - message: must be a valid duration greater than 1ms
-                              rule: duration(self) >= duration('1ms')
-                          minimumPercent:
-                            format: double
-                            maximum: 100
-                            minimum: 0
-                            nullable: true
-                            type: number
-                        required:
-                        - duration
-                        type: object
-                      warmupDurationSecs:
-                        description: 'Deprecated: use `warmup` instead.'
-                        type: string
-                        x-kubernetes-validations:
-                        - message: must be a valid duration greater than 1ms
-                          rule: duration(self) >= duration('1ms')
-                    type: object
-                  outlierDetection:
-                    properties:
-                      baseEjectionTime:
-                        description: Minimum ejection duration.
-                        type: string
-                        x-kubernetes-validations:
-                        - message: must be a valid duration greater than 1ms
-                          rule: duration(self) >= duration('1ms')
-                      consecutive5xxErrors:
-                        description: Number of 5xx errors before a host is ejected
-                          from the connection pool.
-                        maximum: 4294967295
-                        minimum: 0
-                        nullable: true
-                        type: integer
-                      consecutiveErrors:
-                        format: int32
-                        type: integer
-                      consecutiveGatewayErrors:
-                        description: Number of gateway errors before a host is ejected
-                          from the connection pool.
-                        maximum: 4294967295
-                        minimum: 0
-                        nullable: true
-                        type: integer
-                      consecutiveLocalOriginFailures:
-                        description: The number of consecutive locally originated
-                          failures before ejection occurs.
-                        maximum: 4294967295
-                        minimum: 0
-                        nullable: true
-                        type: integer
-                      interval:
-                        description: Time interval between ejection sweep analysis.
-                        type: string
-                        x-kubernetes-validations:
-                        - message: must be a valid duration greater than 1ms
-                          rule: duration(self) >= duration('1ms')
-                      maxEjectionPercent:
-                        description: Maximum % of hosts in the load balancing pool
-                          for the upstream service that can be ejected.
-                        format: int32
-                        type: integer
-                      minHealthPercent:
-                        description: Outlier detection will be enabled as long as
-                          the associated load balancing pool has at least `minHealthPercent`
-                          hosts in healthy mode.
-                        format: int32
-                        type: integer
-                      splitExternalLocalOriginErrors:
-                        description: Determines whether to distinguish local origin
-                          failures from external errors.
-                        type: boolean
-                    type: object
-                  portLevelSettings:
-                    description: Traffic policies specific to individual ports.
-                    items:
-                      properties:
-                        connectionPool:
-                          properties:
-                            http:
-                              description: HTTP connection pool settings.
-                              properties:
-                                h2UpgradePolicy:
-                                  description: |-
-                                    Specify if http1.1 connection should be upgraded to http2 for the associated destination.
-
-                                    Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
-                                  enum:
-                                  - DEFAULT
-                                  - DO_NOT_UPGRADE
-                                  - UPGRADE
-                                  type: string
-                                http1MaxPendingRequests:
-                                  description: Maximum number of requests that will
-                                    be queued while waiting for a ready connection
-                                    pool connection.
-                                  format: int32
-                                  type: integer
-                                http2MaxRequests:
-                                  description: Maximum number of active requests to
-                                    a destination.
-                                  format: int32
-                                  type: integer
-                                idleTimeout:
-                                  description: The idle timeout for upstream connection
-                                    pool connections.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConcurrentStreams:
-                                  description: The maximum number of concurrent streams
-                                    allowed for a peer on one HTTP/2 connection.
-                                  format: int32
-                                  type: integer
-                                maxRequestsPerConnection:
-                                  description: Maximum number of requests per connection
-                                    to a backend.
-                                  format: int32
-                                  type: integer
-                                maxRetries:
-                                  description: Maximum number of retries that can
-                                    be outstanding to all hosts in a cluster at a
-                                    given time.
-                                  format: int32
-                                  type: integer
-                                useClientProtocol:
-                                  description: If set to true, client protocol will
-                                    be preserved while initiating connection to backend.
-                                  type: boolean
-                              type: object
-                            tcp:
-                              description: Settings common to both HTTP and TCP upstream
-                                connections.
-                              properties:
-                                connectTimeout:
-                                  description: TCP connection timeout.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                idleTimeout:
-                                  description: The idle timeout for TCP connections.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConnectionDuration:
-                                  description: The maximum duration of a connection.
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                maxConnections:
-                                  description: Maximum number of HTTP1 /TCP connections
-                                    to a destination host.
-                                  format: int32
-                                  type: integer
-                                tcpKeepalive:
-                                  description: If set then set SO_KEEPALIVE on the
-                                    socket to enable TCP Keepalives.
-                                  properties:
-                                    interval:
-                                      description: The time duration between keep-alive
-                                        probes.
-                                      type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
-                                    probes:
-                                      description: Maximum number of keepalive probes
-                                        to send without response before deciding the
-                                        connection is dead.
-                                      maximum: 4294967295
-                                      minimum: 0
-                                      type: integer
-                                    time:
-                                      description: The time duration a connection
-                                        needs to be idle before keep-alive probes
-                                        start being sent.
-                                      type: string
-                                      x-kubernetes-validations:
-                                      - message: must be a valid duration greater
-                                          than 1ms
-                                        rule: duration(self) >= duration('1ms')
-                                  type: object
-                              type: object
-                          type: object
-                        loadBalancer:
-                          description: Settings controlling the load balancer algorithms.
-                          oneOf:
-                          - not:
-                              anyOf:
-                              - required:
-                                - simple
-                              - required:
-                                - consistentHash
-                          - required:
-                            - simple
-                          - required:
-                            - consistentHash
-                          properties:
-                            consistentHash:
-                              allOf:
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - httpHeaderName
-                                    - required:
-                                      - httpCookie
-                                    - required:
-                                      - useSourceIp
-                                    - required:
-                                      - httpQueryParameterName
-                                - required:
-                                  - httpHeaderName
-                                - required:
-                                  - httpCookie
-                                - required:
-                                  - useSourceIp
-                                - required:
-                                  - httpQueryParameterName
-                              - oneOf:
-                                - not:
-                                    anyOf:
-                                    - required:
-                                      - ringHash
-                                    - required:
-                                      - maglev
-                                - required:
-                                  - ringHash
-                                - required:
-                                  - maglev
-                              properties:
-                                httpCookie:
-                                  description: Hash based on HTTP cookie.
-                                  properties:
-                                    name:
-                                      description: Name of the cookie.
-                                      type: string
-                                    path:
-                                      description: Path to set for the cookie.
-                                      type: string
-                                    ttl:
-                                      description: Lifetime of the cookie.
-                                      type: string
-                                  required:
-                                  - name
-                                  type: object
-                                httpHeaderName:
-                                  description: Hash based on a specific HTTP header.
-                                  type: string
-                                httpQueryParameterName:
-                                  description: Hash based on a specific HTTP query
-                                    parameter.
-                                  type: string
-                                maglev:
-                                  description: The Maglev load balancer implements
-                                    consistent hashing to backend hosts.
-                                  properties:
-                                    tableSize:
-                                      description: The table size for Maglev hashing.
-                                      minimum: 0
-                                      type: integer
-                                  type: object
-                                minimumRingSize:
-                                  description: Deprecated.
-                                  minimum: 0
-                                  type: integer
-                                ringHash:
-                                  description: The ring/modulo hash load balancer
-                                    implements consistent hashing to backend hosts.
-                                  properties:
-                                    minimumRingSize:
-                                      description: The minimum number of virtual nodes
-                                        to use for the hash ring.
-                                      minimum: 0
-                                      type: integer
-                                  type: object
-                                useSourceIp:
-                                  description: Hash based on the source IP address.
-                                  type: boolean
-                              type: object
-                            localityLbSetting:
-                              properties:
-                                distribute:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating locality, '/' separated,
-                                          e.g.
-                                        type: string
-                                      to:
-                                        additionalProperties:
-                                          maximum: 4294967295
-                                          minimum: 0
-                                          type: integer
-                                        description: Map of upstream localities to
-                                          traffic distribution weights.
-                                        type: object
-                                    type: object
-                                  type: array
-                                enabled:
-                                  description: Enable locality load balancing.
-                                  nullable: true
-                                  type: boolean
-                                failover:
-                                  description: 'Optional: only one of distribute,
-                                    failover or failoverPriority can be set.'
-                                  items:
-                                    properties:
-                                      from:
-                                        description: Originating region.
-                                        type: string
-                                      to:
-                                        description: Destination region the traffic
-                                          will fail over to when endpoints in the
-                                          'from' region becomes unhealthy.
-                                        type: string
-                                    type: object
-                                  type: array
-                                failoverPriority:
-                                  description: failoverPriority is an ordered list
-                                    of labels used to sort endpoints to do priority
-                                    based load balancing.
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            simple:
-                              description: |2-
-
-
-                                Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
-                              enum:
-                              - UNSPECIFIED
-                              - LEAST_CONN
-                              - RANDOM
-                              - PASSTHROUGH
-                              - ROUND_ROBIN
-                              - LEAST_REQUEST
-                              type: string
-                            warmup:
-                              description: Represents the warmup configuration of
-                                Service.
-                              properties:
-                                aggression:
-                                  description: This parameter controls the speed of
-                                    traffic increase over the warmup duration.
-                                  format: double
-                                  minimum: 1
-                                  nullable: true
-                                  type: number
-                                duration:
-                                  type: string
-                                  x-kubernetes-validations:
-                                  - message: must be a valid duration greater than
-                                      1ms
-                                    rule: duration(self) >= duration('1ms')
-                                minimumPercent:
-                                  format: double
-                                  maximum: 100
-                                  minimum: 0
-                                  nullable: true
-                                  type: number
-                              required:
-                              - duration
-                              type: object
-                            warmupDurationSecs:
-                              description: 'Deprecated: use `warmup` instead.'
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                          type: object
-                        outlierDetection:
-                          properties:
-                            baseEjectionTime:
-                              description: Minimum ejection duration.
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                            consecutive5xxErrors:
-                              description: Number of 5xx errors before a host is ejected
-                                from the connection pool.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            consecutiveErrors:
-                              format: int32
-                              type: integer
-                            consecutiveGatewayErrors:
-                              description: Number of gateway errors before a host
-                                is ejected from the connection pool.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            consecutiveLocalOriginFailures:
-                              description: The number of consecutive locally originated
-                                failures before ejection occurs.
-                              maximum: 4294967295
-                              minimum: 0
-                              nullable: true
-                              type: integer
-                            interval:
-                              description: Time interval between ejection sweep analysis.
-                              type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
-                            maxEjectionPercent:
-                              description: Maximum % of hosts in the load balancing
-                                pool for the upstream service that can be ejected.
-                              format: int32
-                              type: integer
-                            minHealthPercent:
-                              description: Outlier detection will be enabled as long
-                                as the associated load balancing pool has at least
-                                `minHealthPercent` hosts in healthy mode.
-                              format: int32
-                              type: integer
-                            splitExternalLocalOriginErrors:
-                              description: Determines whether to distinguish local
-                                origin failures from external errors.
-                              type: boolean
-                          type: object
-                        port:
-                          description: Specifies the number of a port on the destination
-                            service on which this policy is being applied.
-                          properties:
-                            number:
-                              maximum: 4294967295
-                              minimum: 0
-                              type: integer
-                          type: object
-                        tls:
-                          description: TLS related settings for connections to the
-                            upstream service.
-                          properties:
-                            caCertificates:
-                              description: 'OPTIONAL: The path to the file containing
-                                certificate authority certificates to use in verifying
-                                a presented server certificate.'
-                              type: string
-                            caCrl:
-                              description: 'OPTIONAL: The path to the file containing
-                                the certificate revocation list (CRL) to use in verifying
-                                a presented server certificate.'
-                              type: string
-                            clientCertificate:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            credentialName:
-                              description: The name of the secret that holds the TLS
-                                certs for the client including the CA certificates.
-                              type: string
-                            insecureSkipVerify:
-                              description: '`insecureSkipVerify` specifies whether
-                                the proxy should skip verifying the CA signature and
-                                SAN for the server certificate corresponding to the
-                                host.'
-                              nullable: true
-                              type: boolean
-                            mode:
-                              description: |-
-                                Indicates whether connections to this port should be secured using TLS.
-
-                                Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
-                              enum:
-                              - DISABLE
-                              - SIMPLE
-                              - MUTUAL
-                              - ISTIO_MUTUAL
-                              type: string
-                            privateKey:
-                              description: REQUIRED if mode is `MUTUAL`.
-                              type: string
-                            sni:
-                              description: SNI string to present to the server during
-                                TLS handshake.
-                              type: string
-                            subjectAltNames:
-                              description: A list of alternate names to verify the
-                                subject identity in the certificate.
-                              items:
-                                type: string
-                              type: array
-                          type: object
-                      type: object
-                    maxItems: 4096
-                    type: array
-                  proxyProtocol:
-                    description: The upstream PROXY protocol settings.
-                    properties:
-                      version:
-                        description: |-
-                          The PROXY protocol version to use.
-
-                          Valid Options: V1, V2
-                        enum:
-                        - V1
-                        - V2
-                        type: string
+                        type: number
                     type: object
                   tls:
                     description: TLS related settings for connections to the upstream
@@ -6161,6 +2359,3884 @@ spec:
     storage: true
     subresources:
       status: {}
+  - additionalPrinterColumns:
+    - description: The name of a service from the service registry
+      jsonPath: .spec.host
+      name: Host
+      type: string
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. For more information, see [Kubernetes API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha3
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting load balancing, outlier detection,
+              etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
+            properties:
+              exportTo:
+                description: A list of namespaces to which this destination rule is
+                  exported.
+                items:
+                  type: string
+                type: array
+              host:
+                description: The name of a service from the service registry.
+                type: string
+              subsets:
+                description: One or more named sets that represent individual versions
+                  of a service.
+                items:
+                  properties:
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels apply a filter over the endpoints of a service
+                        in the service registry.
+                      type: object
+                    name:
+                      description: Name of the subset.
+                      type: string
+                    trafficPolicy:
+                      description: Traffic policies that apply to this subset.
+                      properties:
+                        connectionPool:
+                          properties:
+                            http:
+                              description: HTTP connection pool settings.
+                              properties:
+                                h2UpgradePolicy:
+                                  description: |-
+                                    Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+
+                                    Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
+                                  enum:
+                                  - DEFAULT
+                                  - DO_NOT_UPGRADE
+                                  - UPGRADE
+                                  type: string
+                                http1MaxPendingRequests:
+                                  description: Maximum number of requests that will
+                                    be queued while waiting for a ready connection
+                                    pool connection.
+                                  format: int32
+                                  type: integer
+                                http2MaxRequests:
+                                  description: Maximum number of active requests to
+                                    a destination.
+                                  format: int32
+                                  type: integer
+                                idleTimeout:
+                                  description: The idle timeout for upstream connection
+                                    pool connections.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                maxConcurrentStreams:
+                                  description: The maximum number of concurrent streams
+                                    allowed for a peer on one HTTP/2 connection.
+                                  format: int32
+                                  type: integer
+                                maxRequestsPerConnection:
+                                  description: Maximum number of requests per connection
+                                    to a backend.
+                                  format: int32
+                                  type: integer
+                                maxRetries:
+                                  description: Maximum number of retries that can
+                                    be outstanding to all hosts in a cluster at a
+                                    given time.
+                                  format: int32
+                                  type: integer
+                                useClientProtocol:
+                                  description: If set to true, client protocol will
+                                    be preserved while initiating connection to backend.
+                                  type: boolean
+                              type: object
+                            tcp:
+                              description: Settings common to both HTTP and TCP upstream
+                                connections.
+                              properties:
+                                connectTimeout:
+                                  description: TCP connection timeout.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                idleTimeout:
+                                  description: The idle timeout for TCP connections.
+                                  type: string
+                                maxConnectionDuration:
+                                  description: The maximum duration of a connection.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                maxConnections:
+                                  description: Maximum number of HTTP1 /TCP connections
+                                    to a destination host.
+                                  format: int32
+                                  type: integer
+                                tcpKeepalive:
+                                  description: If set then set SO_KEEPALIVE on the
+                                    socket to enable TCP Keepalives.
+                                  properties:
+                                    interval:
+                                      description: The time duration between keep-alive
+                                        probes.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: must be a valid duration greater
+                                          than 1ms
+                                        rule: duration(self) >= duration('1ms')
+                                    probes:
+                                      description: Maximum number of keepalive probes
+                                        to send without response before deciding the
+                                        connection is dead.
+                                      maximum: 4294967295
+                                      minimum: 0
+                                      type: integer
+                                    time:
+                                      description: The time duration a connection
+                                        needs to be idle before keep-alive probes
+                                        start being sent.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: must be a valid duration greater
+                                          than 1ms
+                                        rule: duration(self) >= duration('1ms')
+                                  type: object
+                              type: object
+                          type: object
+                        loadBalancer:
+                          description: Settings controlling the load balancer algorithms.
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - simple
+                              - required:
+                                - consistentHash
+                          - required:
+                            - simple
+                          - required:
+                            - consistentHash
+                          properties:
+                            consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
+                              properties:
+                                httpCookie:
+                                  description: Hash based on HTTP cookie.
+                                  properties:
+                                    name:
+                                      description: Name of the cookie.
+                                      type: string
+                                    path:
+                                      description: Path to set for the cookie.
+                                      type: string
+                                    ttl:
+                                      description: Lifetime of the cookie.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                httpHeaderName:
+                                  description: Hash based on a specific HTTP header.
+                                  type: string
+                                httpQueryParameterName:
+                                  description: Hash based on a specific HTTP query
+                                    parameter.
+                                  type: string
+                                maglev:
+                                  description: The Maglev load balancer implements
+                                    consistent hashing to backend hosts.
+                                  properties:
+                                    tableSize:
+                                      description: The table size for Maglev hashing.
+                                      minimum: 0
+                                      type: integer
+                                  type: object
+                                minimumRingSize:
+                                  description: Deprecated.
+                                  minimum: 0
+                                  type: integer
+                                ringHash:
+                                  description: The ring/modulo hash load balancer
+                                    implements consistent hashing to backend hosts.
+                                  properties:
+                                    minimumRingSize:
+                                      description: The minimum number of virtual nodes
+                                        to use for the hash ring.
+                                      minimum: 0
+                                      type: integer
+                                  type: object
+                                useSourceIp:
+                                  description: Hash based on the source IP address.
+                                  type: boolean
+                              type: object
+                            localityLbSetting:
+                              properties:
+                                distribute:
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating locality, '/' separated,
+                                          e.g.
+                                        type: string
+                                      to:
+                                        additionalProperties:
+                                          maximum: 4294967295
+                                          minimum: 0
+                                          type: integer
+                                        description: Map of upstream localities to
+                                          traffic distribution weights.
+                                        type: object
+                                    type: object
+                                  type: array
+                                enabled:
+                                  description: Enable locality load balancing.
+                                  nullable: true
+                                  type: boolean
+                                failover:
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating region.
+                                        type: string
+                                      to:
+                                        description: Destination region the traffic
+                                          will fail over to when endpoints in the
+                                          'from' region becomes unhealthy.
+                                        type: string
+                                    type: object
+                                  type: array
+                                failoverPriority:
+                                  description: failoverPriority is an ordered list
+                                    of labels used to sort endpoints to do priority
+                                    based load balancing.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            simple:
+                              description: |2-
+
+
+                                Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
+                              enum:
+                              - UNSPECIFIED
+                              - LEAST_CONN
+                              - RANDOM
+                              - PASSTHROUGH
+                              - ROUND_ROBIN
+                              - LEAST_REQUEST
+                              type: string
+                            warmup:
+                              description: Represents the warmup configuration of
+                                Service.
+                              properties:
+                                aggression:
+                                  description: This parameter controls the speed of
+                                    traffic increase over the warmup duration.
+                                  format: double
+                                  minimum: 1
+                                  nullable: true
+                                  type: number
+                                duration:
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                minimumPercent:
+                                  format: double
+                                  maximum: 100
+                                  minimum: 0
+                                  nullable: true
+                                  type: number
+                              required:
+                              - duration
+                              type: object
+                            warmupDurationSecs:
+                              description: 'Deprecated: use `warmup` instead.'
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                          type: object
+                        outlierDetection:
+                          properties:
+                            baseEjectionTime:
+                              description: Minimum ejection duration.
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                            consecutive5xxErrors:
+                              description: Number of 5xx errors before a host is ejected
+                                from the connection pool.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            consecutiveErrors:
+                              format: int32
+                              type: integer
+                            consecutiveGatewayErrors:
+                              description: Number of gateway errors before a host
+                                is ejected from the connection pool.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            consecutiveLocalOriginFailures:
+                              description: The number of consecutive locally originated
+                                failures before ejection occurs.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            interval:
+                              description: Time interval between ejection sweep analysis.
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                            maxEjectionPercent:
+                              description: Maximum % of hosts in the load balancing
+                                pool for the upstream service that can be ejected.
+                              format: int32
+                              type: integer
+                            minHealthPercent:
+                              description: Outlier detection will be enabled as long
+                                as the associated load balancing pool has at least
+                                `minHealthPercent` hosts in healthy mode.
+                              format: int32
+                              type: integer
+                            splitExternalLocalOriginErrors:
+                              description: Determines whether to distinguish local
+                                origin failures from external errors.
+                              type: boolean
+                          type: object
+                        portLevelSettings:
+                          description: Traffic policies specific to individual ports.
+                          items:
+                            properties:
+                              connectionPool:
+                                properties:
+                                  http:
+                                    description: HTTP connection pool settings.
+                                    properties:
+                                      h2UpgradePolicy:
+                                        description: |-
+                                          Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+
+                                          Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
+                                        enum:
+                                        - DEFAULT
+                                        - DO_NOT_UPGRADE
+                                        - UPGRADE
+                                        type: string
+                                      http1MaxPendingRequests:
+                                        description: Maximum number of requests that
+                                          will be queued while waiting for a ready
+                                          connection pool connection.
+                                        format: int32
+                                        type: integer
+                                      http2MaxRequests:
+                                        description: Maximum number of active requests
+                                          to a destination.
+                                        format: int32
+                                        type: integer
+                                      idleTimeout:
+                                        description: The idle timeout for upstream
+                                          connection pool connections.
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: must be a valid duration greater
+                                            than 1ms
+                                          rule: duration(self) >= duration('1ms')
+                                      maxConcurrentStreams:
+                                        description: The maximum number of concurrent
+                                          streams allowed for a peer on one HTTP/2
+                                          connection.
+                                        format: int32
+                                        type: integer
+                                      maxRequestsPerConnection:
+                                        description: Maximum number of requests per
+                                          connection to a backend.
+                                        format: int32
+                                        type: integer
+                                      maxRetries:
+                                        description: Maximum number of retries that
+                                          can be outstanding to all hosts in a cluster
+                                          at a given time.
+                                        format: int32
+                                        type: integer
+                                      useClientProtocol:
+                                        description: If set to true, client protocol
+                                          will be preserved while initiating connection
+                                          to backend.
+                                        type: boolean
+                                    type: object
+                                  tcp:
+                                    description: Settings common to both HTTP and
+                                      TCP upstream connections.
+                                    properties:
+                                      connectTimeout:
+                                        description: TCP connection timeout.
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: must be a valid duration greater
+                                            than 1ms
+                                          rule: duration(self) >= duration('1ms')
+                                      idleTimeout:
+                                        description: The idle timeout for TCP connections.
+                                        type: string
+                                      maxConnectionDuration:
+                                        description: The maximum duration of a connection.
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: must be a valid duration greater
+                                            than 1ms
+                                          rule: duration(self) >= duration('1ms')
+                                      maxConnections:
+                                        description: Maximum number of HTTP1 /TCP
+                                          connections to a destination host.
+                                        format: int32
+                                        type: integer
+                                      tcpKeepalive:
+                                        description: If set then set SO_KEEPALIVE
+                                          on the socket to enable TCP Keepalives.
+                                        properties:
+                                          interval:
+                                            description: The time duration between
+                                              keep-alive probes.
+                                            type: string
+                                            x-kubernetes-validations:
+                                            - message: must be a valid duration greater
+                                                than 1ms
+                                              rule: duration(self) >= duration('1ms')
+                                          probes:
+                                            description: Maximum number of keepalive
+                                              probes to send without response before
+                                              deciding the connection is dead.
+                                            maximum: 4294967295
+                                            minimum: 0
+                                            type: integer
+                                          time:
+                                            description: The time duration a connection
+                                              needs to be idle before keep-alive probes
+                                              start being sent.
+                                            type: string
+                                            x-kubernetes-validations:
+                                            - message: must be a valid duration greater
+                                                than 1ms
+                                              rule: duration(self) >= duration('1ms')
+                                        type: object
+                                    type: object
+                                type: object
+                              loadBalancer:
+                                description: Settings controlling the load balancer
+                                  algorithms.
+                                oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - simple
+                                    - required:
+                                      - consistentHash
+                                - required:
+                                  - simple
+                                - required:
+                                  - consistentHash
+                                properties:
+                                  consistentHash:
+                                    allOf:
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - httpHeaderName
+                                          - required:
+                                            - httpCookie
+                                          - required:
+                                            - useSourceIp
+                                          - required:
+                                            - httpQueryParameterName
+                                      - required:
+                                        - httpHeaderName
+                                      - required:
+                                        - httpCookie
+                                      - required:
+                                        - useSourceIp
+                                      - required:
+                                        - httpQueryParameterName
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - ringHash
+                                          - required:
+                                            - maglev
+                                      - required:
+                                        - ringHash
+                                      - required:
+                                        - maglev
+                                    properties:
+                                      httpCookie:
+                                        description: Hash based on HTTP cookie.
+                                        properties:
+                                          name:
+                                            description: Name of the cookie.
+                                            type: string
+                                          path:
+                                            description: Path to set for the cookie.
+                                            type: string
+                                          ttl:
+                                            description: Lifetime of the cookie.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      httpHeaderName:
+                                        description: Hash based on a specific HTTP
+                                          header.
+                                        type: string
+                                      httpQueryParameterName:
+                                        description: Hash based on a specific HTTP
+                                          query parameter.
+                                        type: string
+                                      maglev:
+                                        description: The Maglev load balancer implements
+                                          consistent hashing to backend hosts.
+                                        properties:
+                                          tableSize:
+                                            description: The table size for Maglev
+                                              hashing.
+                                            minimum: 0
+                                            type: integer
+                                        type: object
+                                      minimumRingSize:
+                                        description: Deprecated.
+                                        minimum: 0
+                                        type: integer
+                                      ringHash:
+                                        description: The ring/modulo hash load balancer
+                                          implements consistent hashing to backend
+                                          hosts.
+                                        properties:
+                                          minimumRingSize:
+                                            description: The minimum number of virtual
+                                              nodes to use for the hash ring.
+                                            minimum: 0
+                                            type: integer
+                                        type: object
+                                      useSourceIp:
+                                        description: Hash based on the source IP address.
+                                        type: boolean
+                                    type: object
+                                  localityLbSetting:
+                                    properties:
+                                      distribute:
+                                        description: 'Optional: only one of distribute,
+                                          failover or failoverPriority can be set.'
+                                        items:
+                                          properties:
+                                            from:
+                                              description: Originating locality, '/'
+                                                separated, e.g.
+                                              type: string
+                                            to:
+                                              additionalProperties:
+                                                maximum: 4294967295
+                                                minimum: 0
+                                                type: integer
+                                              description: Map of upstream localities
+                                                to traffic distribution weights.
+                                              type: object
+                                          type: object
+                                        type: array
+                                      enabled:
+                                        description: Enable locality load balancing.
+                                        nullable: true
+                                        type: boolean
+                                      failover:
+                                        description: 'Optional: only one of distribute,
+                                          failover or failoverPriority can be set.'
+                                        items:
+                                          properties:
+                                            from:
+                                              description: Originating region.
+                                              type: string
+                                            to:
+                                              description: Destination region the
+                                                traffic will fail over to when endpoints
+                                                in the 'from' region becomes unhealthy.
+                                              type: string
+                                          type: object
+                                        type: array
+                                      failoverPriority:
+                                        description: failoverPriority is an ordered
+                                          list of labels used to sort endpoints to
+                                          do priority based load balancing.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  simple:
+                                    description: |2-
+
+
+                                      Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
+                                    enum:
+                                    - UNSPECIFIED
+                                    - LEAST_CONN
+                                    - RANDOM
+                                    - PASSTHROUGH
+                                    - ROUND_ROBIN
+                                    - LEAST_REQUEST
+                                    type: string
+                                  warmup:
+                                    description: Represents the warmup configuration
+                                      of Service.
+                                    properties:
+                                      aggression:
+                                        description: This parameter controls the speed
+                                          of traffic increase over the warmup duration.
+                                        format: double
+                                        minimum: 1
+                                        nullable: true
+                                        type: number
+                                      duration:
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: must be a valid duration greater
+                                            than 1ms
+                                          rule: duration(self) >= duration('1ms')
+                                      minimumPercent:
+                                        format: double
+                                        maximum: 100
+                                        minimum: 0
+                                        nullable: true
+                                        type: number
+                                    required:
+                                    - duration
+                                    type: object
+                                  warmupDurationSecs:
+                                    description: 'Deprecated: use `warmup` instead.'
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: must be a valid duration greater than
+                                        1ms
+                                      rule: duration(self) >= duration('1ms')
+                                type: object
+                              outlierDetection:
+                                properties:
+                                  baseEjectionTime:
+                                    description: Minimum ejection duration.
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: must be a valid duration greater than
+                                        1ms
+                                      rule: duration(self) >= duration('1ms')
+                                  consecutive5xxErrors:
+                                    description: Number of 5xx errors before a host
+                                      is ejected from the connection pool.
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    nullable: true
+                                    type: integer
+                                  consecutiveErrors:
+                                    format: int32
+                                    type: integer
+                                  consecutiveGatewayErrors:
+                                    description: Number of gateway errors before a
+                                      host is ejected from the connection pool.
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    nullable: true
+                                    type: integer
+                                  consecutiveLocalOriginFailures:
+                                    description: The number of consecutive locally
+                                      originated failures before ejection occurs.
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    nullable: true
+                                    type: integer
+                                  interval:
+                                    description: Time interval between ejection sweep
+                                      analysis.
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: must be a valid duration greater than
+                                        1ms
+                                      rule: duration(self) >= duration('1ms')
+                                  maxEjectionPercent:
+                                    description: Maximum % of hosts in the load balancing
+                                      pool for the upstream service that can be ejected.
+                                    format: int32
+                                    type: integer
+                                  minHealthPercent:
+                                    description: Outlier detection will be enabled
+                                      as long as the associated load balancing pool
+                                      has at least `minHealthPercent` hosts in healthy
+                                      mode.
+                                    format: int32
+                                    type: integer
+                                  splitExternalLocalOriginErrors:
+                                    description: Determines whether to distinguish
+                                      local origin failures from external errors.
+                                    type: boolean
+                                type: object
+                              port:
+                                description: Specifies the number of a port on the
+                                  destination service on which this policy is being
+                                  applied.
+                                properties:
+                                  number:
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    type: integer
+                                type: object
+                              tls:
+                                description: TLS related settings for connections
+                                  to the upstream service.
+                                properties:
+                                  caCertificates:
+                                    description: 'OPTIONAL: The path to the file containing
+                                      certificate authority certificates to use in
+                                      verifying a presented server certificate.'
+                                    type: string
+                                  caCrl:
+                                    description: 'OPTIONAL: The path to the file containing
+                                      the certificate revocation list (CRL) to use
+                                      in verifying a presented server certificate.'
+                                    type: string
+                                  clientCertificate:
+                                    description: REQUIRED if mode is `MUTUAL`.
+                                    type: string
+                                  credentialName:
+                                    description: The name of the secret that holds
+                                      the TLS certs for the client including the CA
+                                      certificates.
+                                    type: string
+                                  insecureSkipVerify:
+                                    description: '`insecureSkipVerify` specifies whether
+                                      the proxy should skip verifying the CA signature
+                                      and SAN for the server certificate corresponding
+                                      to the host.'
+                                    nullable: true
+                                    type: boolean
+                                  mode:
+                                    description: |-
+                                      Indicates whether connections to this port should be secured using TLS.
+
+                                      Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
+                                    enum:
+                                    - DISABLE
+                                    - SIMPLE
+                                    - MUTUAL
+                                    - ISTIO_MUTUAL
+                                    type: string
+                                  privateKey:
+                                    description: REQUIRED if mode is `MUTUAL`.
+                                    type: string
+                                  sni:
+                                    description: SNI string to present to the server
+                                      during TLS handshake.
+                                    type: string
+                                  subjectAltNames:
+                                    description: A list of alternate names to verify
+                                      the subject identity in the certificate.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          maxItems: 4096
+                          type: array
+                        proxyProtocol:
+                          description: The upstream PROXY protocol settings.
+                          properties:
+                            version:
+                              description: |-
+                                The PROXY protocol version to use.
+
+                                Valid Options: V1, V2
+                              enum:
+                              - V1
+                              - V2
+                              type: string
+                          type: object
+                        retryBudget:
+                          description: Specifies a limit on concurrent retries in
+                            relation to the number of active requests.
+                          properties:
+                            minRetryConcurrency:
+                              description: Specifies the minimum retry concurrency
+                                allowed for the retry budget.
+                              maximum: 4294967295
+                              minimum: 0
+                              type: integer
+                            percent:
+                              description: Specifies the limit on concurrent retries
+                                as a percentage of the sum of active requests and
+                                active pending requests.
+                              format: double
+                              maximum: 100
+                              minimum: 0
+                              nullable: true
+                              type: number
+                          type: object
+                        tls:
+                          description: TLS related settings for connections to the
+                            upstream service.
+                          properties:
+                            caCertificates:
+                              description: 'OPTIONAL: The path to the file containing
+                                certificate authority certificates to use in verifying
+                                a presented server certificate.'
+                              type: string
+                            caCrl:
+                              description: 'OPTIONAL: The path to the file containing
+                                the certificate revocation list (CRL) to use in verifying
+                                a presented server certificate.'
+                              type: string
+                            clientCertificate:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              type: string
+                            credentialName:
+                              description: The name of the secret that holds the TLS
+                                certs for the client including the CA certificates.
+                              type: string
+                            insecureSkipVerify:
+                              description: '`insecureSkipVerify` specifies whether
+                                the proxy should skip verifying the CA signature and
+                                SAN for the server certificate corresponding to the
+                                host.'
+                              nullable: true
+                              type: boolean
+                            mode:
+                              description: |-
+                                Indicates whether connections to this port should be secured using TLS.
+
+                                Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
+                              enum:
+                              - DISABLE
+                              - SIMPLE
+                              - MUTUAL
+                              - ISTIO_MUTUAL
+                              type: string
+                            privateKey:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              type: string
+                            sni:
+                              description: SNI string to present to the server during
+                                TLS handshake.
+                              type: string
+                            subjectAltNames:
+                              description: A list of alternate names to verify the
+                                subject identity in the certificate.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        tunnel:
+                          description: Configuration of tunneling TCP over other transport
+                            or application layers for the host configured in the DestinationRule.
+                          properties:
+                            protocol:
+                              description: Specifies which protocol to use for tunneling
+                                the downstream connection.
+                              type: string
+                            targetHost:
+                              description: Specifies a host to which the downstream
+                                connection is tunneled.
+                              type: string
+                            targetPort:
+                              description: Specifies a port to which the downstream
+                                connection is tunneled.
+                              maximum: 4294967295
+                              minimum: 0
+                              type: integer
+                          required:
+                          - targetHost
+                          - targetPort
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              trafficPolicy:
+                description: Traffic policies to apply (load balancing policy, connection
+                  pool sizes, outlier detection).
+                properties:
+                  connectionPool:
+                    properties:
+                      http:
+                        description: HTTP connection pool settings.
+                        properties:
+                          h2UpgradePolicy:
+                            description: |-
+                              Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+
+                              Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
+                            enum:
+                            - DEFAULT
+                            - DO_NOT_UPGRADE
+                            - UPGRADE
+                            type: string
+                          http1MaxPendingRequests:
+                            description: Maximum number of requests that will be queued
+                              while waiting for a ready connection pool connection.
+                            format: int32
+                            type: integer
+                          http2MaxRequests:
+                            description: Maximum number of active requests to a destination.
+                            format: int32
+                            type: integer
+                          idleTimeout:
+                            description: The idle timeout for upstream connection
+                              pool connections.
+                            type: string
+                            x-kubernetes-validations:
+                            - message: must be a valid duration greater than 1ms
+                              rule: duration(self) >= duration('1ms')
+                          maxConcurrentStreams:
+                            description: The maximum number of concurrent streams
+                              allowed for a peer on one HTTP/2 connection.
+                            format: int32
+                            type: integer
+                          maxRequestsPerConnection:
+                            description: Maximum number of requests per connection
+                              to a backend.
+                            format: int32
+                            type: integer
+                          maxRetries:
+                            description: Maximum number of retries that can be outstanding
+                              to all hosts in a cluster at a given time.
+                            format: int32
+                            type: integer
+                          useClientProtocol:
+                            description: If set to true, client protocol will be preserved
+                              while initiating connection to backend.
+                            type: boolean
+                        type: object
+                      tcp:
+                        description: Settings common to both HTTP and TCP upstream
+                          connections.
+                        properties:
+                          connectTimeout:
+                            description: TCP connection timeout.
+                            type: string
+                            x-kubernetes-validations:
+                            - message: must be a valid duration greater than 1ms
+                              rule: duration(self) >= duration('1ms')
+                          idleTimeout:
+                            description: The idle timeout for TCP connections.
+                            type: string
+                          maxConnectionDuration:
+                            description: The maximum duration of a connection.
+                            type: string
+                            x-kubernetes-validations:
+                            - message: must be a valid duration greater than 1ms
+                              rule: duration(self) >= duration('1ms')
+                          maxConnections:
+                            description: Maximum number of HTTP1 /TCP connections
+                              to a destination host.
+                            format: int32
+                            type: integer
+                          tcpKeepalive:
+                            description: If set then set SO_KEEPALIVE on the socket
+                              to enable TCP Keepalives.
+                            properties:
+                              interval:
+                                description: The time duration between keep-alive
+                                  probes.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: must be a valid duration greater than 1ms
+                                  rule: duration(self) >= duration('1ms')
+                              probes:
+                                description: Maximum number of keepalive probes to
+                                  send without response before deciding the connection
+                                  is dead.
+                                maximum: 4294967295
+                                minimum: 0
+                                type: integer
+                              time:
+                                description: The time duration a connection needs
+                                  to be idle before keep-alive probes start being
+                                  sent.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: must be a valid duration greater than 1ms
+                                  rule: duration(self) >= duration('1ms')
+                            type: object
+                        type: object
+                    type: object
+                  loadBalancer:
+                    description: Settings controlling the load balancer algorithms.
+                    oneOf:
+                    - not:
+                        anyOf:
+                        - required:
+                          - simple
+                        - required:
+                          - consistentHash
+                    - required:
+                      - simple
+                    - required:
+                      - consistentHash
+                    properties:
+                      consistentHash:
+                        allOf:
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpHeaderName
+                              - required:
+                                - httpCookie
+                              - required:
+                                - useSourceIp
+                              - required:
+                                - httpQueryParameterName
+                          - required:
+                            - httpHeaderName
+                          - required:
+                            - httpCookie
+                          - required:
+                            - useSourceIp
+                          - required:
+                            - httpQueryParameterName
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - ringHash
+                              - required:
+                                - maglev
+                          - required:
+                            - ringHash
+                          - required:
+                            - maglev
+                        properties:
+                          httpCookie:
+                            description: Hash based on HTTP cookie.
+                            properties:
+                              name:
+                                description: Name of the cookie.
+                                type: string
+                              path:
+                                description: Path to set for the cookie.
+                                type: string
+                              ttl:
+                                description: Lifetime of the cookie.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          httpHeaderName:
+                            description: Hash based on a specific HTTP header.
+                            type: string
+                          httpQueryParameterName:
+                            description: Hash based on a specific HTTP query parameter.
+                            type: string
+                          maglev:
+                            description: The Maglev load balancer implements consistent
+                              hashing to backend hosts.
+                            properties:
+                              tableSize:
+                                description: The table size for Maglev hashing.
+                                minimum: 0
+                                type: integer
+                            type: object
+                          minimumRingSize:
+                            description: Deprecated.
+                            minimum: 0
+                            type: integer
+                          ringHash:
+                            description: The ring/modulo hash load balancer implements
+                              consistent hashing to backend hosts.
+                            properties:
+                              minimumRingSize:
+                                description: The minimum number of virtual nodes to
+                                  use for the hash ring.
+                                minimum: 0
+                                type: integer
+                            type: object
+                          useSourceIp:
+                            description: Hash based on the source IP address.
+                            type: boolean
+                        type: object
+                      localityLbSetting:
+                        properties:
+                          distribute:
+                            description: 'Optional: only one of distribute, failover
+                              or failoverPriority can be set.'
+                            items:
+                              properties:
+                                from:
+                                  description: Originating locality, '/' separated,
+                                    e.g.
+                                  type: string
+                                to:
+                                  additionalProperties:
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    type: integer
+                                  description: Map of upstream localities to traffic
+                                    distribution weights.
+                                  type: object
+                              type: object
+                            type: array
+                          enabled:
+                            description: Enable locality load balancing.
+                            nullable: true
+                            type: boolean
+                          failover:
+                            description: 'Optional: only one of distribute, failover
+                              or failoverPriority can be set.'
+                            items:
+                              properties:
+                                from:
+                                  description: Originating region.
+                                  type: string
+                                to:
+                                  description: Destination region the traffic will
+                                    fail over to when endpoints in the 'from' region
+                                    becomes unhealthy.
+                                  type: string
+                              type: object
+                            type: array
+                          failoverPriority:
+                            description: failoverPriority is an ordered list of labels
+                              used to sort endpoints to do priority based load balancing.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      simple:
+                        description: |2-
+
+
+                          Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
+                        enum:
+                        - UNSPECIFIED
+                        - LEAST_CONN
+                        - RANDOM
+                        - PASSTHROUGH
+                        - ROUND_ROBIN
+                        - LEAST_REQUEST
+                        type: string
+                      warmup:
+                        description: Represents the warmup configuration of Service.
+                        properties:
+                          aggression:
+                            description: This parameter controls the speed of traffic
+                              increase over the warmup duration.
+                            format: double
+                            minimum: 1
+                            nullable: true
+                            type: number
+                          duration:
+                            type: string
+                            x-kubernetes-validations:
+                            - message: must be a valid duration greater than 1ms
+                              rule: duration(self) >= duration('1ms')
+                          minimumPercent:
+                            format: double
+                            maximum: 100
+                            minimum: 0
+                            nullable: true
+                            type: number
+                        required:
+                        - duration
+                        type: object
+                      warmupDurationSecs:
+                        description: 'Deprecated: use `warmup` instead.'
+                        type: string
+                        x-kubernetes-validations:
+                        - message: must be a valid duration greater than 1ms
+                          rule: duration(self) >= duration('1ms')
+                    type: object
+                  outlierDetection:
+                    properties:
+                      baseEjectionTime:
+                        description: Minimum ejection duration.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: must be a valid duration greater than 1ms
+                          rule: duration(self) >= duration('1ms')
+                      consecutive5xxErrors:
+                        description: Number of 5xx errors before a host is ejected
+                          from the connection pool.
+                        maximum: 4294967295
+                        minimum: 0
+                        nullable: true
+                        type: integer
+                      consecutiveErrors:
+                        format: int32
+                        type: integer
+                      consecutiveGatewayErrors:
+                        description: Number of gateway errors before a host is ejected
+                          from the connection pool.
+                        maximum: 4294967295
+                        minimum: 0
+                        nullable: true
+                        type: integer
+                      consecutiveLocalOriginFailures:
+                        description: The number of consecutive locally originated
+                          failures before ejection occurs.
+                        maximum: 4294967295
+                        minimum: 0
+                        nullable: true
+                        type: integer
+                      interval:
+                        description: Time interval between ejection sweep analysis.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: must be a valid duration greater than 1ms
+                          rule: duration(self) >= duration('1ms')
+                      maxEjectionPercent:
+                        description: Maximum % of hosts in the load balancing pool
+                          for the upstream service that can be ejected.
+                        format: int32
+                        type: integer
+                      minHealthPercent:
+                        description: Outlier detection will be enabled as long as
+                          the associated load balancing pool has at least `minHealthPercent`
+                          hosts in healthy mode.
+                        format: int32
+                        type: integer
+                      splitExternalLocalOriginErrors:
+                        description: Determines whether to distinguish local origin
+                          failures from external errors.
+                        type: boolean
+                    type: object
+                  portLevelSettings:
+                    description: Traffic policies specific to individual ports.
+                    items:
+                      properties:
+                        connectionPool:
+                          properties:
+                            http:
+                              description: HTTP connection pool settings.
+                              properties:
+                                h2UpgradePolicy:
+                                  description: |-
+                                    Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+
+                                    Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
+                                  enum:
+                                  - DEFAULT
+                                  - DO_NOT_UPGRADE
+                                  - UPGRADE
+                                  type: string
+                                http1MaxPendingRequests:
+                                  description: Maximum number of requests that will
+                                    be queued while waiting for a ready connection
+                                    pool connection.
+                                  format: int32
+                                  type: integer
+                                http2MaxRequests:
+                                  description: Maximum number of active requests to
+                                    a destination.
+                                  format: int32
+                                  type: integer
+                                idleTimeout:
+                                  description: The idle timeout for upstream connection
+                                    pool connections.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                maxConcurrentStreams:
+                                  description: The maximum number of concurrent streams
+                                    allowed for a peer on one HTTP/2 connection.
+                                  format: int32
+                                  type: integer
+                                maxRequestsPerConnection:
+                                  description: Maximum number of requests per connection
+                                    to a backend.
+                                  format: int32
+                                  type: integer
+                                maxRetries:
+                                  description: Maximum number of retries that can
+                                    be outstanding to all hosts in a cluster at a
+                                    given time.
+                                  format: int32
+                                  type: integer
+                                useClientProtocol:
+                                  description: If set to true, client protocol will
+                                    be preserved while initiating connection to backend.
+                                  type: boolean
+                              type: object
+                            tcp:
+                              description: Settings common to both HTTP and TCP upstream
+                                connections.
+                              properties:
+                                connectTimeout:
+                                  description: TCP connection timeout.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                idleTimeout:
+                                  description: The idle timeout for TCP connections.
+                                  type: string
+                                maxConnectionDuration:
+                                  description: The maximum duration of a connection.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                maxConnections:
+                                  description: Maximum number of HTTP1 /TCP connections
+                                    to a destination host.
+                                  format: int32
+                                  type: integer
+                                tcpKeepalive:
+                                  description: If set then set SO_KEEPALIVE on the
+                                    socket to enable TCP Keepalives.
+                                  properties:
+                                    interval:
+                                      description: The time duration between keep-alive
+                                        probes.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: must be a valid duration greater
+                                          than 1ms
+                                        rule: duration(self) >= duration('1ms')
+                                    probes:
+                                      description: Maximum number of keepalive probes
+                                        to send without response before deciding the
+                                        connection is dead.
+                                      maximum: 4294967295
+                                      minimum: 0
+                                      type: integer
+                                    time:
+                                      description: The time duration a connection
+                                        needs to be idle before keep-alive probes
+                                        start being sent.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: must be a valid duration greater
+                                          than 1ms
+                                        rule: duration(self) >= duration('1ms')
+                                  type: object
+                              type: object
+                          type: object
+                        loadBalancer:
+                          description: Settings controlling the load balancer algorithms.
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - simple
+                              - required:
+                                - consistentHash
+                          - required:
+                            - simple
+                          - required:
+                            - consistentHash
+                          properties:
+                            consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
+                              properties:
+                                httpCookie:
+                                  description: Hash based on HTTP cookie.
+                                  properties:
+                                    name:
+                                      description: Name of the cookie.
+                                      type: string
+                                    path:
+                                      description: Path to set for the cookie.
+                                      type: string
+                                    ttl:
+                                      description: Lifetime of the cookie.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                httpHeaderName:
+                                  description: Hash based on a specific HTTP header.
+                                  type: string
+                                httpQueryParameterName:
+                                  description: Hash based on a specific HTTP query
+                                    parameter.
+                                  type: string
+                                maglev:
+                                  description: The Maglev load balancer implements
+                                    consistent hashing to backend hosts.
+                                  properties:
+                                    tableSize:
+                                      description: The table size for Maglev hashing.
+                                      minimum: 0
+                                      type: integer
+                                  type: object
+                                minimumRingSize:
+                                  description: Deprecated.
+                                  minimum: 0
+                                  type: integer
+                                ringHash:
+                                  description: The ring/modulo hash load balancer
+                                    implements consistent hashing to backend hosts.
+                                  properties:
+                                    minimumRingSize:
+                                      description: The minimum number of virtual nodes
+                                        to use for the hash ring.
+                                      minimum: 0
+                                      type: integer
+                                  type: object
+                                useSourceIp:
+                                  description: Hash based on the source IP address.
+                                  type: boolean
+                              type: object
+                            localityLbSetting:
+                              properties:
+                                distribute:
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating locality, '/' separated,
+                                          e.g.
+                                        type: string
+                                      to:
+                                        additionalProperties:
+                                          maximum: 4294967295
+                                          minimum: 0
+                                          type: integer
+                                        description: Map of upstream localities to
+                                          traffic distribution weights.
+                                        type: object
+                                    type: object
+                                  type: array
+                                enabled:
+                                  description: Enable locality load balancing.
+                                  nullable: true
+                                  type: boolean
+                                failover:
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating region.
+                                        type: string
+                                      to:
+                                        description: Destination region the traffic
+                                          will fail over to when endpoints in the
+                                          'from' region becomes unhealthy.
+                                        type: string
+                                    type: object
+                                  type: array
+                                failoverPriority:
+                                  description: failoverPriority is an ordered list
+                                    of labels used to sort endpoints to do priority
+                                    based load balancing.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            simple:
+                              description: |2-
+
+
+                                Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
+                              enum:
+                              - UNSPECIFIED
+                              - LEAST_CONN
+                              - RANDOM
+                              - PASSTHROUGH
+                              - ROUND_ROBIN
+                              - LEAST_REQUEST
+                              type: string
+                            warmup:
+                              description: Represents the warmup configuration of
+                                Service.
+                              properties:
+                                aggression:
+                                  description: This parameter controls the speed of
+                                    traffic increase over the warmup duration.
+                                  format: double
+                                  minimum: 1
+                                  nullable: true
+                                  type: number
+                                duration:
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                minimumPercent:
+                                  format: double
+                                  maximum: 100
+                                  minimum: 0
+                                  nullable: true
+                                  type: number
+                              required:
+                              - duration
+                              type: object
+                            warmupDurationSecs:
+                              description: 'Deprecated: use `warmup` instead.'
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                          type: object
+                        outlierDetection:
+                          properties:
+                            baseEjectionTime:
+                              description: Minimum ejection duration.
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                            consecutive5xxErrors:
+                              description: Number of 5xx errors before a host is ejected
+                                from the connection pool.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            consecutiveErrors:
+                              format: int32
+                              type: integer
+                            consecutiveGatewayErrors:
+                              description: Number of gateway errors before a host
+                                is ejected from the connection pool.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            consecutiveLocalOriginFailures:
+                              description: The number of consecutive locally originated
+                                failures before ejection occurs.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            interval:
+                              description: Time interval between ejection sweep analysis.
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                            maxEjectionPercent:
+                              description: Maximum % of hosts in the load balancing
+                                pool for the upstream service that can be ejected.
+                              format: int32
+                              type: integer
+                            minHealthPercent:
+                              description: Outlier detection will be enabled as long
+                                as the associated load balancing pool has at least
+                                `minHealthPercent` hosts in healthy mode.
+                              format: int32
+                              type: integer
+                            splitExternalLocalOriginErrors:
+                              description: Determines whether to distinguish local
+                                origin failures from external errors.
+                              type: boolean
+                          type: object
+                        port:
+                          description: Specifies the number of a port on the destination
+                            service on which this policy is being applied.
+                          properties:
+                            number:
+                              maximum: 4294967295
+                              minimum: 0
+                              type: integer
+                          type: object
+                        tls:
+                          description: TLS related settings for connections to the
+                            upstream service.
+                          properties:
+                            caCertificates:
+                              description: 'OPTIONAL: The path to the file containing
+                                certificate authority certificates to use in verifying
+                                a presented server certificate.'
+                              type: string
+                            caCrl:
+                              description: 'OPTIONAL: The path to the file containing
+                                the certificate revocation list (CRL) to use in verifying
+                                a presented server certificate.'
+                              type: string
+                            clientCertificate:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              type: string
+                            credentialName:
+                              description: The name of the secret that holds the TLS
+                                certs for the client including the CA certificates.
+                              type: string
+                            insecureSkipVerify:
+                              description: '`insecureSkipVerify` specifies whether
+                                the proxy should skip verifying the CA signature and
+                                SAN for the server certificate corresponding to the
+                                host.'
+                              nullable: true
+                              type: boolean
+                            mode:
+                              description: |-
+                                Indicates whether connections to this port should be secured using TLS.
+
+                                Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
+                              enum:
+                              - DISABLE
+                              - SIMPLE
+                              - MUTUAL
+                              - ISTIO_MUTUAL
+                              type: string
+                            privateKey:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              type: string
+                            sni:
+                              description: SNI string to present to the server during
+                                TLS handshake.
+                              type: string
+                            subjectAltNames:
+                              description: A list of alternate names to verify the
+                                subject identity in the certificate.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                    maxItems: 4096
+                    type: array
+                  proxyProtocol:
+                    description: The upstream PROXY protocol settings.
+                    properties:
+                      version:
+                        description: |-
+                          The PROXY protocol version to use.
+
+                          Valid Options: V1, V2
+                        enum:
+                        - V1
+                        - V2
+                        type: string
+                    type: object
+                  retryBudget:
+                    description: Specifies a limit on concurrent retries in relation
+                      to the number of active requests.
+                    properties:
+                      minRetryConcurrency:
+                        description: Specifies the minimum retry concurrency allowed
+                          for the retry budget.
+                        maximum: 4294967295
+                        minimum: 0
+                        type: integer
+                      percent:
+                        description: Specifies the limit on concurrent retries as
+                          a percentage of the sum of active requests and active pending
+                          requests.
+                        format: double
+                        maximum: 100
+                        minimum: 0
+                        nullable: true
+                        type: number
+                    type: object
+                  tls:
+                    description: TLS related settings for connections to the upstream
+                      service.
+                    properties:
+                      caCertificates:
+                        description: 'OPTIONAL: The path to the file containing certificate
+                          authority certificates to use in verifying a presented server
+                          certificate.'
+                        type: string
+                      caCrl:
+                        description: 'OPTIONAL: The path to the file containing the
+                          certificate revocation list (CRL) to use in verifying a
+                          presented server certificate.'
+                        type: string
+                      clientCertificate:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        type: string
+                      credentialName:
+                        description: The name of the secret that holds the TLS certs
+                          for the client including the CA certificates.
+                        type: string
+                      insecureSkipVerify:
+                        description: '`insecureSkipVerify` specifies whether the proxy
+                          should skip verifying the CA signature and SAN for the server
+                          certificate corresponding to the host.'
+                        nullable: true
+                        type: boolean
+                      mode:
+                        description: |-
+                          Indicates whether connections to this port should be secured using TLS.
+
+                          Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
+                        enum:
+                        - DISABLE
+                        - SIMPLE
+                        - MUTUAL
+                        - ISTIO_MUTUAL
+                        type: string
+                      privateKey:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        type: string
+                      sni:
+                        description: SNI string to present to the server during TLS
+                          handshake.
+                        type: string
+                      subjectAltNames:
+                        description: A list of alternate names to verify the subject
+                          identity in the certificate.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  tunnel:
+                    description: Configuration of tunneling TCP over other transport
+                      or application layers for the host configured in the DestinationRule.
+                    properties:
+                      protocol:
+                        description: Specifies which protocol to use for tunneling
+                          the downstream connection.
+                        type: string
+                      targetHost:
+                        description: Specifies a host to which the downstream connection
+                          is tunneled.
+                        type: string
+                      targetPort:
+                        description: Specifies a port to which the downstream connection
+                          is tunneled.
+                        maximum: 4294967295
+                        minimum: 0
+                        type: integer
+                    required:
+                    - targetHost
+                    - targetPort
+                    type: object
+                type: object
+              workloadSelector:
+                description: Criteria used to select the specific set of pods/VMs
+                  on which this `DestinationRule` configuration should be applied.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      maxLength: 63
+                      type: string
+                      x-kubernetes-validations:
+                      - message: wildcard not allowed in label value match
+                        rule: '!self.contains("*")'
+                    description: One or more labels that indicate a specific set of
+                      pods/VMs on which a policy should be applied.
+                    maxProperties: 4096
+                    type: object
+                    x-kubernetes-validations:
+                    - message: wildcard not allowed in label key match
+                      rule: self.all(key, !key.contains("*"))
+                    - message: key must not be empty
+                      rule: self.all(key, key.size() != 0)
+                type: object
+            required:
+            - host
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Current service state of the resource.
+                items:
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    observedGeneration:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Resource Generation to which the Condition refers.
+                      x-kubernetes-int-or-string: true
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: Status is the status of the condition.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                anyOf:
+                - type: integer
+                - type: string
+                x-kubernetes-int-or-string: true
+              validationMessages:
+                description: Includes any errors or warnings detected by Istio's analyzers.
+                items:
+                  properties:
+                    documentationUrl:
+                      description: A url pointing to the Istio documentation for this
+                        specific error type.
+                      type: string
+                    level:
+                      description: |-
+                        Represents how severe a message is.
+
+                        Valid Options: UNKNOWN, ERROR, WARNING, INFO
+                      enum:
+                      - UNKNOWN
+                      - ERROR
+                      - WARNING
+                      - INFO
+                      type: string
+                    type:
+                      properties:
+                        code:
+                          description: A 7 character code matching `^IST[0-9]{4}$`
+                            intended to uniquely identify the message type.
+                          type: string
+                        name:
+                          description: A human-readable name for the message type.
+                          type: string
+                      type: object
+                  type: object
+                type: array
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - additionalPrinterColumns:
+    - description: The name of a service from the service registry
+      jsonPath: .spec.host
+      name: Host
+      type: string
+    - description: CreationTimestamp is a timestamp representing the server time when
+        this object was created. It is not guaranteed to be set in happens-before
+        order across separate operations. Clients may not set this value. It is represented
+        in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+        lists. For more information, see [Kubernetes API Conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata)
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        properties:
+          spec:
+            description: 'Configuration affecting load balancing, outlier detection,
+              etc. See more details at: https://istio.io/docs/reference/config/networking/destination-rule.html'
+            properties:
+              exportTo:
+                description: A list of namespaces to which this destination rule is
+                  exported.
+                items:
+                  type: string
+                type: array
+              host:
+                description: The name of a service from the service registry.
+                type: string
+              subsets:
+                description: One or more named sets that represent individual versions
+                  of a service.
+                items:
+                  properties:
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: Labels apply a filter over the endpoints of a service
+                        in the service registry.
+                      type: object
+                    name:
+                      description: Name of the subset.
+                      type: string
+                    trafficPolicy:
+                      description: Traffic policies that apply to this subset.
+                      properties:
+                        connectionPool:
+                          properties:
+                            http:
+                              description: HTTP connection pool settings.
+                              properties:
+                                h2UpgradePolicy:
+                                  description: |-
+                                    Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+
+                                    Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
+                                  enum:
+                                  - DEFAULT
+                                  - DO_NOT_UPGRADE
+                                  - UPGRADE
+                                  type: string
+                                http1MaxPendingRequests:
+                                  description: Maximum number of requests that will
+                                    be queued while waiting for a ready connection
+                                    pool connection.
+                                  format: int32
+                                  type: integer
+                                http2MaxRequests:
+                                  description: Maximum number of active requests to
+                                    a destination.
+                                  format: int32
+                                  type: integer
+                                idleTimeout:
+                                  description: The idle timeout for upstream connection
+                                    pool connections.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                maxConcurrentStreams:
+                                  description: The maximum number of concurrent streams
+                                    allowed for a peer on one HTTP/2 connection.
+                                  format: int32
+                                  type: integer
+                                maxRequestsPerConnection:
+                                  description: Maximum number of requests per connection
+                                    to a backend.
+                                  format: int32
+                                  type: integer
+                                maxRetries:
+                                  description: Maximum number of retries that can
+                                    be outstanding to all hosts in a cluster at a
+                                    given time.
+                                  format: int32
+                                  type: integer
+                                useClientProtocol:
+                                  description: If set to true, client protocol will
+                                    be preserved while initiating connection to backend.
+                                  type: boolean
+                              type: object
+                            tcp:
+                              description: Settings common to both HTTP and TCP upstream
+                                connections.
+                              properties:
+                                connectTimeout:
+                                  description: TCP connection timeout.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                idleTimeout:
+                                  description: The idle timeout for TCP connections.
+                                  type: string
+                                maxConnectionDuration:
+                                  description: The maximum duration of a connection.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                maxConnections:
+                                  description: Maximum number of HTTP1 /TCP connections
+                                    to a destination host.
+                                  format: int32
+                                  type: integer
+                                tcpKeepalive:
+                                  description: If set then set SO_KEEPALIVE on the
+                                    socket to enable TCP Keepalives.
+                                  properties:
+                                    interval:
+                                      description: The time duration between keep-alive
+                                        probes.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: must be a valid duration greater
+                                          than 1ms
+                                        rule: duration(self) >= duration('1ms')
+                                    probes:
+                                      description: Maximum number of keepalive probes
+                                        to send without response before deciding the
+                                        connection is dead.
+                                      maximum: 4294967295
+                                      minimum: 0
+                                      type: integer
+                                    time:
+                                      description: The time duration a connection
+                                        needs to be idle before keep-alive probes
+                                        start being sent.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: must be a valid duration greater
+                                          than 1ms
+                                        rule: duration(self) >= duration('1ms')
+                                  type: object
+                              type: object
+                          type: object
+                        loadBalancer:
+                          description: Settings controlling the load balancer algorithms.
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - simple
+                              - required:
+                                - consistentHash
+                          - required:
+                            - simple
+                          - required:
+                            - consistentHash
+                          properties:
+                            consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
+                              properties:
+                                httpCookie:
+                                  description: Hash based on HTTP cookie.
+                                  properties:
+                                    name:
+                                      description: Name of the cookie.
+                                      type: string
+                                    path:
+                                      description: Path to set for the cookie.
+                                      type: string
+                                    ttl:
+                                      description: Lifetime of the cookie.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                httpHeaderName:
+                                  description: Hash based on a specific HTTP header.
+                                  type: string
+                                httpQueryParameterName:
+                                  description: Hash based on a specific HTTP query
+                                    parameter.
+                                  type: string
+                                maglev:
+                                  description: The Maglev load balancer implements
+                                    consistent hashing to backend hosts.
+                                  properties:
+                                    tableSize:
+                                      description: The table size for Maglev hashing.
+                                      minimum: 0
+                                      type: integer
+                                  type: object
+                                minimumRingSize:
+                                  description: Deprecated.
+                                  minimum: 0
+                                  type: integer
+                                ringHash:
+                                  description: The ring/modulo hash load balancer
+                                    implements consistent hashing to backend hosts.
+                                  properties:
+                                    minimumRingSize:
+                                      description: The minimum number of virtual nodes
+                                        to use for the hash ring.
+                                      minimum: 0
+                                      type: integer
+                                  type: object
+                                useSourceIp:
+                                  description: Hash based on the source IP address.
+                                  type: boolean
+                              type: object
+                            localityLbSetting:
+                              properties:
+                                distribute:
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating locality, '/' separated,
+                                          e.g.
+                                        type: string
+                                      to:
+                                        additionalProperties:
+                                          maximum: 4294967295
+                                          minimum: 0
+                                          type: integer
+                                        description: Map of upstream localities to
+                                          traffic distribution weights.
+                                        type: object
+                                    type: object
+                                  type: array
+                                enabled:
+                                  description: Enable locality load balancing.
+                                  nullable: true
+                                  type: boolean
+                                failover:
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating region.
+                                        type: string
+                                      to:
+                                        description: Destination region the traffic
+                                          will fail over to when endpoints in the
+                                          'from' region becomes unhealthy.
+                                        type: string
+                                    type: object
+                                  type: array
+                                failoverPriority:
+                                  description: failoverPriority is an ordered list
+                                    of labels used to sort endpoints to do priority
+                                    based load balancing.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            simple:
+                              description: |2-
+
+
+                                Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
+                              enum:
+                              - UNSPECIFIED
+                              - LEAST_CONN
+                              - RANDOM
+                              - PASSTHROUGH
+                              - ROUND_ROBIN
+                              - LEAST_REQUEST
+                              type: string
+                            warmup:
+                              description: Represents the warmup configuration of
+                                Service.
+                              properties:
+                                aggression:
+                                  description: This parameter controls the speed of
+                                    traffic increase over the warmup duration.
+                                  format: double
+                                  minimum: 1
+                                  nullable: true
+                                  type: number
+                                duration:
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                minimumPercent:
+                                  format: double
+                                  maximum: 100
+                                  minimum: 0
+                                  nullable: true
+                                  type: number
+                              required:
+                              - duration
+                              type: object
+                            warmupDurationSecs:
+                              description: 'Deprecated: use `warmup` instead.'
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                          type: object
+                        outlierDetection:
+                          properties:
+                            baseEjectionTime:
+                              description: Minimum ejection duration.
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                            consecutive5xxErrors:
+                              description: Number of 5xx errors before a host is ejected
+                                from the connection pool.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            consecutiveErrors:
+                              format: int32
+                              type: integer
+                            consecutiveGatewayErrors:
+                              description: Number of gateway errors before a host
+                                is ejected from the connection pool.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            consecutiveLocalOriginFailures:
+                              description: The number of consecutive locally originated
+                                failures before ejection occurs.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            interval:
+                              description: Time interval between ejection sweep analysis.
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                            maxEjectionPercent:
+                              description: Maximum % of hosts in the load balancing
+                                pool for the upstream service that can be ejected.
+                              format: int32
+                              type: integer
+                            minHealthPercent:
+                              description: Outlier detection will be enabled as long
+                                as the associated load balancing pool has at least
+                                `minHealthPercent` hosts in healthy mode.
+                              format: int32
+                              type: integer
+                            splitExternalLocalOriginErrors:
+                              description: Determines whether to distinguish local
+                                origin failures from external errors.
+                              type: boolean
+                          type: object
+                        portLevelSettings:
+                          description: Traffic policies specific to individual ports.
+                          items:
+                            properties:
+                              connectionPool:
+                                properties:
+                                  http:
+                                    description: HTTP connection pool settings.
+                                    properties:
+                                      h2UpgradePolicy:
+                                        description: |-
+                                          Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+
+                                          Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
+                                        enum:
+                                        - DEFAULT
+                                        - DO_NOT_UPGRADE
+                                        - UPGRADE
+                                        type: string
+                                      http1MaxPendingRequests:
+                                        description: Maximum number of requests that
+                                          will be queued while waiting for a ready
+                                          connection pool connection.
+                                        format: int32
+                                        type: integer
+                                      http2MaxRequests:
+                                        description: Maximum number of active requests
+                                          to a destination.
+                                        format: int32
+                                        type: integer
+                                      idleTimeout:
+                                        description: The idle timeout for upstream
+                                          connection pool connections.
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: must be a valid duration greater
+                                            than 1ms
+                                          rule: duration(self) >= duration('1ms')
+                                      maxConcurrentStreams:
+                                        description: The maximum number of concurrent
+                                          streams allowed for a peer on one HTTP/2
+                                          connection.
+                                        format: int32
+                                        type: integer
+                                      maxRequestsPerConnection:
+                                        description: Maximum number of requests per
+                                          connection to a backend.
+                                        format: int32
+                                        type: integer
+                                      maxRetries:
+                                        description: Maximum number of retries that
+                                          can be outstanding to all hosts in a cluster
+                                          at a given time.
+                                        format: int32
+                                        type: integer
+                                      useClientProtocol:
+                                        description: If set to true, client protocol
+                                          will be preserved while initiating connection
+                                          to backend.
+                                        type: boolean
+                                    type: object
+                                  tcp:
+                                    description: Settings common to both HTTP and
+                                      TCP upstream connections.
+                                    properties:
+                                      connectTimeout:
+                                        description: TCP connection timeout.
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: must be a valid duration greater
+                                            than 1ms
+                                          rule: duration(self) >= duration('1ms')
+                                      idleTimeout:
+                                        description: The idle timeout for TCP connections.
+                                        type: string
+                                      maxConnectionDuration:
+                                        description: The maximum duration of a connection.
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: must be a valid duration greater
+                                            than 1ms
+                                          rule: duration(self) >= duration('1ms')
+                                      maxConnections:
+                                        description: Maximum number of HTTP1 /TCP
+                                          connections to a destination host.
+                                        format: int32
+                                        type: integer
+                                      tcpKeepalive:
+                                        description: If set then set SO_KEEPALIVE
+                                          on the socket to enable TCP Keepalives.
+                                        properties:
+                                          interval:
+                                            description: The time duration between
+                                              keep-alive probes.
+                                            type: string
+                                            x-kubernetes-validations:
+                                            - message: must be a valid duration greater
+                                                than 1ms
+                                              rule: duration(self) >= duration('1ms')
+                                          probes:
+                                            description: Maximum number of keepalive
+                                              probes to send without response before
+                                              deciding the connection is dead.
+                                            maximum: 4294967295
+                                            minimum: 0
+                                            type: integer
+                                          time:
+                                            description: The time duration a connection
+                                              needs to be idle before keep-alive probes
+                                              start being sent.
+                                            type: string
+                                            x-kubernetes-validations:
+                                            - message: must be a valid duration greater
+                                                than 1ms
+                                              rule: duration(self) >= duration('1ms')
+                                        type: object
+                                    type: object
+                                type: object
+                              loadBalancer:
+                                description: Settings controlling the load balancer
+                                  algorithms.
+                                oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - simple
+                                    - required:
+                                      - consistentHash
+                                - required:
+                                  - simple
+                                - required:
+                                  - consistentHash
+                                properties:
+                                  consistentHash:
+                                    allOf:
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - httpHeaderName
+                                          - required:
+                                            - httpCookie
+                                          - required:
+                                            - useSourceIp
+                                          - required:
+                                            - httpQueryParameterName
+                                      - required:
+                                        - httpHeaderName
+                                      - required:
+                                        - httpCookie
+                                      - required:
+                                        - useSourceIp
+                                      - required:
+                                        - httpQueryParameterName
+                                    - oneOf:
+                                      - not:
+                                          anyOf:
+                                          - required:
+                                            - ringHash
+                                          - required:
+                                            - maglev
+                                      - required:
+                                        - ringHash
+                                      - required:
+                                        - maglev
+                                    properties:
+                                      httpCookie:
+                                        description: Hash based on HTTP cookie.
+                                        properties:
+                                          name:
+                                            description: Name of the cookie.
+                                            type: string
+                                          path:
+                                            description: Path to set for the cookie.
+                                            type: string
+                                          ttl:
+                                            description: Lifetime of the cookie.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      httpHeaderName:
+                                        description: Hash based on a specific HTTP
+                                          header.
+                                        type: string
+                                      httpQueryParameterName:
+                                        description: Hash based on a specific HTTP
+                                          query parameter.
+                                        type: string
+                                      maglev:
+                                        description: The Maglev load balancer implements
+                                          consistent hashing to backend hosts.
+                                        properties:
+                                          tableSize:
+                                            description: The table size for Maglev
+                                              hashing.
+                                            minimum: 0
+                                            type: integer
+                                        type: object
+                                      minimumRingSize:
+                                        description: Deprecated.
+                                        minimum: 0
+                                        type: integer
+                                      ringHash:
+                                        description: The ring/modulo hash load balancer
+                                          implements consistent hashing to backend
+                                          hosts.
+                                        properties:
+                                          minimumRingSize:
+                                            description: The minimum number of virtual
+                                              nodes to use for the hash ring.
+                                            minimum: 0
+                                            type: integer
+                                        type: object
+                                      useSourceIp:
+                                        description: Hash based on the source IP address.
+                                        type: boolean
+                                    type: object
+                                  localityLbSetting:
+                                    properties:
+                                      distribute:
+                                        description: 'Optional: only one of distribute,
+                                          failover or failoverPriority can be set.'
+                                        items:
+                                          properties:
+                                            from:
+                                              description: Originating locality, '/'
+                                                separated, e.g.
+                                              type: string
+                                            to:
+                                              additionalProperties:
+                                                maximum: 4294967295
+                                                minimum: 0
+                                                type: integer
+                                              description: Map of upstream localities
+                                                to traffic distribution weights.
+                                              type: object
+                                          type: object
+                                        type: array
+                                      enabled:
+                                        description: Enable locality load balancing.
+                                        nullable: true
+                                        type: boolean
+                                      failover:
+                                        description: 'Optional: only one of distribute,
+                                          failover or failoverPriority can be set.'
+                                        items:
+                                          properties:
+                                            from:
+                                              description: Originating region.
+                                              type: string
+                                            to:
+                                              description: Destination region the
+                                                traffic will fail over to when endpoints
+                                                in the 'from' region becomes unhealthy.
+                                              type: string
+                                          type: object
+                                        type: array
+                                      failoverPriority:
+                                        description: failoverPriority is an ordered
+                                          list of labels used to sort endpoints to
+                                          do priority based load balancing.
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  simple:
+                                    description: |2-
+
+
+                                      Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
+                                    enum:
+                                    - UNSPECIFIED
+                                    - LEAST_CONN
+                                    - RANDOM
+                                    - PASSTHROUGH
+                                    - ROUND_ROBIN
+                                    - LEAST_REQUEST
+                                    type: string
+                                  warmup:
+                                    description: Represents the warmup configuration
+                                      of Service.
+                                    properties:
+                                      aggression:
+                                        description: This parameter controls the speed
+                                          of traffic increase over the warmup duration.
+                                        format: double
+                                        minimum: 1
+                                        nullable: true
+                                        type: number
+                                      duration:
+                                        type: string
+                                        x-kubernetes-validations:
+                                        - message: must be a valid duration greater
+                                            than 1ms
+                                          rule: duration(self) >= duration('1ms')
+                                      minimumPercent:
+                                        format: double
+                                        maximum: 100
+                                        minimum: 0
+                                        nullable: true
+                                        type: number
+                                    required:
+                                    - duration
+                                    type: object
+                                  warmupDurationSecs:
+                                    description: 'Deprecated: use `warmup` instead.'
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: must be a valid duration greater than
+                                        1ms
+                                      rule: duration(self) >= duration('1ms')
+                                type: object
+                              outlierDetection:
+                                properties:
+                                  baseEjectionTime:
+                                    description: Minimum ejection duration.
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: must be a valid duration greater than
+                                        1ms
+                                      rule: duration(self) >= duration('1ms')
+                                  consecutive5xxErrors:
+                                    description: Number of 5xx errors before a host
+                                      is ejected from the connection pool.
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    nullable: true
+                                    type: integer
+                                  consecutiveErrors:
+                                    format: int32
+                                    type: integer
+                                  consecutiveGatewayErrors:
+                                    description: Number of gateway errors before a
+                                      host is ejected from the connection pool.
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    nullable: true
+                                    type: integer
+                                  consecutiveLocalOriginFailures:
+                                    description: The number of consecutive locally
+                                      originated failures before ejection occurs.
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    nullable: true
+                                    type: integer
+                                  interval:
+                                    description: Time interval between ejection sweep
+                                      analysis.
+                                    type: string
+                                    x-kubernetes-validations:
+                                    - message: must be a valid duration greater than
+                                        1ms
+                                      rule: duration(self) >= duration('1ms')
+                                  maxEjectionPercent:
+                                    description: Maximum % of hosts in the load balancing
+                                      pool for the upstream service that can be ejected.
+                                    format: int32
+                                    type: integer
+                                  minHealthPercent:
+                                    description: Outlier detection will be enabled
+                                      as long as the associated load balancing pool
+                                      has at least `minHealthPercent` hosts in healthy
+                                      mode.
+                                    format: int32
+                                    type: integer
+                                  splitExternalLocalOriginErrors:
+                                    description: Determines whether to distinguish
+                                      local origin failures from external errors.
+                                    type: boolean
+                                type: object
+                              port:
+                                description: Specifies the number of a port on the
+                                  destination service on which this policy is being
+                                  applied.
+                                properties:
+                                  number:
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    type: integer
+                                type: object
+                              tls:
+                                description: TLS related settings for connections
+                                  to the upstream service.
+                                properties:
+                                  caCertificates:
+                                    description: 'OPTIONAL: The path to the file containing
+                                      certificate authority certificates to use in
+                                      verifying a presented server certificate.'
+                                    type: string
+                                  caCrl:
+                                    description: 'OPTIONAL: The path to the file containing
+                                      the certificate revocation list (CRL) to use
+                                      in verifying a presented server certificate.'
+                                    type: string
+                                  clientCertificate:
+                                    description: REQUIRED if mode is `MUTUAL`.
+                                    type: string
+                                  credentialName:
+                                    description: The name of the secret that holds
+                                      the TLS certs for the client including the CA
+                                      certificates.
+                                    type: string
+                                  insecureSkipVerify:
+                                    description: '`insecureSkipVerify` specifies whether
+                                      the proxy should skip verifying the CA signature
+                                      and SAN for the server certificate corresponding
+                                      to the host.'
+                                    nullable: true
+                                    type: boolean
+                                  mode:
+                                    description: |-
+                                      Indicates whether connections to this port should be secured using TLS.
+
+                                      Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
+                                    enum:
+                                    - DISABLE
+                                    - SIMPLE
+                                    - MUTUAL
+                                    - ISTIO_MUTUAL
+                                    type: string
+                                  privateKey:
+                                    description: REQUIRED if mode is `MUTUAL`.
+                                    type: string
+                                  sni:
+                                    description: SNI string to present to the server
+                                      during TLS handshake.
+                                    type: string
+                                  subjectAltNames:
+                                    description: A list of alternate names to verify
+                                      the subject identity in the certificate.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                            type: object
+                          maxItems: 4096
+                          type: array
+                        proxyProtocol:
+                          description: The upstream PROXY protocol settings.
+                          properties:
+                            version:
+                              description: |-
+                                The PROXY protocol version to use.
+
+                                Valid Options: V1, V2
+                              enum:
+                              - V1
+                              - V2
+                              type: string
+                          type: object
+                        retryBudget:
+                          description: Specifies a limit on concurrent retries in
+                            relation to the number of active requests.
+                          properties:
+                            minRetryConcurrency:
+                              description: Specifies the minimum retry concurrency
+                                allowed for the retry budget.
+                              maximum: 4294967295
+                              minimum: 0
+                              type: integer
+                            percent:
+                              description: Specifies the limit on concurrent retries
+                                as a percentage of the sum of active requests and
+                                active pending requests.
+                              format: double
+                              maximum: 100
+                              minimum: 0
+                              nullable: true
+                              type: number
+                          type: object
+                        tls:
+                          description: TLS related settings for connections to the
+                            upstream service.
+                          properties:
+                            caCertificates:
+                              description: 'OPTIONAL: The path to the file containing
+                                certificate authority certificates to use in verifying
+                                a presented server certificate.'
+                              type: string
+                            caCrl:
+                              description: 'OPTIONAL: The path to the file containing
+                                the certificate revocation list (CRL) to use in verifying
+                                a presented server certificate.'
+                              type: string
+                            clientCertificate:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              type: string
+                            credentialName:
+                              description: The name of the secret that holds the TLS
+                                certs for the client including the CA certificates.
+                              type: string
+                            insecureSkipVerify:
+                              description: '`insecureSkipVerify` specifies whether
+                                the proxy should skip verifying the CA signature and
+                                SAN for the server certificate corresponding to the
+                                host.'
+                              nullable: true
+                              type: boolean
+                            mode:
+                              description: |-
+                                Indicates whether connections to this port should be secured using TLS.
+
+                                Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
+                              enum:
+                              - DISABLE
+                              - SIMPLE
+                              - MUTUAL
+                              - ISTIO_MUTUAL
+                              type: string
+                            privateKey:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              type: string
+                            sni:
+                              description: SNI string to present to the server during
+                                TLS handshake.
+                              type: string
+                            subjectAltNames:
+                              description: A list of alternate names to verify the
+                                subject identity in the certificate.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        tunnel:
+                          description: Configuration of tunneling TCP over other transport
+                            or application layers for the host configured in the DestinationRule.
+                          properties:
+                            protocol:
+                              description: Specifies which protocol to use for tunneling
+                                the downstream connection.
+                              type: string
+                            targetHost:
+                              description: Specifies a host to which the downstream
+                                connection is tunneled.
+                              type: string
+                            targetPort:
+                              description: Specifies a port to which the downstream
+                                connection is tunneled.
+                              maximum: 4294967295
+                              minimum: 0
+                              type: integer
+                          required:
+                          - targetHost
+                          - targetPort
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              trafficPolicy:
+                description: Traffic policies to apply (load balancing policy, connection
+                  pool sizes, outlier detection).
+                properties:
+                  connectionPool:
+                    properties:
+                      http:
+                        description: HTTP connection pool settings.
+                        properties:
+                          h2UpgradePolicy:
+                            description: |-
+                              Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+
+                              Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
+                            enum:
+                            - DEFAULT
+                            - DO_NOT_UPGRADE
+                            - UPGRADE
+                            type: string
+                          http1MaxPendingRequests:
+                            description: Maximum number of requests that will be queued
+                              while waiting for a ready connection pool connection.
+                            format: int32
+                            type: integer
+                          http2MaxRequests:
+                            description: Maximum number of active requests to a destination.
+                            format: int32
+                            type: integer
+                          idleTimeout:
+                            description: The idle timeout for upstream connection
+                              pool connections.
+                            type: string
+                            x-kubernetes-validations:
+                            - message: must be a valid duration greater than 1ms
+                              rule: duration(self) >= duration('1ms')
+                          maxConcurrentStreams:
+                            description: The maximum number of concurrent streams
+                              allowed for a peer on one HTTP/2 connection.
+                            format: int32
+                            type: integer
+                          maxRequestsPerConnection:
+                            description: Maximum number of requests per connection
+                              to a backend.
+                            format: int32
+                            type: integer
+                          maxRetries:
+                            description: Maximum number of retries that can be outstanding
+                              to all hosts in a cluster at a given time.
+                            format: int32
+                            type: integer
+                          useClientProtocol:
+                            description: If set to true, client protocol will be preserved
+                              while initiating connection to backend.
+                            type: boolean
+                        type: object
+                      tcp:
+                        description: Settings common to both HTTP and TCP upstream
+                          connections.
+                        properties:
+                          connectTimeout:
+                            description: TCP connection timeout.
+                            type: string
+                            x-kubernetes-validations:
+                            - message: must be a valid duration greater than 1ms
+                              rule: duration(self) >= duration('1ms')
+                          idleTimeout:
+                            description: The idle timeout for TCP connections.
+                            type: string
+                          maxConnectionDuration:
+                            description: The maximum duration of a connection.
+                            type: string
+                            x-kubernetes-validations:
+                            - message: must be a valid duration greater than 1ms
+                              rule: duration(self) >= duration('1ms')
+                          maxConnections:
+                            description: Maximum number of HTTP1 /TCP connections
+                              to a destination host.
+                            format: int32
+                            type: integer
+                          tcpKeepalive:
+                            description: If set then set SO_KEEPALIVE on the socket
+                              to enable TCP Keepalives.
+                            properties:
+                              interval:
+                                description: The time duration between keep-alive
+                                  probes.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: must be a valid duration greater than 1ms
+                                  rule: duration(self) >= duration('1ms')
+                              probes:
+                                description: Maximum number of keepalive probes to
+                                  send without response before deciding the connection
+                                  is dead.
+                                maximum: 4294967295
+                                minimum: 0
+                                type: integer
+                              time:
+                                description: The time duration a connection needs
+                                  to be idle before keep-alive probes start being
+                                  sent.
+                                type: string
+                                x-kubernetes-validations:
+                                - message: must be a valid duration greater than 1ms
+                                  rule: duration(self) >= duration('1ms')
+                            type: object
+                        type: object
+                    type: object
+                  loadBalancer:
+                    description: Settings controlling the load balancer algorithms.
+                    oneOf:
+                    - not:
+                        anyOf:
+                        - required:
+                          - simple
+                        - required:
+                          - consistentHash
+                    - required:
+                      - simple
+                    - required:
+                      - consistentHash
+                    properties:
+                      consistentHash:
+                        allOf:
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - httpHeaderName
+                              - required:
+                                - httpCookie
+                              - required:
+                                - useSourceIp
+                              - required:
+                                - httpQueryParameterName
+                          - required:
+                            - httpHeaderName
+                          - required:
+                            - httpCookie
+                          - required:
+                            - useSourceIp
+                          - required:
+                            - httpQueryParameterName
+                        - oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - ringHash
+                              - required:
+                                - maglev
+                          - required:
+                            - ringHash
+                          - required:
+                            - maglev
+                        properties:
+                          httpCookie:
+                            description: Hash based on HTTP cookie.
+                            properties:
+                              name:
+                                description: Name of the cookie.
+                                type: string
+                              path:
+                                description: Path to set for the cookie.
+                                type: string
+                              ttl:
+                                description: Lifetime of the cookie.
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          httpHeaderName:
+                            description: Hash based on a specific HTTP header.
+                            type: string
+                          httpQueryParameterName:
+                            description: Hash based on a specific HTTP query parameter.
+                            type: string
+                          maglev:
+                            description: The Maglev load balancer implements consistent
+                              hashing to backend hosts.
+                            properties:
+                              tableSize:
+                                description: The table size for Maglev hashing.
+                                minimum: 0
+                                type: integer
+                            type: object
+                          minimumRingSize:
+                            description: Deprecated.
+                            minimum: 0
+                            type: integer
+                          ringHash:
+                            description: The ring/modulo hash load balancer implements
+                              consistent hashing to backend hosts.
+                            properties:
+                              minimumRingSize:
+                                description: The minimum number of virtual nodes to
+                                  use for the hash ring.
+                                minimum: 0
+                                type: integer
+                            type: object
+                          useSourceIp:
+                            description: Hash based on the source IP address.
+                            type: boolean
+                        type: object
+                      localityLbSetting:
+                        properties:
+                          distribute:
+                            description: 'Optional: only one of distribute, failover
+                              or failoverPriority can be set.'
+                            items:
+                              properties:
+                                from:
+                                  description: Originating locality, '/' separated,
+                                    e.g.
+                                  type: string
+                                to:
+                                  additionalProperties:
+                                    maximum: 4294967295
+                                    minimum: 0
+                                    type: integer
+                                  description: Map of upstream localities to traffic
+                                    distribution weights.
+                                  type: object
+                              type: object
+                            type: array
+                          enabled:
+                            description: Enable locality load balancing.
+                            nullable: true
+                            type: boolean
+                          failover:
+                            description: 'Optional: only one of distribute, failover
+                              or failoverPriority can be set.'
+                            items:
+                              properties:
+                                from:
+                                  description: Originating region.
+                                  type: string
+                                to:
+                                  description: Destination region the traffic will
+                                    fail over to when endpoints in the 'from' region
+                                    becomes unhealthy.
+                                  type: string
+                              type: object
+                            type: array
+                          failoverPriority:
+                            description: failoverPriority is an ordered list of labels
+                              used to sort endpoints to do priority based load balancing.
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      simple:
+                        description: |2-
+
+
+                          Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
+                        enum:
+                        - UNSPECIFIED
+                        - LEAST_CONN
+                        - RANDOM
+                        - PASSTHROUGH
+                        - ROUND_ROBIN
+                        - LEAST_REQUEST
+                        type: string
+                      warmup:
+                        description: Represents the warmup configuration of Service.
+                        properties:
+                          aggression:
+                            description: This parameter controls the speed of traffic
+                              increase over the warmup duration.
+                            format: double
+                            minimum: 1
+                            nullable: true
+                            type: number
+                          duration:
+                            type: string
+                            x-kubernetes-validations:
+                            - message: must be a valid duration greater than 1ms
+                              rule: duration(self) >= duration('1ms')
+                          minimumPercent:
+                            format: double
+                            maximum: 100
+                            minimum: 0
+                            nullable: true
+                            type: number
+                        required:
+                        - duration
+                        type: object
+                      warmupDurationSecs:
+                        description: 'Deprecated: use `warmup` instead.'
+                        type: string
+                        x-kubernetes-validations:
+                        - message: must be a valid duration greater than 1ms
+                          rule: duration(self) >= duration('1ms')
+                    type: object
+                  outlierDetection:
+                    properties:
+                      baseEjectionTime:
+                        description: Minimum ejection duration.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: must be a valid duration greater than 1ms
+                          rule: duration(self) >= duration('1ms')
+                      consecutive5xxErrors:
+                        description: Number of 5xx errors before a host is ejected
+                          from the connection pool.
+                        maximum: 4294967295
+                        minimum: 0
+                        nullable: true
+                        type: integer
+                      consecutiveErrors:
+                        format: int32
+                        type: integer
+                      consecutiveGatewayErrors:
+                        description: Number of gateway errors before a host is ejected
+                          from the connection pool.
+                        maximum: 4294967295
+                        minimum: 0
+                        nullable: true
+                        type: integer
+                      consecutiveLocalOriginFailures:
+                        description: The number of consecutive locally originated
+                          failures before ejection occurs.
+                        maximum: 4294967295
+                        minimum: 0
+                        nullable: true
+                        type: integer
+                      interval:
+                        description: Time interval between ejection sweep analysis.
+                        type: string
+                        x-kubernetes-validations:
+                        - message: must be a valid duration greater than 1ms
+                          rule: duration(self) >= duration('1ms')
+                      maxEjectionPercent:
+                        description: Maximum % of hosts in the load balancing pool
+                          for the upstream service that can be ejected.
+                        format: int32
+                        type: integer
+                      minHealthPercent:
+                        description: Outlier detection will be enabled as long as
+                          the associated load balancing pool has at least `minHealthPercent`
+                          hosts in healthy mode.
+                        format: int32
+                        type: integer
+                      splitExternalLocalOriginErrors:
+                        description: Determines whether to distinguish local origin
+                          failures from external errors.
+                        type: boolean
+                    type: object
+                  portLevelSettings:
+                    description: Traffic policies specific to individual ports.
+                    items:
+                      properties:
+                        connectionPool:
+                          properties:
+                            http:
+                              description: HTTP connection pool settings.
+                              properties:
+                                h2UpgradePolicy:
+                                  description: |-
+                                    Specify if http1.1 connection should be upgraded to http2 for the associated destination.
+
+                                    Valid Options: DEFAULT, DO_NOT_UPGRADE, UPGRADE
+                                  enum:
+                                  - DEFAULT
+                                  - DO_NOT_UPGRADE
+                                  - UPGRADE
+                                  type: string
+                                http1MaxPendingRequests:
+                                  description: Maximum number of requests that will
+                                    be queued while waiting for a ready connection
+                                    pool connection.
+                                  format: int32
+                                  type: integer
+                                http2MaxRequests:
+                                  description: Maximum number of active requests to
+                                    a destination.
+                                  format: int32
+                                  type: integer
+                                idleTimeout:
+                                  description: The idle timeout for upstream connection
+                                    pool connections.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                maxConcurrentStreams:
+                                  description: The maximum number of concurrent streams
+                                    allowed for a peer on one HTTP/2 connection.
+                                  format: int32
+                                  type: integer
+                                maxRequestsPerConnection:
+                                  description: Maximum number of requests per connection
+                                    to a backend.
+                                  format: int32
+                                  type: integer
+                                maxRetries:
+                                  description: Maximum number of retries that can
+                                    be outstanding to all hosts in a cluster at a
+                                    given time.
+                                  format: int32
+                                  type: integer
+                                useClientProtocol:
+                                  description: If set to true, client protocol will
+                                    be preserved while initiating connection to backend.
+                                  type: boolean
+                              type: object
+                            tcp:
+                              description: Settings common to both HTTP and TCP upstream
+                                connections.
+                              properties:
+                                connectTimeout:
+                                  description: TCP connection timeout.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                idleTimeout:
+                                  description: The idle timeout for TCP connections.
+                                  type: string
+                                maxConnectionDuration:
+                                  description: The maximum duration of a connection.
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                maxConnections:
+                                  description: Maximum number of HTTP1 /TCP connections
+                                    to a destination host.
+                                  format: int32
+                                  type: integer
+                                tcpKeepalive:
+                                  description: If set then set SO_KEEPALIVE on the
+                                    socket to enable TCP Keepalives.
+                                  properties:
+                                    interval:
+                                      description: The time duration between keep-alive
+                                        probes.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: must be a valid duration greater
+                                          than 1ms
+                                        rule: duration(self) >= duration('1ms')
+                                    probes:
+                                      description: Maximum number of keepalive probes
+                                        to send without response before deciding the
+                                        connection is dead.
+                                      maximum: 4294967295
+                                      minimum: 0
+                                      type: integer
+                                    time:
+                                      description: The time duration a connection
+                                        needs to be idle before keep-alive probes
+                                        start being sent.
+                                      type: string
+                                      x-kubernetes-validations:
+                                      - message: must be a valid duration greater
+                                          than 1ms
+                                        rule: duration(self) >= duration('1ms')
+                                  type: object
+                              type: object
+                          type: object
+                        loadBalancer:
+                          description: Settings controlling the load balancer algorithms.
+                          oneOf:
+                          - not:
+                              anyOf:
+                              - required:
+                                - simple
+                              - required:
+                                - consistentHash
+                          - required:
+                            - simple
+                          - required:
+                            - consistentHash
+                          properties:
+                            consistentHash:
+                              allOf:
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - httpHeaderName
+                                    - required:
+                                      - httpCookie
+                                    - required:
+                                      - useSourceIp
+                                    - required:
+                                      - httpQueryParameterName
+                                - required:
+                                  - httpHeaderName
+                                - required:
+                                  - httpCookie
+                                - required:
+                                  - useSourceIp
+                                - required:
+                                  - httpQueryParameterName
+                              - oneOf:
+                                - not:
+                                    anyOf:
+                                    - required:
+                                      - ringHash
+                                    - required:
+                                      - maglev
+                                - required:
+                                  - ringHash
+                                - required:
+                                  - maglev
+                              properties:
+                                httpCookie:
+                                  description: Hash based on HTTP cookie.
+                                  properties:
+                                    name:
+                                      description: Name of the cookie.
+                                      type: string
+                                    path:
+                                      description: Path to set for the cookie.
+                                      type: string
+                                    ttl:
+                                      description: Lifetime of the cookie.
+                                      type: string
+                                  required:
+                                  - name
+                                  type: object
+                                httpHeaderName:
+                                  description: Hash based on a specific HTTP header.
+                                  type: string
+                                httpQueryParameterName:
+                                  description: Hash based on a specific HTTP query
+                                    parameter.
+                                  type: string
+                                maglev:
+                                  description: The Maglev load balancer implements
+                                    consistent hashing to backend hosts.
+                                  properties:
+                                    tableSize:
+                                      description: The table size for Maglev hashing.
+                                      minimum: 0
+                                      type: integer
+                                  type: object
+                                minimumRingSize:
+                                  description: Deprecated.
+                                  minimum: 0
+                                  type: integer
+                                ringHash:
+                                  description: The ring/modulo hash load balancer
+                                    implements consistent hashing to backend hosts.
+                                  properties:
+                                    minimumRingSize:
+                                      description: The minimum number of virtual nodes
+                                        to use for the hash ring.
+                                      minimum: 0
+                                      type: integer
+                                  type: object
+                                useSourceIp:
+                                  description: Hash based on the source IP address.
+                                  type: boolean
+                              type: object
+                            localityLbSetting:
+                              properties:
+                                distribute:
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating locality, '/' separated,
+                                          e.g.
+                                        type: string
+                                      to:
+                                        additionalProperties:
+                                          maximum: 4294967295
+                                          minimum: 0
+                                          type: integer
+                                        description: Map of upstream localities to
+                                          traffic distribution weights.
+                                        type: object
+                                    type: object
+                                  type: array
+                                enabled:
+                                  description: Enable locality load balancing.
+                                  nullable: true
+                                  type: boolean
+                                failover:
+                                  description: 'Optional: only one of distribute,
+                                    failover or failoverPriority can be set.'
+                                  items:
+                                    properties:
+                                      from:
+                                        description: Originating region.
+                                        type: string
+                                      to:
+                                        description: Destination region the traffic
+                                          will fail over to when endpoints in the
+                                          'from' region becomes unhealthy.
+                                        type: string
+                                    type: object
+                                  type: array
+                                failoverPriority:
+                                  description: failoverPriority is an ordered list
+                                    of labels used to sort endpoints to do priority
+                                    based load balancing.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            simple:
+                              description: |2-
+
+
+                                Valid Options: LEAST_CONN, RANDOM, PASSTHROUGH, ROUND_ROBIN, LEAST_REQUEST
+                              enum:
+                              - UNSPECIFIED
+                              - LEAST_CONN
+                              - RANDOM
+                              - PASSTHROUGH
+                              - ROUND_ROBIN
+                              - LEAST_REQUEST
+                              type: string
+                            warmup:
+                              description: Represents the warmup configuration of
+                                Service.
+                              properties:
+                                aggression:
+                                  description: This parameter controls the speed of
+                                    traffic increase over the warmup duration.
+                                  format: double
+                                  minimum: 1
+                                  nullable: true
+                                  type: number
+                                duration:
+                                  type: string
+                                  x-kubernetes-validations:
+                                  - message: must be a valid duration greater than
+                                      1ms
+                                    rule: duration(self) >= duration('1ms')
+                                minimumPercent:
+                                  format: double
+                                  maximum: 100
+                                  minimum: 0
+                                  nullable: true
+                                  type: number
+                              required:
+                              - duration
+                              type: object
+                            warmupDurationSecs:
+                              description: 'Deprecated: use `warmup` instead.'
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                          type: object
+                        outlierDetection:
+                          properties:
+                            baseEjectionTime:
+                              description: Minimum ejection duration.
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                            consecutive5xxErrors:
+                              description: Number of 5xx errors before a host is ejected
+                                from the connection pool.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            consecutiveErrors:
+                              format: int32
+                              type: integer
+                            consecutiveGatewayErrors:
+                              description: Number of gateway errors before a host
+                                is ejected from the connection pool.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            consecutiveLocalOriginFailures:
+                              description: The number of consecutive locally originated
+                                failures before ejection occurs.
+                              maximum: 4294967295
+                              minimum: 0
+                              nullable: true
+                              type: integer
+                            interval:
+                              description: Time interval between ejection sweep analysis.
+                              type: string
+                              x-kubernetes-validations:
+                              - message: must be a valid duration greater than 1ms
+                                rule: duration(self) >= duration('1ms')
+                            maxEjectionPercent:
+                              description: Maximum % of hosts in the load balancing
+                                pool for the upstream service that can be ejected.
+                              format: int32
+                              type: integer
+                            minHealthPercent:
+                              description: Outlier detection will be enabled as long
+                                as the associated load balancing pool has at least
+                                `minHealthPercent` hosts in healthy mode.
+                              format: int32
+                              type: integer
+                            splitExternalLocalOriginErrors:
+                              description: Determines whether to distinguish local
+                                origin failures from external errors.
+                              type: boolean
+                          type: object
+                        port:
+                          description: Specifies the number of a port on the destination
+                            service on which this policy is being applied.
+                          properties:
+                            number:
+                              maximum: 4294967295
+                              minimum: 0
+                              type: integer
+                          type: object
+                        tls:
+                          description: TLS related settings for connections to the
+                            upstream service.
+                          properties:
+                            caCertificates:
+                              description: 'OPTIONAL: The path to the file containing
+                                certificate authority certificates to use in verifying
+                                a presented server certificate.'
+                              type: string
+                            caCrl:
+                              description: 'OPTIONAL: The path to the file containing
+                                the certificate revocation list (CRL) to use in verifying
+                                a presented server certificate.'
+                              type: string
+                            clientCertificate:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              type: string
+                            credentialName:
+                              description: The name of the secret that holds the TLS
+                                certs for the client including the CA certificates.
+                              type: string
+                            insecureSkipVerify:
+                              description: '`insecureSkipVerify` specifies whether
+                                the proxy should skip verifying the CA signature and
+                                SAN for the server certificate corresponding to the
+                                host.'
+                              nullable: true
+                              type: boolean
+                            mode:
+                              description: |-
+                                Indicates whether connections to this port should be secured using TLS.
+
+                                Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
+                              enum:
+                              - DISABLE
+                              - SIMPLE
+                              - MUTUAL
+                              - ISTIO_MUTUAL
+                              type: string
+                            privateKey:
+                              description: REQUIRED if mode is `MUTUAL`.
+                              type: string
+                            sni:
+                              description: SNI string to present to the server during
+                                TLS handshake.
+                              type: string
+                            subjectAltNames:
+                              description: A list of alternate names to verify the
+                                subject identity in the certificate.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                      type: object
+                    maxItems: 4096
+                    type: array
+                  proxyProtocol:
+                    description: The upstream PROXY protocol settings.
+                    properties:
+                      version:
+                        description: |-
+                          The PROXY protocol version to use.
+
+                          Valid Options: V1, V2
+                        enum:
+                        - V1
+                        - V2
+                        type: string
+                    type: object
+                  retryBudget:
+                    description: Specifies a limit on concurrent retries in relation
+                      to the number of active requests.
+                    properties:
+                      minRetryConcurrency:
+                        description: Specifies the minimum retry concurrency allowed
+                          for the retry budget.
+                        maximum: 4294967295
+                        minimum: 0
+                        type: integer
+                      percent:
+                        description: Specifies the limit on concurrent retries as
+                          a percentage of the sum of active requests and active pending
+                          requests.
+                        format: double
+                        maximum: 100
+                        minimum: 0
+                        nullable: true
+                        type: number
+                    type: object
+                  tls:
+                    description: TLS related settings for connections to the upstream
+                      service.
+                    properties:
+                      caCertificates:
+                        description: 'OPTIONAL: The path to the file containing certificate
+                          authority certificates to use in verifying a presented server
+                          certificate.'
+                        type: string
+                      caCrl:
+                        description: 'OPTIONAL: The path to the file containing the
+                          certificate revocation list (CRL) to use in verifying a
+                          presented server certificate.'
+                        type: string
+                      clientCertificate:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        type: string
+                      credentialName:
+                        description: The name of the secret that holds the TLS certs
+                          for the client including the CA certificates.
+                        type: string
+                      insecureSkipVerify:
+                        description: '`insecureSkipVerify` specifies whether the proxy
+                          should skip verifying the CA signature and SAN for the server
+                          certificate corresponding to the host.'
+                        nullable: true
+                        type: boolean
+                      mode:
+                        description: |-
+                          Indicates whether connections to this port should be secured using TLS.
+
+                          Valid Options: DISABLE, SIMPLE, MUTUAL, ISTIO_MUTUAL
+                        enum:
+                        - DISABLE
+                        - SIMPLE
+                        - MUTUAL
+                        - ISTIO_MUTUAL
+                        type: string
+                      privateKey:
+                        description: REQUIRED if mode is `MUTUAL`.
+                        type: string
+                      sni:
+                        description: SNI string to present to the server during TLS
+                          handshake.
+                        type: string
+                      subjectAltNames:
+                        description: A list of alternate names to verify the subject
+                          identity in the certificate.
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  tunnel:
+                    description: Configuration of tunneling TCP over other transport
+                      or application layers for the host configured in the DestinationRule.
+                    properties:
+                      protocol:
+                        description: Specifies which protocol to use for tunneling
+                          the downstream connection.
+                        type: string
+                      targetHost:
+                        description: Specifies a host to which the downstream connection
+                          is tunneled.
+                        type: string
+                      targetPort:
+                        description: Specifies a port to which the downstream connection
+                          is tunneled.
+                        maximum: 4294967295
+                        minimum: 0
+                        type: integer
+                    required:
+                    - targetHost
+                    - targetPort
+                    type: object
+                type: object
+              workloadSelector:
+                description: Criteria used to select the specific set of pods/VMs
+                  on which this `DestinationRule` configuration should be applied.
+                properties:
+                  matchLabels:
+                    additionalProperties:
+                      maxLength: 63
+                      type: string
+                      x-kubernetes-validations:
+                      - message: wildcard not allowed in label value match
+                        rule: '!self.contains("*")'
+                    description: One or more labels that indicate a specific set of
+                      pods/VMs on which a policy should be applied.
+                    maxProperties: 4096
+                    type: object
+                    x-kubernetes-validations:
+                    - message: wildcard not allowed in label key match
+                      rule: self.all(key, !key.contains("*"))
+                    - message: key must not be empty
+                      rule: self.all(key, key.size() != 0)
+                type: object
+            required:
+            - host
+            type: object
+          status:
+            properties:
+              conditions:
+                description: Current service state of the resource.
+                items:
+                  properties:
+                    lastProbeTime:
+                      description: Last time we probed the condition.
+                      format: date-time
+                      type: string
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition.
+                      type: string
+                    observedGeneration:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      description: Resource Generation to which the Condition refers.
+                      x-kubernetes-int-or-string: true
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    status:
+                      description: Status is the status of the condition.
+                      type: string
+                    type:
+                      description: Type is the type of the condition.
+                      type: string
+                  type: object
+                type: array
+              observedGeneration:
+                anyOf:
+                - type: integer
+                - type: string
+                x-kubernetes-int-or-string: true
+              validationMessages:
+                description: Includes any errors or warnings detected by Istio's analyzers.
+                items:
+                  properties:
+                    documentationUrl:
+                      description: A url pointing to the Istio documentation for this
+                        specific error type.
+                      type: string
+                    level:
+                      description: |-
+                        Represents how severe a message is.
+
+                        Valid Options: UNKNOWN, ERROR, WARNING, INFO
+                      enum:
+                      - UNKNOWN
+                      - ERROR
+                      - WARNING
+                      - INFO
+                      type: string
+                    type:
+                      properties:
+                        code:
+                          description: A 7 character code matching `^IST[0-9]{4}$`
+                            intended to uniquely identify the message type.
+                          type: string
+                        name:
+                          description: A human-readable name for the message type.
+                          type: string
+                      type: object
+                  type: object
+                type: array
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
 ---
 # Source: base/templates/crds.yaml
 # If we are templating these CRDs, we want to wipe out the "static"/legacy
@@ -6176,8 +6252,8 @@ metadata:
     app.kubernetes.io/instance: istio-base
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
+    helm.sh/chart: base-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
   name: envoyfilters.networking.istio.io
 spec:
   group: networking.istio.io
@@ -6589,8 +6665,8 @@ metadata:
     app.kubernetes.io/instance: istio-base
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
+    helm.sh/chart: base-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
   name: gateways.networking.istio.io
 spec:
   group: networking.istio.io
@@ -6686,6 +6762,13 @@ spec:
                             of the secret that holds the TLS certs including the CA
                             certificates.
                           type: string
+                        credentialNames:
+                          description: Same as CredentialName but for multiple certificates.
+                          items:
+                            type: string
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         httpsRedirect:
                           description: If set to true, the load balancer will send
                             a 301 redirect for all http connections, asking the clients
@@ -6740,6 +6823,24 @@ spec:
                           items:
                             type: string
                           type: array
+                        tlsCertificates:
+                          description: Only one of `server_certificate`, `private_key`
+                            or `credential_name` or `credential_names` or `tls_certificates`
+                            should be specified.
+                          items:
+                            properties:
+                              caCertificates:
+                                type: string
+                              privateKey:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                              serverCertificate:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                            type: object
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         verifyCertificateHash:
                           description: An optional list of hex-encoded SHA-256 hashes
                             of the authorized client certificates.
@@ -6753,6 +6854,19 @@ spec:
                             type: string
                           type: array
                       type: object
+                      x-kubernetes-validations:
+                      - message: only one of credentialNames or tlsCertificates can
+                          be set
+                        rule: '(has(self.tlsCertificates) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or credentialNames can
+                          be set
+                        rule: '(has(self.credentialName) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or tlsCertificates can
+                          be set
+                        rule: '(has(self.credentialNames) ? 1 : 0) + (has(self.tlsCertificates)
+                          ? 1 : 0) <= 1'
                   required:
                   - port
                   - hosts
@@ -6836,7 +6950,7 @@ spec:
             x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - name: v1alpha3
@@ -6919,6 +7033,13 @@ spec:
                             of the secret that holds the TLS certs including the CA
                             certificates.
                           type: string
+                        credentialNames:
+                          description: Same as CredentialName but for multiple certificates.
+                          items:
+                            type: string
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         httpsRedirect:
                           description: If set to true, the load balancer will send
                             a 301 redirect for all http connections, asking the clients
@@ -6973,6 +7094,24 @@ spec:
                           items:
                             type: string
                           type: array
+                        tlsCertificates:
+                          description: Only one of `server_certificate`, `private_key`
+                            or `credential_name` or `credential_names` or `tls_certificates`
+                            should be specified.
+                          items:
+                            properties:
+                              caCertificates:
+                                type: string
+                              privateKey:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                              serverCertificate:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                            type: object
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         verifyCertificateHash:
                           description: An optional list of hex-encoded SHA-256 hashes
                             of the authorized client certificates.
@@ -6986,6 +7125,19 @@ spec:
                             type: string
                           type: array
                       type: object
+                      x-kubernetes-validations:
+                      - message: only one of credentialNames or tlsCertificates can
+                          be set
+                        rule: '(has(self.tlsCertificates) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or credentialNames can
+                          be set
+                        rule: '(has(self.credentialName) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or tlsCertificates can
+                          be set
+                        rule: '(has(self.credentialNames) ? 1 : 0) + (has(self.tlsCertificates)
+                          ? 1 : 0) <= 1'
                   required:
                   - port
                   - hosts
@@ -7152,6 +7304,13 @@ spec:
                             of the secret that holds the TLS certs including the CA
                             certificates.
                           type: string
+                        credentialNames:
+                          description: Same as CredentialName but for multiple certificates.
+                          items:
+                            type: string
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         httpsRedirect:
                           description: If set to true, the load balancer will send
                             a 301 redirect for all http connections, asking the clients
@@ -7206,6 +7365,24 @@ spec:
                           items:
                             type: string
                           type: array
+                        tlsCertificates:
+                          description: Only one of `server_certificate`, `private_key`
+                            or `credential_name` or `credential_names` or `tls_certificates`
+                            should be specified.
+                          items:
+                            properties:
+                              caCertificates:
+                                type: string
+                              privateKey:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                              serverCertificate:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                            type: object
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         verifyCertificateHash:
                           description: An optional list of hex-encoded SHA-256 hashes
                             of the authorized client certificates.
@@ -7219,6 +7396,19 @@ spec:
                             type: string
                           type: array
                       type: object
+                      x-kubernetes-validations:
+                      - message: only one of credentialNames or tlsCertificates can
+                          be set
+                        rule: '(has(self.tlsCertificates) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or credentialNames can
+                          be set
+                        rule: '(has(self.credentialName) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or tlsCertificates can
+                          be set
+                        rule: '(has(self.credentialNames) ? 1 : 0) + (has(self.tlsCertificates)
+                          ? 1 : 0) <= 1'
                   required:
                   - port
                   - hosts
@@ -7302,7 +7492,7 @@ spec:
             x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
 ---
@@ -7320,8 +7510,8 @@ metadata:
     app.kubernetes.io/instance: istio-base
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
+    helm.sh/chart: base-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
   name: proxyconfigs.networking.istio.io
 spec:
   group: networking.istio.io
@@ -7478,8 +7668,8 @@ metadata:
     app.kubernetes.io/instance: istio-base
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
+    helm.sh/chart: base-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
   name: serviceentries.networking.istio.io
 spec:
   group: networking.istio.io
@@ -7790,7 +7980,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -8386,7 +8576,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
 ---
@@ -8404,8 +8594,8 @@ metadata:
     app.kubernetes.io/instance: istio-base
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
+    helm.sh/chart: base-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
   name: sidecars.networking.istio.io
 spec:
   group: networking.istio.io
@@ -8541,9 +8731,6 @@ spec:
                       idleTimeout:
                         description: The idle timeout for TCP connections.
                         type: string
-                        x-kubernetes-validations:
-                        - message: must be a valid duration greater than 1ms
-                          rule: duration(self) >= duration('1ms')
                       maxConnectionDuration:
                         description: The maximum duration of a connection.
                         type: string
@@ -8667,9 +8854,6 @@ spec:
                             idleTimeout:
                               description: The idle timeout for TCP connections.
                               type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
                             maxConnectionDuration:
                               description: The maximum duration of a connection.
                               type: string
@@ -8759,6 +8943,13 @@ spec:
                             of the secret that holds the TLS certs including the CA
                             certificates.
                           type: string
+                        credentialNames:
+                          description: Same as CredentialName but for multiple certificates.
+                          items:
+                            type: string
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         httpsRedirect:
                           description: If set to true, the load balancer will send
                             a 301 redirect for all http connections, asking the clients
@@ -8813,6 +9004,24 @@ spec:
                           items:
                             type: string
                           type: array
+                        tlsCertificates:
+                          description: Only one of `server_certificate`, `private_key`
+                            or `credential_name` or `credential_names` or `tls_certificates`
+                            should be specified.
+                          items:
+                            properties:
+                              caCertificates:
+                                type: string
+                              privateKey:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                              serverCertificate:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                            type: object
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         verifyCertificateHash:
                           description: An optional list of hex-encoded SHA-256 hashes
                             of the authorized client certificates.
@@ -8826,6 +9035,19 @@ spec:
                             type: string
                           type: array
                       type: object
+                      x-kubernetes-validations:
+                      - message: only one of credentialNames or tlsCertificates can
+                          be set
+                        rule: '(has(self.tlsCertificates) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or credentialNames can
+                          be set
+                        rule: '(has(self.credentialName) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or tlsCertificates can
+                          be set
+                        rule: '(has(self.credentialNames) ? 1 : 0) + (has(self.tlsCertificates)
+                          ? 1 : 0) <= 1'
                   required:
                   - port
                   type: object
@@ -8958,7 +9180,7 @@ spec:
             x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - name: v1alpha3
@@ -9083,9 +9305,6 @@ spec:
                       idleTimeout:
                         description: The idle timeout for TCP connections.
                         type: string
-                        x-kubernetes-validations:
-                        - message: must be a valid duration greater than 1ms
-                          rule: duration(self) >= duration('1ms')
                       maxConnectionDuration:
                         description: The maximum duration of a connection.
                         type: string
@@ -9209,9 +9428,6 @@ spec:
                             idleTimeout:
                               description: The idle timeout for TCP connections.
                               type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
                             maxConnectionDuration:
                               description: The maximum duration of a connection.
                               type: string
@@ -9301,6 +9517,13 @@ spec:
                             of the secret that holds the TLS certs including the CA
                             certificates.
                           type: string
+                        credentialNames:
+                          description: Same as CredentialName but for multiple certificates.
+                          items:
+                            type: string
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         httpsRedirect:
                           description: If set to true, the load balancer will send
                             a 301 redirect for all http connections, asking the clients
@@ -9355,6 +9578,24 @@ spec:
                           items:
                             type: string
                           type: array
+                        tlsCertificates:
+                          description: Only one of `server_certificate`, `private_key`
+                            or `credential_name` or `credential_names` or `tls_certificates`
+                            should be specified.
+                          items:
+                            properties:
+                              caCertificates:
+                                type: string
+                              privateKey:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                              serverCertificate:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                            type: object
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         verifyCertificateHash:
                           description: An optional list of hex-encoded SHA-256 hashes
                             of the authorized client certificates.
@@ -9368,6 +9609,19 @@ spec:
                             type: string
                           type: array
                       type: object
+                      x-kubernetes-validations:
+                      - message: only one of credentialNames or tlsCertificates can
+                          be set
+                        rule: '(has(self.tlsCertificates) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or credentialNames can
+                          be set
+                        rule: '(has(self.credentialName) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or tlsCertificates can
+                          be set
+                        rule: '(has(self.credentialNames) ? 1 : 0) + (has(self.tlsCertificates)
+                          ? 1 : 0) <= 1'
                   required:
                   - port
                   type: object
@@ -9625,9 +9879,6 @@ spec:
                       idleTimeout:
                         description: The idle timeout for TCP connections.
                         type: string
-                        x-kubernetes-validations:
-                        - message: must be a valid duration greater than 1ms
-                          rule: duration(self) >= duration('1ms')
                       maxConnectionDuration:
                         description: The maximum duration of a connection.
                         type: string
@@ -9751,9 +10002,6 @@ spec:
                             idleTimeout:
                               description: The idle timeout for TCP connections.
                               type: string
-                              x-kubernetes-validations:
-                              - message: must be a valid duration greater than 1ms
-                                rule: duration(self) >= duration('1ms')
                             maxConnectionDuration:
                               description: The maximum duration of a connection.
                               type: string
@@ -9843,6 +10091,13 @@ spec:
                             of the secret that holds the TLS certs including the CA
                             certificates.
                           type: string
+                        credentialNames:
+                          description: Same as CredentialName but for multiple certificates.
+                          items:
+                            type: string
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         httpsRedirect:
                           description: If set to true, the load balancer will send
                             a 301 redirect for all http connections, asking the clients
@@ -9897,6 +10152,24 @@ spec:
                           items:
                             type: string
                           type: array
+                        tlsCertificates:
+                          description: Only one of `server_certificate`, `private_key`
+                            or `credential_name` or `credential_names` or `tls_certificates`
+                            should be specified.
+                          items:
+                            properties:
+                              caCertificates:
+                                type: string
+                              privateKey:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                              serverCertificate:
+                                description: REQUIRED if mode is `SIMPLE` or `MUTUAL`.
+                                type: string
+                            type: object
+                          maxItems: 2
+                          minItems: 1
+                          type: array
                         verifyCertificateHash:
                           description: An optional list of hex-encoded SHA-256 hashes
                             of the authorized client certificates.
@@ -9910,6 +10183,19 @@ spec:
                             type: string
                           type: array
                       type: object
+                      x-kubernetes-validations:
+                      - message: only one of credentialNames or tlsCertificates can
+                          be set
+                        rule: '(has(self.tlsCertificates) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or credentialNames can
+                          be set
+                        rule: '(has(self.credentialName) ? 1 : 0) + (has(self.credentialNames)
+                          ? 1 : 0) <= 1'
+                      - message: only one of credentialName or tlsCertificates can
+                          be set
+                        rule: '(has(self.credentialNames) ? 1 : 0) + (has(self.tlsCertificates)
+                          ? 1 : 0) <= 1'
                   required:
                   - port
                   type: object
@@ -10042,7 +10328,7 @@ spec:
             x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
 ---
@@ -10060,8 +10346,8 @@ metadata:
     app.kubernetes.io/instance: istio-base
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
+    helm.sh/chart: base-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
   name: virtualservices.networking.istio.io
 spec:
   group: networking.istio.io
@@ -10746,6 +11032,13 @@ spec:
                             request.
                           format: int32
                           type: integer
+                        backoff:
+                          description: Specifies the minimum duration between retry
+                            attempts.
+                          type: string
+                          x-kubernetes-validations:
+                          - message: must be a valid duration greater than 1ms
+                            rule: duration(self) >= duration('1ms')
                         perTryTimeout:
                           description: Timeout per attempt for a given request, including
                             the initial call and any retries.
@@ -11119,7 +11412,7 @@ spec:
             x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -11791,6 +12084,13 @@ spec:
                             request.
                           format: int32
                           type: integer
+                        backoff:
+                          description: Specifies the minimum duration between retry
+                            attempts.
+                          type: string
+                          x-kubernetes-validations:
+                          - message: must be a valid duration greater than 1ms
+                            rule: duration(self) >= duration('1ms')
                         perTryTimeout:
                           description: Timeout per attempt for a given request, including
                             the initial call and any retries.
@@ -12836,6 +13136,13 @@ spec:
                             request.
                           format: int32
                           type: integer
+                        backoff:
+                          description: Specifies the minimum duration between retry
+                            attempts.
+                          type: string
+                          x-kubernetes-validations:
+                          - message: must be a valid duration greater than 1ms
+                            rule: duration(self) >= duration('1ms')
                         perTryTimeout:
                           description: Timeout per attempt for a given request, including
                             the initial call and any retries.
@@ -13209,7 +13516,7 @@ spec:
             x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
 ---
@@ -13227,8 +13534,8 @@ metadata:
     app.kubernetes.io/instance: istio-base
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
+    helm.sh/chart: base-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
   name: workloadentries.networking.istio.io
 spec:
   group: networking.istio.io
@@ -13401,7 +13708,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -13721,7 +14028,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
 ---
@@ -13737,8 +14044,8 @@ metadata:
     app.kubernetes.io/instance: istio-base
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
+    helm.sh/chart: base-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
   name: workloadgroups.networking.istio.io
 spec:
   group: networking.istio.io
@@ -14059,7 +14366,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: false
+    storage: true
     subresources:
       status: {}
   - additionalPrinterColumns:
@@ -14675,7 +14982,7 @@ spec:
         - spec
         type: object
     served: true
-    storage: true
+    storage: false
     subresources:
       status: {}
 ---
@@ -14693,8 +15000,8 @@ metadata:
     app.kubernetes.io/instance: istio-base
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
+    helm.sh/chart: base-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
   name: authorizationpolicies.security.istio.io
 spec:
   group: security.istio.io
@@ -15465,8 +15772,8 @@ metadata:
     app.kubernetes.io/instance: istio-base
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
+    helm.sh/chart: base-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
   name: peerauthentications.security.istio.io
 spec:
   group: security.istio.io
@@ -15823,8 +16130,8 @@ metadata:
     app.kubernetes.io/instance: istio-base
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
+    helm.sh/chart: base-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
   name: requestauthentications.security.istio.io
 spec:
   group: security.istio.io
@@ -15949,8 +16256,6 @@ spec:
                       x-kubernetes-validations:
                       - message: must be a valid duration greater than 1ms
                         rule: duration(self) >= duration('1ms')
-                  required:
-                  - issuer
                   type: object
                   x-kubernetes-validations:
                   - message: only one of jwks or jwksUri can be set
@@ -16232,8 +16537,6 @@ spec:
                       x-kubernetes-validations:
                       - message: must be a valid duration greater than 1ms
                         rule: duration(self) >= duration('1ms')
-                  required:
-                  - issuer
                   type: object
                   x-kubernetes-validations:
                   - message: only one of jwks or jwksUri can be set
@@ -16421,8 +16724,8 @@ metadata:
     app.kubernetes.io/instance: istio-base
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: 1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
+    helm.sh/chart: base-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
   name: telemetries.telemetry.istio.io
 spec:
   group: telemetry.istio.io
@@ -17352,8 +17655,8 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "istio-base"
     app.kubernetes.io/part-of: "istio"
-    app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: base-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
 webhooks:
   - name: validation.istio.io
     clientConfig:

--- a/test/overlays/llm-istio-experimental/istiod.yaml
+++ b/test/overlays/llm-istio-experimental/istiod.yaml
@@ -17,8 +17,8 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "istiod"
     app.kubernetes.io/part-of: "istio"
-    app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: istiod-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
 spec:
   minAvailable: 1
   selector:
@@ -40,15 +40,17 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "istiod"
     app.kubernetes.io/part-of: "istio"
-    app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: istiod-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
 ---
-# Source: istiod/templates/configmap.yaml
+# Source: istiod/templates/configmap-values.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio
+  name: values
   namespace: istio-system
+  annotations:
+    kubernetes.io/description: This ConfigMap contains the Helm values used during chart rendering. This ConfigMap is rendered for debugging purposes and external tooling; modifying these values has no effect.
   labels:
     istio.io/rev: "default"
     install.operator.istio.io/owning-resource: unknown
@@ -58,45 +60,41 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "istiod"
     app.kubernetes.io/part-of: "istio"
-    app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: istiod-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
 data:
-
-  # Configuration file for the mesh networks to be used by the Split Horizon EDS.
-  meshNetworks: |-
-    networks: {}
-
-  mesh: |-
-    defaultConfig:
-      discoveryAddress: istiod.istio-system.svc:15012
-    defaultProviders:
-      metrics:
-      - prometheus
-    enablePrometheusMerge: true
-    rootNamespace: istio-system
-    trustDomain: cluster.local
----
-# Source: istiod/templates/istiod-injector-configmap.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: istio-sidecar-injector
-  namespace: istio-system
-  labels:
-    istio.io/rev: "default"
-    install.operator.istio.io/owning-resource: unknown
-    operator.istio.io/component: "Pilot"
-    release: istiod
-    app.kubernetes.io/name: "istiod"
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "istiod"
-    app.kubernetes.io/part-of: "istio"
-    app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
-data:
-
-  values: |-
+  original-values: |-
     {
+      "hub": "gcr.io/istio-testing",
+      "tag": "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    }
+  merged-values: |-
+    {
+      "affinity": {},
+      "autoscaleBehavior": {},
+      "autoscaleEnabled": true,
+      "autoscaleMax": 5,
+      "autoscaleMin": 1,
+      "base": {
+        "enableIstioConfigCRDs": true
+      },
+      "cni": {
+        "enabled": false,
+        "provider": "default"
+      },
+      "configMap": true,
+      "cpu": {
+        "targetAverageUtilization": 80
+      },
+      "deploymentAnnotations": {},
+      "deploymentLabels": {},
+      "env": {},
+      "envVarFrom": [],
+      "experimental": {
+        "stableValidationPolicy": false
+      },
+      "extraContainerArgs": [],
+      "gatewayClasses": {},
       "gateways": {
         "seccompProfile": {},
         "securityContext": {}
@@ -131,8 +129,7 @@ data:
         "meshNetworks": {},
         "mountMtlsCerts": false,
         "multiCluster": {
-          "clusterName": "",
-          "enabled": false
+          "clusterName": ""
         },
         "network": "",
         "omitSidecarInjectorConfigMap": false,
@@ -186,7 +183,242 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d",
+        "tag": "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7",
+        "variant": "",
+        "waypoint": {
+          "affinity": {},
+          "nodeSelector": {},
+          "resources": {
+            "limits": {
+              "cpu": "2",
+              "memory": "1Gi"
+            },
+            "requests": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            }
+          },
+          "tolerations": [],
+          "topologySpreadConstraints": []
+        }
+      },
+      "hub": "gcr.io/istio-testing",
+      "image": "pilot",
+      "initContainers": [],
+      "ipFamilies": [],
+      "ipFamilyPolicy": "",
+      "istiodRemote": {
+        "enabled": false,
+        "enabledLocalInjectorIstiod": false,
+        "injectionCABundle": "",
+        "injectionPath": "/inject",
+        "injectionURL": ""
+      },
+      "jwksResolverExtraRootCA": "",
+      "keepaliveMaxServerConnectionAge": "30m",
+      "memory": {},
+      "meshConfig": {
+        "enablePrometheusMerge": true
+      },
+      "nodeSelector": {},
+      "ownerName": "",
+      "podAnnotations": {},
+      "podLabels": {},
+      "replicaCount": 1,
+      "resources": {
+        "requests": {
+          "cpu": "500m",
+          "memory": "2048Mi"
+        }
+      },
+      "revision": "",
+      "revisionTags": [],
+      "rollingMaxSurge": "100%",
+      "rollingMaxUnavailable": "25%",
+      "seccompProfile": {},
+      "serviceAccountAnnotations": {},
+      "serviceAnnotations": {},
+      "sidecarInjectorWebhook": {
+        "alwaysInjectSelector": [],
+        "defaultTemplates": [],
+        "enableNamespacesByDefault": false,
+        "injectedAnnotations": {},
+        "neverInjectSelector": [],
+        "reinvocationPolicy": "Never",
+        "rewriteAppHTTPProbe": true,
+        "templates": {}
+      },
+      "sidecarInjectorWebhookAnnotations": {},
+      "tag": "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7",
+      "taint": {
+        "enabled": false,
+        "namespace": ""
+      },
+      "telemetry": {
+        "enabled": true,
+        "v2": {
+          "enabled": true,
+          "prometheus": {
+            "enabled": true
+          },
+          "stackdriver": {
+            "enabled": false
+          }
+        }
+      },
+      "tolerations": [],
+      "topologySpreadConstraints": [],
+      "traceSampling": 1,
+      "trustedZtunnelName": "",
+      "trustedZtunnelNamespace": "",
+      "variant": "",
+      "volumeMounts": [],
+      "volumes": []
+    }
+---
+# Source: istiod/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio
+  namespace: istio-system
+  labels:
+    istio.io/rev: "default"
+    install.operator.istio.io/owning-resource: unknown
+    operator.istio.io/component: "Pilot"
+    release: istiod
+    app.kubernetes.io/name: "istiod"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "istiod"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: istiod-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
+data:
+
+  # Configuration file for the mesh networks to be used by the Split Horizon EDS.
+  meshNetworks: |-
+    networks: {}
+
+  mesh: |-
+    defaultConfig:
+      discoveryAddress: istiod.istio-system.svc:15012
+    defaultProviders:
+      metrics:
+      - prometheus
+    enablePrometheusMerge: true
+    rootNamespace: istio-system
+    trustDomain: cluster.local
+---
+# Source: istiod/templates/istiod-injector-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-sidecar-injector
+  namespace: istio-system
+  labels:
+    istio.io/rev: "default"
+    install.operator.istio.io/owning-resource: unknown
+    operator.istio.io/component: "Pilot"
+    release: istiod
+    app.kubernetes.io/name: "istiod"
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "istiod"
+    app.kubernetes.io/part-of: "istio"
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: istiod-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
+data:
+
+  values: |-
+    {
+      "gateways": {
+        "seccompProfile": {},
+        "securityContext": {}
+      },
+      "global": {
+        "caAddress": "",
+        "caName": "",
+        "certSigners": [],
+        "configCluster": false,
+        "configValidation": true,
+        "defaultPodDisruptionBudget": {
+          "enabled": true
+        },
+        "defaultResources": {
+          "requests": {
+            "cpu": "10m"
+          }
+        },
+        "externalIstiod": false,
+        "hub": "gcr.io/istio-testing",
+        "imagePullPolicy": "",
+        "imagePullSecrets": [],
+        "istioNamespace": "istio-system",
+        "istiod": {
+          "enableAnalysis": false
+        },
+        "logAsJson": false,
+        "logging": {
+          "level": "default:info"
+        },
+        "meshID": "",
+        "meshNetworks": {},
+        "mountMtlsCerts": false,
+        "multiCluster": {
+          "clusterName": ""
+        },
+        "network": "",
+        "omitSidecarInjectorConfigMap": false,
+        "operatorManageWebhooks": false,
+        "pilotCertProvider": "istiod",
+        "priorityClassName": "",
+        "proxy": {
+          "autoInject": "enabled",
+          "clusterDomain": "cluster.local",
+          "componentLogLevel": "misc:error",
+          "excludeIPRanges": "",
+          "excludeInboundPorts": "",
+          "excludeOutboundPorts": "",
+          "image": "proxyv2",
+          "includeIPRanges": "*",
+          "includeInboundPorts": "*",
+          "includeOutboundPorts": "",
+          "logLevel": "warning",
+          "outlierLogPath": "",
+          "privileged": false,
+          "readinessFailureThreshold": 4,
+          "readinessInitialDelaySeconds": 0,
+          "readinessPeriodSeconds": 15,
+          "resources": {
+            "limits": {
+              "cpu": "2000m",
+              "memory": "1024Mi"
+            },
+            "requests": {
+              "cpu": "100m",
+              "memory": "128Mi"
+            }
+          },
+          "startupProbe": {
+            "enabled": true,
+            "failureThreshold": 600
+          },
+          "statusPort": 15020,
+          "tracer": "none"
+        },
+        "proxy_init": {
+          "forceApplyIptables": false,
+          "image": "proxyv2"
+        },
+        "remotePilotAddress": "",
+        "sds": {
+          "token": {
+            "aud": "istio-ca"
+          }
+        },
+        "sts": {
+          "servicePort": 0
+        },
+        "tag": "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7",
         "variant": "",
         "waypoint": {
           "affinity": {},
@@ -209,7 +441,8 @@ data:
         "cni": {
           "enabled": false,
           "provider": "default"
-        }
+        },
+        "env": {}
       },
       "revision": "",
       "sidecarInjectorWebhook": {
@@ -268,6 +501,8 @@ data:
           {{- end }}
         {{- end }}
         {{ $nativeSidecar := (or (and (not (isset .ObjectMeta.Annotations `sidecar.istio.io/nativeSidecar`)) (eq (env "ENABLE_NATIVE_SIDECARS" "false") "true")) (eq (index .ObjectMeta.Annotations `sidecar.istio.io/nativeSidecar`) "true")) }}
+        {{ $tproxy := (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) }}
+        {{ $capNetBindService := (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) }}
         {{- $containers := list }}
         {{- range $index, $container := .Spec.Containers }}{{ if not (eq $container.Name "istio-proxy") }}{{ $containers = append $containers $container.Name }}{{end}}{{- end}}
         metadata:
@@ -337,7 +572,7 @@ data:
             - "-z"
             - {{ .MeshConfig.ProxyInboundListenPort | default "15006" | quote }}
             - "-u"
-            - {{ .ProxyUID | default "1337" | quote }}
+            - {{ if $tproxy }} "1337" {{ else }} {{ .ProxyUID | default "1337" | quote }} {{ end }}
             - "-m"
             - "{{ annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode }}"
             - "-i"
@@ -410,8 +645,8 @@ data:
               runAsUser: 0
             {{- else }}
               readOnlyRootFilesystem: true
-              runAsGroup: {{ .ProxyGID | default "1337" }}
-              runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ if $tproxy }} 1337 {{ else }} {{ .ProxyGID | default "1337" }} {{ end }}
+              runAsUser: {{ if $tproxy }} 1337 {{ else }} {{ .ProxyUID | default "1337" }} {{ end }}
               runAsNonRoot: true
             {{- end }}
           {{ end -}}
@@ -618,12 +853,12 @@ data:
               {{- else }}
               allowPrivilegeEscalation: {{ .Values.global.proxy.privileged }}
               capabilities:
-                {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
+                {{ if or $tproxy $capNetBindService -}}
                 add:
-                {{ if eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY` -}}
+                {{ if $tproxy -}}
                 - NET_ADMIN
                 {{- end }}
-                {{ if eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true` -}}
+                {{ if $capNetBindService -}}
                 - NET_BIND_SERVICE
                 {{- end }}
                 {{- end }}
@@ -631,13 +866,14 @@ data:
                 - ALL
               privileged: {{ .Values.global.proxy.privileged }}
               readOnlyRootFilesystem: true
-              runAsGroup: {{ .ProxyGID | default "1337" }}
-              {{ if or (eq (annotation .ObjectMeta `sidecar.istio.io/interceptionMode` .ProxyConfig.InterceptionMode) `TPROXY`) (eq (annotation .ObjectMeta `sidecar.istio.io/capNetBindService` .Values.global.proxy.capNetBindService) `true`) -}}
+              {{ if or $tproxy $capNetBindService -}}
               runAsNonRoot: false
               runAsUser: 0
+              runAsGroup: 1337
               {{- else -}}
               runAsNonRoot: true
               runAsUser: {{ .ProxyUID | default "1337" }}
+              runAsGroup: {{ .ProxyGID | default "1337" }}
               {{- end }}
               {{- end }}
             resources:
@@ -658,6 +894,8 @@ data:
             {{- if eq .Values.global.pilotCertProvider "istiod" }}
             - mountPath: /var/run/secrets/istio
               name: istiod-ca-cert
+            - mountPath: /var/run/secrets/istio/crl
+              name: istio-ca-crl
             {{- end }}
             - mountPath: /var/lib/istio/data
               name: istio-data
@@ -731,9 +969,21 @@ data:
                   audience: {{ .Values.global.sds.token.aud }}
           {{- if eq .Values.global.pilotCertProvider "istiod" }}
           - name: istiod-ca-cert
+          {{- if eq (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
+            projected:
+              sources:
+              - clusterTrustBundle:
+                  name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
+                  path: root-cert.pem
+          {{- else }}
             configMap:
-              name: istio-ca-root-cert
+              name: {{ .Values.global.trustBundleName | default "istio-ca-root-cert" }}
           {{- end }}
+          {{- end }}
+          - name: istio-ca-crl
+            configMap:
+              name: istio-ca-crl
+              optional: true
           {{- if .Values.global.mountMtlsCerts }}
           # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
           - name: istio-certs
@@ -904,6 +1154,10 @@ data:
             - name: ISTIO_META_OWNER
               value: kubernetes://apis/{{ .TypeMeta.APIVersion }}/namespaces/{{ valueOrDefault .DeploymentMeta.Namespace `default` }}/{{ toLower .TypeMeta.Kind}}s/{{ .DeploymentMeta.Name }}
             {{- end}}
+            {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
+            - name: ISTIO_BOOTSTRAP_OVERRIDE
+              value: "/etc/istio/custom-bootstrap/custom_bootstrap.json"
+            {{- end }}
             {{- if .Values.global.meshID }}
             - name: ISTIO_META_MESH_ID
               value: "{{ .Values.global.meshID }}"
@@ -947,6 +1201,10 @@ data:
             {{- end }}
             - mountPath: /var/lib/istio/data
               name: istio-data
+            {{ if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
+            - mountPath: /etc/istio/custom-bootstrap
+              name: custom-bootstrap-volume
+            {{- end }}
             # SDS channel between istioagent and Envoy
             - mountPath: /etc/istio/proxy
               name: istio-envoy
@@ -961,7 +1219,7 @@ data:
             - name: istio-podinfo
               mountPath: /etc/istio/pod
           volumes:
-          - emptyDir: {}
+          - emptyDir:
             name: workload-socket
           - emptyDir: {}
             name: credential-socket
@@ -972,6 +1230,11 @@ data:
           {{- else}}
           - emptyDir: {}
             name: workload-certs
+          {{- end }}
+          {{- if (isset .ObjectMeta.Annotations `sidecar.istio.io/bootstrapOverride`) }}
+          - name: custom-bootstrap-volume
+            configMap:
+              name: {{ annotation .ObjectMeta `sidecar.istio.io/bootstrapOverride` "" }}
           {{- end }}
           # SDS channel between istioagent and Envoy
           - emptyDir:
@@ -997,8 +1260,16 @@ data:
                   audience: {{ .Values.global.sds.token.aud }}
           {{- if eq .Values.global.pilotCertProvider "istiod" }}
           - name: istiod-ca-cert
+          {{- if eq (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
+            projected:
+              sources:
+              - clusterTrustBundle:
+                  name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
+                  path: root-cert.pem
+          {{- else }}
             configMap:
-              name: istio-ca-root-cert
+              name: {{ .Values.global.trustBundleName | default "istio-ca-root-cert" }}
+          {{- end }}
           {{- end }}
           {{- if .Values.global.mountMtlsCerts }}
           # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
@@ -1368,8 +1639,16 @@ data:
                   audience: {{ .Values.global.sds.token.aud }}
           {{- if eq .Values.global.pilotCertProvider "istiod" }}
           - name: istiod-ca-cert
+          {{- if eq (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
+            projected:
+              sources:
+              - clusterTrustBundle:
+                  name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
+                  path: root-cert.pem
+          {{- else }}
             configMap:
-              name: istio-ca-root-cert
+              name: {{ .Values.global.trustBundleName | default "istio-ca-root-cert" }}
+          {{- end }}
           {{- end }}
           {{- if .Values.global.mountMtlsCerts }}
           # Use the key and cert mounted to /etc/certs/ for the in-cluster mTLS communications.
@@ -1429,7 +1708,7 @@ data:
               .InfrastructureLabels
               (strdict
                 "gateway.networking.k8s.io/gateway-name" .Name
-                "gateway.istio.io/managed" "istio.io-mesh-controller"
+                "gateway.istio.io/managed" .ControllerLabel
               ) | nindent 4 }}
           ownerReferences:
           - apiVersion: gateway.networking.k8s.io/v1beta1
@@ -1462,7 +1741,7 @@ data:
                   .InfrastructureLabels
                   (strdict
                     "gateway.networking.k8s.io/gateway-name" .Name
-                    "gateway.istio.io/managed" "istio.io-mesh-controller"
+                    "gateway.istio.io/managed" .ControllerLabel
                   ) | nindent 8}}
             spec:
               {{- if .Values.global.waypoint.affinity }}
@@ -1684,9 +1963,17 @@ data:
                       audience: istio-ca
                       expirationSeconds: 43200
                       path: istio-token
-              - configMap:
-                  name: istio-ca-root-cert
-                name: istiod-ca-cert
+              - name: istiod-ca-cert
+              {{- if eq (.Values.pilot.env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
+                projected:
+                  sources:
+                  - clusterTrustBundle:
+                      name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
+                      path: root-cert.pem
+              {{- else }}
+                configMap:
+                  name: {{ .Values.global.trustBundleName | default "istio-ca-root-cert" }}
+              {{- end }}
               {{- if .Values.global.imagePullSecrets }}
               imagePullSecrets:
                 {{- range .Values.global.imagePullSecrets }}
@@ -1735,6 +2022,53 @@ data:
           {{- end }}
           type: {{ .ServiceType | quote }}
         ---
+        apiVersion: autoscaling/v2
+        kind: HorizontalPodAutoscaler
+        metadata:
+          name: {{.DeploymentName | quote}}
+          namespace: {{.Namespace | quote}}
+          annotations:
+            {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+          labels:
+            {{- toJsonMap
+                  .InfrastructureLabels
+                  (strdict
+                  "gateway.networking.k8s.io/gateway-name" .Name
+                  ) | nindent 4 }}
+          ownerReferences:
+            - apiVersion: gateway.networking.k8s.io/v1beta1
+              kind: Gateway
+              name: {{.Name}}
+              uid: "{{.UID}}"
+        spec:
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name:  {{.DeploymentName | quote}}
+          maxReplicas: 1
+        ---
+        apiVersion: policy/v1
+        kind: PodDisruptionBudget
+        metadata:
+          name: {{.DeploymentName | quote}}
+          namespace: {{.Namespace | quote}}
+          annotations:
+            {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+          labels:
+            {{- toJsonMap
+                  .InfrastructureLabels
+                  (strdict
+                  "gateway.networking.k8s.io/gateway-name" .Name
+                  ) | nindent 4 }}
+          ownerReferences:
+            - apiVersion: gateway.networking.k8s.io/v1beta1
+              kind: Gateway
+              name: {{.Name}}
+              uid: "{{.UID}}"
+        spec:
+          selector:
+            matchLabels:
+              gateway.networking.k8s.io/gateway-name: {{.Name|quote}}
       kube-gateway: |
         apiVersion: v1
         kind: ServiceAccount
@@ -2037,8 +2371,16 @@ data:
                       audience: {{ .Values.global.sds.token.aud }}
               {{- if eq .Values.global.pilotCertProvider "istiod" }}
               - name: istiod-ca-cert
+              {{- if eq ((.Values.pilot).env).ENABLE_CLUSTER_TRUST_BUNDLE_API true }}
+                projected:
+                  sources:
+                  - clusterTrustBundle:
+                      name: istio.io:istiod-ca:{{ .Values.global.trustBundleName | default "root-cert" }}
+                      path: root-cert.pem
+              {{- else }}
                 configMap:
-                  name: istio-ca-root-cert
+                  name: {{ .Values.global.trustBundleName | default "istio-ca-root-cert" }}
+              {{- end }}
               {{- end }}
               {{- if .Values.global.imagePullSecrets }}
               imagePullSecrets:
@@ -2081,6 +2423,53 @@ data:
           {{- end }}
           type: {{ .ServiceType | quote }}
         ---
+        apiVersion: autoscaling/v2
+        kind: HorizontalPodAutoscaler
+        metadata:
+          name: {{.DeploymentName | quote}}
+          namespace: {{.Namespace | quote}}
+          annotations:
+            {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+          labels:
+            {{- toJsonMap
+                  .InfrastructureLabels
+                  (strdict
+                  "gateway.networking.k8s.io/gateway-name" .Name
+                  ) | nindent 4 }}
+          ownerReferences:
+            - apiVersion: gateway.networking.k8s.io/v1beta1
+              kind: Gateway
+              name: {{.Name}}
+              uid: "{{.UID}}"
+        spec:
+          scaleTargetRef:
+            apiVersion: apps/v1
+            kind: Deployment
+            name:  {{.DeploymentName | quote}}
+          maxReplicas: 1
+        ---
+        apiVersion: policy/v1
+        kind: PodDisruptionBudget
+        metadata:
+          name: {{.DeploymentName | quote}}
+          namespace: {{.Namespace | quote}}
+          annotations:
+            {{- toJsonMap (omit .InfrastructureAnnotations "kubectl.kubernetes.io/last-applied-configuration" "gateway.istio.io/name-override" "gateway.istio.io/service-account" "gateway.istio.io/controller-version") | nindent 4 }}
+          labels:
+            {{- toJsonMap
+                  .InfrastructureLabels
+                  (strdict
+                  "gateway.networking.k8s.io/gateway-name" .Name
+                  ) | nindent 4 }}
+          ownerReferences:
+            - apiVersion: gateway.networking.k8s.io/v1beta1
+              kind: Gateway
+              name: {{.Name}}
+              uid: "{{.UID}}"
+        spec:
+          selector:
+            matchLabels:
+              gateway.networking.k8s.io/gateway-name: {{.Name|quote}}
 ---
 # Source: istiod/templates/clusterrole.yaml
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
@@ -2096,8 +2485,8 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "istiod"
     app.kubernetes.io/part-of: "istio"
-    app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: istiod-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
 rules:
   # sidecar injection controller
   - apiGroups: ["admissionregistration.k8s.io"]
@@ -2167,9 +2556,14 @@ rules:
     verbs: ["create"]
 
   # Use for Kubernetes Service APIs
-  - apiGroups: ["gateway.networking.k8s.io"]
+  - apiGroups: ["gateway.networking.k8s.io", "gateway.networking.x-k8s.io"]
     resources: ["*"]
     verbs: ["get", "watch", "list"]
+  - apiGroups: ["gateway.networking.x-k8s.io"]
+    resources:
+    - xbackendtrafficpolicies/status
+    - xlistenersets/status
+    verbs: ["update", "patch"]
   - apiGroups: ["gateway.networking.k8s.io"]
     resources:
     - backendtlspolicies/status
@@ -2219,12 +2613,18 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "istiod"
     app.kubernetes.io/part-of: "istio"
-    app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: istiod-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
 rules:
   - apiGroups: ["apps"]
     verbs: [ "get", "watch", "list", "update", "patch", "create", "delete" ]
     resources: [ "deployments" ]
+  - apiGroups: ["autoscaling"]
+    verbs: [ "get", "watch", "list", "update", "patch", "create", "delete" ]
+    resources: [ "horizontalpodautoscalers" ]
+  - apiGroups: ["policy"]
+    verbs: [ "get", "watch", "list", "update", "patch", "create", "delete" ]
+    resources: [ "poddisruptionbudgets" ]
   - apiGroups: [""]
     verbs: [ "get", "watch", "list", "update", "patch", "create", "delete" ]
     resources: [ "services" ]
@@ -2244,8 +2644,8 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "istiod"
     app.kubernetes.io/part-of: "istio"
-    app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: istiod-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
 rules:
   - apiGroups:
       - "config.istio.io"
@@ -2258,7 +2658,9 @@ rules:
     resources: ["*"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers", "namespaces", "secrets"]
+    # TODO(keithmattix): See if we can conditionally give permission to read secrets and configmaps iff externalIstiod
+    # is enabled. Best I can tell, these two resources are only needed for configuring proxy TLS (i.e. CA certs).
+    resources: ["endpoints", "pods", "services", "nodes", "replicationcontrollers", "namespaces", "secrets", "configmaps"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["networking.istio.io"]
     verbs: [ "get", "watch", "list" ]
@@ -2301,8 +2703,8 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "istiod"
     app.kubernetes.io/part-of: "istio"
-    app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: istiod-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -2324,8 +2726,8 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "istiod"
     app.kubernetes.io/part-of: "istio"
-    app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: istiod-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -2347,8 +2749,8 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "istiod"
     app.kubernetes.io/part-of: "istio"
-    app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: istiod-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -2372,8 +2774,8 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "istiod"
     app.kubernetes.io/part-of: "istio"
-    app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: istiod-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
 rules:
 # permissions to verify the webhook is ready and rejecting
 # invalid config. We use --server-dry-run so no config is persisted.
@@ -2411,8 +2813,8 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "istiod"
     app.kubernetes.io/part-of: "istio"
-    app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: istiod-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -2440,8 +2842,8 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "istiod"
     app.kubernetes.io/part-of: "istio"
-    app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: istiod-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
 spec:
   ports:
     - port: 15010
@@ -2481,8 +2883,8 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "istiod"
     app.kubernetes.io/part-of: "istio"
-    app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: istiod-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
 spec:
   strategy:
     rollingUpdate:
@@ -2505,8 +2907,8 @@ spec:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "istiod"
         app.kubernetes.io/part-of: "istio"
-        app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-        helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+        app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+        helm.sh/chart: istiod-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
       annotations:
         prometheus.io/port: "15014"
         prometheus.io/scrape: "true"
@@ -2518,7 +2920,7 @@ spec:
       serviceAccountName: istiod
       containers:
         - name: discovery
-          image: "gcr.io/istio-testing/pilot:1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
+          image: "gcr.io/istio-testing/pilot:1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
           args:
           - "discovery"
           - --monitoringAddr=:15014
@@ -2593,6 +2995,7 @@ spec:
             valueFrom:
               resourceFieldRef:
                 resource: limits.memory
+                divisor: "1"
           - name: GOMAXPROCS
             valueFrom:
               resourceFieldRef:
@@ -2679,8 +3082,8 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "istiod"
     app.kubernetes.io/part-of: "istio"
-    app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: istiod-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
 spec:
   maxReplicas: 5
   minReplicas: 1
@@ -2699,18 +3102,14 @@ spec:
 # Source: istiod/templates/configmap-jwks.yaml
 # Not created if istiod is running remotely
 ---
-# Source: istiod/templates/remote-istiod-endpoints.yaml
-# This file is only used for remote `istiod` installs.
----
 # Source: istiod/templates/remote-istiod-service.yaml
-# This file is only used for remote `istiod` installs.
+# This file is only used for remote
 ---
 # Source: istiod/templates/revision-tags.yaml
 # Adapted from istio-discovery/templates/mutatingwebhook.yaml
 # Removed paths for legacy and default selectors since a revision tag
 # is inherently created from a specific revision
 # TODO BML istiodRemote.injectionURL is invalid to set if `istiodRemote.enabled` is false, we should express that.
-# Not created if istiod is running remotely
 ---
 # Source: istiod/templates/validatingadmissionpolicy.yaml
 # Created if this is not a remote istiod, OR if it is and is also a config cluster
@@ -2735,8 +3134,8 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "istiod"
     app.kubernetes.io/part-of: "istio"
-    app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: istiod-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
 webhooks:
 - name: rev.namespace.sidecar-injector.istio.io
   clientConfig:
@@ -2874,8 +3273,8 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "istiod"
     app.kubernetes.io/part-of: "istio"
-    app.kubernetes.io/version: "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d"
-    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    app.kubernetes.io/version: "1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7"
+    helm.sh/chart: istiod-1.27-alpha.0551127f00634403cddd4634567e65a8ecc499a7
 webhooks:
   # Webhook handling per-revision validation. Mostly here so we can determine whether webhooks
   # are rejecting invalid configs on a per-revision basis.


### PR DESCRIPTION
While Istio 1.26 experimental GIE build was silently falling back to model when Endpoint Picker service was not created, with the lately merged 1.27 alpha builds this yields  an error and makes it impossible to curl the model using well-known URL.

This PR enhances the reconcile logic and brings:

- missing `-epp-service` when the scheduler is managed by the reconciler
- required (for llm-d-scheduler using GIE epp machinery not aligned with release-1.0 branch) InferenceModel
- Istio 1.27-alpha build for testing

Fixes [RHOAIENG-29123](https://issues.redhat.com/browse/RHOAIENG-29123)

> [!IMPORTANT]
> While existence of the `InferenceModel` is [mandatory for the version of GIE in  `llm-d-scheduler` we use](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/release-0.4/pkg/epp/requestcontrol/director.go#L91-L97), it is not anymore in the  planned [1.0.0 version](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/release-1.0/pkg/epp/requestcontrol/director.go#L102-L111). Something to validate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scheduler now manages a dedicated InferenceModel resource and a corresponding Service, improving deployment flexibility.
  * Istio overlays updated to 1.27-alpha, introducing enhanced retry policies, TLS credential options, and new autoscaling/disruption budget resources for gateways.
  * Added support for custom bootstrap overrides and improved certificate handling in Istio deployments.

* **Documentation**
  * Updated deployment instructions to include required Istio DestinationRule configuration for proper HTTPS connectivity with self-signed certificates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->