### PR TITLE
feat(storage): add model storage support for multi-node LLM workloads (LWS)

### DIFF
--- a/config/llmisvc/config-llm-decode-template.yaml
+++ b/config/llmisvc/config-llm-decode-template.yaml
@@ -14,6 +14,7 @@ spec:
         command:
           - vllm
           - serve
+          - /mnt/models
         args:
           - --served-model-name
           - "{{ .Spec.Model.Name }}"

--- a/config/llmisvc/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvc/config-llm-decode-worker-data-parallel.yaml
@@ -72,7 +72,7 @@ spec:
               # Leader-only launch
               #################
               vllm serve \
-                {{ .Spec.Model.Name }} \
+                /mnt/models \
                 --port 8001 \
                 --api-server-count 4 \
                 --disable-log-requests \
@@ -94,7 +94,7 @@ spec:
               # Worker-only launch
               #################
               vllm serve \
-                {{ .Spec.Model.Name }} \
+                /mnt/models \
                 --port 8001 \
                 --disable-log-requests \
                 {{- if .Spec.Parallelism.Expert }}--enable-expert-parallel \{{- end }}

--- a/config/llmisvc/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvc/config-llm-decode-worker-data-parallel.yaml
@@ -73,6 +73,7 @@ spec:
               #################
               vllm serve \
                 /mnt/models \
+                --served-model-name "{{ .Spec.Model.Name }}" \
                 --port 8001 \
                 --api-server-count 4 \
                 --disable-log-requests \
@@ -95,6 +96,7 @@ spec:
               #################
               vllm serve \
                 /mnt/models \
+                --served-model-name "{{ .Spec.Model.Name }}" \
                 --port 8001 \
                 --disable-log-requests \
                 {{- if .Spec.Parallelism.Expert }}--enable-expert-parallel \{{- end }}

--- a/config/llmisvc/config-llm-prefill-template.yaml
+++ b/config/llmisvc/config-llm-prefill-template.yaml
@@ -15,6 +15,7 @@ spec:
           command:
             - vllm
             - serve
+            - /mnt/models
           args:
             - --served-model-name
             - "{{ .Spec.Model.Name }}"

--- a/config/llmisvc/config-llm-prefill-worker-data-parallel.yaml
+++ b/config/llmisvc/config-llm-prefill-worker-data-parallel.yaml
@@ -26,7 +26,7 @@ spec:
                 # Leader-only launch
                 #################
                 vllm serve \
-                  {{ .Spec.Model.Name }} \
+                  - /mnt/models \
                   --port 8000 \
                   --api-server-count 4 \
                   --disable-log-requests \
@@ -48,7 +48,7 @@ spec:
                 # Worker-only launch
                 #################
                 vllm serve \
-                  {{ .Spec.Model.Name }} \
+                  /mnt/models \
                   --port 8000 \
                   --disable-log-requests \
                   {{- if .Spec.Prefill.Parallelism.Expert -}}--enable-expert-parallel \{{- end }}

--- a/config/llmisvc/config-llm-prefill-worker-data-parallel.yaml
+++ b/config/llmisvc/config-llm-prefill-worker-data-parallel.yaml
@@ -26,7 +26,8 @@ spec:
                 # Leader-only launch
                 #################
                 vllm serve \
-                  - /mnt/models \
+                  /mnt/models \
+                  --served-model-name "{{ .Spec.Model.Name }}" \
                   --port 8000 \
                   --api-server-count 4 \
                   --disable-log-requests \
@@ -49,6 +50,7 @@ spec:
                 #################
                 vllm serve \
                   /mnt/models \
+                  --served-model-name "{{ .Spec.Model.Name }}" \
                   --port 8000 \
                   --disable-log-requests \
                   {{- if .Spec.Prefill.Parallelism.Expert -}}--enable-expert-parallel \{{- end }}

--- a/config/llmisvc/config-llm-template.yaml
+++ b/config/llmisvc/config-llm-template.yaml
@@ -14,6 +14,7 @@ spec:
         command:
           - vllm
           - serve
+          - /mnt/models
         args:
           - --served-model-name
           - "{{ .Spec.Model.Name }}"

