### PR TITLE
feat: disallows BaseRefs field in LLMInferenceServiceConfig

### DIFF
--- a/pkg/controller/llmisvc/webhook/config_validator.go
+++ b/pkg/controller/llmisvc/webhook/config_validator.go
@@ -18,6 +18,7 @@ package webhook
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -102,6 +103,10 @@ func (l *LLMInferenceServiceConfigValidator) ValidateDelete(ctx context.Context,
 func (l *LLMInferenceServiceConfigValidator) validate(ctx context.Context, llmSvcConfig *v1alpha1.LLMInferenceServiceConfig) error {
 	logger := log.FromContext(ctx)
 	llmSvcConfig = llmSvcConfig.DeepCopy()
+
+	if len(llmSvcConfig.Spec.BaseRefs) > 0 {
+		return errors.New("spec.baseRefs is not a permitted field in LLMInferenceServiceConfig, support for recursive refs has been disabled")
+	}
 
 	config, err := llmisvc.LoadConfig(ctx, l.ClientSet)
 	if err != nil {

--- a/pkg/controller/llmisvc/webhook/config_validator_int_test.go
+++ b/pkg/controller/llmisvc/webhook/config_validator_int_test.go
@@ -19,28 +19,22 @@ package webhook_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/ptr"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/controller/llmisvc/fixture"
 )
 
 var _ = Describe("Validating config configs", func() {
 	Context("validating new configs", func() {
 		It("should reject config with invalid template fields", func(ctx SpecContext) {
 			// given
-			preset := &v1alpha1.LLMInferenceServiceConfig{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "invalid-template-fields",
-					Namespace: constants.KServeNamespace,
-				},
-				Spec: v1alpha1.LLMInferenceServiceSpec{
-					Model: v1alpha1.LLMModelSpec{
-						Name: ptr.To("{{ .NonExisting }}"),
-					},
-				},
-			}
+			preset := fixture.LLMInferenceServiceConfig("invalid-template-fields",
+				fixture.InNamespace[*v1alpha1.LLMInferenceServiceConfig](constants.KServeNamespace),
+				fixture.WithConfigModelName("{{ .NonExisting }}"),
+			)
 
 			// when
 			admissionError := envTest.Client.Create(ctx, preset)
@@ -52,17 +46,10 @@ var _ = Describe("Validating config configs", func() {
 
 		It("should reject updating config with wrong template syntax", func(ctx SpecContext) {
 			// given
-			preset := &v1alpha1.LLMInferenceServiceConfig{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "invalid-template-fields",
-					Namespace: constants.KServeNamespace,
-				},
-				Spec: v1alpha1.LLMInferenceServiceSpec{
-					Model: v1alpha1.LLMModelSpec{
-						Name: ptr.To("{{ ChildName .ObjectMeta.Name `-inference-pool` }}"),
-					},
-				},
-			}
+			preset := fixture.LLMInferenceServiceConfig("invalid-template-fields",
+				fixture.InNamespace[*v1alpha1.LLMInferenceServiceConfig](constants.KServeNamespace),
+				fixture.WithConfigModelName("{{ ChildName .ObjectMeta.Name `-inference-pool` }}"),
+			)
 			Expect(envTest.Client.Create(ctx, preset)).To(Succeed())
 
 			// when
@@ -72,6 +59,25 @@ var _ = Describe("Validating config configs", func() {
 			// then
 			Expect(admissionError).To(HaveOccurred())
 			Expect(admissionError.Error()).To(ContainSubstring(`unexpected "\\" in operand`))
+		})
+
+		It("should reject config with baseRefs", func(ctx SpecContext) {
+			// given
+			preset := fixture.LLMInferenceServiceConfig("config-with-baserefs",
+				fixture.InNamespace[*v1alpha1.LLMInferenceServiceConfig](constants.KServeNamespace),
+				fixture.WithConfigModelName("test-model"),
+			)
+
+			preset.Spec.BaseRefs = []corev1.LocalObjectReference{
+				{Name: "base-config"},
+			}
+
+			// when
+			admissionError := envTest.Client.Create(ctx, preset)
+
+			// then
+			Expect(admissionError).To(HaveOccurred())
+			Expect(admissionError.Error()).To(ContainSubstring("spec.baseRefs is not a permitted field in LLMInferenceServiceConfig"))
 		})
 	})
 })


### PR DESCRIPTION
Prevents creation of nested configurations by disallowing `.spec.baseRefs`  in `LLMInferenceServiceConfig` resources. 

As we share the `.spec` between both custom resources we need to make sure that BaseRefs are only used in `LLMInferenceService` resources to reference configuration templates. Using them within the configuration templates introduces additional complexity and can introduce circular dependencies.
