### PR TITLE
fix(webhook): adds new webhooks to self-signed-cert script

### DIFF
--- a/hack/self-signed-ca.sh
+++ b/hack/self-signed-ca.sh
@@ -75,7 +75,7 @@ done
 [ -z "${secret}" ] && secret=kserve-webhook-server-cert
 [ -z "${namespace}" ] && namespace=kserve
 [ -z "${webhookDeployment}" ] && webhookDeployment=kserve-controller-manager
-[ "${#validatingWebhookNames[@]}" -eq 0 ] && validatingWebhookNames=("inferenceservice.serving.kserve.io" "inferencegraph.serving.kserve.io" "servingruntime.serving.kserve.io" "clusterservingruntime.serving.kserve.io" "trainedmodel.serving.kserve.io" "localmodelcache.serving.kserve.io")
+[ "${#validatingWebhookNames[@]}" -eq 0 ] && validatingWebhookNames=("inferenceservice.serving.kserve.io" "inferencegraph.serving.kserve.io" "servingruntime.serving.kserve.io" "clusterservingruntime.serving.kserve.io" "trainedmodel.serving.kserve.io" "localmodelcache.serving.kserve.io" "llminferenceserviceconfig.serving.kserve.io" "llminferenceservice.serving.kserve.io")
 [ "${#mutatingWebhookNames[@]}" -eq 0 ] && mutatingWebhookNames=("inferenceservice.serving.kserve.io")
 [ -z "${service}" ] && service=kserve-webhook-server-service
 webhookDeploymentName=${webhookDeployment}


### PR DESCRIPTION
When using `KSERVE_ENABLE_SELF_SIGNED_CA` cert manager's Certificate is removed while setting up dev environment.

That renders certificate injection useless, as `cert-manager.io/inject-ca-from: kserve/serving-cert` is ignored, leading to errors from newly created webhooks:

```
Error from server (InternalError): Internal error occurred: failed calling webhook "llminferenceserviceconfig.kserve-webhook-server.validator": failed to call webhook: Post "https://kserve-webhook-server-service.kserve.svc:443/validate-serving-kserve-io-v1alpha1-llminferenceserviceconfig?timeout=10s": tls: failed to verify certificate: x509: certificate signed by unknown authority
```

Instead, manual patching is done in the script.

This PR adds two new webhooks to the list so `caBundle` can be propagated properly.

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.