--- a/config/llmisvc/config-llm-worker-data-parallel.yaml
+++ b/config/llmisvc/config-llm-worker-data-parallel.yaml
@@ -25,7 +25,7 @@ spec:
               # Leader-only launch
               #################
               vllm serve \
-                {{ .Spec.Model.Name }} \
+                /mnt/models \
                 --port 8000 \
                 --api-server-count 4 \
                 --disable-log-requests \
@@ -47,7 +47,7 @@ spec:
               # Worker-only launch
               #################
               vllm serve \
-                {{ .Spec.Model.Name }} \
+                /mnt/models \
                 --port 8000 \
                 --disable-log-requests \
                 {{- if .Spec.Parallelism.Expert }}--enable-expert-parallel \{{- end }}

--- a/config/llmisvc/config-llm-worker-data-parallel.yaml
+++ b/config/llmisvc/config-llm-worker-data-parallel.yaml
@@ -26,6 +26,7 @@ spec:
               #################
               vllm serve \
                 /mnt/models \
+                --served-model-name "{{ .Spec.Model.Name }}" \
                 --port 8000 \
                 --api-server-count 4 \
                 --disable-log-requests \
@@ -48,6 +49,7 @@ spec:
               #################
               vllm serve \
                 /mnt/models \
+                --served-model-name "{{ .Spec.Model.Name }}" \
                 --port 8000 \
                 --disable-log-requests \
                 {{- if .Spec.Parallelism.Expert }}--enable-expert-parallel \{{- end }}

--- a/pkg/controller/llmisvc/config_presets_test.go
+++ b/pkg/controller/llmisvc/config_presets_test.go
@@ -254,6 +254,7 @@ if [ "${LWS_WORKER_INDEX:-0}" -eq 0 ]; then
   #################
   vllm serve \
     /mnt/models \
+    --served-model-name "llama" \
     --port 8001 \
     --api-server-count 4 \
     --disable-log-requests \
@@ -276,6 +277,7 @@ else
   #################
   vllm serve \
     /mnt/models \
+    --served-model-name "llama" \
     --port 8001 \
     --disable-log-requests \
 --enable-expert-parallel \

--- a/pkg/controller/llmisvc/config_presets_test.go
+++ b/pkg/controller/llmisvc/config_presets_test.go
@@ -253,7 +253,7 @@ if [ "${LWS_WORKER_INDEX:-0}" -eq 0 ]; then
   # Leader-only launch
   #################
   vllm serve \
-    llama \
+    /mnt/models \
     --port 8001 \
     --api-server-count 4 \
     --disable-log-requests \
@@ -275,7 +275,7 @@ else
   # Worker-only launch
   #################
   vllm serve \
-    llama \
+    /mnt/models \
     --port 8001 \
     --disable-log-requests \
 --enable-expert-parallel \

--- a/pkg/controller/llmisvc/controller_workload_storage_int_test.go
+++ b/pkg/controller/llmisvc/controller_workload_storage_int_test.go
@@ -327,9 +327,7 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 						URI:  *modelURL,
 					},
 					WorkloadSpec: v1alpha1.WorkloadSpec{
-						Worker: &corev1.PodSpec{
-							Containers: []corev1.Container{},
-						},
+						Worker: &corev1.PodSpec{Containers: []corev1.Container{}},
 						Parallelism: &v1alpha1.ParallelismSpec{
 							Data:      ptr.To[int32](1),
 							DataLocal: ptr.To[int32](1),
@@ -340,7 +338,13 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 						Gateway:   &v1alpha1.GatewaySpec{},
 						Scheduler: &v1alpha1.SchedulerSpec{},
 					},
-					Prefill: &v1alpha1.WorkloadSpec{},
+					Prefill: &v1alpha1.WorkloadSpec{
+						Worker: &corev1.PodSpec{Containers: []corev1.Container{}},
+						Parallelism: &v1alpha1.ParallelismSpec{
+							Data:      ptr.To[int32](1),
+							DataLocal: ptr.To[int32](1),
+						},
+					},
 				},
 			}
 
@@ -413,7 +417,13 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 						Gateway:   &v1alpha1.GatewaySpec{},
 						Scheduler: &v1alpha1.SchedulerSpec{},
 					},
