### PR TITLE
fix(presets): respects baseRefs defaults

### DIFF
--- a/pkg/controller/llmisvc/config_merge_test.go
+++ b/pkg/controller/llmisvc/config_merge_test.go
@@ -70,6 +70,46 @@ func TestMergeSpecs(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "two configs simple merge with sub-field override",
+			cfgs: []v1alpha1.LLMInferenceServiceSpec{
+				{
+					Model: v1alpha1.LLMModelSpec{URI: apis.URL{Path: "model-a"}},
+					Router: &v1alpha1.RouterSpec{
+						Route:     &v1alpha1.GatewayRoutesSpec{},
+						Gateway:   &v1alpha1.GatewaySpec{},
+						Scheduler: &v1alpha1.SchedulerSpec{},
+					},
+				},
+				{
+					Model: v1alpha1.LLMModelSpec{URI: apis.URL{Path: "model-a"}},
+					Router: &v1alpha1.RouterSpec{
+						Scheduler: &v1alpha1.SchedulerSpec{
+							Pool: &v1alpha1.InferencePoolSpec{
+								Spec: &igwapi.InferencePoolSpec{
+									TargetPortNumber: 9999,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: v1alpha1.LLMInferenceServiceSpec{
+				Model: v1alpha1.LLMModelSpec{URI: apis.URL{Path: "model-a"}},
+				Router: &v1alpha1.RouterSpec{
+					Route:   &v1alpha1.GatewayRoutesSpec{},
+					Gateway: &v1alpha1.GatewaySpec{},
+					Scheduler: &v1alpha1.SchedulerSpec{
+						Pool: &v1alpha1.InferencePoolSpec{
+							Spec: &igwapi.InferencePoolSpec{
+								TargetPortNumber: 9999,
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "two configs with override",
 			cfgs: []v1alpha1.LLMInferenceServiceSpec{
 				{

--- a/pkg/controller/llmisvc/fixture/llmisvc_builders.go
+++ b/pkg/controller/llmisvc/fixture/llmisvc_builders.go
@@ -52,6 +52,12 @@ func WithModelURI(uri string) LLMInferenceServiceOption {
 	}
 }
 
+func WithModelName(name string) LLMInferenceServiceOption {
+	return func(llmSvc *v1alpha1.LLMInferenceService) {
+		llmSvc.Spec.Model.Name = &name
+	}
+}
+
 func WithGatewayRefs(refs ...v1alpha1.UntypedObjectReference) LLMInferenceServiceOption {
 	return func(llmSvc *v1alpha1.LLMInferenceService) {
 		if llmSvc.Spec.Router == nil {
@@ -193,5 +199,60 @@ func SimpleWorkerPodSpec() *corev1.PodSpec {
 				Image: "test-worker:latest",
 			},
 		},
+	}
+}
+
+func WithBaseRefs(refs ...corev1.LocalObjectReference) LLMInferenceServiceOption {
+	return func(llmSvc *v1alpha1.LLMInferenceService) {
+		llmSvc.Spec.BaseRefs = refs
+	}
+}
+
+type LLMInferenceServiceConfigOption ObjectOption[*v1alpha1.LLMInferenceServiceConfig]
+
+func LLMInferenceServiceConfig(name string, opts ...LLMInferenceServiceConfigOption) *v1alpha1.LLMInferenceServiceConfig {
+	config := &v1alpha1.LLMInferenceServiceConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1alpha1.LLMInferenceServiceSpec{},
+	}
+
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	return config
+}
+
+func WithConfigModelURI(uri string) LLMInferenceServiceConfigOption {
+	return func(config *v1alpha1.LLMInferenceServiceConfig) {
+		modelURL, err := apis.ParseURL(uri)
+		if err != nil {
+			panic(err) // For test fixtures, panic is acceptable
+		}
+		config.Spec.Model.URI = *modelURL
+	}
+}
+
+func WithConfigModelName(name string) LLMInferenceServiceConfigOption {
+	return func(config *v1alpha1.LLMInferenceServiceConfig) {
+		config.Spec.Model.Name = &name
+	}
+}
+
+func WithConfigManagedRouter() LLMInferenceServiceConfigOption {
+	return func(config *v1alpha1.LLMInferenceServiceConfig) {
+		config.Spec.Router = &v1alpha1.RouterSpec{
+			Gateway:   &v1alpha1.GatewaySpec{},
+			Route:     &v1alpha1.GatewayRoutesSpec{},
+			Scheduler: &v1alpha1.SchedulerSpec{},
+		}
+	}
+}
+
+func WithConfigWorkloadTemplate(podSpec *corev1.PodSpec) LLMInferenceServiceConfigOption {
+	return func(config *v1alpha1.LLMInferenceServiceConfig) {
+		config.Spec.Template = podSpec
 	}
 }


### PR DESCRIPTION
When using LLMInferenceService with only baseRefs, if one of the configs was zeroing `scheduler: {}` or other elements, the well-known presets were not applied, in contrary, they were removed, as baseRefs were applied after defaulting logic. With this change we resolve baseRefs first to check if we need defaulting.

[Example
Gist](https://gist.github.com/bartoszmajsak/86578f89c27f9c9b05819e68b4f8f0fa)

Additionally, defaulting of model name to LLMInferenceService (`llm-inference-service-model-fb-opt-125m-router-managed-workload` - manifested by the gist above) was causing presets to be ignored, leading to failures of the served model, as it was not able to find wrongly named model in e.g. hugging face repo:

```
ERROR 07-24 10:41:07 [config.py:112] Repository Not Found for url: https://huggingface.co/api/models/llm-inference-service-model-fb-opt-125m-router-managed-workload/tree/main?recursive=True&e
xpand=False.
```
