### PR TITLE
chore: remaining Reconcile re-use

### DIFF
--- a/pkg/controller/llmisvc/lifecycle_crud.go
+++ b/pkg/controller/llmisvc/lifecycle_crud.go
@@ -70,7 +70,7 @@ func Delete[O client.Object, T client.Object](ctx context.Context, c clientWithR
 func Reconcile[O client.Object, T client.Object](ctx context.Context, c clientWithRecorder, owner O, empty, expected T, isEqual SemanticEqual[T]) error {
 	typeLogLine := logLineForObject(expected)
 
-	curr := empty
+	curr := empty.DeepCopyObject().(T)
 	if err := c.Get(ctx, client.ObjectKeyFromObject(expected), curr); err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			return fmt.Errorf("failed to get %s %s/%s: %w", typeLogLine, expected.GetNamespace(), expected.GetName(), err)

--- a/pkg/controller/llmisvc/scheduler.go
+++ b/pkg/controller/llmisvc/scheduler.go
@@ -29,11 +29,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"knative.dev/pkg/kmeta"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
 
@@ -41,14 +39,7 @@ import (
 )
 
 func (r *LLMInferenceServiceReconciler) reconcileScheduler(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {
-	serviceAccount, err := r.reconcileSchedulerServiceAccount(ctx, llmSvc)
-	if err != nil {
-		return err
-	}
-	if err := r.reconcileSchedulerRole(ctx, llmSvc); err != nil {
-		return err
-	}
-	if err := r.reconcileSchedulerRoleBinding(ctx, llmSvc, serviceAccount); err != nil {
+	if err := r.reconcileSchedulerServiceAccount(ctx, llmSvc); err != nil {
 		return err
 	}
 	if err := r.reconcileSchedulerInferenceModel(ctx, llmSvc); err != nil {
@@ -67,51 +58,45 @@ func (r *LLMInferenceServiceReconciler) reconcileScheduler(ctx context.Context, 
 }
 
 func (r *LLMInferenceServiceReconciler) reconcileSchedulerRole(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {
-	expected := r.expectedSchedulerRole(llmSvc)
+	role := r.expectedSchedulerRole(llmSvc)
 	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil {
-		return Delete(ctx, r, llmSvc, expected)
+		return Delete(ctx, r, llmSvc, role)
 	}
-	curr := &rbacv1.Role{}
-	err := r.Client.Get(ctx, client.ObjectKeyFromObject(expected), curr)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to get role %s/%s: %w", expected.GetNamespace(), expected.GetName(), err)
+	if err := Reconcile(ctx, r, llmSvc, &rbacv1.Role{}, role, semanticRoleIsEqual); err != nil {
+		return fmt.Errorf("failed to reconcile scheduler deployment %s/%s: %w", role.GetNamespace(), role.GetName(), err)
 	}
-	if apierrors.IsNotFound(err) {
-		return Create(ctx, r, llmSvc, expected)
-	}
-	return Update(ctx, r, llmSvc, curr, expected, semanticRoleIsEqual)
+
+	return nil
 }
 
 func (r *LLMInferenceServiceReconciler) reconcileSchedulerRoleBinding(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService, sa *corev1.ServiceAccount) error {
-	expected := r.expectedSchedulerRoleBinding(llmSvc, sa)
+	roleBinding := r.expectedSchedulerRoleBinding(llmSvc, sa)
 	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil {
-		return Delete(ctx, r, llmSvc, expected)
+		return Delete(ctx, r, llmSvc, roleBinding)
 	}
-	curr := &rbacv1.RoleBinding{}
-	err := r.Client.Get(ctx, client.ObjectKeyFromObject(expected), curr)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to get role %s/%s: %w", expected.GetNamespace(), expected.GetName(), err)
+
+	if err := Reconcile(ctx, r, llmSvc, &rbacv1.RoleBinding{}, roleBinding, semanticRoleBindingIsEqual); err != nil {
+		return fmt.Errorf("failed to reconcile scheduler deployment %s/%s: %w", roleBinding.GetNamespace(), roleBinding.GetName(), err)
 	}
-	if apierrors.IsNotFound(err) {
-		return Create(ctx, r, llmSvc, expected)
-	}
-	return Update(ctx, r, llmSvc, curr, expected, semanticRoleBindingIsEqual)
+
+	return nil
 }
 
-func (r *LLMInferenceServiceReconciler) reconcileSchedulerServiceAccount(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) (*corev1.ServiceAccount, error) {
-	expected := r.expectedSchedulerServiceAccount(llmSvc)
+func (r *LLMInferenceServiceReconciler) reconcileSchedulerServiceAccount(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {
+	serviceAccount := r.expectedSchedulerServiceAccount(llmSvc)
 	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil {
-		return expected, Delete(ctx, r, llmSvc, expected)
+		return Delete(ctx, r, llmSvc, serviceAccount)
 	}
-	curr := &corev1.ServiceAccount{}
-	err := r.Client.Get(ctx, client.ObjectKeyFromObject(expected), curr)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return expected, fmt.Errorf("failed to get service account %s/%s: %w", expected.GetNamespace(), expected.GetName(), err)
+
+	if err := Reconcile(ctx, r, llmSvc, &corev1.ServiceAccount{}, serviceAccount, semanticServiceAccountIsEqual); err != nil {
+		return fmt.Errorf("failed to reconcile scheduler deployment %s/%s: %w", serviceAccount.GetNamespace(), serviceAccount.GetName(), err)
 	}
-	if apierrors.IsNotFound(err) {
-		return expected, Create(ctx, r, llmSvc, expected)
+
+	if err := r.reconcileSchedulerRole(ctx, llmSvc); err != nil {
+		return err
 	}
-	return expected, Update(ctx, r, llmSvc, curr, expected, semanticServiceAccountIsEqual)
+
+	return r.reconcileSchedulerRoleBinding(ctx, llmSvc, serviceAccount)
 }
 
 func (r *LLMInferenceServiceReconciler) reconcileSchedulerDeployment(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {

--- a/pkg/controller/llmisvc/scheduler.go
+++ b/pkg/controller/llmisvc/scheduler.go
@@ -63,7 +63,7 @@ func (r *LLMInferenceServiceReconciler) reconcileSchedulerRole(ctx context.Conte
 		return Delete(ctx, r, llmSvc, role)
 	}
 	if err := Reconcile(ctx, r, llmSvc, &rbacv1.Role{}, role, semanticRoleIsEqual); err != nil {
-		return fmt.Errorf("failed to reconcile scheduler deployment %s/%s: %w", role.GetNamespace(), role.GetName(), err)
+		return fmt.Errorf("failed to reconcile scheduler role %s/%s: %w", role.GetNamespace(), role.GetName(), err)
 	}
 
 	return nil
@@ -76,7 +76,7 @@ func (r *LLMInferenceServiceReconciler) reconcileSchedulerRoleBinding(ctx contex
 	}
 
 	if err := Reconcile(ctx, r, llmSvc, &rbacv1.RoleBinding{}, roleBinding, semanticRoleBindingIsEqual); err != nil {
-		return fmt.Errorf("failed to reconcile scheduler deployment %s/%s: %w", roleBinding.GetNamespace(), roleBinding.GetName(), err)
+		return fmt.Errorf("failed to reconcile scheduler rolebinding %s/%s: %w", roleBinding.GetNamespace(), roleBinding.GetName(), err)
 	}
 
 	return nil
@@ -89,7 +89,7 @@ func (r *LLMInferenceServiceReconciler) reconcileSchedulerServiceAccount(ctx con
 	}
 
 	if err := Reconcile(ctx, r, llmSvc, &corev1.ServiceAccount{}, serviceAccount, semanticServiceAccountIsEqual); err != nil {
-		return fmt.Errorf("failed to reconcile scheduler deployment %s/%s: %w", serviceAccount.GetNamespace(), serviceAccount.GetName(), err)
+		return fmt.Errorf("failed to reconcile scheduler service account %s/%s: %w", serviceAccount.GetNamespace(), serviceAccount.GetName(), err)
 	}
 
 	if err := r.reconcileSchedulerRole(ctx, llmSvc); err != nil {


### PR DESCRIPTION
After introducing generic `Reconcile` func I noticed that in a few places we still use old code that was extracted to promote common flow for reconcilation in our controller.

This change removes this duplication and groups `ServiceAccount`-related reconcilations (`ServiceAccount`, `Role` and `RoleBinding`) together.

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the reconciliation logic for scheduler resources, consolidating resource management into a unified process and simplifying error handling.
  * Improved internal object handling to ensure distinct copies are used during reconciliation operations.

* **Chores**
  * Removed unused imports related to client and API errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->