### PR TITLE
fixing bug caused by misspelled BeControlledBy method

### DIFF
--- a/pkg/controller/llmisvc/controller_int_test.go
+++ b/pkg/controller/llmisvc/controller_int_test.go
@@ -305,7 +305,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 					return nil
 				}).WithContext(ctx).Should(Succeed())
 
-				Expect(expectedHTTPRoute).To(BeControllerBy(llmSvc))
+				Expect(expectedHTTPRoute).To(BeControlledBy(llmSvc))
 				Expect(expectedHTTPRoute).To(HaveGatewayRefs(gatewayapi.ParentReference{Name: "kserve-ingress-gateway"}))
 				Expect(expectedHTTPRoute).To(HaveBackendRefs(BackendRefInferencePool(infPoolName)))
 				Expect(expectedHTTPRoute).To(Not(HaveBackendRefs(BackendRefService(svcName + "-kserve-workload-svc"))))
@@ -368,7 +368,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 				svcName := kmeta.ChildName(llmSvcName, "-kserve-workload-svc")
 
-				Expect(expectedHTTPRoute).To(BeControllerBy(llmSvc))
+				Expect(expectedHTTPRoute).To(BeControlledBy(llmSvc))
 				Expect(expectedHTTPRoute).To(HaveGatewayRefs(gatewayapi.ParentReference{Name: "kserve-ingress-gateway"}))
 				Expect(expectedHTTPRoute).To(HaveBackendRefs(BackendRefService(svcName)))
 				Expect(expectedHTTPRoute).To(Not(HaveBackendRefs(BackendRefInferencePool(kmeta.ChildName(llmSvcName, "-inference-pool")))))


### PR DESCRIPTION
**What this PR does / why we need it**:

The `BeControlledBy` method is incorrectly spelled as `BeControllerBy` in the `pkg/controller/llmisvc/controller_int_test.go` file preventing Go Builds from completing successfully due to the following error:

```
go fmt ./pkg/... ./cmd/... && cd qpext && go fmt ./...
pkg/controller/llmisvc/workload.go
pkg/openapi/openapi_generated.go
go vet ./pkg/... ./cmd/... && cd qpext && go vet ./...
# github.com/kserve/kserve/pkg/controller/llmisvc_test
# [github.com/kserve/kserve/pkg/controller/llmisvc_test]
vet: pkg/controller/llmisvc/controller_int_test.go:308:34: undefined: BeControllerBy
make: *** [Makefile:70: vet] Error 1
```

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.