### PR TITLE
fix: defaults GITHUB_SHA for graph images

### DIFF
--- a/test/e2e/graph/test_inference_graph.py
+++ b/test/e2e/graph/test_inference_graph.py
@@ -25,14 +25,18 @@ from httpx import HTTPStatusError
 
 from ..common.utils import KSERVE_TEST_NAMESPACE, predict_ig
 
-if os.environ.get("SUCCESS_200_ISVC_IMAGE") is not None:
-    SUCCESS_ISVC_IMAGE = os.environ.get("SUCCESS_200_ISVC_IMAGE")
-else:
-    SUCCESS_ISVC_IMAGE = "kserve/success-200-isvc:" + os.environ.get("GITHUB_SHA")
-if os.environ.get("ERROR_404_ISVC_IMAGE") is not None:
-    ERROR_ISVC_IMAGE = os.environ.get("ERROR_404_ISVC_IMAGE")
-else:
-    ERROR_ISVC_IMAGE = "kserve/error-404-isvc:" + os.environ.get("GITHUB_SHA")
+img_version = os.environ.get("GITHUB_SHA", "latest")
+
+SUCCESS_ISVC_IMAGE = os.environ.get(
+    "SUCCESS_200_ISVC_IMAGE",
+    f"kserve/success-200-isvc:{img_version}"
+)
+
+ERROR_ISVC_IMAGE = os.environ.get(
+    "ERROR_404_ISVC_IMAGE",
+    f"kserve/error-404-isvc:{img_version}"
+)
+
 IG_TEST_RESOURCES_BASE_LOCATION = "graph/test-resources"
 
 


### PR DESCRIPTION
If `GITHUB_SHA` is not defined as environment variable, running pytest yield error:

```
_______________________________________________________________________ ERROR collecting graph/test_inference_graph.py ________________________________________________________________________
graph/test_inference_graph.py:31: in <module>
    SUCCESS_ISVC_IMAGE = "kserve/success-200-isvc:" + os.environ.get("GITHUB_SHA")
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   TypeError: can only concatenate str (not "NoneType") to str
_______________________________________________________________________ ERROR collecting graph/test_inference_graph.py ________________________________________________________________________
graph/test_inference_graph.py:31: in <module>
    SUCCESS_ISVC_IMAGE = "kserve/success-200-isvc:" + os.environ.get("GITHUB_SHA")
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   TypeError: can only concatenate str (not "NoneType") to str
```
