### PR TITLE
fix(scheduler): Uses ClusterRole for TokenReview and SAR resources

### DIFF
--- a/charts/kserve-resources/templates/clusterrole.yaml
+++ b/charts/kserve-resources/templates/clusterrole.yaml
@@ -230,6 +230,7 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
+  - clusterrolebindings
   - rolebindings
   - roles
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -217,6 +217,7 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
+  - clusterrolebindings
   - rolebindings
   - roles
   verbs:

--- a/pkg/controller/llmisvc/controller.go
+++ b/pkg/controller/llmisvc/controller.go
@@ -154,7 +154,7 @@ func (r *LLMInferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.
 	} else {
 		logger.Info("Marked for deletion, finalizing resources")
 		if controllerutil.ContainsFinalizer(original, finalizerName) {
-			if cleanupErr := r.reconcileSchedulerServiceAccount(ctx, original); cleanupErr != nil {
+			if cleanupErr := r.finalize(ctx, original); cleanupErr != nil {
 				logger.Error(cleanupErr, "Finalization failed")
 				return ctrl.Result{}, cleanupErr
 			}
@@ -218,6 +218,10 @@ func (r *LLMInferenceServiceReconciler) reconcile(ctx context.Context, llmSvc *v
 	}
 
 	return nil
+}
+
+func (r *LLMInferenceServiceReconciler) finalize(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {
+	return r.reconcileSchedulerServiceAccount(ctx, llmSvc)
 }
 
 func (r *LLMInferenceServiceReconciler) updateStatus(ctx context.Context, desired *v1alpha1.LLMInferenceService) error {

--- a/pkg/controller/llmisvc/controller.go
+++ b/pkg/controller/llmisvc/controller.go
@@ -221,7 +221,11 @@ func (r *LLMInferenceServiceReconciler) reconcile(ctx context.Context, llmSvc *v
 }
 
 func (r *LLMInferenceServiceReconciler) finalize(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {
-	return r.reconcileSchedulerServiceAccount(ctx, llmSvc)
+	if err := r.reconcileSchedulerServiceAccount(ctx, llmSvc); err != nil {
+		return fmt.Errorf("failed to finalize scheduler service account: %w", err)
+	}
+
+	return nil
 }
 
 func (r *LLMInferenceServiceReconciler) updateStatus(ctx context.Context, desired *v1alpha1.LLMInferenceService) error {

--- a/pkg/controller/llmisvc/controller.go
+++ b/pkg/controller/llmisvc/controller.go
@@ -152,10 +152,10 @@ func (r *LLMInferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.
 			}
 		}
 	} else {
-		logger.Info("Mark for deletion, cleaning resources")
+		logger.Info("Marked for deletion, finalizing resources")
 		if controllerutil.ContainsFinalizer(original, finalizerName) {
 			if cleanupErr := r.reconcileSchedulerServiceAccount(ctx, original); cleanupErr != nil {
-				logger.Error(cleanupErr, "Cleanup failed")
+				logger.Error(cleanupErr, "Finalization failed")
 				return ctrl.Result{}, cleanupErr
 			}
 

--- a/pkg/controller/llmisvc/controller_int_test.go
+++ b/pkg/controller/llmisvc/controller_int_test.go
@@ -608,7 +608,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 		It("should use storage-initializer to download model when uri starts with hf://", func(ctx SpecContext) {
 			// given
-			svcName := "test-llm"
+			svcName := "test-llm-storage-hf"
 			nsName := kmeta.ChildName(svcName, "-test")
 			namespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
@@ -686,7 +686,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 		It("should use storage-initializer to download model when uri starts with s3://", func(ctx SpecContext) {
 			// given
-			svcName := "test-llm-s3"
+			svcName := "test-llm-storage-s3"
 			nsName := kmeta.ChildName(svcName, "-test")
 			namespace := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/llmisvc/lifecycle_crud.go
+++ b/pkg/controller/llmisvc/lifecycle_crud.go
@@ -48,13 +48,15 @@ func Delete[O client.Object, T client.Object](ctx context.Context, c clientWithR
 	typeLogLine := logLineForObject(expected)
 	ownerLogLine := logLineForObject(owner)
 
-	if !metav1.IsControlledBy(expected, owner) {
-		return fmt.Errorf("failed to delete %s %s/%s: it is not controlled by %s %s/%s",
-			typeLogLine,
-			expected.GetNamespace(), expected.GetName(),
-			ownerLogLine,
-			owner.GetNamespace(), owner.GetName(),
-		)
+	if len(expected.GetNamespace()) != 0 {
+		if !metav1.IsControlledBy(expected, owner) {
+			return fmt.Errorf("failed to delete %s %s/%s: it is not controlled by %s %s/%s",
+				typeLogLine,
+				expected.GetNamespace(), expected.GetName(),
+				ownerLogLine,
+				owner.GetNamespace(), owner.GetName(),
+			)
+		}
 	}
 
 	if err := c.Delete(ctx, expected); err != nil {
@@ -85,13 +87,15 @@ func Update[O client.Object, T client.Object](ctx context.Context, c clientWithR
 	typeLogLine := logLineForObject(expected)
 	ownerLogLine := logLineForObject(owner)
 
-	if !metav1.IsControlledBy(curr, owner) {
-		return fmt.Errorf("failed to update %s %s/%s: it is not controlled by %s %s/%s",
-			typeLogLine,
-			curr.GetNamespace(), curr.GetName(),
-			ownerLogLine,
-			owner.GetNamespace(), owner.GetName(),
-		)
+	if len(curr.GetNamespace()) != 0 {
+		if !metav1.IsControlledBy(curr, owner) {
+			return fmt.Errorf("failed to update %s %s/%s: it is not controlled by %s %s/%s",
+				typeLogLine,
+				curr.GetNamespace(), curr.GetName(),
+				ownerLogLine,
+				owner.GetNamespace(), owner.GetName(),
+			)
+		}
 	}
 
 	expected.SetResourceVersion(curr.GetResourceVersion())

--- a/pkg/controller/llmisvc/scheduler.go
+++ b/pkg/controller/llmisvc/scheduler.go
@@ -415,7 +415,7 @@ func (r *LLMInferenceServiceReconciler) expectedSchedulerServiceAccount(llmSvc *
 func (r *LLMInferenceServiceReconciler) expectedSchedulerAuthDelegatorBinding(llmSvc *v1alpha1.LLMInferenceService, sa *corev1.ServiceAccount) *rbacv1.ClusterRoleBinding {
 	crb := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   kmeta.ChildName(llmSvc.GetName(), "-epp-auth-rb"),
+			Name:   kmeta.ChildName(llmSvc.GetNamespace(), "-"+llmSvc.GetName()+"-epp-auth-rb"),
 			Labels: r.schedulerLabels(llmSvc),
 		},
 		Subjects: []rbacv1.Subject{{

--- a/pkg/controller/llmisvc/scheduler.go
+++ b/pkg/controller/llmisvc/scheduler.go
@@ -61,6 +61,19 @@ func (r *LLMInferenceServiceReconciler) reconcileScheduler(ctx context.Context, 
 	return nil
 }
 
+func (r *LLMInferenceServiceReconciler) reconcileSchedulerAuthDelegatorBinding(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService, sa *corev1.ServiceAccount) error {
+	authDelegatorBinding := r.expectedSchedulerAuthDelegatorBinding(llmSvc, sa)
+	if !llmSvc.DeletionTimestamp.IsZero() || llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil {
+		return Delete(ctx, r, llmSvc, authDelegatorBinding)
+	}
+
+	if err := Reconcile(ctx, r, llmSvc, &rbacv1.ClusterRoleBinding{}, authDelegatorBinding, semanticClusterRoleBindingIsEqual); err != nil {
+		return fmt.Errorf("failed to reconcile scheduler clusterrolebinding %s: %w", authDelegatorBinding.GetName(), err)
+	}
+
+	return nil
+}
+
 func (r *LLMInferenceServiceReconciler) reconcileSchedulerRole(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {
 	role := r.expectedSchedulerRole(llmSvc)
 	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil {
@@ -88,19 +101,28 @@ func (r *LLMInferenceServiceReconciler) reconcileSchedulerRoleBinding(ctx contex
 
 func (r *LLMInferenceServiceReconciler) reconcileSchedulerServiceAccount(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {
 	serviceAccount := r.expectedSchedulerServiceAccount(llmSvc)
-	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil {
-		return Delete(ctx, r, llmSvc, serviceAccount)
-	}
 
-	if err := Reconcile(ctx, r, llmSvc, &corev1.ServiceAccount{}, serviceAccount, semanticServiceAccountIsEqual); err != nil {
-		return fmt.Errorf("failed to reconcile scheduler service account %s/%s: %w", serviceAccount.GetNamespace(), serviceAccount.GetName(), err)
-	}
+	if llmSvc.DeletionTimestamp.IsZero() {
+		if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil {
+			return Delete(ctx, r, llmSvc, serviceAccount)
+		}
 
-	if err := r.reconcileSchedulerRole(ctx, llmSvc); err != nil {
-		return err
-	}
+		if err := Reconcile(ctx, r, llmSvc, &corev1.ServiceAccount{}, serviceAccount, semanticServiceAccountIsEqual); err != nil {
+			return fmt.Errorf("failed to reconcile scheduler service account %s/%s: %w", serviceAccount.GetNamespace(), serviceAccount.GetName(), err)
+		}
 
-	return r.reconcileSchedulerRoleBinding(ctx, llmSvc, serviceAccount)
+		if err := r.reconcileSchedulerAuthDelegatorBinding(ctx, llmSvc, serviceAccount); err != nil {
+			return err
+		}
+
+		if err := r.reconcileSchedulerRole(ctx, llmSvc); err != nil {
+			return err
+		}
+
+		return r.reconcileSchedulerRoleBinding(ctx, llmSvc, serviceAccount)
+	} else {
+		return r.reconcileSchedulerAuthDelegatorBinding(ctx, llmSvc, serviceAccount)
+	}
 }
 
 func (r *LLMInferenceServiceReconciler) reconcileSchedulerDeployment(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {
@@ -390,6 +412,26 @@ func (r *LLMInferenceServiceReconciler) expectedSchedulerServiceAccount(llmSvc *
 	return sa
 }
 
+func (r *LLMInferenceServiceReconciler) expectedSchedulerAuthDelegatorBinding(llmSvc *v1alpha1.LLMInferenceService, sa *corev1.ServiceAccount) *rbacv1.ClusterRoleBinding {
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   kmeta.ChildName(llmSvc.GetName(), "-epp-auth-rb"),
+			Labels: r.schedulerLabels(llmSvc),
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      sa.GetName(),
+			Namespace: sa.GetNamespace(),
+		}},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "system:auth-delegator",
+		},
+	}
+	return crb
+}
+
 func (r *LLMInferenceServiceReconciler) expectedSchedulerRole(llmSvc *v1alpha1.LLMInferenceService) *rbacv1.Role {
 	role := &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
@@ -404,7 +446,6 @@ func (r *LLMInferenceServiceReconciler) expectedSchedulerRole(llmSvc *v1alpha1.L
 			{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "list", "watch"}},
 			{APIGroups: []string{"inference.networking.x-k8s.io"}, Resources: []string{"inferencepools", "inferencemodels"}, Verbs: []string{"get", "list", "watch"}},
 			{APIGroups: []string{"discovery.k8s.io"}, Resources: []string{"endpointslices"}, Verbs: []string{"get", "list", "watch"}},
-			{APIGroups: []string{"authentication.k8s.io"}, Resources: []string{"tokenreviews", "subjectaccessreviews"}, Verbs: []string{"create"}},
 		},
 	}
 	return role
@@ -461,6 +502,13 @@ func semanticServiceAccountIsEqual(expected *corev1.ServiceAccount, current *cor
 
 func semanticRoleIsEqual(expected *rbacv1.Role, curr *rbacv1.Role) bool {
 	return equality.Semantic.DeepDerivative(expected.Rules, curr.Rules) &&
+		equality.Semantic.DeepDerivative(expected.Labels, curr.Labels) &&
+		equality.Semantic.DeepDerivative(expected.Annotations, curr.Annotations)
+}
+
+func semanticClusterRoleBindingIsEqual(expected *rbacv1.ClusterRoleBinding, curr *rbacv1.ClusterRoleBinding) bool {
+	return equality.Semantic.DeepDerivative(expected.Subjects, curr.Subjects) &&
+		equality.Semantic.DeepDerivative(expected.RoleRef, curr.RoleRef) &&
 		equality.Semantic.DeepDerivative(expected.Labels, curr.Labels) &&
 		equality.Semantic.DeepDerivative(expected.Annotations, curr.Annotations)
 }

--- a/pkg/controller/llmisvc/scheduler.go
+++ b/pkg/controller/llmisvc/scheduler.go
@@ -102,27 +102,27 @@ func (r *LLMInferenceServiceReconciler) reconcileSchedulerRoleBinding(ctx contex
 func (r *LLMInferenceServiceReconciler) reconcileSchedulerServiceAccount(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {
 	serviceAccount := r.expectedSchedulerServiceAccount(llmSvc)
 
-	if llmSvc.DeletionTimestamp.IsZero() {
-		if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil {
-			return Delete(ctx, r, llmSvc, serviceAccount)
-		}
-
-		if err := Reconcile(ctx, r, llmSvc, &corev1.ServiceAccount{}, serviceAccount, semanticServiceAccountIsEqual); err != nil {
-			return fmt.Errorf("failed to reconcile scheduler service account %s/%s: %w", serviceAccount.GetNamespace(), serviceAccount.GetName(), err)
-		}
-
-		if err := r.reconcileSchedulerAuthDelegatorBinding(ctx, llmSvc, serviceAccount); err != nil {
-			return err
-		}
-
-		if err := r.reconcileSchedulerRole(ctx, llmSvc); err != nil {
-			return err
-		}
-
-		return r.reconcileSchedulerRoleBinding(ctx, llmSvc, serviceAccount)
-	} else {
+	if !llmSvc.DeletionTimestamp.IsZero() {
 		return r.reconcileSchedulerAuthDelegatorBinding(ctx, llmSvc, serviceAccount)
 	}
+
+	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil {
+		return Delete(ctx, r, llmSvc, serviceAccount)
+	}
+
+	if err := Reconcile(ctx, r, llmSvc, &corev1.ServiceAccount{}, serviceAccount, semanticServiceAccountIsEqual); err != nil {
+		return fmt.Errorf("failed to reconcile scheduler service account %s/%s: %w", serviceAccount.GetNamespace(), serviceAccount.GetName(), err)
+	}
+
+	if err := r.reconcileSchedulerAuthDelegatorBinding(ctx, llmSvc, serviceAccount); err != nil {
+		return err
+	}
+
+	if err := r.reconcileSchedulerRole(ctx, llmSvc); err != nil {
+		return err
+	}
+
+	return r.reconcileSchedulerRoleBinding(ctx, llmSvc, serviceAccount)
 }
 
 func (r *LLMInferenceServiceReconciler) reconcileSchedulerDeployment(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

The llm-d scheduler uses cluster-scoped `TokenReviews` and `SubjectAccessReview` resources to validate for access to the metrics endpoint. This fixes the RBAC privileges to correctly enable scraping metrics.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Related to https://issues.redhat.com/browse/RHOAIENG-28166

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

Manual testing

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved management of scheduler service account permissions, including explicit handling of authorization delegation.
  * Enhanced cleanup and lifecycle handling for inference service resources.

* **Bug Fixes**
  * Adjusted ownership checks to handle objects without a namespace more gracefully.

* **Chores**
  * Expanded cluster permissions to include management of ClusterRoleBindings for better integration and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->