### PR TITLE
Updating s3 tls fvt tests to cover all new scenarios

### DIFF
--- a/test/e2e/storagespec/test_s3_tls_storagespec.py
+++ b/test/e2e/storagespec/test_s3_tls_storagespec.py
@@ -13,7 +13,7 @@
 
 import os
 import time
-from base64 import b64decode
+from base64 import b64decode, b64encode
 from kubernetes import client
 from kserve import (
     constants,
@@ -30,7 +30,6 @@ import pytest
 
 from ..common.utils import KSERVE_NAMESPACE, KSERVE_TEST_NAMESPACE
 
-ssl_error = "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed"
 invalid_cert = """
 -----BEGIN CERTIFICATE-----
 MIIFLTCCAxWgAwIBAgIUF4tP6T1S5H/Gt8BpjFsbXo7f0SYwDQYJKoZIhvcNAQEL
@@ -63,6 +62,89 @@ TbVunBmL9HUClHgUc2B0NSfNyqXSwo+Gp5Kg4iYIw4hJw2EPwilUFafcM8uVDktK
 5kwH30e7WUlkXz+j8p1UIuFM5kKHW/OwPBdLU/1Pl5ts
 -----END CERTIFICATE-----
 """
+invalid_data_connection=(
+    '{"type": "s3","access_key_id":"minio","secret_access_key":"minio123",'
+    '"endpoint_url":"https://minio-tls-serving-service.kserve.svc:9000",'
+    '"bucket":"mlpipeline","region":"us-south","anonymous":"False"}'
+)
+ssl_error = "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed"
+
+
+@pytest.mark.kserve_on_openshift
+@pytest.mark.asyncio(scope="session")
+async def test_s3_tls_global_custom_cert_storagespec_kserve():
+    kserve_client = KServeClient(
+        config_file=os.environ.get("KUBECONFIG", "~/.kube/config")
+    )
+
+    # Mimic the RHOAI/ODH operators by creating the odh-trusted-ca-bundle configmap containing the custom cert as a global cert
+    minio_tls_custom_certs = kserve_client.core_api.read_namespaced_secret(
+        "minio-tls-custom", KSERVE_NAMESPACE
+    ).data
+    odh_trusted_ca_configmap = client.V1ConfigMap(
+        api_version="v1",
+        kind="ConfigMap",
+        metadata=client.V1ObjectMeta(name="odh-trusted-ca-bundle"),
+        data={
+            "ca-bundle.crt": b64decode(minio_tls_custom_certs["root.crt"]).decode()
+        },
+    )
+    kserve_client.core_api.create_namespaced_config_map(
+        namespace=KSERVE_TEST_NAMESPACE, body=odh_trusted_ca_configmap
+    )
+
+    # Validate that the model is successfully loaded when the global custom cert is present
+    service_name = "isvc-sklearn-s3-tls-global-pass"
+    predictor = V1beta1PredictorSpec(
+        min_replicas=1,
+        sklearn=V1beta1SKLearnSpec(
+            storage=V1beta1StorageSpec(
+                key="localTLSMinIOCustom",
+                path="sklearn",
+                parameters={"bucket": "example-models"},
+            ),
+            resources=V1ResourceRequirements(
+                requests={"cpu": "50m", "memory": "128Mi"},
+                limits={"cpu": "100m", "memory": "256Mi"},
+            ),
+        ),
+    )
+    isvc = V1beta1InferenceService(
+        api_version=constants.KSERVE_V1BETA1,
+        kind=constants.KSERVE_KIND_INFERENCESERVICE,
+        metadata=client.V1ObjectMeta(
+            name=service_name, namespace=KSERVE_TEST_NAMESPACE
+        ),
+        spec=V1beta1InferenceServiceSpec(predictor=predictor),
+    )
+    kserve_client.create(isvc)
+    check_model_status(kserve_client, service_name, KSERVE_TEST_NAMESPACE, "UpToDate")
+    kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
+
+    # Patch the odh-trusted-ca-bundle configmap to replace the global custom cert with an invalid cert
+    kserve_client.core_api.patch_namespaced_config_map(
+        name="odh-trusted-ca-bundle",
+        namespace=KSERVE_TEST_NAMESPACE,
+        body={"data": {"ca-bundle.crt": invalid_cert.strip()}},
+    )
+
+    # Validate that the model fails to load when the global custom cert is not present
+    service_name = "isvc-sklearn-s3-tls-global-fail"
+    isvc.metadata.name = service_name
+    kserve_client.create(isvc)
+    check_model_status(
+        kserve_client,
+        service_name,
+        KSERVE_TEST_NAMESPACE,
+        "BlockedByFailedLoad",
+        ssl_error,
+    )
+    kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
+
+    # Cleanup the configmap
+    kserve_client.core_api.delete_namespaced_config_map(
+        name="odh-trusted-ca-bundle", namespace=KSERVE_TEST_NAMESPACE
+    )
 
 
 @pytest.mark.kserve_on_openshift
@@ -117,16 +199,10 @@ async def test_s3_tls_custom_cert_storagespec_kserve():
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
     # Patch the odh-trusted-ca-bundle configmap to replace the custom cert with an invalid cert
-    odh_trusted_ca_configmap_patch = client.V1ConfigMap(
-        api_version="v1",
-        kind="ConfigMap",
-        metadata=client.V1ObjectMeta(name="odh-trusted-ca-bundle"),
-        data={"odh-ca-bundle.crt": invalid_cert},
-    )
     kserve_client.core_api.patch_namespaced_config_map(
         name="odh-trusted-ca-bundle",
         namespace=KSERVE_TEST_NAMESPACE,
-        body=odh_trusted_ca_configmap_patch,
+        body={"data": {"odh-ca-bundle.crt": invalid_cert.strip()}},
     )
 
     # Validate that the model fails to load when the custom cert is not present
@@ -155,23 +231,7 @@ async def test_s3_tls_serving_cert_storagespec_kserve():
         config_file=os.environ.get("KUBECONFIG", "~/.kube/config")
     )
 
