### PR TITLE
Odh v2.32 release

### DIFF
--- a/.tekton/kserve-agent-push.yaml
+++ b/.tekton/kserve-agent-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-agent:odh-v2.32
+    value: quay.io/opendatahub/kserve-agent:odh-v2.33
   - name: dockerfile
     value: agent.Dockerfile
   - name: path-context

--- a/.tekton/kserve-controller-push.yaml
+++ b/.tekton/kserve-controller-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-controller:odh-v2.32
+    value: quay.io/opendatahub/kserve-controller:odh-v2.33
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/kserve-router-push.yaml
+++ b/.tekton/kserve-router-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-router:odh-v2.32
+    value: quay.io/opendatahub/kserve-router:odh-v2.33
   - name: dockerfile
     value: router.Dockerfile
   - name: path-context

--- a/.tekton/kserve-storage-initializer-push.yaml
+++ b/.tekton/kserve-storage-initializer-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-storage-initializer:odh-v2.32
+    value: quay.io/opendatahub/kserve-storage-initializer:odh-v2.33
   - name: dockerfile
     value: storage-initializer.Dockerfile
   - name: path-context


### PR DESCRIPTION
Update Tekton output-image tags to version odh-v2.33 
[RHOAIENG-29332]