### PR TITLE
chore(parallelism): sets minimum value to 1

### DIFF
--- a/config/crd/full/serving.kserve.io_llminferenceserviceconfigs.yaml
+++ b/config/crd/full/serving.kserve.io_llminferenceserviceconfigs.yaml
@@ -76,11 +76,11 @@ spec:
                   properties:
                     data:
                       format: int32
-                      minimum: 0
+                      minimum: 1
                       type: integer
                     dataLocal:
                       format: int32
-                      minimum: 0
+                      minimum: 1
                       type: integer
                     dataRPCPort:
                       format: int32
@@ -91,11 +91,11 @@ spec:
                       type: boolean
                     pipeline:
                       format: int32
-                      minimum: 0
+                      minimum: 1
                       type: integer
                     tensor:
                       format: int32
-                      minimum: 0
+                      minimum: 1
                       type: integer
                   type: object
                 prefill:
@@ -104,11 +104,11 @@ spec:
                       properties:
                         data:
                           format: int32
-                          minimum: 0
+                          minimum: 1
                           type: integer
                         dataLocal:
                           format: int32
-                          minimum: 0
+                          minimum: 1
                           type: integer
                         dataRPCPort:
                           format: int32
@@ -119,11 +119,11 @@ spec:
                           type: boolean
                         pipeline:
                           format: int32
-                          minimum: 0
+                          minimum: 1
                           type: integer
                         tensor:
                           format: int32
-                          minimum: 0
+                          minimum: 1
                           type: integer
                       type: object
                     replicas:

--- a/config/crd/full/serving.kserve.io_llminferenceservices.yaml
+++ b/config/crd/full/serving.kserve.io_llminferenceservices.yaml
@@ -95,11 +95,11 @@ spec:
                 properties:
                   data:
                     format: int32
-                    minimum: 0
+                    minimum: 1
                     type: integer
                   dataLocal:
                     format: int32
-                    minimum: 0
+                    minimum: 1
                     type: integer
                   dataRPCPort:
                     format: int32
@@ -110,11 +110,11 @@ spec:
                     type: boolean
                   pipeline:
                     format: int32
-                    minimum: 0
+                    minimum: 1
                     type: integer
                   tensor:
                     format: int32
-                    minimum: 0
+                    minimum: 1
                     type: integer
                 type: object
               prefill:
@@ -123,11 +123,11 @@ spec:
                     properties:
                       data:
                         format: int32
-                        minimum: 0
+                        minimum: 1
                         type: integer
                       dataLocal:
                         format: int32
-                        minimum: 0
+                        minimum: 1
                         type: integer
                       dataRPCPort:
                         format: int32
@@ -138,11 +138,11 @@ spec:
                         type: boolean
                       pipeline:
                         format: int32
-                        minimum: 0
+                        minimum: 1
                         type: integer
                       tensor:
                         format: int32
-                        minimum: 0
+                        minimum: 1
                         type: integer
                     type: object
                   replicas:

