### PR TITLE
fix(gomega): uses default timeouts when ctx is passed

### DIFF
--- a/pkg/controller/llmisvc/fixture/envtest.go
+++ b/pkg/controller/llmisvc/fixture/envtest.go
@@ -41,6 +41,7 @@ func SetupTestEnv() *pkgtest.Client {
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	gomega.SetDefaultEventuallyTimeout(duration)
 	gomega.SetDefaultEventuallyPollingInterval(250 * time.Millisecond)
+	gomega.EnforceDefaultTimeoutsWhenUsingContexts()
 
 	ginkgo.By("Setting up the test environment")
 	systemNs := constants.KServeNamespace


### PR DESCRIPTION
See: https://github.com/onsi/gomega/issues/781