### PR TITLE
feat(storage): add OCI storage support via modelcars

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -175,11 +175,6 @@ func main() {
 		setupLog.Error(err, "unable to get ingress config.")
 		os.Exit(1)
 	}
-	storageInitializerConfig, err := v1beta1.GetStorageInitializerConfigs(isvcConfigMap)
-	if err != nil {
-		setupLog.Error(err, "unable to get storage initializer config.")
-		os.Exit(1)
-	}
 
 	// Update Global GPU Resource Type List when custom GPU resource types are provided
 	_, err = v1beta1.NewMultiNodeConfig(isvcConfigMap)
@@ -282,7 +277,6 @@ func main() {
 		Client:        mgr.GetClient(),
 		Clientset:     clientSet,
 		EventRecorder: llmEventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: "LLMInferenceServiceController"}),
-		StorageConfig: storageInitializerConfig,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "v1beta1Controller", "InferenceService")
 		os.Exit(1)

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -175,6 +175,11 @@ func main() {
 		setupLog.Error(err, "unable to get ingress config.")
 		os.Exit(1)
 	}
+	storageInitializerConfig, err := v1beta1.GetStorageInitializerConfigs(isvcConfigMap)
+	if err != nil {
+		setupLog.Error(err, "unable to get storage initializer config.")
+		os.Exit(1)
+	}
 
 	// Update Global GPU Resource Type List when custom GPU resource types are provided
 	_, err = v1beta1.NewMultiNodeConfig(isvcConfigMap)
@@ -277,6 +282,7 @@ func main() {
 		Client:        mgr.GetClient(),
 		Clientset:     clientSet,
 		EventRecorder: llmEventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: "LLMInferenceServiceController"}),
+		StorageConfig: storageInitializerConfig,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "v1beta1Controller", "InferenceService")
 		os.Exit(1)

--- a/pkg/apis/serving/v1beta1/configmap.go
+++ b/pkg/apis/serving/v1beta1/configmap.go
@@ -25,26 +25,29 @@ import (
 	"text/template"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/types"
 	"github.com/kserve/kserve/pkg/utils"
 )
 
 // ConfigMap Keys
 const (
-	ExplainerConfigKeyName        = "explainers"
-	InferenceServiceConfigKeyName = "inferenceService"
-	IngressConfigKeyName          = "ingress"
-	DeployConfigName              = "deploy"
-	LocalModelConfigName          = "localModel"
-	SecurityConfigName            = "security"
-	ServiceConfigName             = "service"
-	ResourceConfigName            = "resource"
-	MultiNodeConfigKeyName        = "multiNode"
-	OtelCollectorConfigName       = "opentelemetryCollector"
+	ExplainerConfigKeyName             = "explainers"
+	InferenceServiceConfigKeyName      = "inferenceService"
+	IngressConfigKeyName               = "ingress"
+	DeployConfigName                   = "deploy"
+	LocalModelConfigName               = "localModel"
+	SecurityConfigName                 = "security"
+	ServiceConfigName                  = "service"
+	ResourceConfigName                 = "resource"
+	MultiNodeConfigKeyName             = "multiNode"
+	OtelCollectorConfigName            = "opentelemetryCollector"
+	StorageInitializerConfigMapKeyName = "storageInitializer"
 )
 
 const (
@@ -360,4 +363,43 @@ func NewServiceConfig(isvcConfigMap *corev1.ConfigMap) (*ServiceConfig, error) {
 		}
 	}
 	return serviceConfig, nil
