### PR TITLE
feat(storage): Add support to LLMIsvc for downloading from HF and S3

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -154,10 +154,16 @@ var (
 )
 
 const (
-	OciURIPrefix                 = "oci://"
-	PvcURIPrefix                 = "pvc://"
+	HfURIPrefix  = "hf://"
+	OciURIPrefix = "oci://"
+	PvcURIPrefix = "pvc://"
+	S3URIPrefix  = "s3://"
+
 	PvcSourceMountName           = "kserve-pvc-source"
 	StorageInitializerVolumeName = "kserve-provision-location"
+
+	StorageInitializerContainerImage        = "kserve/storage-initializer"
+	StorageInitializerContainerImageVersion = "latest"
 
 	CpuModelcarDefault    = "10m"
 	MemoryModelcarDefault = "15Mi"

--- a/pkg/controller/llmisvc/controller_int_test.go
+++ b/pkg/controller/llmisvc/controller_int_test.go
@@ -565,6 +565,162 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				HaveField("ReadOnly", false),
 			)))
 		})
+
+		It("should use storage-initializer to download model when uri starts with hf://", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(namespace)
+			}()
+
+			modelURL, err := apis.ParseURL("hf://user-id/repo-id:tag")
+			Expect(err).ToNot(HaveOccurred())
+
+			llmSvc := &v1alpha1.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      svcName,
+					Namespace: nsName,
+				},
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					Model: v1alpha1.LLMModelSpec{
+						Name: ptr.To("foo"),
+						URI:  *modelURL,
+					},
+					WorkloadSpec: v1alpha1.WorkloadSpec{},
+					Router: &v1alpha1.RouterSpec{
+						Route:     &v1alpha1.GatewayRoutesSpec{},
+						Gateway:   &v1alpha1.GatewaySpec{},
+						Scheduler: &v1alpha1.SchedulerSpec{},
+					},
+				},
+			}
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			// then
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, expectedDeployment)
+			}).WithContext(ctx).Should(Succeed())
+
+			// Check the volume to store the model exists
+			Expect(expectedDeployment.Spec.Template.Spec.Volumes).To(ContainElement(And(
+				HaveField("Name", constants.StorageInitializerVolumeName),
+				HaveField("EmptyDir", Not(BeNil())),
+			)))
+
+			// Check the storage-initializer container is present.
+			Expect(expectedDeployment.Spec.Template.Spec.InitContainers).To(ContainElement(And(
+				HaveField("Name", constants.StorageInitializerContainerName),
+				HaveField("Args", ContainElements("hf://user-id/repo-id:tag", constants.DefaultModelLocalMountPath)),
+				HaveField("VolumeMounts", ContainElement(And(
+					HaveField("Name", constants.StorageInitializerVolumeName),
+					HaveField("MountPath", constants.DefaultModelLocalMountPath),
+				))),
+			)))
+
+			// Check the main container has the model mounted
+			mainContainer := utils.GetContainerWithName(&expectedDeployment.Spec.Template.Spec, "main")
+			Expect(mainContainer).ToNot(BeNil())
+			Expect(mainContainer.Command).To(ContainElement(constants.DefaultModelLocalMountPath))
+			Expect(mainContainer.VolumeMounts).To(ContainElement(And(
+				HaveField("Name", constants.StorageInitializerVolumeName),
+				HaveField("MountPath", constants.DefaultModelLocalMountPath),
+				HaveField("ReadOnly", BeTrue()),
+			)))
+		})
+
+		It("should use storage-initializer to download model when uri starts with s3://", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-s3"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(namespace)
+			}()
+
+			modelURL, err := apis.ParseURL("s3://user-id/repo-id:tag")
+			Expect(err).ToNot(HaveOccurred())
+
+			llmSvc := &v1alpha1.LLMInferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      svcName,
+					Namespace: nsName,
+				},
+				Spec: v1alpha1.LLMInferenceServiceSpec{
+					Model: v1alpha1.LLMModelSpec{
+						Name: ptr.To("foo"),
+						URI:  *modelURL,
+					},
+					WorkloadSpec: v1alpha1.WorkloadSpec{},
+					Router: &v1alpha1.RouterSpec{
+						Route:     &v1alpha1.GatewayRoutesSpec{},
+						Gateway:   &v1alpha1.GatewaySpec{},
+						Scheduler: &v1alpha1.SchedulerSpec{},
+					},
+				},
+			}
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			// then
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, expectedDeployment)
+			}).WithContext(ctx).Should(Succeed())
+
+			// Check the volume to store the model exists
+			Expect(expectedDeployment.Spec.Template.Spec.Volumes).To(ContainElement(And(
+				HaveField("Name", constants.StorageInitializerVolumeName),
+				HaveField("EmptyDir", Not(BeNil())),
+			)))
+
+			// Check the storage-initializer container is present.
+			Expect(expectedDeployment.Spec.Template.Spec.InitContainers).To(ContainElement(And(
+				HaveField("Name", constants.StorageInitializerContainerName),
+				HaveField("Args", ContainElements("s3://user-id/repo-id:tag", constants.DefaultModelLocalMountPath)),
+				HaveField("VolumeMounts", ContainElement(And(
+					HaveField("Name", constants.StorageInitializerVolumeName),
+					HaveField("MountPath", constants.DefaultModelLocalMountPath),
+				))),
+			)))
+
+			// Check the main container has the model mounted
+			mainContainer := utils.GetContainerWithName(&expectedDeployment.Spec.Template.Spec, "main")
+			Expect(mainContainer).ToNot(BeNil())
+			Expect(mainContainer.Command).To(ContainElement(constants.DefaultModelLocalMountPath))
+			Expect(mainContainer.VolumeMounts).To(ContainElement(And(
+				HaveField("Name", constants.StorageInitializerVolumeName),
+				HaveField("MountPath", constants.DefaultModelLocalMountPath),
+				HaveField("ReadOnly", BeTrue()),
+			)))
+		})
 	})
 })
 

