### PR TITLE
fix(test): adds required storage initializer settings to test configmap

### DIFF
--- a/config/overlays/test/configmap/inferenceservice.yaml
+++ b/config/overlays/test/configmap/inferenceservice.yaml
@@ -18,7 +18,11 @@ data:
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
         "cpuLimit": "1",
-        "enableDirectPvcVolumeMount": true
+        "enableDirectPvcVolumeMount": true,
+        "cpuModelcar": "10m",
+        "memoryModelcar": "15Mi",
+        "enableModelcar": true,
+        "uidModelcar": 1010
     }
   credentials: |-
     {


### PR DESCRIPTION
Without this fix we see following when using `kserve-setup.sh` for CI jobs:

```
Error from server (Forbidden): admission webhook "llminferenceserviceconfig.kserve-webhook-server.validator" denied the request: failed to convert InferenceServiceConfigMap to StorageInitializerConfig: Failed to parse resource configuration for "storageInitializer": "quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'"
```