+}
+
+// GetStorageInitializerConfigs parses the StorageInitializer configuration from the provided ConfigMap.
+// It unmarshals the JSON configuration under the "storageInitializer" key into a StorageInitializerConfig struct.
+// The fields related to CPU and memory resource values are validated to contain valid Kubernetes resource quantities.
+//
+// Parameters:
+//
+//	configMap: The Kubernetes ConfigMap containing the storage initializer configuration.
+//
+// Returns:
+//
+//	*types.StorageInitializerConfig: The parsed storage initializer configuration.
+//	error: An error if the configuration is missing, invalid, or resource values cannot be parsed.
+func GetStorageInitializerConfigs(configMap *corev1.ConfigMap) (*types.StorageInitializerConfig, error) {
+	storageInitializerConfig := &types.StorageInitializerConfig{}
+	if initializerConfig, ok := configMap.Data[StorageInitializerConfigMapKeyName]; ok {
+		err := json.Unmarshal([]byte(initializerConfig), &storageInitializerConfig)
+		if err != nil {
+			panic(fmt.Errorf("Unable to unmarshall %v json string due to %w ", StorageInitializerConfigMapKeyName, err))
+		}
+	}
+	// Ensure that we set proper values for CPU/Memory Limit/Request
+	resourceDefaults := []string{
+		storageInitializerConfig.MemoryRequest,
+		storageInitializerConfig.MemoryLimit,
+		storageInitializerConfig.CpuRequest,
+		storageInitializerConfig.CpuLimit,
+		storageInitializerConfig.CpuModelcar,
+		storageInitializerConfig.MemoryModelcar,
+	}
+	for _, key := range resourceDefaults {
+		_, err := resource.ParseQuantity(key)
+		if err != nil {
+			return storageInitializerConfig, fmt.Errorf("Failed to parse resource configuration for %q: %q", StorageInitializerConfigMapKeyName, err.Error())
+		}
+	}
+
+	return storageInitializerConfig, nil
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -154,8 +154,13 @@ var (
 )
 
 const (
-	PvcURIPrefix       = "pvc://"
-	PvcSourceMountName = "kserve-pvc-source"
+	OciURIPrefix                 = "oci://"
+	PvcURIPrefix                 = "pvc://"
+	PvcSourceMountName           = "kserve-pvc-source"
+	StorageInitializerVolumeName = "kserve-provision-location"
+
+	CpuModelcarDefault    = "10m"
+	MemoryModelcarDefault = "15Mi"
 )
 
 // Controller Constants
@@ -270,6 +275,7 @@ const (
 	CustomSpecMultiModelServerEnvVarKey               = "MULTI_MODEL_SERVER"
 	KServeContainerPrometheusMetricsPortEnvVarKey     = "KSERVE_CONTAINER_PROMETHEUS_METRICS_PORT"
 	KServeContainerPrometheusMetricsPathEnvVarKey     = "KSERVE_CONTAINER_PROMETHEUS_METRICS_PATH"
+	ModelInitModeEnv                                  = "MODEL_INIT_MODE"
 	QueueProxyAggregatePrometheusMetricsPortEnvVarKey = "AGGREGATE_PROMETHEUS_METRICS_PORT"
 )
 
@@ -368,6 +374,9 @@ const (
 	// WorkerContainerName is for worker node container
 	WorkerContainerName     = "worker-container"
 	QueueProxyContainerName = "queue-proxy"
+
+	ModelcarContainerName     = "modelcar"
+	ModelcarInitContainerName = "modelcar-init"
 )
 
 // DefaultModelLocalMountPath is where models will be mounted by the storage-initializer

--- a/pkg/controller/llmisvc/controller.go
+++ b/pkg/controller/llmisvc/controller.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
+	kserveTypes "github.com/kserve/kserve/pkg/types"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 
@@ -92,6 +93,8 @@ type LLMInferenceServiceReconciler struct {
 	client.Client
 	record.EventRecorder
 	Clientset kubernetes.Interface
+
+	StorageConfig *kserveTypes.StorageInitializerConfig
 }
 
 //+kubebuilder:rbac:groups=serving.kserve.io,resources=llminferenceservices,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/controller/llmisvc/fixture/required_resources.go
+++ b/pkg/controller/llmisvc/fixture/required_resources.go
@@ -22,12 +22,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
-	"github.com/kserve/kserve/pkg/constants"
-
 	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kserve/kserve/pkg/constants"
 
 	"github.com/kserve/kserve/pkg/testing"
 
@@ -83,6 +83,16 @@ func InferenceServiceCfgMap(ns string) *corev1.ConfigMap {
 				"localGateway": "knative-serving/knative-local-gateway",
 				"localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local",
 				"additionalIngressDomains": ["additional.example.com"]
+			}`,
+		"storageInitializer": `{
+				"memoryRequest": "100Mi",
+				"memoryLimit": "1Gi",
+				"cpuRequest": "100m",
+				"cpuLimit": "1",
+				"cpuModelcar": "10m",
+				"memoryModelcar": "15Mi",
+				"enableModelcar": true,
+				"uidModelcar": 1010
 			}`,
 	}
 	configMap := &corev1.ConfigMap{

--- a/pkg/controller/llmisvc/suite_test.go
+++ b/pkg/controller/llmisvc/suite_test.go
@@ -27,14 +27,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/controller/llmisvc"
 	"github.com/kserve/kserve/pkg/controller/llmisvc/fixture"
 	pkgtest "github.com/kserve/kserve/pkg/testing"
-	"github.com/kserve/kserve/pkg/types"
 )
 
 func TestLLMInferenceServiceController(t *testing.T) {
@@ -63,13 +61,6 @@ var _ = SynchronizedBeforeSuite(func() {
 			Clientset: clientSet,
 			// TODO fix it to be set up similar to main.go, for now it's stub
 			EventRecorder: eventBroadcaster.NewRecorder(mgr.GetScheme(), corev1.EventSource{Component: "v1beta1Controllers"}),
-
-			StorageConfig: &types.StorageInitializerConfig{
-				CpuModelcar:          "50m",
-				MemoryModelcar:       "50Mi",
-				EnableOciImageSource: true,
-				UidModelcar:          ptr.To[int64](0),
-			},
 		}
 		return llmCtrl.SetupWithManager(mgr)
 	}

--- a/pkg/controller/llmisvc/suite_test.go
+++ b/pkg/controller/llmisvc/suite_test.go
@@ -21,22 +21,20 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kserve/kserve/pkg/controller/llmisvc/fixture"
-
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-
-	"github.com/kserve/kserve/pkg/constants"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/record"
-	ctrl "sigs.k8s.io/controller-runtime"
-
-	"github.com/kserve/kserve/pkg/controller/llmisvc"
-	pkgtest "github.com/kserve/kserve/pkg/testing"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/controller/llmisvc"
+	"github.com/kserve/kserve/pkg/controller/llmisvc/fixture"
+	pkgtest "github.com/kserve/kserve/pkg/testing"
+	"github.com/kserve/kserve/pkg/types"
 )
 
 func TestLLMInferenceServiceController(t *testing.T) {
@@ -65,6 +63,13 @@ var _ = SynchronizedBeforeSuite(func() {
 			Clientset: clientSet,
 			// TODO fix it to be set up similar to main.go, for now it's stub
 			EventRecorder: eventBroadcaster.NewRecorder(mgr.GetScheme(), corev1.EventSource{Component: "v1beta1Controllers"}),
+
+			StorageConfig: &types.StorageInitializerConfig{
+				CpuModelcar:          "50m",
+				MemoryModelcar:       "50Mi",
+				EnableOciImageSource: true,
+				UidModelcar:          ptr.To[int64](0),
+			},
 		}
 		return llmCtrl.SetupWithManager(mgr)
 	}

--- a/pkg/controller/llmisvc/workload.go
+++ b/pkg/controller/llmisvc/workload.go
@@ -24,11 +24,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	kserveTypes "github.com/kserve/kserve/pkg/types"
 )
 
 // reconcileWorkload manages the Deployments and Services for the LLM.
 // It handles standard, multi-node, and disaggregated (prefill/decode) deployment patterns.
-func (r *LLMInferenceServiceReconciler) reconcileWorkload(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {
+func (r *LLMInferenceServiceReconciler) reconcileWorkload(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService, storageConfig *kserveTypes.StorageInitializerConfig) error {
 	logger := log.FromContext(ctx).WithName("reconcileWorkload")
 	ctx = log.IntoContext(ctx, logger)
 
@@ -42,7 +43,7 @@ func (r *LLMInferenceServiceReconciler) reconcileWorkload(ctx context.Context, l
 		return fmt.Errorf("failed to reconcile multi node workload: %w", err)
 	}
 
-	if err := r.reconcileSingleNodeWorkload(ctx, llmSvc); err != nil {
+	if err := r.reconcileSingleNodeWorkload(ctx, llmSvc, storageConfig); err != nil {
 		llmSvc.MarkWorkloadNotReady("ReconcileSingleNodeWorkloadError", err.Error())
 		return fmt.Errorf("failed to reconcile single node workload: %w", err)
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/cabundleconfigmap/cabundle_configmap_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/cabundleconfigmap/cabundle_configmap_reconciler.go
@@ -34,7 +34,7 @@ import (
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
-	"github.com/kserve/kserve/pkg/webhook/admission/pod"
+	"github.com/kserve/kserve/pkg/types"
 )
 
 var log = logf.Log.WithName("CaBundleConfigMapReconciler")
@@ -61,7 +61,7 @@ func (c *CaBundleConfigMapReconciler) Reconcile(ctx context.Context, isvc *v1bet
 		return err
 	}
 
-	storageInitializerConfig := &pod.StorageInitializerConfig{}
+	storageInitializerConfig := &types.StorageInitializerConfig{}
 	if storageInitializerConfigValue, ok := isvcConfigMap.Data["storageInitializer"]; ok {
 		err := json.Unmarshal([]byte(storageInitializerConfigValue), &storageInitializerConfig)
 		if err != nil {

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package types
 
 type StorageInitializerConfig struct {

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -1,0 +1,16 @@
+package types
+
+type StorageInitializerConfig struct {
+	Image                      string `json:"image"`
+	CpuRequest                 string `json:"cpuRequest"`
+	CpuLimit                   string `json:"cpuLimit"`
+	CpuModelcar                string `json:"cpuModelcar"`
+	MemoryRequest              string `json:"memoryRequest"`
+	MemoryLimit                string `json:"memoryLimit"`
+	CaBundleConfigMapName      string `json:"caBundleConfigMapName"`
+	CaBundleVolumeMountPath    string `json:"caBundleVolumeMountPath"`
+	MemoryModelcar             string `json:"memoryModelcar"`
+	EnableDirectPvcVolumeMount bool   `json:"enableDirectPvcVolumeMount"`
+	EnableOciImageSource       bool   `json:"enableModelcar"`
+	UidModelcar                *int64 `json:"uidModelcar"`
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -131,6 +132,27 @@ func AppendEnvVarIfNotExists(slice []corev1.EnvVar, elems ...corev1.EnvVar) []co
 	return slice
 }
 
+// Add an environment variable with the given value to the environments
+// variables of the given container, potentially replacing an env var that already exists
+// with this name
+func AddOrReplaceEnv(container *corev1.Container, envKey string, envValue string) {
+	if container.Env == nil {
+		container.Env = []corev1.EnvVar{}
+	}
+
+	for i, envVar := range container.Env {
+		if envVar.Name == envKey {
+			container.Env[i].Value = envValue
+			return
+		}
+	}
+
+	container.Env = append(container.Env, corev1.EnvVar{
+		Name:  envKey,
+		Value: envValue,
+	})
+}
+
 func AppendPortIfNotExists(slice []corev1.ContainerPort, elems ...corev1.ContainerPort) []corev1.ContainerPort {
 	for _, elem := range elems {
 		isElemExists := false
@@ -213,6 +235,31 @@ func GetEnvVarValue(envVars []corev1.EnvVar, key string) (string, bool) {
 		}
 	}
 	return "", false // if key does not exist, return "", false
+}
+
+func GetContainerWithName(podSpec *corev1.PodSpec, name string) *corev1.Container {
+	for idx, container := range podSpec.Containers {
+		if strings.Compare(container.Name, name) == 0 {
+			return &podSpec.Containers[idx]
+		}
+	}
+	return nil
+}
+
+// AddVolumeMountIfNotPresent adds a volume mount to a given container but only if no volume mount
+// with this name has been already added. Container must not be nil
+func AddVolumeMountIfNotPresent(container *corev1.Container, mountName string, mountPath string) {
+	for _, v := range container.VolumeMounts {
+		if v.Name == mountName {
+			return
+		}
+	}
+	modelMount := corev1.VolumeMount{
+		Name:      mountName,
+		MountPath: mountPath,
+		ReadOnly:  false,
+	}
+	container.VolumeMounts = append(container.VolumeMounts, modelMount)
 }
 
 // Returns the value of the stop annotation
@@ -378,4 +425,18 @@ func GetGPUResourceQtyByType(resourceRequirements *corev1.ResourceRequirements, 
 	qty := resource.NewQuantity(0, resource.DecimalSI)
 
 	return "", qty, false
+}
+
+// GetParentDirectory returns the parent directory of the given path,
+// or "/" if the path is a top-level directory.
+func GetParentDirectory(path string) string {
+	// Get the parent directory
+	parentDir := filepath.Dir(path)
+
+	// Check if it's a top-level directory
+	if parentDir == "." || parentDir == "/" {
+		return "/"
+	}
+
+	return parentDir
 }

--- a/pkg/webhook/admission/pod/mutator.go
+++ b/pkg/webhook/admission/pod/mutator.go
@@ -80,7 +80,7 @@ func (mutator *Mutator) Handle(ctx context.Context, req admission.Request) admis
 func (mutator *Mutator) mutate(pod *corev1.Pod, configMap *corev1.ConfigMap) error {
 	credentialBuilder := credentials.NewCredentialBuilder(mutator.Client, mutator.Clientset, configMap)
 
-	storageInitializerConfig, err := getStorageInitializerConfigs(configMap)
+	storageInitializerConfig, err := v1beta1.GetStorageInitializerConfigs(configMap)
 	if err != nil {
 		return err
 	}

--- a/pkg/webhook/admission/pod/mutator_test.go
+++ b/pkg/webhook/admission/pod/mutator_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
 )
 
@@ -73,12 +74,14 @@ func TestMutator_Handle(t *testing.T) {
 				},
 				Immutable: nil,
 				Data: map[string]string{
-					StorageInitializerConfigMapKeyName: `{
+					v1beta1.StorageInitializerConfigMapKeyName: `{
 						"image" : "kserve/storage-initializer:latest",
 						"memoryRequest": "100Mi",
 						"memoryLimit": "1Gi",
 						"cpuRequest": "100m",
 						"cpuLimit": "1",
+						"cpuModelcar": "100m",
+						"memoryModelcar": "50Mi",
 						"storageSpecSecretName": "storage-config"
 					}`,
 					LoggerConfigMapKeyName: `{
@@ -179,12 +182,14 @@ func TestMutator_Handle(t *testing.T) {
 				},
 				Immutable: nil,
 				Data: map[string]string{
-					StorageInitializerConfigMapKeyName: `{
+					v1beta1.StorageInitializerConfigMapKeyName: `{
 						"image" : "kserve/storage-initializer:latest",
 						"memoryRequest": "100Mi",
 						"memoryLimit": "1Gi",
 						"cpuRequest": "100m",
 						"cpuLimit": "1",
+						"cpuModelcar": "100m",
+						"memoryModelcar": "50Mi",
 						"storageSpecSecretName": "storage-config"
 					}`,
 					LoggerConfigMapKeyName: `{

--- a/pkg/webhook/admission/pod/storage_initializer_injector_test.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector_test.go
@@ -32,10 +32,12 @@ import (
 	"knative.dev/pkg/ptr"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/credentials"
 	"github.com/kserve/kserve/pkg/credentials/gcs"
 	"github.com/kserve/kserve/pkg/credentials/s3"
+	kserveTypes "github.com/kserve/kserve/pkg/types"
 	"github.com/kserve/kserve/pkg/utils"
 )
 
@@ -50,7 +52,7 @@ const (
 )
 
 var (
-	storageInitializerConfig = &StorageInitializerConfig{
+	storageInitializerConfig = &kserveTypes.StorageInitializerConfig{
 		CpuRequest:                 StorageInitializerDefaultCPURequest,
 		CpuLimit:                   StorageInitializerDefaultCPULimit,
 		MemoryRequest:              StorageInitializerDefaultMemoryRequest,
@@ -231,7 +233,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 							Name: constants.InferenceServiceContainerName,
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      StorageInitializerVolumeName,
+									Name:      constants.StorageInitializerVolumeName,
 									MountPath: constants.DefaultModelLocalMountPath,
 									ReadOnly:  true,
 								},
@@ -247,7 +249,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      StorageInitializerVolumeName,
+									Name:      constants.StorageInitializerVolumeName,
 									MountPath: constants.DefaultModelLocalMountPath,
 								},
 							},
@@ -255,7 +257,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 					},
 					Volumes: []corev1.Volume{
 						{
-							Name: StorageInitializerVolumeName,
+							Name: constants.StorageInitializerVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
@@ -293,7 +295,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 							Name: constants.InferenceServiceContainerName,
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      StorageInitializerVolumeName,
+									Name:      constants.StorageInitializerVolumeName,
 									MountPath: constants.DefaultModelLocalMountPath,
 									ReadOnly:  false,
 								},
@@ -309,7 +311,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      StorageInitializerVolumeName,
+									Name:      constants.StorageInitializerVolumeName,
 									MountPath: constants.DefaultModelLocalMountPath,
 								},
 							},
@@ -317,7 +319,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 					},
 					Volumes: []corev1.Volume{
 						{
-							Name: StorageInitializerVolumeName,
+							Name: constants.StorageInitializerVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
@@ -355,7 +357,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 							Name: constants.InferenceServiceContainerName,
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      StorageInitializerVolumeName,
+									Name:      constants.StorageInitializerVolumeName,
 									MountPath: constants.DefaultModelLocalMountPath,
 									ReadOnly:  true,
 								},
@@ -371,7 +373,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
-									Name:      StorageInitializerVolumeName,
+									Name:      constants.StorageInitializerVolumeName,
 									MountPath: constants.DefaultModelLocalMountPath,
 								},
 							},
@@ -379,7 +381,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 					},
 					Volumes: []corev1.Volume{
 						{
-							Name: StorageInitializerVolumeName,
+							Name: constants.StorageInitializerVolumeName,
 							VolumeSource: corev1.VolumeSource{
 								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
@@ -1226,7 +1228,7 @@ func TestStorageInitializerConfigmap(t *testing.T) {
 			credentialBuilder: credentials.NewCredentialBuilder(c, clientset, &corev1.ConfigMap{
 				Data: map[string]string{},
 			}),
-			config: &StorageInitializerConfig{
+			config: &kserveTypes.StorageInitializerConfig{
 				Image:                   "kserve/storage-initializer@sha256:xxx",
 				CpuRequest:              StorageInitializerDefaultCPURequest,
 				CpuLimit:                StorageInitializerDefaultCPULimit,
@@ -1259,25 +1261,29 @@ func TestGetStorageInitializerConfigs(t *testing.T) {
 				TypeMeta:   metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{},
 				Data: map[string]string{
-					StorageInitializerConfigMapKeyName: `{
+					v1beta1.StorageInitializerConfigMapKeyName: `{
 						"Image":        		 "gcr.io/kserve/storage-initializer:latest",
 						"CpuRequest":   		 "100m",
 						"CpuLimit":      		 "1",
 						"MemoryRequest": 		 "200Mi",
 						"MemoryLimit":   		 "1Gi",
-						"CaBundleConfigMapName":      "",
+						"CpuModelcar": 			 "100m",
+						"MemoryModelcar": 		 "50Mi",
+						"CaBundleConfigMapName": "",
 						"CaBundleVolumeMountPath": "/etc/ssl/custom-certs"
 					}`,
 				},
 				BinaryData: map[string][]byte{},
 			},
 			matchers: []types.GomegaMatcher{
-				gomega.Equal(&StorageInitializerConfig{
+				gomega.Equal(&kserveTypes.StorageInitializerConfig{
 					Image:                   "gcr.io/kserve/storage-initializer:latest",
 					CpuRequest:              "100m",
 					CpuLimit:                "1",
 					MemoryRequest:           "200Mi",
 					MemoryLimit:             "1Gi",
+					CpuModelcar:             "100m",
+					MemoryModelcar:          "50Mi",
 					CaBundleConfigMapName:   "",
 					CaBundleVolumeMountPath: "/etc/ssl/custom-certs",
 				}),
@@ -1290,12 +1296,14 @@ func TestGetStorageInitializerConfigs(t *testing.T) {
 				TypeMeta:   metav1.TypeMeta{},
 				ObjectMeta: metav1.ObjectMeta{},
 				Data: map[string]string{
-					StorageInitializerConfigMapKeyName: `{
+					v1beta1.StorageInitializerConfigMapKeyName: `{
 						"Image":        		 "gcr.io/kserve/storage-initializer:latest",
 						"CpuRequest":   		 "100m",
 						"CpuLimit":      		 "1",
 						"MemoryRequest": 		 "200MC",
 						"MemoryLimit":   		 "1Gi",
+						"CpuModelcar": 			 "100m",
+						"MemoryModelcar": 		 "50Mi",
 						"CaBundleConfigMapName":      "",
 						"CaBundleVolumeMountPath": "/etc/ssl/custom-certs"
 					}`,
@@ -1303,12 +1311,14 @@ func TestGetStorageInitializerConfigs(t *testing.T) {
 				BinaryData: map[string][]byte{},
 			},
 			matchers: []types.GomegaMatcher{
-				gomega.Equal(&StorageInitializerConfig{
+				gomega.Equal(&kserveTypes.StorageInitializerConfig{
 					Image:                   "gcr.io/kserve/storage-initializer:latest",
 					CpuRequest:              "100m",
 					CpuLimit:                "1",
 					MemoryRequest:           "200MC",
 					MemoryLimit:             "1Gi",
+					CpuModelcar:             "100m",
+					MemoryModelcar:          "50Mi",
 					CaBundleConfigMapName:   "",
 					CaBundleVolumeMountPath: "/etc/ssl/custom-certs",
 				}),
@@ -1318,7 +1328,7 @@ func TestGetStorageInitializerConfigs(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		loggerConfigs, err := getStorageInitializerConfigs(tc.configMap)
+		loggerConfigs, err := v1beta1.GetStorageInitializerConfigs(tc.configMap)
 		g.Expect(err).Should(tc.matchers[1])
 		g.Expect(loggerConfigs).Should(tc.matchers[0])
 	}
@@ -1375,7 +1385,7 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 		},
 	}
 	scenarios := map[string]struct {
-		storageConfig *StorageInitializerConfig
+		storageConfig *kserveTypes.StorageInitializerConfig
 		secret        *corev1.Secret
 		sa            *corev1.ServiceAccount
 		original      *corev1.Pod
@@ -1476,7 +1486,7 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 			},
 		},
 		"MountsCaBundleConfigMapVolumeWhenCaBundleConfigMapNameSet": {
-			storageConfig: &StorageInitializerConfig{
+			storageConfig: &kserveTypes.StorageInitializerConfig{
 				Image:                 "kserve/storage-initializer:latest",
 				CpuRequest:            "100m",
 				CpuLimit:              "1",
@@ -1594,7 +1604,7 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 			},
 		},
 		"MountsCaBundleConfigMapVolumeByAnnotation": {
-			storageConfig: &StorageInitializerConfig{
+			storageConfig: &kserveTypes.StorageInitializerConfig{
 				Image:         "kserve/storage-initializer:latest",
 				CpuRequest:    "100m",
 				CpuLimit:      "1",
@@ -1715,7 +1725,7 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 			},
 		},
 		"MountsCaBundleConfigMapVolumeByAnnotationInstreadOfConfigMap": {
-			storageConfig: &StorageInitializerConfig{
+			storageConfig: &kserveTypes.StorageInitializerConfig{
 				Image:                 "kserve/storage-initializer:latest",
 				CpuRequest:            "100m",
 				CpuLimit:              "1",
@@ -1935,7 +1945,7 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 			},
 		},
 		"SetMountsCaBundleConfigMapVolumePathByAnnotationInstreadOfConfigMap": {
-			storageConfig: &StorageInitializerConfig{
+			storageConfig: &kserveTypes.StorageInitializerConfig{
 				Image:                   "kserve/storage-initializer:latest",
 				CpuRequest:              "100m",
 				CpuLimit:                "1",
@@ -2291,7 +2301,7 @@ func TestDirectVolumeMountForPvc(t *testing.T) {
 			credentialBuilder: credentials.NewCredentialBuilder(c, clientset, &corev1.ConfigMap{
 				Data: map[string]string{},
 			}),
-			config: &StorageInitializerConfig{
+			config: &kserveTypes.StorageInitializerConfig{
 				EnableDirectPvcVolumeMount: true, // enable direct volume mount for PVC
 			},
 			client: c,
@@ -2307,7 +2317,7 @@ func TestDirectVolumeMountForPvc(t *testing.T) {
 
 func TestTransformerCollocation(t *testing.T) {
 	scenarios := map[string]struct {
-		storageConfig *StorageInitializerConfig
+		storageConfig *kserveTypes.StorageInitializerConfig
 		original      *corev1.Pod
 		expected      *corev1.Pod
 	}{
@@ -2422,7 +2432,7 @@ func TestTransformerCollocation(t *testing.T) {
 			},
 		},
 		"Transformer collocation with pvc direct mount": {
-			storageConfig: &StorageInitializerConfig{
+			storageConfig: &kserveTypes.StorageInitializerConfig{
 				EnableDirectPvcVolumeMount: true, // enable direct volume mount for PVC
 			},
 			original: &corev1.Pod{
@@ -2939,7 +2949,7 @@ func TestAddOrReplaceEnv(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			addOrReplaceEnv(tt.container, tt.envKey, tt.envValue)
+			utils.AddOrReplaceEnv(tt.container, tt.envKey, tt.envValue)
 
 			if len(tt.container.Env) != tt.wantEnvLen {
 				t.Errorf("Expected env length %d, but got %d", tt.wantEnvLen, len(tt.container.Env))
@@ -2991,7 +3001,7 @@ func TestInjectModelcar(t *testing.T) {
 	{
 		pod := createTestPodForModelcar()
 		mi := &StorageInitializerInjector{
-			config: &StorageInitializerConfig{},
+			config: &kserveTypes.StorageInitializerConfig{},
 		}
 		err := mi.InjectModelcar(pod)
 		if err != nil {
@@ -2999,8 +3009,8 @@ func TestInjectModelcar(t *testing.T) {
 		}
 
 		// Check that an emptyDir volume has been attached
-		if len(pod.Spec.Volumes) != 1 || pod.Spec.Volumes[0].Name != StorageInitializerVolumeName {
-			t.Errorf("Expected one volume with name %s, but got %v", StorageInitializerVolumeName, pod.Spec.Volumes)
+		if len(pod.Spec.Volumes) != 1 || pod.Spec.Volumes[0].Name != constants.StorageInitializerVolumeName {
+			t.Errorf("Expected one volume with name %s, but got %v", constants.StorageInitializerVolumeName, pod.Spec.Volumes)
 		}
 
 		// Check that a sidecar container has been injected
@@ -3012,7 +3022,7 @@ func TestInjectModelcar(t *testing.T) {
 		switch {
 		case len(pod.Spec.InitContainers) != 1:
 			t.Errorf("Expected one init container but got %d", len(pod.Spec.InitContainers))
-		case pod.Spec.InitContainers[0].Name != ModelcarInitContainerName:
+		case pod.Spec.InitContainers[0].Name != constants.ModelcarInitContainerName:
 			t.Errorf("Expected the init container to be the model but got %s", pod.Spec.InitContainers[0].Name)
 		default:
 			// Check that resources are correctly set.
@@ -3040,14 +3050,14 @@ func TestInjectModelcar(t *testing.T) {
 		found := false
 		if pod.Spec.Containers[0].Env != nil {
 			for _, env := range pod.Spec.Containers[0].Env {
-				if env.Name == ModelInitModeEnv && env.Value == "async" {
+				if env.Name == constants.ModelInitModeEnv && env.Value == "async" {
 					found = true
 					break
 				}
 			}
 		}
 		if !found {
-			t.Errorf("Expected env var %s=async but did not find it", ModelInitModeEnv)
+			t.Errorf("Expected env var %s=async but did not find it", constants.ModelInitModeEnv)
 		}
 
 		// Check volume mounts in both containers
@@ -3067,7 +3077,7 @@ func createTestPodForModelcar() *corev1.Pod {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				constants.StorageInitializerSourceUriInternalAnnotationKey: OciURIPrefix + "myrepo/mymodelimage",
+				constants.StorageInitializerSourceUriInternalAnnotationKey: constants.OciURIPrefix + "myrepo/mymodelimage",
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -3088,28 +3098,28 @@ func createTestPodForModelcarWithTransformer() *corev1.Pod {
 func TestModelcarVolumeMounts(t *testing.T) {
 	t.Run("Test that volume mounts has been added (no transformer)", func(t *testing.T) {
 		pod := createTestPodForModelcar()
-		assert.Nil(t, getContainerWithName(pod, constants.TransformerContainerName))
-		checkVolumeMounts(t, pod, []string{ModelcarContainerName, constants.InferenceServiceContainerName})
+		assert.Nil(t, utils.GetContainerWithName(&pod.Spec, constants.TransformerContainerName))
+		checkVolumeMounts(t, pod, []string{constants.ModelcarContainerName, constants.InferenceServiceContainerName})
 	})
 
 	t.Run("Test that volume mounts has been added (with transformer)", func(t *testing.T) {
 		pod := createTestPodForModelcarWithTransformer()
-		checkVolumeMounts(t, pod, []string{ModelcarContainerName, constants.InferenceServiceContainerName, constants.TransformerContainerName})
+		checkVolumeMounts(t, pod, []string{constants.ModelcarContainerName, constants.InferenceServiceContainerName, constants.TransformerContainerName})
 	})
 }
 
 func checkVolumeMounts(t *testing.T, pod *corev1.Pod, containerNames []string) {
-	injector := &StorageInitializerInjector{config: &StorageInitializerConfig{}}
+	injector := &StorageInitializerInjector{config: &kserveTypes.StorageInitializerConfig{}}
 	err := injector.InjectModelcar(pod)
 	require.NoError(t, err)
 
 	for _, containerName := range containerNames {
-		container := getContainerWithName(pod, containerName)
+		container := utils.GetContainerWithName(&pod.Spec, containerName)
 		assert.NotNil(t, container)
 		volumeMounts := container.VolumeMounts
 		assert.NotEmpty(t, volumeMounts)
 		assert.Len(t, volumeMounts, 1)
-		assert.Equal(t, volumeMounts[0].MountPath, getParentDirectory(constants.DefaultModelLocalMountPath))
+		assert.Equal(t, volumeMounts[0].MountPath, utils.GetParentDirectory(constants.DefaultModelLocalMountPath))
 	}
 }
 
@@ -3118,7 +3128,7 @@ func TestModelcarIdempotency(t *testing.T) {
 		podReference := createTestPodForModelcarWithTransformer()
 		pod := createTestPodForModelcarWithTransformer()
 
-		injector := &StorageInitializerInjector{config: &StorageInitializerConfig{}}
+		injector := &StorageInitializerInjector{config: &kserveTypes.StorageInitializerConfig{}}
 
 		// Inject modelcar twice
 		err := injector.InjectModelcar(pod)
@@ -3137,7 +3147,7 @@ func TestModelcarIdempotency(t *testing.T) {
 
 func TestStorageInitializerInjectorWithModelcarConfig(t *testing.T) {
 	t.Run("Test empty config", func(t *testing.T) {
-		config := &StorageInitializerConfig{}
+		config := &kserveTypes.StorageInitializerConfig{}
 		injector := &StorageInitializerInjector{config: config}
 
 		pod := createTestPodForModelcar()
@@ -3145,17 +3155,17 @@ func TestStorageInitializerInjectorWithModelcarConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		// Assertions
-		modelcarContainer := getContainerWithName(pod, ModelcarContainerName)
+		modelcarContainer := utils.GetContainerWithName(&pod.Spec, constants.ModelcarContainerName)
 		assert.NotNil(t, modelcarContainer)
-		assert.Equal(t, resource.MustParse(CpuModelcarDefault), modelcarContainer.Resources.Limits["cpu"])
-		assert.Equal(t, resource.MustParse(MemoryModelcarDefault), modelcarContainer.Resources.Limits["memory"])
-		assert.Equal(t, resource.MustParse(CpuModelcarDefault), modelcarContainer.Resources.Requests["cpu"])
-		assert.Equal(t, resource.MustParse(MemoryModelcarDefault), modelcarContainer.Resources.Requests["memory"])
+		assert.Equal(t, resource.MustParse(constants.CpuModelcarDefault), modelcarContainer.Resources.Limits["cpu"])
+		assert.Equal(t, resource.MustParse(constants.MemoryModelcarDefault), modelcarContainer.Resources.Limits["memory"])
+		assert.Equal(t, resource.MustParse(constants.CpuModelcarDefault), modelcarContainer.Resources.Requests["cpu"])
+		assert.Equal(t, resource.MustParse(constants.MemoryModelcarDefault), modelcarContainer.Resources.Requests["memory"])
 		assert.Nil(t, modelcarContainer.SecurityContext)
 	})
 
 	t.Run("Test uidModelcar config", func(t *testing.T) {
-		config := &StorageInitializerConfig{UidModelcar: ptr.Int64(10)}
+		config := &kserveTypes.StorageInitializerConfig{UidModelcar: ptr.Int64(10)}
 		injector := &StorageInitializerInjector{config: config}
 
 		pod := createTestPodForModelcar()
@@ -3163,8 +3173,8 @@ func TestStorageInitializerInjectorWithModelcarConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		// Assertions
-		modelcarContainer := getContainerWithName(pod, ModelcarContainerName)
-		userContainer := getContainerWithName(pod, constants.InferenceServiceContainerName)
+		modelcarContainer := utils.GetContainerWithName(&pod.Spec, constants.ModelcarContainerName)
+		userContainer := utils.GetContainerWithName(&pod.Spec, constants.InferenceServiceContainerName)
 		assert.NotNil(t, modelcarContainer)
 		assert.NotNil(t, userContainer)
 		assert.Equal(t, int64(10), *modelcarContainer.SecurityContext.RunAsUser)
@@ -3172,7 +3182,7 @@ func TestStorageInitializerInjectorWithModelcarConfig(t *testing.T) {
 	})
 
 	t.Run("Test CPU and Memory config", func(t *testing.T) {
-		config := &StorageInitializerConfig{CpuModelcar: "50m", MemoryModelcar: "50Mi"}
+		config := &kserveTypes.StorageInitializerConfig{CpuModelcar: "50m", MemoryModelcar: "50Mi"}
 		injector := &StorageInitializerInjector{config: config}
 
 		pod := createTestPodForModelcar()
@@ -3180,7 +3190,7 @@ func TestStorageInitializerInjectorWithModelcarConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		// Assertions
-		modelcarContainer := getContainerWithName(pod, ModelcarContainerName)
+		modelcarContainer := utils.GetContainerWithName(&pod.Spec, constants.ModelcarContainerName)
 		assert.NotNil(t, modelcarContainer)
 		assert.Equal(t, resource.MustParse("50m"), modelcarContainer.Resources.Limits["cpu"])
 		assert.Equal(t, resource.MustParse("50Mi"), modelcarContainer.Resources.Requests["memory"])
@@ -3202,7 +3212,7 @@ func TestGetContainerWithName(t *testing.T) {
 		}
 
 		seekName := "container-1"
-		got := getContainerWithName(pod, seekName)
+		got := utils.GetContainerWithName(&pod.Spec, seekName)
 
 		if got == nil {
 			t.Errorf("Expected a container, but got nil")
@@ -3223,7 +3233,7 @@ func TestGetContainerWithName(t *testing.T) {
 		}
 
 		seekName := "non-existent-container"
-		got := getContainerWithName(pod, seekName)
+		got := utils.GetContainerWithName(&pod.Spec, seekName)
 
 		if got != nil {
 			t.Errorf("Expected nil, but got a container")
@@ -3993,7 +4003,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 }
 
 func TestLocalModelPVC(t *testing.T) {
-	storageConfig := &StorageInitializerConfig{
+	storageConfig := &kserveTypes.StorageInitializerConfig{
 		EnableDirectPvcVolumeMount: true, // enable direct volume mount for PVC
 	}
 	scenarios := map[string]struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support for loading models from OCI-compliant registries in LLMIsvc by introducing logic to handle `oci://` URIs. The controller configures the workload to use a modelcar sidecar container, which uses the specified OCI image.

Key changes:
- Recognize and process `oci://` URIs in LLMIsvc controller.
- Add and configure the modelcar sidecar for OCI-based models.
- Refactor and move utility functions for reusing storage initializer injector code in the LLMIsvc controller.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Related to https://issues.redhat.com/browse/RHOAIENG-27817

**Type of changes**

- [x] New feature (non-breaking change which adds functionality)

**Feature/Issue validation/testing**:

You can follow the instruction of [DEV.md](https://github.com/opendatahub-io/kserve/blob/5638c59a6f1c27f2e74573b53e83e756cfaa29c3/pkg/controller/llmisvc/DEV.md) with a small variant:

When applying the LLMIsvc resource, instead of:

```sh
kubectl apply -n ${NS} -f ${LLM_ISVC}
```

use the following:

```sh
yq '.spec.model.uri="oci://quay.io/edgarhz/oci-model-images:facebook-opt-125m"' ${LLM_ISVC} | kubectl apply -n ${NS} -f -
```


**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using OCI (Open Container Initiative) model sources, enabling deployments from OCI registries in addition to PVC sources.
  * Introduced new configuration options for storage initialization, including resource limits and feature toggles for OCI and direct PVC support.

* **Bug Fixes**
  * Improved validation and error reporting for resource configuration values in storage initializer settings.

* **Refactor**
  * Centralized and streamlined container, volume, and environment variable setup using new utility functions.
  * Replaced local configuration and helper logic with shared utilities and constants for consistency.

* **Tests**
  * Expanded test coverage for OCI model source scenarios and refactored tests to use new utilities and constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->