### PR TITLE
Fix llmisvc PodMonitor portNumber -> targetPort

### DIFF
--- a/config/monitoring/llmisvc/engine_vllm_monitor.yaml
+++ b/config/monitoring/llmisvc/engine_vllm_monitor.yaml
@@ -21,7 +21,7 @@ spec:
   namespaceSelector:
     any: true
   podMetricsEndpoints:
-  - portNumber: 8000
+  - targetPort: 8000
     scheme: https
     tlsConfig:
       insecureSkipVerify: true


### PR DESCRIPTION
Use targetPort (even if it's deprecated) as the operator is using old libraries.