-    # Mimic the RHOAI/ODH operators by creating the odh-trusted-ca-bundle configmap containing the serving cert
-    minio_tls_serving_certs = kserve_client.core_api.read_namespaced_secret(
-        "minio-tls-serving", KSERVE_NAMESPACE
-    ).data
-    odhTrustedCAConfigmap = client.V1ConfigMap(
-        api_version="v1",
-        kind="ConfigMap",
-        metadata=client.V1ObjectMeta(name="odh-trusted-ca-bundle"),
-        data={
-            "odh-ca-bundle.crt": b64decode(minio_tls_serving_certs["tls.crt"]).decode()
-        },
-    )
-    kserve_client.core_api.create_namespaced_config_map(
-        namespace=KSERVE_TEST_NAMESPACE, body=odhTrustedCAConfigmap
-    )
-
-    # Validate that the model is successfully loaded when the serving cert is present
+    # Validate that the model is successfully loaded using the serving cert
     service_name = "isvc-sklearn-s3-tls-serving-pass"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -199,20 +259,19 @@ async def test_s3_tls_serving_cert_storagespec_kserve():
     check_model_status(kserve_client, service_name, KSERVE_TEST_NAMESPACE, "UpToDate")
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
-    # Patch the odh-trusted-ca-bundle configmap to replace the serving cert with an invalid cert
-    odhTrustedCAConfigmapPatch = client.V1ConfigMap(
-        api_version="v1",
-        kind="ConfigMap",
-        metadata=client.V1ObjectMeta(name="odh-trusted-ca-bundle"),
-        data={"odh-ca-bundle.crt": invalid_cert},
-    )
-    kserve_client.core_api.patch_namespaced_config_map(
-        name="odh-trusted-ca-bundle",
+    # Remove the cabundle configmap reference containing the serving certificate from the storage config secret
+    storage_config_data = kserve_client.core_api.read_namespaced_secret(
+        "storage-config", KSERVE_TEST_NAMESPACE
+    ).data
+    original_data_connection = storage_config_data["localTLSMinIOServing"] 
+
+    kserve_client.core_api.patch_namespaced_secret(
+        name="storage-config",
         namespace=KSERVE_TEST_NAMESPACE,
-        body=odhTrustedCAConfigmapPatch,
+        body={"data": {"localTLSMinIOServing": b64encode(invalid_data_connection.encode()).decode()}},
     )
 
-    # Validate that the model fails to load when the custom cert is not present
+    # Validate that the model fails to load when the serving cert is not present
     service_name = "isvc-sklearn-s3-tls-serving-fail"
     isvc.metadata.name = service_name
     kserve_client.create(isvc)
@@ -225,9 +284,11 @@ async def test_s3_tls_serving_cert_storagespec_kserve():
     )
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
-    # Cleanup the configmap
-    kserve_client.core_api.delete_namespaced_config_map(
-        name="odh-trusted-ca-bundle", namespace=KSERVE_TEST_NAMESPACE
+    # Restore the storage config secret
+    kserve_client.core_api.patch_namespaced_secret(
+        name="storage-config",
+        namespace=KSERVE_TEST_NAMESPACE,
+        body={"data": {"localTLSMinIOServing": original_data_connection}},
     )
 
 

--- a/test/e2e/storagespec/test_s3_tls_storagespec.py
+++ b/test/e2e/storagespec/test_s3_tls_storagespec.py
@@ -62,7 +62,7 @@ TbVunBmL9HUClHgUc2B0NSfNyqXSwo+Gp5Kg4iYIw4hJw2EPwilUFafcM8uVDktK
 5kwH30e7WUlkXz+j8p1UIuFM5kKHW/OwPBdLU/1Pl5ts
 -----END CERTIFICATE-----
 """
-invalid_data_connection=(
+invalid_data_connection = (
     '{"type": "s3","access_key_id":"minio","secret_access_key":"minio123",'
     '"endpoint_url":"https://minio-tls-serving-service.kserve.svc:9000",'
     '"bucket":"mlpipeline","region":"us-south","anonymous":"False"}'
@@ -263,7 +263,7 @@ async def test_s3_tls_serving_cert_storagespec_kserve():
     storage_config_data = kserve_client.core_api.read_namespaced_secret(
         "storage-config", KSERVE_TEST_NAMESPACE
     ).data
-    original_data_connection = storage_config_data["localTLSMinIOServing"] 
+    original_data_connection = storage_config_data["localTLSMinIOServing"]
 
     kserve_client.core_api.patch_namespaced_secret(
         name="storage-config",

--- a/test/scripts/openshift-ci/teardown-e2e-setup.sh
+++ b/test/scripts/openshift-ci/teardown-e2e-setup.sh
@@ -79,6 +79,7 @@ if [ "$1" =~ "kserve_on_openshift" ]; then
   echo "Deleting TLS MinIO resources and generated certificates"
   kustomize build $PROJECT_ROOT/test/overlays/openshift-ci |
     oc delete -n kserve -f -
+  oc delete secret minio-tls-custom -n kserve
   rm -rf $PROJECT_ROOT/test/scripts/openshift-ci/tls/certs
 fi
 # Install DSC/DSCI for test. (sometimes there is timing issue when it is under the same kustomization so it is separated)

--- a/test/scripts/openshift-ci/teardown-e2e-setup.sh
+++ b/test/scripts/openshift-ci/teardown-e2e-setup.sh
@@ -79,7 +79,7 @@ if [ "$1" =~ "kserve_on_openshift" ]; then
   echo "Deleting TLS MinIO resources and generated certificates"
   kustomize build $PROJECT_ROOT/test/overlays/openshift-ci |
     oc delete -n kserve -f -
-  oc delete secret minio-tls-custom -n kserve
+  oc delete secret minio-tls-custom -n kserve --ignore-not-found
   rm -rf $PROJECT_ROOT/test/scripts/openshift-ci/tls/certs
 fi
 # Install DSC/DSCI for test. (sometimes there is timing issue when it is under the same kustomization so it is separated)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
[RHOAIENG-27522](https://issues.redhat.com/browse/RHOAIENG-27522)

This PR updates the s3 tls model download test to cover the following scenarios:
1. Custom certificate added to the `ca-bundle.crt` field in the `odh-trusted-ca-bundle` configmap
2. Custom certificate added to the `odh-ca-bundle.crt` field in the `odh-trusted-ca-bundle` configmap
3. Openshift serving certificate using the certificate found in the `service-ca.crt` field of the  `openshift-service-ca.crt` configmap

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- Execute the pytests with marker `kserve_on_openshift` by executing the following command:
```
SETUP_E2E=true ./test/scripts/openshift-ci/run-e2e-tests.sh kserve_on_openshift
```
- Logs
```
predictor/test_multi_container_probing.py::test_multi_container_probing 
[gw0] [ 20%] PASSED predictor/test_multi_container_probing.py::test_multi_container_probing 
predictor/test_scheduler_name.py::test_scheduler_name 
[gw0] [ 40%] PASSED predictor/test_scheduler_name.py::test_scheduler_name 
storagespec/test_s3_tls_storagespec.py::test_s3_tls_global_custom_cert_storagespec_kserve 
[gw0] [ 60%] PASSED storagespec/test_s3_tls_storagespec.py::test_s3_tls_global_custom_cert_storagespec_kserve 
storagespec/test_s3_tls_storagespec.py::test_s3_tls_custom_cert_storagespec_kserve 
[gw0] [ 80%] PASSED storagespec/test_s3_tls_storagespec.py::test_s3_tls_custom_cert_storagespec_kserve 
storagespec/test_s3_tls_storagespec.py::test_s3_tls_serving_cert_storagespec_kserve 
[gw0] [100%] PASSED storagespec/test_s3_tls_storagespec.py::test_s3_tls_serving_cert_storagespec_kserve 

=================== 5 passed, 3 skipped in 378.89s (0:06:18) ===================

```

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved organization and clarity of S3 TLS storage specification tests, with clearer separation and naming for global custom cert, custom cert, and serving cert scenarios.
  * Added a new test to validate serving certificate handling and failure cases.
  * Enhanced test reliability with simplified certificate patching and consistent naming.

* **Chores**
  * Updated teardown script to ensure proper cleanup of custom TLS secrets in the environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->