-					Prefill: &v1alpha1.WorkloadSpec{},
+					Prefill: &v1alpha1.WorkloadSpec{
+						Worker: &corev1.PodSpec{Containers: []corev1.Container{}},
+						Parallelism: &v1alpha1.ParallelismSpec{
+							Data:      ptr.To[int32](1),
+							DataLocal: ptr.To[int32](1),
+						},
+					},
 				},
 			}
 
@@ -486,7 +496,13 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 						Gateway:   &v1alpha1.GatewaySpec{},
 						Scheduler: &v1alpha1.SchedulerSpec{},
 					},
-					Prefill: &v1alpha1.WorkloadSpec{},
+					Prefill: &v1alpha1.WorkloadSpec{
+						Worker: &corev1.PodSpec{Containers: []corev1.Container{}},
+						Parallelism: &v1alpha1.ParallelismSpec{
+							Data:      ptr.To[int32](1),
+							DataLocal: ptr.To[int32](1),
+						},
+					},
 				},
 			}
 
@@ -559,7 +575,13 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 						Gateway:   &v1alpha1.GatewaySpec{},
 						Scheduler: &v1alpha1.SchedulerSpec{},
 					},
-					Prefill: &v1alpha1.WorkloadSpec{},
+					Prefill: &v1alpha1.WorkloadSpec{
+						Worker: &corev1.PodSpec{Containers: []corev1.Container{}},
+						Parallelism: &v1alpha1.ParallelismSpec{
+							Data:      ptr.To[int32](1),
+							DataLocal: ptr.To[int32](1),
+						},
+					},
 				},
 			}
 
