### PR TITLE
Fix llmisvc PodMonitor portNumber -> port

### DIFF
--- a/config/monitoring/llmisvc/engine_vllm_monitor.yaml
+++ b/config/monitoring/llmisvc/engine_vllm_monitor.yaml
@@ -21,7 +21,7 @@ spec:
   namespaceSelector:
     any: true
   podMetricsEndpoints:
-  - portNumber: 8000
+  - port: 8000
     scheme: https
     tlsConfig:
       insecureSkipVerify: true


### PR DESCRIPTION
```
.spec.podMetricsEndpoints[0].portNumber: field not declared in schema
```

https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PodMetricsEndpoint
