### PR TITLE
fix(reconcile): populates routing status for user-def routes

### DIFF
--- a/pkg/apis/serving/v1alpha1/llm_inference_service_types_func.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_types_func.go
@@ -20,10 +20,6 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func (in *GatewayRoutesSpec) IsManaged() bool {
-	return in != nil && in == &GatewayRoutesSpec{}
-}
-
 func (in *GatewaySpec) HasRefs() bool {
 	return in != nil && len(in.Refs) > 0
 }

--- a/pkg/controller/llmisvc/router.go
+++ b/pkg/controller/llmisvc/router.go
@@ -92,11 +92,13 @@ func (r *LLMInferenceServiceReconciler) reconcileHTTPRoutes(ctx context.Context,
 			referencedRoutes = append(referencedRoutes, providedRoute)
 		}
 
-		return Delete(ctx, r, llmSvc, expectedHTTPRoute)
+		if errDel := Delete(ctx, r, llmSvc, expectedHTTPRoute); errDel != nil {
+			return fmt.Errorf("failed to delete managed HTTPRoute %s/%s: %w", expectedHTTPRoute.GetNamespace(), expectedHTTPRoute.GetName(), errDel)
+		}
 	}
 
 	// TODO(validation): referenced gateway exists
-	if route.IsManaged() || route.HTTP.HasSpec() {
+	if route.HTTP.HasSpec() {
 		if err := Reconcile(ctx, r, llmSvc, &gatewayapi.HTTPRoute{}, expectedHTTPRoute, semanticHTTPRouteIsEqual); err != nil {
 			return fmt.Errorf("failed to reconcile HTTPRoute %s/%s: %w", expectedHTTPRoute.GetNamespace(), expectedHTTPRoute.GetName(), err)
 		}


### PR DESCRIPTION
This PR corrects the flow when handling "user-defined routes" (through `spec.router.route.refs`) was terminating reconcile too early after deleting potentially pre-existing managed router.

This was causing incomplete status reporting.

Initially introduced `GatewayRoutesSpec#IsManaged` did not express the aspect of managed routes properly. This could lead to confusing or even wrong code. This method is now removed.


**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when deleting HTTPRoutes, providing clearer information if an error occurs.

* **Refactor**
  * Simplified the logic for reconciling HTTPRoutes by removing unnecessary checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->