### PR TITLE
Configure scheduler to FailOpen and fallback to random loadbalancing

### DIFF
--- a/config/llmisvc/config-llm-scheduler.yaml
+++ b/config/llmisvc/config-llm-scheduler.yaml
@@ -8,7 +8,7 @@ spec:
       pool:
         spec:
           extensionRef:
-            failureMode: FailClose
+            failureMode: FailOpen
             kind: Service
             name: |-
               {{ ChildName .ObjectMeta.Name `-epp-service` }}


### PR DESCRIPTION
If the scheduler fails, we would rather serve the request than immediately drop it (for now at least, until we have a better HA story)

https://gateway-api-inference-extension.sigs.k8s.io/reference/spec/?h=failopen#extensionfailuremode