@@ -613,7 +635,6 @@ func validatePvcStorageForPodSpec(podSpec *corev1.PodSpec) {
 	mainContainer := utils.GetContainerWithName(podSpec, "main")
 	Expect(mainContainer).ToNot(BeNil())
 
-	Expect(mainContainer.Command).To(ContainElement(constants.DefaultModelLocalMountPath))
 	Expect(podSpec.Volumes).To(ContainElement(And(
 		HaveField("Name", constants.PvcSourceMountName),
 		HaveField("VolumeSource.PersistentVolumeClaim.ClaimName", "facebook-models"),
@@ -642,9 +663,6 @@ func validateOciStorageForPodSpec(podSpec *corev1.PodSpec) {
 	// Check container are sharing resources.
 	Expect(podSpec.ShareProcessNamespace).To(Not(BeNil()))
 	Expect(*podSpec.ShareProcessNamespace).To(BeTrue())
-
-	// Check the model server is directed to the mount point of the OCI container
-	Expect(mainContainer.Command).To(ContainElement(constants.DefaultModelLocalMountPath))
 
 	// Check the model server has an envvar indicating that the model may not be mounted immediately.
 	Expect(mainContainer.Env).To(ContainElement(And(
@@ -699,7 +717,6 @@ func validateStorageInitializerForPodSpec(podSpec *corev1.PodSpec, storageUri st
 	// Check the main container has the model mounted
 	mainContainer := utils.GetContainerWithName(podSpec, "main")
 	Expect(mainContainer).ToNot(BeNil())
-	Expect(mainContainer.Command).To(ContainElement(constants.DefaultModelLocalMountPath))
 	Expect(mainContainer.VolumeMounts).To(ContainElement(And(
 		HaveField("Name", constants.StorageInitializerVolumeName),
 		HaveField("MountPath", constants.DefaultModelLocalMountPath),

--- a/pkg/controller/llmisvc/workload.go
+++ b/pkg/controller/llmisvc/workload.go
@@ -55,7 +55,7 @@ func (r *LLMInferenceServiceReconciler) reconcileWorkload(ctx context.Context, l
 	// We need to always reconcile every type of workload to handle transitions from P/D to another topology (meaning
 	// finalizing superfluous workloads).
 
-	if err := r.reconcileMultiNodeWorkload(ctx, llmSvc); err != nil {
+	if err := r.reconcileMultiNodeWorkload(ctx, llmSvc, storageConfig); err != nil {
 		llmSvc.MarkWorkloadNotReady("ReconcileMultiNodeWorkloadError", err.Error())
 		return fmt.Errorf("failed to reconcile multi node workload: %w", err)
 	}

--- a/pkg/controller/llmisvc/workload_multi_node.go
+++ b/pkg/controller/llmisvc/workload_multi_node.go
@@ -206,8 +206,10 @@ func (r *LLMInferenceServiceReconciler) expectedMainMultiNodeLWS(ctx context.Con
 		}
 
 		// Attach model artifacts to worker template
-		if err := r.attachModelArtifacts(llmSvc, &expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec, storageConfig); err != nil {
-			return nil, fmt.Errorf("failed to attach model artifacts to worker template: %w", err)
+		if llmSvc.Spec.Worker != nil {
+			if err := r.attachModelArtifacts(llmSvc, &expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec, storageConfig); err != nil {
+				return nil, fmt.Errorf("failed to attach model artifacts to worker template: %w", err)
+			}
 		}
 	}
 
@@ -287,8 +289,10 @@ func (r *LLMInferenceServiceReconciler) expectedPrefillMultiNodeLWS(ctx context.
 		}
 
 		// Attach model artifacts to worker template
-		if err := r.attachModelArtifacts(llmSvc, &expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec, storageConfig); err != nil {
-			return nil, fmt.Errorf("failed to attach model artifacts to prefill worker template: %w", err)
+		if llmSvc.Spec.Prefill != nil && llmSvc.Spec.Prefill.Worker != nil {
+			if err := r.attachModelArtifacts(llmSvc, &expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec, storageConfig); err != nil {
+				return nil, fmt.Errorf("failed to attach model artifacts to prefill worker template: %w", err)
+			}
 		}
 	}
 

--- a/pkg/controller/llmisvc/workload_storage.go
+++ b/pkg/controller/llmisvc/workload_storage.go
@@ -91,10 +91,6 @@ func (r *LLMInferenceServiceReconciler) attachOciModelArtifact(modelUri string, 
 		return err
 	}
 
-	if mainContainer := utils.GetContainerWithName(podSpec, "main"); mainContainer != nil {
-		mainContainer.Command = append(mainContainer.Command, constants.DefaultModelLocalMountPath)
-	}
-
 	return nil
 }
 
@@ -114,9 +110,6 @@ func (r *LLMInferenceServiceReconciler) attachOciModelArtifact(modelUri string, 
 func (r *LLMInferenceServiceReconciler) attachPVCModelArtifact(modelUri string, podSpec *corev1.PodSpec) error {
 	if err := utils.AddModelPvcMount(modelUri, "main", true, podSpec); err != nil {
 		return err
-	}
-	if mainContainer := utils.GetContainerWithName(podSpec, "main"); mainContainer != nil {
-		mainContainer.Command = append(mainContainer.Command, constants.DefaultModelLocalMountPath)
 	}
 
 	return nil
@@ -159,9 +152,6 @@ func (r *LLMInferenceServiceReconciler) attachS3ModelArtifact(modelUri string, p
 //	An error if the configuration fails, otherwise nil.
 func (r *LLMInferenceServiceReconciler) attachStorageInitializer(modelUri string, podSpec *corev1.PodSpec, storageConfig *types.StorageInitializerConfig) error {
 	utils.AddStorageInitializerContainer(podSpec, "main", modelUri, true, storageConfig)
-	if mainContainer := utils.GetContainerWithName(podSpec, "main"); mainContainer != nil {
-		mainContainer.Command = append(mainContainer.Command, constants.DefaultModelLocalMountPath)
-	}
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Port the existing storage-related functionality from single-node workloads to support PVC, OCI, Hugging Face, S3 in multi-node setups.

Both leader and worker pods in the LeaderWorkerSet receive model artifact configuration, and also P/D configurations is covered.

The mutation of the `main` container command to specify the model location had to be removed from the code and hard-coded in the templates.  The motivation is because multi-node (LWS based) deployments are using a smarter start-up script which turns the command more complex. This effectively aligns LLMIsvc implementation to how InferenceServices work: the templates consistently use /mnt/models as the location for loading the model.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Related to https://issues.redhat.com/browse/RHOAIENG-27817

**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

**Feature/Issue validation/testing**:

- Help needed

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [N/A] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

