### PR TITLE
chore: moves config logic to its own file

### DIFF
--- a/pkg/controller/llmisvc/config_loader.go
+++ b/pkg/controller/llmisvc/config_loader.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/types"
+)
+
+type Config struct {
+	SystemNamespace             string   `json:"systemNamespace,omitempty"`
+	IngressGatewayName          string   `json:"ingressGatewayName,omitempty"`
+	IngressGatewayNamespace     string   `json:"ingressGatewayNamespace,omitempty"`
+	IstioGatewayControllerNames []string `json:"istioGatewayControllerNames,omitempty"`
+
+	StorageConfig *types.StorageInitializerConfig `json:"-"`
+}
+
+// NewConfig creates an instance of llm-specific config based on predefined values
+// in IngressConfig struct
+func NewConfig(ingressConfig *v1beta1.IngressConfig, storageConfig *types.StorageInitializerConfig) *Config {
+	igwNs := constants.KServeNamespace
+	igwName := ingressConfig.KserveIngressGateway
+	igw := strings.Split(igwName, "/")
+	if len(igw) == 2 {
+		igwNs = igw[0]
+		igwName = igw[1]
+	}
+
+	return &Config{
+		SystemNamespace:         constants.KServeNamespace,
+		IngressGatewayNamespace: igwNs,
+		IngressGatewayName:      igwName,
+		// TODO make it configurable
+		IstioGatewayControllerNames: []string{
+			"istio.io/gateway-controller",
+			"istio.io/unmanaged-gateway",
+			"openshift.io/gateway-controller/v1",
+		},
+		StorageConfig: storageConfig,
+	}
+}
+
+func LoadConfig(ctx context.Context, clientset kubernetes.Interface) (*Config, error) {
+	isvcConfigMap, errCfgMap := v1beta1.GetInferenceServiceConfigMap(ctx, clientset) // Fetch directly from API Server
+	if errCfgMap != nil {
+		return nil, fmt.Errorf("failed to load InferenceServiceConfigMap: %w", errCfgMap)
+	}
+
+	ingressConfig, errConvert := v1beta1.NewIngressConfig(isvcConfigMap)
+	if errConvert != nil {
+		return nil, fmt.Errorf("failed to convert InferenceServiceConfigMap to IngressConfig: %w", errConvert)
+	}
+
+	storageInitializerConfig, errConvert := v1beta1.GetStorageInitializerConfigs(isvcConfigMap)
+	if errConvert != nil {
+		return nil, fmt.Errorf("failed to convert InferenceServiceConfigMap to StorageInitializerConfig: %w", errConvert)
+	}
+
+	return NewConfig(ingressConfig, storageInitializerConfig), nil
+}
+
+func (c Config) isIstioGatewayController(name string) bool {
+	return slices.Contains(c.IstioGatewayControllerNames, name)
+}

--- a/pkg/controller/llmisvc/controller.go
+++ b/pkg/controller/llmisvc/controller.go
@@ -19,19 +19,15 @@ package llmisvc
 import (
 	"context"
 	"fmt"
-	"slices"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	lwsapi "sigs.k8s.io/lws/api/leaderworkerset/v1"
 
-	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
-	"github.com/kserve/kserve/pkg/constants"
-	kserveTypes "github.com/kserve/kserve/pkg/types"
-
 	"k8s.io/apimachinery/pkg/api/equality"
+
+	"github.com/kserve/kserve/pkg/constants"
 
 	"knative.dev/pkg/reconciler"
 
@@ -66,44 +62,6 @@ var childResourcesPredicate, _ = predicate.LabelSelectorPredicate(metav1.LabelSe
 		"app.kubernetes.io/part-of": "llminferenceservice",
 	},
 })
-
-type Config struct {
-	SystemNamespace             string   `json:"systemNamespace,omitempty"`
-	IngressGatewayName          string   `json:"ingressGatewayName,omitempty"`
-	IngressGatewayNamespace     string   `json:"ingressGatewayNamespace,omitempty"`
-	IstioGatewayControllerNames []string `json:"istioGatewayControllerNames,omitempty"`
-
-	StorageConfig *kserveTypes.StorageInitializerConfig `json:"-"`
-}
-
-func (c Config) isIstioGatewayController(name string) bool {
-	return slices.Contains(c.IstioGatewayControllerNames, name)
-}
-
-// NewConfig creates an instance of llm-specific config based on predefined values
-// in IngressConfig struct
-func NewConfig(ingressConfig *v1beta1.IngressConfig, storageConfig *kserveTypes.StorageInitializerConfig) *Config {
-	igwNs := constants.KServeNamespace
-	igwName := ingressConfig.KserveIngressGateway
-	igw := strings.Split(igwName, "/")
-	if len(igw) == 2 {
-		igwNs = igw[0]
-		igwName = igw[1]
-	}
-
-	return &Config{
-		SystemNamespace:         constants.KServeNamespace,
-		IngressGatewayNamespace: igwNs,
-		IngressGatewayName:      igwName,
-		// TODO make it configurable
-		IstioGatewayControllerNames: []string{
-			"istio.io/gateway-controller",
-			"istio.io/unmanaged-gateway",
-			"openshift.io/gateway-controller/v1",
-		},
-		StorageConfig: storageConfig,
-	}
-}
 
 // LLMInferenceServiceReconciler reconciles an LLMInferenceService object.
 // It orchestrates the reconciliation of child resources based on the spec.
@@ -247,25 +205,6 @@ func (r *LLMInferenceServiceReconciler) updateStatus(ctx context.Context, desire
 
 		return nil
 	})
-}
-
-func LoadConfig(ctx context.Context, clientset kubernetes.Interface) (*Config, error) {
-	isvcConfigMap, errCfgMap := v1beta1.GetInferenceServiceConfigMap(ctx, clientset) // Fetch directly from API Server
-	if errCfgMap != nil {
-		return nil, fmt.Errorf("failed to load InferenceServiceConfigMap: %w", errCfgMap)
-	}
-
-	ingressConfig, errConvert := v1beta1.NewIngressConfig(isvcConfigMap)
-	if errConvert != nil {
-		return nil, fmt.Errorf("failed to convert InferenceServiceConfigMap to IngressConfig: %w", errConvert)
-	}
-
-	storageInitializerConfig, errConvert := v1beta1.GetStorageInitializerConfigs(isvcConfigMap)
-	if errConvert != nil {
-		return nil, fmt.Errorf("failed to convert InferenceServiceConfigMap to StorageInitializerConfig: %w", errConvert)
-	}
-
-	return NewConfig(ingressConfig, storageInitializerConfig), nil
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
To simplify upstreaming controller bits the whole Config struct and related functions has been moved to its own file.

This will help upstreaming efforts as it keeps the logic isolated and less vulnerable to merge conflicts moving forward.