--- a/pkg/controller/llmisvc/workload_single_node.go
+++ b/pkg/controller/llmisvc/workload_single_node.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/credentials/s3"
 	"github.com/kserve/kserve/pkg/types"
 	"github.com/kserve/kserve/pkg/utils"
 )
@@ -166,14 +167,32 @@ func (r *LLMInferenceServiceReconciler) expectedPrefillMainDeployment(ctx contex
 	return d
 }
 
+// attachModelArtifacts configures a PodSpec to fetch and use a model froma provided URI in the LLMInferenceService.
+// The storage backend (PVC, OCI, Hugging Face, or S3) is determined from the URI schema and the appropriate helper function
+// is called to configure the PodSpec. This function will adjust volumes, container arguments, container volume mounts,
+// add containers, and do other changes to the PodSpec to ensure the model is fetched properly from storage.
+//
+// Parameters:
+//   - llmSvc: The LLMInferenceService resource containing the model specification.
+//   - podSpec: The PodSpec to configure with the model artifact.
+//   - storageConfig: The storage initializer configuration.
+//
+// Returns:
+//
+//	An error if the configuration fails, otherwise nil.
 func (r *LLMInferenceServiceReconciler) attachModelArtifacts(llmSvc *v1alpha1.LLMInferenceService, podSpec *corev1.PodSpec, storageConfig *types.StorageInitializerConfig) error {
 	modelUri := llmSvc.Spec.Model.URI.String()
+	schema, _, sepFound := strings.Cut(modelUri, "://")
 
-	switch {
-	case strings.HasPrefix(modelUri, constants.PvcURIPrefix):
+	if !sepFound {
+		return fmt.Errorf("invalid model URI: %s", modelUri)
+	}
+
+	switch schema + "://" {
+	case constants.PvcURIPrefix:
 		return r.attachPVCModelArtifact(modelUri, podSpec)
 
-	case strings.HasPrefix(modelUri, constants.OciURIPrefix):
+	case constants.OciURIPrefix:
 		// Check of OCI is enabled
 		if !storageConfig.EnableOciImageSource {
 			return errors.New("OCI modelcars is not enabled")
@@ -181,17 +200,14 @@ func (r *LLMInferenceServiceReconciler) attachModelArtifacts(llmSvc *v1alpha1.LL
 
 		return r.attachOciModelArtifact(modelUri, podSpec, storageConfig)
 
-	default:
-		// Backwards compatibility
-		// TODO: Evaluate if this is needed, because it essentially ignores the model URI.
-		for idx := range podSpec.Containers {
-			if podSpec.Containers[idx].Name == "main" {
-				podSpec.Containers[idx].Command = append(podSpec.Containers[idx].Command, *llmSvc.Spec.Model.Name)
-			}
-		}
+	case constants.HfURIPrefix:
+		return r.attachStorageInitializer(modelUri, podSpec, storageConfig)
+
+	case constants.S3URIPrefix:
+		return r.attachS3ModelArtifact(modelUri, podSpec, storageConfig)
 	}
 
-	return nil
+	return fmt.Errorf("unsupported schema in model URI: %s", modelUri)
 }
 
 // attachOciModelArtifact configures a PodSpec to use a model stored in an OCI registry.
@@ -202,6 +218,7 @@ func (r *LLMInferenceServiceReconciler) attachModelArtifacts(llmSvc *v1alpha1.LL
 //   - ctx: The context for API calls and logging.
 //   - modelUri: The URI of the model in the OCI registry.
 //   - podSpec: The PodSpec to which the OCI model should be attached.
+//   - storageConfig: The storage initializer configuration.
 //
 // Returns:
 //
@@ -237,6 +254,50 @@ func (r *LLMInferenceServiceReconciler) attachPVCModelArtifact(modelUri string, 
 	}
 	if mainContainer := utils.GetContainerWithName(podSpec, "main"); mainContainer != nil {
 		mainContainer.Args = append(mainContainer.Args, constants.DefaultModelLocalMountPath)
+	}
+
+	return nil
+}
+
+// attachS3ModelArtifact configures a PodSpec to use a model stored in an S3-compatible object store.
+// Model downloading is delegated to vLLM by passing the S3 URI and other required arguments.
+//
+// Parameters:
+//   - modelUri: The URI of the model in the S3-compatible object store.
+//   - podSpec: The PodSpec to which the S3 model should be attached.
+//   - storageConfig: The storage initializer configuration.
+//
+// Returns:
+//
+//	An error if the configuration fails, otherwise nil.
+func (r *LLMInferenceServiceReconciler) attachS3ModelArtifact(modelUri string, podSpec *corev1.PodSpec, storageConfig *types.StorageInitializerConfig) error {
+	if err := r.attachStorageInitializer(modelUri, podSpec, storageConfig); err != nil {
+		return err
+	}
+	if initContainer := utils.GetInitContainerWithName(podSpec, constants.StorageInitializerContainerName); initContainer != nil {
+		initContainer.Env = append(initContainer.Env, corev1.EnvVar{
+			Name:  s3.AWSAnonymousCredential,
+			Value: "true",
+		})
+	}
+
+	return nil
+}
+
+// attachStorageInitializer configures a PodSpec to use KServe storage-initializer for
+// downloading a model from compatible storage.
+//
+// Parameters:
+//   - modelUri: The URI of the model in compatible object store.
+//   - podSpec: The PodSpec to which the storage-initializer container should be attached.
+//
+// Returns:
+//
+//	An error if the configuration fails, otherwise nil.
+func (r *LLMInferenceServiceReconciler) attachStorageInitializer(modelUri string, podSpec *corev1.PodSpec, storageConfig *types.StorageInitializerConfig) error {
+	utils.AddStorageInitializerContainer(podSpec, "main", modelUri, true, storageConfig)
+	if mainContainer := utils.GetContainerWithName(podSpec, "main"); mainContainer != nil {
+		mainContainer.Command = append(mainContainer.Command, constants.DefaultModelLocalMountPath)
 	}
 
 	return nil

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -246,9 +246,18 @@ func GetContainerWithName(podSpec *corev1.PodSpec, name string) *corev1.Containe
 	return nil
 }
 
+func GetInitContainerWithName(podSpec *corev1.PodSpec, name string) *corev1.Container {
+	for idx, container := range podSpec.InitContainers {
+		if strings.Compare(container.Name, name) == 0 {
+			return &podSpec.InitContainers[idx]
+		}
+	}
+	return nil
+}
+
 // AddVolumeMountIfNotPresent adds a volume mount to a given container but only if no volume mount
 // with this name has been already added. Container must not be nil
-func AddVolumeMountIfNotPresent(container *corev1.Container, mountName string, mountPath string) {
+func AddVolumeMountIfNotPresent(container *corev1.Container, mountName, mountPath string, readOnly bool) {
 	for _, v := range container.VolumeMounts {
 		if v.Name == mountName {
 			return
@@ -257,7 +266,7 @@ func AddVolumeMountIfNotPresent(container *corev1.Container, mountName string, m
 	modelMount := corev1.VolumeMount{
 		Name:      mountName,
 		MountPath: mountPath,
-		ReadOnly:  false,
+		ReadOnly:  readOnly,
 	}
 	container.VolumeMounts = append(container.VolumeMounts, modelMount)
 }

--- a/pkg/webhook/admission/pod/storage_initializer_injector_test.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector_test.go
@@ -182,7 +182,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -243,7 +243,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -305,7 +305,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -367,7 +367,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -433,24 +433,30 @@ func TestStorageInitializerInjector(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"/mnt/pvc/some/path/on/pvc", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
+									Name:      "kserve-provision-location",
+									MountPath: constants.DefaultModelLocalMountPath,
+								},
+								{
 									Name:      "kserve-pvc-source",
 									MountPath: "/mnt/pvc",
 									ReadOnly:  true,
-								},
-								{
-									Name:      "kserve-provision-location",
-									MountPath: constants.DefaultModelLocalMountPath,
 								},
 							},
 						},
 					},
 					Volumes: []corev1.Volume{
+						{
+							Name: "kserve-provision-location",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
 						{
 							Name: "kserve-pvc-source",
 							VolumeSource: corev1.VolumeSource{
@@ -458,12 +464,6 @@ func TestStorageInitializerInjector(t *testing.T) {
 									ClaimName: "mypvcname",
 									ReadOnly:  false,
 								},
-							},
-						},
-						{
-							Name: "kserve-provision-location",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},
@@ -512,7 +512,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:  "storage-initializer",
-							Image: StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:  []string{"s3://my-bucket/foo/bar", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{
@@ -786,7 +786,7 @@ func TestCredentialInjection(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -886,7 +886,7 @@ func TestCredentialInjection(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -987,7 +987,7 @@ func TestCredentialInjection(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:  "storage-initializer",
-							Image: StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:  []string{"s3://my-bucket/foo/bar", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{
@@ -1082,7 +1082,7 @@ func TestCredentialInjection(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:  "storage-initializer",
-							Image: StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:  []string{"s3://my-bucket/foo/bar", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{
@@ -1438,7 +1438,7 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:  "storage-initializer",
-							Image: StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{
@@ -1539,7 +1539,7 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:  "storage-initializer",
-							Image: StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{
@@ -1659,7 +1659,7 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:  "storage-initializer",
-							Image: StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{
@@ -1781,7 +1781,7 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:  "storage-initializer",
-							Image: StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{
@@ -1896,7 +1896,7 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:  "storage-initializer",
-							Image: StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{
@@ -2002,7 +2002,7 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:  "storage-initializer",
-							Image: StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{
@@ -2394,24 +2394,30 @@ func TestTransformerCollocation(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"/mnt/pvc/some/path/on/pvc", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
+									Name:      "kserve-provision-location",
+									MountPath: constants.DefaultModelLocalMountPath,
+								},
+								{
 									Name:      "kserve-pvc-source",
 									MountPath: "/mnt/pvc",
 									ReadOnly:  true,
-								},
-								{
-									Name:      "kserve-provision-location",
-									MountPath: constants.DefaultModelLocalMountPath,
 								},
 							},
 						},
 					},
 					Volumes: []corev1.Volume{
+						{
+							Name: "kserve-provision-location",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
 						{
 							Name: "kserve-pvc-source",
 							VolumeSource: corev1.VolumeSource{
@@ -2419,12 +2425,6 @@ func TestTransformerCollocation(t *testing.T) {
 									ClaimName: "mypvcname",
 									ReadOnly:  false,
 								},
-							},
-						},
-						{
-							Name: "kserve-provision-location",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},
@@ -2562,24 +2562,30 @@ func TestTransformerCollocation(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"/mnt/pvc/some/path/on/pvc", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
 								{
+									Name:      "kserve-provision-location",
+									MountPath: constants.DefaultModelLocalMountPath,
+								},
+								{
 									Name:      "kserve-pvc-source",
 									MountPath: "/mnt/pvc",
 									ReadOnly:  true,
-								},
-								{
-									Name:      "kserve-provision-location",
-									MountPath: constants.DefaultModelLocalMountPath,
 								},
 							},
 						},
 					},
 					Volumes: []corev1.Volume{
+						{
+							Name: "kserve-provision-location",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
 						{
 							Name: "kserve-pvc-source",
 							VolumeSource: corev1.VolumeSource{
@@ -2587,12 +2593,6 @@ func TestTransformerCollocation(t *testing.T) {
 									ClaimName: "mypvcname",
 									ReadOnly:  false,
 								},
-							},
-						},
-						{
-							Name: "kserve-provision-location",
-							VolumeSource: corev1.VolumeSource{
-								EmptyDir: &corev1.EmptyDirVolumeSource{},
 							},
 						},
 					},
@@ -2790,7 +2790,7 @@ func TestStorageContainerCRDInjection(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:  "storage-initializer",
-							Image: StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image: constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:  []string{"s3://foo", constants.DefaultModelLocalMountPath},
 							Resources: corev1.ResourceRequirements{
 								Limits: map[corev1.ResourceName]resource.Quantity{
@@ -2862,7 +2862,7 @@ func TestStorageContainerCRDInjection(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"https://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement, // from configMap instead of the CR
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -3297,7 +3297,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -3368,7 +3368,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -3453,7 +3453,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 						},
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -3515,7 +3515,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -3589,7 +3589,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -3663,7 +3663,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -3737,7 +3737,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -3810,7 +3810,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -3883,7 +3883,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -3957,7 +3957,7 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 					InitContainers: []corev1.Container{
 						{
 							Name:                     "storage-initializer",
-							Image:                    StorageInitializerContainerImage + ":" + StorageInitializerContainerImageVersion,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
 							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",


### PR DESCRIPTION
**What this PR does / why we need it**:

- Introduces formal support for downloading models from Hugging Face (hf://) and S3 (s3://) URIs in LLMInferenceService.
- Refactors model artifact attachment logic to use URI schema for backend selection.
- Updates integration tests to cover Hugging Face and S3 model download scenarios.

This change enables users to specify models hosted on Hugging Face or S3-compatible storage. The KServe storage initializer handles downloading model artifacts, thus an init-container is added to the workloads in these cases.

**NOTE**: This PR covers only anonymous access to S3 and HF.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Related to https://issues.redhat.com/browse/RHOAIENG-27817

**Type of changes**

- [x] New feature (non-breaking change which adds functionality)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading models from Hugging Face (hf://) and S3 (s3://) URIs, enabling automatic model downloading using a storage initializer container.

* **Bug Fixes**
  * Improved error handling for unsupported or invalid model URI schemes.

* **Tests**
  * Introduced new integration tests to verify correct behavior when using Hugging Face and S3 model URIs.

* **Chores**
  * Centralized and standardized storage initializer configuration and constant usage for easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->