### PR TITLE
[DO NOT MERGE] CI TEST

### DIFF
--- a/test/scripts/openshift-ci/setup-e2e-tests.sh
+++ b/test/scripts/openshift-ci/setup-e2e-tests.sh
@@ -229,6 +229,7 @@ spec:
   - Egress
 EOF
 
+# setup minio resources with tls enabled
 if [[ $1 =~ "kserve_on_openshift" ]]; then
   echo "Configuring minio tls"
   ${PROJECT_ROOT}/test/scripts/openshift-ci/tls/setup-minio-tls-custom-cert.sh


### PR DESCRIPTION
DO NOT MERGE. 

Testing test execution in openshift CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Updated OpenShift end-to-end test setup to execute additional MinIO TLS configuration steps (custom and serving certificates) when the OpenShift-specific path is used.
  - Test environments now provision TLS using both certificate types where applicable.
  - This change only affects CI/testing workflows; no changes to application features or behavior.
  - No updates to public APIs or user-facing settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->