--- a/pkg/apis/serving/v1alpha1/llm_inference_service_types.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_types.go
@@ -244,19 +244,19 @@ type InferencePoolSpec struct {
 type ParallelismSpec struct {
 	// Tensor parallelism size.
 	// +optional
-	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=1
 	Tensor *int32 `json:"tensor,omitempty"`
 	// Pipeline parallelism size.
 	// +optional
-	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=1
 	Pipeline *int32 `json:"pipeline,omitempty"`
 	// Data parallelism size.
 	// +optional
-	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=1
 	Data *int32 `json:"data,omitempty"`
 	// DataLocal data local parallelism size.
 	// +optional
-	// +kubebuilder:validation:Minimum=0
+	// +kubebuilder:validation:Minimum=1
 	DataLocal *int32 `json:"dataLocal,omitempty"`
 	// DataRPCPort is the data parallelism RPC port.
 	// +optional

--- a/pkg/controller/llmisvc/validation/llminferenceservice_validator_int_test.go
+++ b/pkg/controller/llmisvc/validation/llminferenceservice_validator_int_test.go
@@ -372,7 +372,7 @@ var _ = Describe("LLMInferenceService API validation", func() {
 
 			// then
 			Expect(errValidation).To(HaveOccurred(), "Expected the Create call to fail due to a validation error, but it succeeded")
-			Expect(errValidation.Error()).To(ContainSubstring("spec.parallelism.tensor in body should be greater than or equal to 0"))
+			Expect(errValidation.Error()).To(ContainSubstring("spec.parallelism.tensor in body should be greater than or equal to 1"))
 		})
 
 		It("should reject LLMInferenceService with negative pipeline parallelism", func(ctx SpecContext) {
@@ -390,7 +390,7 @@ var _ = Describe("LLMInferenceService API validation", func() {
 
 			// then
 			Expect(errValidation).To(HaveOccurred(), "Expected the Create call to fail due to a validation error, but it succeeded")
-			Expect(errValidation.Error()).To(ContainSubstring("spec.parallelism.pipeline in body should be greater than or equal to 0"))
+			Expect(errValidation.Error()).To(ContainSubstring("spec.parallelism.pipeline in body should be greater than or equal to 1"))
 		})
 
 		It("should reject LLMInferenceService with negative data parallelism", func(ctx SpecContext) {
@@ -409,17 +409,17 @@ var _ = Describe("LLMInferenceService API validation", func() {
 
 			// then
 			Expect(errValidation).To(HaveOccurred(), "Expected the Create call to fail due to a validation error, but it succeeded")
-			Expect(errValidation.Error()).To(ContainSubstring("spec.parallelism.data in body should be greater than or equal to 0"))
+			Expect(errValidation.Error()).To(ContainSubstring("spec.parallelism.data in body should be greater than or equal to 1"))
 		})
 
-		It("should reject LLMInferenceService with negative dataLocal parallelism", func(ctx SpecContext) {
+		It("should reject LLMInferenceService with zero dataLocal parallelism", func(ctx SpecContext) {
 			// given
 			llmSvc := fixture.LLMInferenceService("test-negative-datalocal",
 				fixture.InNamespace[*v1alpha1.LLMInferenceService](nsName),
 				fixture.WithModelURI("hf://facebook/opt-125m"),
 				fixture.WithParallelism(fixture.ParallelismSpec(
 					fixture.WithDataParallelism(4),
-					fixture.WithDataLocalParallelism(-1),
+					fixture.WithDataLocalParallelism(0),
 				)),
 			)
 
@@ -428,7 +428,7 @@ var _ = Describe("LLMInferenceService API validation", func() {
 
 			// then
 			Expect(errValidation).To(HaveOccurred(), "Expected the Create call to fail due to a validation error, but it succeeded")
-			Expect(errValidation.Error()).To(ContainSubstring("spec.parallelism.dataLocal in body should be greater than or equal to 0"))
+			Expect(errValidation.Error()).To(ContainSubstring("spec.parallelism.dataLocal in body should be greater than or equal to 1"))
 		})
 
 		It("should reject LLMInferenceService with zero data parallelism RPC Port", func(ctx SpecContext) {

--- a/test/crds/serving.kserve.io_all_crds.yaml
+++ b/test/crds/serving.kserve.io_all_crds.yaml
@@ -23035,11 +23035,11 @@ spec:
                 properties:
                   data:
                     format: int32
-                    minimum: 0
+                    minimum: 1
                     type: integer
                   dataLocal:
                     format: int32
-                    minimum: 0
+                    minimum: 1
                     type: integer
                   dataRPCPort:
                     format: int32
@@ -23050,11 +23050,11 @@ spec:
                     type: boolean
                   pipeline:
                     format: int32
-                    minimum: 0
+                    minimum: 1
                     type: integer
                   tensor:
                     format: int32
-                    minimum: 0
+                    minimum: 1
                     type: integer
                 type: object
               prefill:
@@ -23063,11 +23063,11 @@ spec:
                     properties:
                       data:
                         format: int32
-                        minimum: 0
+                        minimum: 1
                         type: integer
                       dataLocal:
                         format: int32
-                        minimum: 0
+                        minimum: 1
                         type: integer
                       dataRPCPort:
                         format: int32
@@ -23078,11 +23078,11 @@ spec:
                         type: boolean
                       pipeline:
                         format: int32
-                        minimum: 0
+                        minimum: 1
                         type: integer
                       tensor:
                         format: int32
-                        minimum: 0
+                        minimum: 1
                         type: integer
                     type: object
                   replicas:
@@ -42546,11 +42546,11 @@ spec:
                 properties:
                   data:
                     format: int32
-                    minimum: 0
+                    minimum: 1
                     type: integer
                   dataLocal:
                     format: int32
-                    minimum: 0
+                    minimum: 1
                     type: integer
                   dataRPCPort:
                     format: int32
@@ -42561,11 +42561,11 @@ spec:
                     type: boolean
                   pipeline:
                     format: int32
-                    minimum: 0
+                    minimum: 1
                     type: integer
                   tensor:
                     format: int32
-                    minimum: 0
+                    minimum: 1
                     type: integer
                 type: object
               prefill:
@@ -42574,11 +42574,11 @@ spec:
                     properties:
                       data:
                         format: int32
-                        minimum: 0
+                        minimum: 1
                         type: integer
                       dataLocal:
                         format: int32
-                        minimum: 0
+                        minimum: 1
                         type: integer
                       dataRPCPort:
                         format: int32
@@ -42589,11 +42589,11 @@ spec:
                         type: boolean
                       pipeline:
                         format: int32
-                        minimum: 0
+                        minimum: 1
                         type: integer
                       tensor:
                         format: int32
-                        minimum: 0
+                        minimum: 1
                         type: integer
                     type: object
                   replicas:


### PR DESCRIPTION
Instead of allowing `0` as a way to disable certain parallelism mode the validation now restricts it to 1. To disable we can always remove the field or set corresponding field to `null`.

Follow-up to #792 
