### PR TITLE
feat(webhook): ensures proper paralellism settings

### DIFF
--- a/pkg/controller/llmisvc/fixture/llmisvc_builders.go
+++ b/pkg/controller/llmisvc/fixture/llmisvc_builders.go
@@ -128,3 +128,70 @@ func HTTPRouteRef(name string) corev1.LocalObjectReference {
 		Name: name,
 	}
 }
+
+func WithParallelism(parallelism *v1alpha1.ParallelismSpec) LLMInferenceServiceOption {
+	return func(llmSvc *v1alpha1.LLMInferenceService) {
+		llmSvc.Spec.Parallelism = parallelism
+	}
+}
+
+func WithPrefillParallelism(parallelism *v1alpha1.ParallelismSpec) LLMInferenceServiceOption {
+	return func(llmSvc *v1alpha1.LLMInferenceService) {
+		if llmSvc.Spec.Prefill == nil {
+			llmSvc.Spec.Prefill = &v1alpha1.WorkloadSpec{}
+		}
+		llmSvc.Spec.Prefill.Parallelism = parallelism
+	}
+}
+
+func WithWorker(worker *corev1.PodSpec) LLMInferenceServiceOption {
+	return func(llmSvc *v1alpha1.LLMInferenceService) {
+		llmSvc.Spec.Worker = worker
+	}
+}
+
+func WithPrefillWorker(worker *corev1.PodSpec) LLMInferenceServiceOption {
+	return func(llmSvc *v1alpha1.LLMInferenceService) {
+		if llmSvc.Spec.Prefill == nil {
+			llmSvc.Spec.Prefill = &v1alpha1.WorkloadSpec{}
+		}
+		llmSvc.Spec.Prefill.Worker = worker
+	}
+}
+
+func ParallelismSpec(opts ...func(*v1alpha1.ParallelismSpec)) *v1alpha1.ParallelismSpec {
+	p := &v1alpha1.ParallelismSpec{}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+func WithPipelineParallelism(pipeline int32) func(*v1alpha1.ParallelismSpec) {
+	return func(p *v1alpha1.ParallelismSpec) {
+		p.Pipeline = &pipeline
+	}
+}
+
+func WithDataParallelism(data int32) func(*v1alpha1.ParallelismSpec) {
+	return func(p *v1alpha1.ParallelismSpec) {
+		p.Data = &data
+	}
+}
+
+func WithDataLocalParallelism(dataLocal int32) func(*v1alpha1.ParallelismSpec) {
+	return func(p *v1alpha1.ParallelismSpec) {
+		p.DataLocal = &dataLocal
+	}
+}
+
+func SimpleWorkerPodSpec() *corev1.PodSpec {
+	return &corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  "worker",
+				Image: "test-worker:latest",
+			},
+		},
+	}
+}


### PR DESCRIPTION
Implements checks for parallelism configuration, both for main workload as well as prefill.

Fixes [RHOAIENG-28893](https://issues.redhat.com/browse/RHOAIENG-28893)


**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive validation for parallelism settings in LLMInferenceService resources, ensuring proper configuration and error reporting for both main and prefill workloads.
  * Extended configuration options to support detailed parallelism and worker pod specifications for main and prefill workloads.

* **Bug Fixes**
  * Improved robustness of router validation to handle cases where the router may be nil.

* **Tests**
  * Introduced extensive test cases to verify parallelism constraint validation, covering both valid and invalid configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->