### PR TITLE
feat(ci): adds status check for system namespace

### DIFF
--- a/test/scripts/gh-actions/status-check.sh
+++ b/test/scripts/gh-actions/status-check.sh
@@ -18,6 +18,14 @@ echo "::group::List Pods in all other namespaces"
 kubectl get pods -A --field-selector=metadata.namespace!=kserve,metadata.namespace!=kserve-ci-e2e-test
 echo "::endgroup::"
 
+echo "::group::Describe Pods in kserve namespace"
+kubectl describe pods -n kserve
+echo "::endgroup::"
+
+echo "::group::K8s Events in kserve"
+kubectl get events -n kserve
+echo "::endgroup::"
+
 echo "::group::Describe Pods in kserve-ci-e2e-test namespace"
 kubectl describe pods -n kserve-ci-e2e-test
 echo "::endgroup::"


### PR DESCRIPTION
Enhances status check for CI jobs to dump pod details and events in the system namespace.

This should help in diagnosing setup issues faster, as previously this was only shown when kserve-setup action succeeded.

> [!NOTE]
> As a follow-up (also upstream) we can remove kubectl commands that are
executed as part of "Install KServe" steps.
