### PR TITLE
no longer prematurely exiting llmisvc route reconciliation

### DIFF
--- a/pkg/controller/llmisvc/router.go
+++ b/pkg/controller/llmisvc/router.go
@@ -104,7 +104,10 @@ func (r *LLMInferenceServiceReconciler) reconcileHTTPRoutes(ctx context.Context,
 	route := llmSvc.Spec.Router.Route
 
 	if route.HTTP.HasRefs() {
-		return Delete(ctx, r, llmSvc, expectedHTTPRoute)
+		err = Delete(ctx, r, llmSvc, expectedHTTPRoute)
+		if err != nil {
+			return fmt.Errorf("failed to delete expected HTTPRoute %s/%s: %w", expectedHTTPRoute.GetNamespace(), expectedHTTPRoute.GetName(), err)
+		}
 	}
 
 	if route.HTTP.HasSpec() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
In the current LLMInferenceservice route reconciliation flow, if the LLMInferenceservice route contains references, reconciliation will delete the expected route if it exists and exit reconciliatoin: https://github.com/opendatahub-io/kserve/blob/release-v0.15/pkg/controller/llmisvc/router.go#L107

This premature exit prevents the rest of route reconciliation so the updateRoutingStatus method, which adds the URLs and addresses associated with llmisvc's routes to the llmisvc spec, never gets called.

This PR updates the line above to capture the error returned by the `Delete` method and only return if the error is non nil. This allows route reconciliation to continue as expected and for the proper url/address values to be added to the llmisvc spec for referenced routes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
[RHOAIENG-33674](https://issues.redhat.com/browse/RHOAIENG-33674)

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- Run fvt referenced route tests included in https://github.com/opendatahub-io/kserve/pull/870
- All unit tests pass

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.