### PR TITLE
Add InferencePoolsReady as a subcondition to RouterReady

### DIFF
--- a/pkg/apis/serving/v1alpha1/llm_inference_service_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_lifecycle.go
@@ -39,8 +39,9 @@ const (
 )
 
 const (
-	GatewaysReady   apis.ConditionType = "GatewaysReady"
-	HTTPRoutesReady apis.ConditionType = "HTTPRoutesReady"
+	GatewaysReady       apis.ConditionType = "GatewaysReady"
+	HTTPRoutesReady     apis.ConditionType = "HTTPRoutesReady"
+	InferencePoolsReady apis.ConditionType = "InferencePoolsReady"
 )
 
 var llmInferenceServiceCondSet = apis.NewLivingConditionSet(
@@ -140,10 +141,19 @@ func (in *LLMInferenceService) MarkHTTPRoutesNotReady(reason, messageFormat stri
 	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(HTTPRoutesReady, reason, messageFormat, messageA...)
 }
 
+func (in *LLMInferenceService) MarkInferencePoolsReady() {
+	in.GetConditionSet().Manage(in.GetStatus()).MarkTrue(InferencePoolsReady)
+}
+
+func (in *LLMInferenceService) MarkInferencePoolsNotReady(reason, messageFormat string, messageA ...interface{}) {
+	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(InferencePoolsReady, reason, messageFormat, messageA...)
+}
+
 func (in *LLMInferenceService) DetermineRouterReadiness() {
 	subConditions := []*apis.Condition{
 		in.GetStatus().GetCondition(GatewaysReady),
 		in.GetStatus().GetCondition(HTTPRoutesReady),
+		in.GetStatus().GetCondition(InferencePoolsReady),
 		in.GetStatus().GetCondition(SchedulerWorkloadReady),
 	}
 

--- a/pkg/apis/serving/v1alpha1/llm_inference_service_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_lifecycle.go
@@ -39,9 +39,9 @@ const (
 )
 
 const (
-	GatewaysReady       apis.ConditionType = "GatewaysReady"
-	HTTPRoutesReady     apis.ConditionType = "HTTPRoutesReady"
-	InferencePoolsReady apis.ConditionType = "InferencePoolsReady"
+	GatewaysReady      apis.ConditionType = "GatewaysReady"
+	HTTPRoutesReady    apis.ConditionType = "HTTPRoutesReady"
+	InferencePoolReady apis.ConditionType = "InferencePoolReady"
 )
 
 var llmInferenceServiceCondSet = apis.NewLivingConditionSet(
@@ -141,19 +141,19 @@ func (in *LLMInferenceService) MarkHTTPRoutesNotReady(reason, messageFormat stri
 	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(HTTPRoutesReady, reason, messageFormat, messageA...)
 }
 
-func (in *LLMInferenceService) MarkInferencePoolsReady() {
-	in.GetConditionSet().Manage(in.GetStatus()).MarkTrue(InferencePoolsReady)
+func (in *LLMInferenceService) MarkInferencePoolReady() {
+	in.GetConditionSet().Manage(in.GetStatus()).MarkTrue(InferencePoolReady)
 }
 
-func (in *LLMInferenceService) MarkInferencePoolsNotReady(reason, messageFormat string, messageA ...interface{}) {
-	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(InferencePoolsReady, reason, messageFormat, messageA...)
+func (in *LLMInferenceService) MarkInferencePoolNotReady(reason, messageFormat string, messageA ...interface{}) {
+	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(InferencePoolReady, reason, messageFormat, messageA...)
 }
 
 func (in *LLMInferenceService) DetermineRouterReadiness() {
 	subConditions := []*apis.Condition{
 		in.GetStatus().GetCondition(GatewaysReady),
 		in.GetStatus().GetCondition(HTTPRoutesReady),
-		in.GetStatus().GetCondition(InferencePoolsReady),
+		in.GetStatus().GetCondition(InferencePoolReady),
 		in.GetStatus().GetCondition(SchedulerWorkloadReady),
 	}
 

--- a/pkg/controller/llmisvc/fixture/gwapi_builders.go
+++ b/pkg/controller/llmisvc/fixture/gwapi_builders.go
@@ -591,9 +591,10 @@ func WithInferencePoolReadyStatus() InferencePoolOption {
 			{
 				Conditions: []metav1.Condition{
 					{
-						Type:   string(igwapi.InferencePoolConditionAccepted),
-						Status: metav1.ConditionTrue,
-						Reason: string(igwapi.InferencePoolReasonAccepted),
+						Type:               string(igwapi.InferencePoolConditionAccepted),
+						Status:             metav1.ConditionTrue,
+						Reason:             string(igwapi.InferencePoolReasonAccepted),
+						LastTransitionTime: metav1.Now(),
 					},
 				},
 			},

--- a/pkg/controller/llmisvc/router.go
+++ b/pkg/controller/llmisvc/router.go
@@ -66,13 +66,17 @@ func (r *LLMInferenceServiceReconciler) reconcileRouter(ctx context.Context, llm
 		return fmt.Errorf("failed to reconcile istio destination rules: %w", err)
 	}
 
-	// Evaluate Gateway conditions and set GatewaysReady condition
+	// Evaluate the subconditions
 	if err := r.EvaluateGatewayConditions(ctx, llmSvc); err != nil {
 		return fmt.Errorf("failed to evaluate gateway conditions: %w", err)
 	}
 
 	if err := r.EvaluateHTTPRouteConditions(ctx, llmSvc); err != nil {
 		return fmt.Errorf("failed to evaluate HTTPRoute conditions: %w", err)
+	}
+
+	if err := r.EvaluateInferencePoolConditions(ctx, llmSvc); err != nil {
+		return fmt.Errorf("failed to evaluate Inference Pool conditions: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
[RHOAIENG-28859](https://issues.redhat.com/browse/RHOAIENG-28859)
Populates the status of InferencePools in an LLMInferenceService, aggregating their readiness to reflect the overall routing readiness in the `RouterReady` condition.

**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.