### PR TITLE
[RHOAIENG-31248] - KServe http: TLS handshake error from XXXXXX: remo…

### DIFF
--- a/config/default/localmodelcache_validatingwebhook_cainjection_patch.yaml
+++ b/config/default/localmodelcache_validatingwebhook_cainjection_patch.yaml
@@ -3,6 +3,6 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: localmodelcache.serving.kserve.io
   annotations:
-    cert-manager.io/inject-ca-from: $(kserveNamespace)/serving-cert
+    service.beta.openshift.io/inject-cabundle: "true"
 webhooks:
   - name: localmodelcache.kserve-webhook-server.validator

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -182,33 +182,33 @@ webhooks:
           - UPDATE
         resources:
           - servingruntimes
----
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  creationTimestamp: null
-  name: localmodelcache.serving.kserve.io
-webhooks:
-  - clientConfig:
-      service:
-        name: $(webhookServiceName)
-        namespace: $(kserveNamespace)
-        path: /validate-serving-kserve-io-v1alpha1-localmodelcache
-    failurePolicy: Fail
-    name: localmodelcache.kserve-webhook-server.validator
-    sideEffects: None
-    admissionReviewVersions: ["v1beta1"]
-    rules:
-      - apiGroups:
-          - serving.kserve.io
-        apiVersions:
-          - v1alpha1
-        operations:
-          - CREATE
-          - UPDATE
-          - DELETE
-        resources:
-          - localmodelcaches
+# ---
+# apiVersion: admissionregistration.k8s.io/v1
+# kind: ValidatingWebhookConfiguration
+# metadata:
+#   creationTimestamp: null
+#   name: localmodelcache.serving.kserve.io
+# webhooks:
+#   - clientConfig:
+#       service:
+#         name: $(webhookServiceName)
+#         namespace: $(kserveNamespace)
+#         path: /validate-serving-kserve-io-v1alpha1-localmodelcache
+#     failurePolicy: Fail
+#     name: localmodelcache.kserve-webhook-server.validator
+#     sideEffects: None
+#     admissionReviewVersions: ["v1beta1"]
+#     rules:
+#       - apiGroups:
+#           - serving.kserve.io
+#         apiVersions:
+#           - v1alpha1
+#         operations:
+#           - CREATE
+#           - UPDATE
+#           - DELETE
+#         resources:
+#           - localmodelcaches
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration


### PR DESCRIPTION
…te error: tls: bad certificate

chore:	Fix tls handshake due bad certificate configuration.
	The localmodel webhook needs to have the service.beta.openshift.io/inject-cabundle: "true"
	annotation, however, we don't use localmodelcache feature and it shouldn't be installed.
	This commit aims to remove it and already configure the webhook correctly.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This issue was caused by a webhook that should not be installed.
The webhook relies on the cert-manager to install its certificate; however, the kube-api expects the CA bundle certificate to be injected into the webhooks.
This PR removes the offending webhook and fixes the annotation that OpenShift expects to inject the correct certificate.

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

It was manually tested by following the steps below:

Update the DSC by adding the CRDs updated by this PR:
```yaml
spec:
  components:
    codeflare:
      managementState: Removed
    dashboard:
      managementState: Removed
    datasciencepipelines:
      managementState: Removed
    feastoperator:
      managementState: Removed
    kserve:
      devFlags:
        manifests:
          - contextDir: config
            sourcePath: ''
            uri: 'https://github.com/spolti/kserve/tarball/RHOAIENG-31248-odh-0.15'
      managementState: Managed
      nim:
        managementState: Managed
      rawDeploymentServiceConfig: Headed
      serving:
        ingressGateway:
          certificate:
            type: OpenshiftDefaultIngress
        managementState: Managed
        name: knative-serving
    kueue:
      managementState: Removed
    llamastackoperator:
      managementState: Removed
    modelmeshserving:
      managementState: Removed
    modelregistry:
      managementState: Removed
      registriesNamespace: odh-model-registries
    ray:
      managementState: Removed
    trainingoperator:
      managementState: Removed
    trustyai:
      managementState: Removed
    workbenches:
      managementState: Removed
```

After the opendatahub operator finishes to reconcile, deploy any model and notice no more handshake failure messages present in the logs.

It also has a workaround that can be applied:
```bash
oc patch validatingwebhookconfiguration localmodelcache.serving.kserve.io --type='merge' -p='{"metadata":{"annotations":{"service.beta.openshift.io/inject-cabundle":"true"}}}'
validatingwebhookconfiguration.admissionregistration.k8s.io/localmodelcache.serving.kserve.io patched
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.