### PR TITLE
Allow using HTTPRoute without scheduler and external InferencePool Ref

### DIFF
--- a/docs/samples/llmisvc/opt-125m/llm-inference-service-facebook-opt-125m-cpu-no-scheduler.yaml
+++ b/docs/samples/llmisvc/opt-125m/llm-inference-service-facebook-opt-125m-cpu-no-scheduler.yaml
@@ -1,0 +1,30 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: facebook-opt-125m-single
+spec:
+  model:
+    uri: hf://facebook/opt-125m
+    name: facebook/opt-125m
+  replicas: 1
+  router:
+    route: { }
+  template:
+    containers:
+      - name: main
+        image: quay.io/pierdipi/vllm-cpu:latest
+        env:
+          - name: VLLM_LOGGING_LEVEL
+            value: DEBUG
+        resources:
+          limits:
+            cpu: '1'
+            memory: 10Gi
+          requests:
+            cpu: '100m'
+            memory: 8Gi
+        livenessProbe:
+          initialDelaySeconds: 30
+          periodSeconds: 30
+          timeoutSeconds: 30
+          failureThreshold: 5

--- a/pkg/controller/llmisvc/config_merge.go
+++ b/pkg/controller/llmisvc/config_merge.go
@@ -200,8 +200,7 @@ func (r *LLMInferenceServiceReconciler) combineBaseRefsConfig(ctx context.Contex
 	// InferencePool (to handle cases where the HTTPRoute Spec uses a custom BackendRef).
 	if llmSvcCfg.Spec.Router != nil &&
 		llmSvcCfg.Spec.Router.Route != nil &&
-		llmSvcCfg.Spec.Router.Route.HTTP != nil &&
-		llmSvcCfg.Spec.Router.Route.HTTP.Spec != nil &&
+		llmSvcCfg.Spec.Router.Route.HTTP.HasSpec() &&
 		llmSvcCfg.Spec.Router.Scheduler == nil {
 		for i := range llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules {
 			for j := range llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs {
@@ -217,8 +216,7 @@ func (r *LLMInferenceServiceReconciler) combineBaseRefsConfig(ctx context.Contex
 	// Point HTTPRoute to InferencePool reference if specified.
 	if llmSvcCfg.Spec.Router != nil &&
 		llmSvcCfg.Spec.Router.Route != nil &&
-		llmSvcCfg.Spec.Router.Route.HTTP != nil &&
-		llmSvcCfg.Spec.Router.Route.HTTP.Spec != nil &&
+		llmSvcCfg.Spec.Router.Route.HTTP.HasSpec() &&
 		llmSvcCfg.Spec.Router.Scheduler != nil &&
 		llmSvcCfg.Spec.Router.Scheduler.Pool.HasRef() {
 		for i := range llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules {
@@ -351,7 +349,7 @@ func mergeSpecs(ctx context.Context, base, override v1alpha1.LLMInferenceService
 
 func isDefaultBackendRef(llmSvc *v1alpha1.LLMInferenceService, ref gatewayapi.BackendRef) bool {
 	defaultInfPoolName := (&v1alpha1.SchedulerSpec{}).InferencePoolName(llmSvc)
-	return ref.Group != nil && string(*ref.Group) == igwapi.GroupName &&
-		ref.Kind != nil && string(*ref.Kind) == "InferencePool" &&
+	return ptr.Deref[gatewayapi.Group](ref.Group, "") == igwapi.GroupName &&
+		ptr.Deref[gatewayapi.Kind](ref.Kind, "") == "InferencePool" &&
 		string(ref.Name) == defaultInfPoolName
 }

--- a/pkg/controller/llmisvc/config_merge.go
+++ b/pkg/controller/llmisvc/config_merge.go
@@ -214,6 +214,22 @@ func (r *LLMInferenceServiceReconciler) combineBaseRefsConfig(ctx context.Contex
 		}
 	}
 
+	// Point HTTPRoute to InferencePool reference if specified.
+	if llmSvcCfg.Spec.Router != nil &&
+		llmSvcCfg.Spec.Router.Route != nil &&
+		llmSvcCfg.Spec.Router.Route.HTTP != nil &&
+		llmSvcCfg.Spec.Router.Route.HTTP.Spec != nil &&
+		llmSvcCfg.Spec.Router.Scheduler != nil &&
+		llmSvcCfg.Spec.Router.Scheduler.Pool.HasRef() {
+		for i := range llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules {
+			for j := range llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs {
+				if isDefaultBackendRef(llmSvc, llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs[j].BackendRef) {
+					llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs[j].Name = gatewayapi.ObjectName(llmSvcCfg.Spec.Router.Scheduler.Pool.Ref.Name)
+				}
+			}
+		}
+	}
+
 	return llmSvcCfg, nil
 }
 

--- a/pkg/controller/llmisvc/config_merge.go
+++ b/pkg/controller/llmisvc/config_merge.go
@@ -23,15 +23,16 @@ import (
 	"fmt"
 	"text/template"
 
-	"sigs.k8s.io/controller-runtime/pkg/log"
-
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/utils/ptr"
 	"knative.dev/pkg/kmeta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
+	gatewayapi "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/constants"
@@ -174,7 +175,7 @@ func (r *LLMInferenceServiceReconciler) combineBaseRefsConfig(ctx context.Contex
 		llmSvcCfg.Spec.Router.Scheduler.Pool != nil &&
 		llmSvcCfg.Spec.Router.Scheduler.Pool.Spec != nil &&
 		len(llmSvcCfg.Spec.Router.Scheduler.Pool.Spec.Selector) == 0 {
-		selector := getInferencePoolWorkloadLabelSelector(llmSvc.ObjectMeta, &llmSvcCfg.Spec)
+		selector := GetWorkloadLabelSelector(llmSvc.ObjectMeta, &llmSvcCfg.Spec)
 
 		gieSelector := make(map[igwapi.LabelKey]igwapi.LabelValue, len(selector))
 		for k, v := range selector {
@@ -193,6 +194,24 @@ func (r *LLMInferenceServiceReconciler) combineBaseRefsConfig(ctx context.Contex
 	llmSvcCfg, err = ReplaceVariables(llmSvc, llmSvcCfg, reconcilerConfig)
 	if err != nil {
 		return llmSvcCfg, err
+	}
+
+	// Point HTTPRoute to a Service if there is no Scheduler or InferencePool, and the HTTPRoute uses the default
+	// InferencePool (to handle cases where the HTTPRoute Spec uses a custom BackendRef).
+	if llmSvcCfg.Spec.Router != nil &&
+		llmSvcCfg.Spec.Router.Route != nil &&
+		llmSvcCfg.Spec.Router.Route.HTTP != nil &&
+		llmSvcCfg.Spec.Router.Route.HTTP.Spec != nil &&
+		llmSvcCfg.Spec.Router.Scheduler == nil {
+		for i := range llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules {
+			for j := range llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs {
+				if isDefaultBackendRef(llmSvc, llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs[j].BackendRef) {
+					llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs[j].Group = ptr.To[gatewayapi.Group]("")
+					llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs[j].Kind = ptr.To[gatewayapi.Kind]("Service")
+					llmSvcCfg.Spec.Router.Route.HTTP.Spec.Rules[i].BackendRefs[j].Name = gatewayapi.ObjectName(kmeta.ChildName(llmSvc.GetName(), "-kserve-workload-svc"))
+				}
+			}
+		}
 	}
 
 	return llmSvcCfg, nil
@@ -312,4 +331,11 @@ func mergeSpecs(ctx context.Context, base, override v1alpha1.LLMInferenceService
 		return v1alpha1.LLMInferenceServiceSpec{}, fmt.Errorf("could not unmarshal merged spec: %w", err)
 	}
 	return finalSpec, nil
+}
+
+func isDefaultBackendRef(llmSvc *v1alpha1.LLMInferenceService, ref gatewayapi.BackendRef) bool {
+	defaultInfPoolName := (&v1alpha1.SchedulerSpec{}).InferencePoolName(llmSvc)
+	return ref.Group != nil && string(*ref.Group) == igwapi.GroupName &&
+		ref.Kind != nil && string(*ref.Kind) == "InferencePool" &&
+		string(ref.Name) == defaultInfPoolName
 }

--- a/pkg/controller/llmisvc/controller.go
+++ b/pkg/controller/llmisvc/controller.go
@@ -163,10 +163,10 @@ func (r *LLMInferenceServiceReconciler) reconcile(ctx context.Context, llmSvc *v
 		return fmt.Errorf("failed to combine base-configurations: %w", err)
 	}
 	llmSvc.MarkPresetsCombinedReady()
+
+	logger.Info("Reconciling with combined base configurations", "combined.spec", baseCfg.Spec, "original.spec", llmSvc.Spec)
 	// We are only writing to status, so we can safely use the original object.
 	llmSvc.Spec = baseCfg.Spec
-
-	logger.Info("Reconciling with combined base configurations", "spec", llmSvc.Spec)
 
 	if err := r.reconcileWorkload(ctx, llmSvc, config.StorageConfig); err != nil {
 		return fmt.Errorf("failed to reconcile workload: %w", err)

--- a/pkg/controller/llmisvc/controller_int_test.go
+++ b/pkg/controller/llmisvc/controller_int_test.go
@@ -278,43 +278,13 @@ var _ = Describe("LLMInferenceService Controller", func() {
 					},
 				}
 
-				infPool := &igwapi.InferencePool{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      infPoolName,
-						Namespace: nsName,
-					},
-					Spec: igwapi.InferencePoolSpec{
-						Selector: map[igwapi.LabelKey]igwapi.LabelValue{
-							"app": "workload",
-						},
-						TargetPortNumber: 8000,
-						EndpointPickerConfig: igwapi.EndpointPickerConfig{
-							ExtensionRef: &igwapi.Extension{
-								ExtensionReference: igwapi.ExtensionReference{
-									Group: ptr.To(igwapi.Group("")),
-									Kind:  ptr.To(igwapi.Kind("Service")),
-									Name:  igwapi.ObjectName(kmeta.ChildName(svcName, "-epp-service")),
-								},
-								ExtensionConnection: igwapi.ExtensionConnection{
-									FailureMode: ptr.To(igwapi.FailOpen),
-								},
-							},
-						},
-					},
-					Status: igwapi.InferencePoolStatus{
-						Parents: []igwapi.PoolStatus{
-							{
-								Conditions: []metav1.Condition{
-									{
-										Type:   string(igwapi.InferencePoolConditionAccepted),
-										Status: metav1.ConditionTrue,
-										Reason: string(igwapi.InferencePoolReasonAccepted),
-									},
-								},
-							},
-						},
-					},
-				}
+				infPool := InferencePool(infPoolName,
+					InNamespace[*igwapi.InferencePool](nsName),
+					WithSelector("app", "workload"),
+					WithTargetPort(8000),
+					WithExtensionRef("", "Service", kmeta.ChildName(svcName, "-epp-service")),
+					WithInferencePoolReadyStatus(),
+				)
 
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())

--- a/pkg/controller/llmisvc/controller_int_test.go
+++ b/pkg/controller/llmisvc/controller_int_test.go
@@ -18,14 +18,15 @@ package llmisvc_test
 
 import (
 	"context"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -194,8 +195,9 @@ var _ = Describe("LLMInferenceService Controller", func() {
 						},
 						WorkloadSpec: v1alpha1.WorkloadSpec{},
 						Router: &v1alpha1.RouterSpec{
-							Route:   &v1alpha1.GatewayRoutesSpec{},
-							Gateway: &v1alpha1.GatewaySpec{},
+							Route:     &v1alpha1.GatewayRoutesSpec{},
+							Gateway:   &v1alpha1.GatewaySpec{},
+							Scheduler: &v1alpha1.SchedulerSpec{},
 						},
 					},
 				}
@@ -219,13 +221,98 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 				Expect(expectedHTTPRoute).To(BeControllerBy(llmSvc))
 				Expect(expectedHTTPRoute).To(HaveGatewayRefs(gatewayapi.ParentReference{Name: "kserve-ingress-gateway"}))
-				Expect(expectedHTTPRoute).To(HaveBackendRefs(svcName + "-inference-pool"))
+				Expect(expectedHTTPRoute).To(HaveBackendRefs(BackendRefInferencePool(svcName + "-inference-pool")))
+				Expect(expectedHTTPRoute).To(Not(HaveBackendRefs(BackendRefService(svcName + "-kserve-workload-svc"))))
+
+				ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvc)
+
+				Eventually(func(g Gomega, ctx context.Context) error {
+					ip := igwapi.InferencePool{}
+					return envTest.Client.Get(ctx, client.ObjectKey{Name: svcName + "-inference-pool", Namespace: llmSvc.GetNamespace()}, &ip)
+				}).WithContext(ctx).Should(Succeed())
+
+				Eventually(LLMInferenceServiceIsReady(llmSvc)).WithContext(ctx).Should(Succeed())
+			})
+
+			It("should create routes pointing to workload service when no scheduler is configured", func(ctx SpecContext) {
+				// given
+				llmSvcName := "test-llm-create-http-route-no-scheduler"
+				nsName := kmeta.ChildName(llmSvcName, "-test")
+				namespace := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: nsName,
+					},
+				}
+				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+				Expect(envTest.Client.Create(ctx, IstioShadowService(llmSvcName, nsName))).To(Succeed())
+				defer func() {
+					envTest.DeleteAll(namespace)
+				}()
+
+				modelURL, err := apis.ParseURL("hf://facebook/opt-125m")
+				Expect(err).ToNot(HaveOccurred())
+
+				llmSvc := &v1alpha1.LLMInferenceService{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      llmSvcName,
+						Namespace: nsName,
+					},
+					Spec: v1alpha1.LLMInferenceServiceSpec{
+						Model: v1alpha1.LLMModelSpec{
+							URI: *modelURL,
+						},
+						Router: &v1alpha1.RouterSpec{
+							Route:   &v1alpha1.GatewayRoutesSpec{},
+							Gateway: &v1alpha1.GatewaySpec{},
+						},
+					},
+				}
+
+				// when
+				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+				defer func() {
+					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				}()
+
+				// then
+				expectedHTTPRoute := &gatewayapi.HTTPRoute{}
+				Eventually(func(g Gomega, ctx context.Context) error {
+					routes, errList := managedRoutes(ctx, llmSvc)
+					g.Expect(errList).ToNot(HaveOccurred())
+					g.Expect(routes).To(HaveLen(1))
+					expectedHTTPRoute = &routes[0]
+
+					return nil
+				}).WithContext(ctx).Should(Succeed())
+
+				svcName := kmeta.ChildName(llmSvcName, "-kserve-workload-svc")
+
+				Expect(expectedHTTPRoute).To(BeControllerBy(llmSvc))
+				Expect(expectedHTTPRoute).To(HaveGatewayRefs(gatewayapi.ParentReference{Name: "kserve-ingress-gateway"}))
+				Expect(expectedHTTPRoute).To(HaveBackendRefs(BackendRefService(svcName)))
+				Expect(expectedHTTPRoute).To(Not(HaveBackendRefs(BackendRefInferencePool(kmeta.ChildName(llmSvcName, "-inference-pool")))))
+
+				Eventually(func(g Gomega, ctx context.Context) error {
+					svc := &corev1.Service{}
+					err := envTest.Client.Get(ctx, client.ObjectKey{Name: svcName, Namespace: nsName}, svc)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(svc.Spec.Selector).To(Equal(llmisvc.GetWorkloadLabelSelector(llmSvc.ObjectMeta, &llmSvc.Spec)))
+					return nil
+				})
 
 				ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvc)
 
 				Eventually(LLMInferenceServiceIsReady(llmSvc, func(g Gomega, current *v1alpha1.LLMInferenceService) {
 					g.Expect(current.Status).To(HaveCondition(string(v1alpha1.HTTPRoutesReady), "True"))
 				})).WithContext(ctx).Should(Succeed())
+
+				Consistently(func(g Gomega, ctx context.Context) error {
+					ip := igwapi.InferencePool{}
+					return envTest.Client.Get(ctx, client.ObjectKey{Name: llmSvcName + "-inference-pool", Namespace: llmSvc.GetNamespace()}, &ip)
+				}).WithContext(ctx).
+					Within(2 * time.Second).
+					WithPolling(300 * time.Millisecond).
+					Should(HaveOccurred())
 			})
 
 			It("should create HTTPRoute with defined spec", func(ctx SpecContext) {
@@ -259,9 +346,12 @@ var _ = Describe("LLMInferenceService Controller", func() {
 						Router: &v1alpha1.RouterSpec{
 							Route: &v1alpha1.GatewayRoutesSpec{
 								HTTP: &v1alpha1.HTTPRouteSpec{
-									Spec: customRouteSpec(ctx, envTest.Client, nsName, "my-ingress-gateway", "my-inference-pool"),
+									// TODO: this is configuring a core.v1 Service to be the BackendRef, isn't this technically invalid since Scheduler != nil and the BackendRef doesn't point to the InferencePool ?
+									Spec: customRouteSpec(ctx, envTest.Client, nsName, "my-ingress-gateway", "my-inference-service"),
 								},
 							},
+							Gateway:   &v1alpha1.GatewaySpec{},
+							Scheduler: &v1alpha1.SchedulerSpec{},
 						},
 					},
 				}
@@ -284,12 +374,15 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 				Expect(expectedHTTPRoute).To(BeControllerBy(llmSvc))
 				Expect(expectedHTTPRoute).To(HaveGatewayRefs(gatewayapi.ParentReference{Name: "my-ingress-gateway"}))
-				Expect(expectedHTTPRoute).To(HaveBackendRefs("my-inference-pool"))
+				Expect(expectedHTTPRoute).To(HaveBackendRefs(BackendRefService("my-inference-service")))
+				Expect(expectedHTTPRoute).To(Not(HaveBackendRefs(BackendRefInferencePool(kmeta.ChildName(svcName, "-inference-pool")))))
 
 				// Advanced fixture pattern: Update the HTTPRoute status using fixture functions
 				updatedRoute := expectedHTTPRoute.DeepCopy()
 				WithHTTPRouteReadyStatus(DefaultGatewayControllerName)(updatedRoute)
 				Expect(envTest.Client.Status().Update(ctx, updatedRoute)).To(Succeed())
+
+				ensureSchedulerDeploymentReady(ctx, envTest.Client, llmSvc)
 
 				Eventually(LLMInferenceServiceIsReady(llmSvc, func(g Gomega, current *v1alpha1.LLMInferenceService) {
 					g.Expect(current.Status).To(HaveCondition(string(v1alpha1.HTTPRoutesReady), "True"))
@@ -563,18 +656,6 @@ var _ = Describe("LLMInferenceService Controller", func() {
 						llmSvc.Spec.Router = nil
 					},
 				),
-				Entry("should delete HTTPRoutes when entire route spec is set to nil",
-					"router-route-spec-nil",
-					&v1alpha1.RouterSpec{
-						Route: &v1alpha1.GatewayRoutesSpec{
-							HTTP: &v1alpha1.HTTPRouteSpec{}, // Default empty spec
-						},
-						Gateway: &v1alpha1.GatewaySpec{},
-					},
-					func(llmSvc *v1alpha1.LLMInferenceService) {
-						llmSvc.Spec.Router.Route = nil
-					},
-				),
 			)
 		})
 	})
@@ -755,26 +836,30 @@ func ensureRouterManagedResourcesAreReady(ctx context.Context, c client.Client, 
 		// Ensure at least one HTTPRoute was found and made ready
 		g.Expect(httpRoutes.Items).To(gomega.HaveLen(1), "Expected exactly one managed HTTPRoute")
 
-		schedulerListOpts := &client.ListOptions{
-			Namespace:     llmSvc.Namespace,
-			LabelSelector: labels.SelectorFromSet(llmisvc.SchedulerLabels(llmSvc)),
-		}
-		deployments := &appsv1.DeploymentList{}
-		err = c.List(ctx, deployments, schedulerListOpts)
-		if err != nil && !errors.IsNotFound(err) {
-			g.Expect(err).NotTo(gomega.HaveOccurred())
-		}
-
-		logf.FromContext(ctx).Info("Marking scheduler ready (if any)", "deployments", deployments)
-		for _, d := range deployments.Items {
-			dep := d.DeepCopy()
-			dep.Status.Conditions = append(dep.Status.Conditions, appsv1.DeploymentCondition{
-				Type:   appsv1.DeploymentAvailable,
-				Status: corev1.ConditionTrue,
-			})
-			g.Expect(c.Status().Update(ctx, dep)).To(gomega.Succeed())
-		}
+		ensureSchedulerDeploymentReady(ctx, c, llmSvc)
 	}).WithContext(ctx).Should(gomega.Succeed())
+}
+
+func ensureSchedulerDeploymentReady(ctx context.Context, c client.Client, llmSvc *v1alpha1.LLMInferenceService) {
+	schedulerListOpts := &client.ListOptions{
+		Namespace:     llmSvc.Namespace,
+		LabelSelector: labels.SelectorFromSet(llmisvc.SchedulerLabels(llmSvc)),
+	}
+	deployments := &appsv1.DeploymentList{}
+	err := c.List(ctx, deployments, schedulerListOpts)
+	if err != nil && !errors.IsNotFound(err) {
+		Expect(err).NotTo(gomega.HaveOccurred())
+	}
+
+	logf.FromContext(ctx).Info("Marking scheduler ready (if any)", "deployments", deployments)
+	for _, d := range deployments.Items {
+		dep := d.DeepCopy()
+		dep.Status.Conditions = append(dep.Status.Conditions, appsv1.DeploymentCondition{
+			Type:   appsv1.DeploymentAvailable,
+			Status: corev1.ConditionTrue,
+		})
+		Expect(c.Status().Update(ctx, dep)).To(gomega.Succeed())
+	}
 }
 
 func customRouteSpec(ctx context.Context, c client.Client, nsName, gatewayRefName, backendRefName string) *gatewayapi.HTTPRouteSpec {

--- a/pkg/controller/llmisvc/fixture/gwapi_builders.go
+++ b/pkg/controller/llmisvc/fixture/gwapi_builders.go
@@ -282,6 +282,34 @@ func WithBackendRefs(refs ...gatewayapi.HTTPBackendRef) HTTPRouteRuleOption {
 	}
 }
 
+func BackendRefInferencePool(name string) gatewayapi.HTTPBackendRef {
+	return gatewayapi.HTTPBackendRef{
+		BackendRef: gatewayapi.BackendRef{
+			BackendObjectReference: gatewayapi.BackendObjectReference{
+				Group: ptr.To(gatewayapi.Group("inference.networking.x-k8s.io")),
+				Kind:  ptr.To(gatewayapi.Kind("InferencePool")),
+				Name:  gatewayapi.ObjectName(name),
+				Port:  ptr.To(gatewayapi.PortNumber(8000)),
+			},
+			Weight: ptr.To(int32(1)),
+		},
+	}
+}
+
+func BackendRefService(name string) gatewayapi.HTTPBackendRef {
+	return gatewayapi.HTTPBackendRef{
+		BackendRef: gatewayapi.BackendRef{
+			BackendObjectReference: gatewayapi.BackendObjectReference{
+				Group: ptr.To(gatewayapi.Group("")),
+				Kind:  ptr.To(gatewayapi.Kind("Service")),
+				Name:  gatewayapi.ObjectName(name),
+				Port:  ptr.To(gatewayapi.PortNumber(8000)),
+			},
+			Weight: ptr.To(int32(1)),
+		},
+	}
+}
+
 func WithTimeouts(backendTimeout, requestTimeout string) HTTPRouteRuleOption {
 	return func(rule *gatewayapi.HTTPRouteRule) {
 		rule.Timeouts = &gatewayapi.HTTPRouteTimeouts{

--- a/pkg/controller/llmisvc/router.go
+++ b/pkg/controller/llmisvc/router.go
@@ -83,8 +83,7 @@ func (r *LLMInferenceServiceReconciler) reconcileHTTPRoutes(ctx context.Context,
 
 	expectedHTTPRoute := r.expectedHTTPRoute(ctx, llmSvc)
 
-	// TODO should we remove "llmSvc.Spec.Router.Route.HTTP == nil" from the condition below so that a non nil Route meeans "all type of routes are enabled"?
-	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Route == nil || llmSvc.Spec.Router.Route.HTTP == nil {
+	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Route == nil {
 		return Delete(ctx, r, llmSvc, expectedHTTPRoute)
 	}
 

--- a/pkg/controller/llmisvc/scheduler.go
+++ b/pkg/controller/llmisvc/scheduler.go
@@ -63,7 +63,7 @@ func (r *LLMInferenceServiceReconciler) reconcileScheduler(ctx context.Context, 
 
 func (r *LLMInferenceServiceReconciler) reconcileSchedulerAuthDelegatorBinding(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService, sa *corev1.ServiceAccount) error {
 	authDelegatorBinding := r.expectedSchedulerAuthDelegatorBinding(llmSvc, sa)
-	if !llmSvc.DeletionTimestamp.IsZero() || llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil {
+	if !llmSvc.DeletionTimestamp.IsZero() || llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil || llmSvc.Spec.Router.Scheduler.Template == nil || llmSvc.Spec.Router.Scheduler.Pool.HasRef() {
 		return Delete(ctx, r, llmSvc, authDelegatorBinding)
 	}
 
@@ -76,7 +76,7 @@ func (r *LLMInferenceServiceReconciler) reconcileSchedulerAuthDelegatorBinding(c
 
 func (r *LLMInferenceServiceReconciler) reconcileSchedulerRole(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {
 	role := r.expectedSchedulerRole(llmSvc)
-	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil {
+	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil || llmSvc.Spec.Router.Scheduler.Template == nil || llmSvc.Spec.Router.Scheduler.Pool.HasRef() {
 		return Delete(ctx, r, llmSvc, role)
 	}
 	if err := Reconcile(ctx, r, llmSvc, &rbacv1.Role{}, role, semanticRoleIsEqual); err != nil {
@@ -88,7 +88,7 @@ func (r *LLMInferenceServiceReconciler) reconcileSchedulerRole(ctx context.Conte
 
 func (r *LLMInferenceServiceReconciler) reconcileSchedulerRoleBinding(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService, sa *corev1.ServiceAccount) error {
 	roleBinding := r.expectedSchedulerRoleBinding(llmSvc, sa)
-	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil {
+	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil || llmSvc.Spec.Router.Scheduler.Template == nil || llmSvc.Spec.Router.Scheduler.Pool.HasRef() {
 		return Delete(ctx, r, llmSvc, roleBinding)
 	}
 
@@ -106,7 +106,7 @@ func (r *LLMInferenceServiceReconciler) reconcileSchedulerServiceAccount(ctx con
 		return r.reconcileSchedulerAuthDelegatorBinding(ctx, llmSvc, serviceAccount)
 	}
 
-	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil {
+	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil || llmSvc.Spec.Router.Scheduler.Template == nil || llmSvc.Spec.Router.Scheduler.Pool.HasRef() {
 		return Delete(ctx, r, llmSvc, serviceAccount)
 	}
 
@@ -127,7 +127,7 @@ func (r *LLMInferenceServiceReconciler) reconcileSchedulerServiceAccount(ctx con
 
 func (r *LLMInferenceServiceReconciler) reconcileSchedulerDeployment(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {
 	scheduler := r.expectedSchedulerDeployment(ctx, llmSvc)
-	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil {
+	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil || llmSvc.Spec.Router.Scheduler.Template == nil || llmSvc.Spec.Router.Scheduler.Pool.HasRef() {
 		return Delete(ctx, r, llmSvc, scheduler)
 	}
 	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, scheduler, semanticDeploymentIsEqual); err != nil {
@@ -138,7 +138,7 @@ func (r *LLMInferenceServiceReconciler) reconcileSchedulerDeployment(ctx context
 
 func (r *LLMInferenceServiceReconciler) reconcileSchedulerInferencePool(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {
 	expected := r.expectedSchedulerInferencePool(ctx, llmSvc)
-	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil || llmSvc.Spec.Router.Scheduler.Pool.HasRef() {
+	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil || llmSvc.Spec.Router.Scheduler.Template == nil || llmSvc.Spec.Router.Scheduler.Pool.HasRef() {
 		return Delete(ctx, r, llmSvc, expected)
 	}
 
@@ -151,7 +151,7 @@ func (r *LLMInferenceServiceReconciler) reconcileSchedulerInferencePool(ctx cont
 
 func (r *LLMInferenceServiceReconciler) reconcileSchedulerService(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {
 	expected := r.expectedSchedulerService(ctx, llmSvc)
-	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil || llmSvc.Spec.Router.Scheduler.Template == nil {
+	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil || llmSvc.Spec.Router.Scheduler.Template == nil || llmSvc.Spec.Router.Scheduler.Pool.HasRef() {
 		return Delete(ctx, r, llmSvc, expected)
 	}
 
@@ -164,7 +164,7 @@ func (r *LLMInferenceServiceReconciler) reconcileSchedulerService(ctx context.Co
 
 func (r *LLMInferenceServiceReconciler) reconcileSchedulerInferenceModel(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {
 	expected := r.expectedSchedulerInferenceModel(ctx, llmSvc)
-	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil {
+	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil || llmSvc.Spec.Router.Scheduler.Template == nil || llmSvc.Spec.Router.Scheduler.Pool.HasRef() {
 		return Delete(ctx, r, llmSvc, expected)
 	}
 

--- a/pkg/controller/llmisvc/workload.go
+++ b/pkg/controller/llmisvc/workload.go
@@ -23,6 +23,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	"knative.dev/pkg/kmeta"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
@@ -66,10 +69,50 @@ func (r *LLMInferenceServiceReconciler) reconcileWorkload(ctx context.Context, l
 		return fmt.Errorf("failed to reconcile single node workload: %w", err)
 	}
 
+	if err := r.reconcileWorkloadService(ctx, llmSvc); err != nil {
+		llmSvc.MarkMainWorkloadNotReady("ReconcileWorkloadServiceError", err.Error())
+		return fmt.Errorf("failed to reconcile workload service: %w", err)
+	}
+
 	return nil
 }
 
-func getInferencePoolWorkloadLabelSelector(meta metav1.ObjectMeta, _ *v1alpha1.LLMInferenceServiceSpec) map[string]string {
+func (r *LLMInferenceServiceReconciler) reconcileWorkloadService(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {
+	expected := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kmeta.ChildName(llmSvc.GetName(), "-kserve-workload-svc"),
+			Namespace: llmSvc.GetNamespace(),
+			Labels: map[string]string{
+				"app.kubernetes.io/component": "llminferenceservice-workload",
+				"app.kubernetes.io/name":      llmSvc.GetName(),
+				"app.kubernetes.io/part-of":   "llminferenceservice",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(llmSvc, v1alpha1.LLMInferenceServiceGVK),
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:        "https",
+					Protocol:    corev1.ProtocolTCP,
+					AppProtocol: ptr.To("https"),
+					Port:        8000,
+					TargetPort: intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 8000,
+					},
+				},
+			},
+			Selector: GetWorkloadLabelSelector(llmSvc.ObjectMeta, &llmSvc.Spec),
+			Type:     corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	return Reconcile(ctx, r, llmSvc, &corev1.Service{}, expected, semanticServiceIsEqual)
+}
+
+func GetWorkloadLabelSelector(meta metav1.ObjectMeta, _ *v1alpha1.LLMInferenceServiceSpec) map[string]string {
 	s := map[string]string{
 		"app.kubernetes.io/part-of": "llminferenceservice",
 		"app.kubernetes.io/name":    meta.GetName(),


### PR DESCRIPTION
Allow 
- using "raw vllm" without inference-scheduler `Gateway` -- (HTTPRoute) --> `Service`
- using external provided InferencePool and scheduler