### PR TITLE
Fix indentation issue on go unit test:check-coverage workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -61,140 +61,140 @@ jobs:
                 label: coverage
                 message: ${{ steps.test.outputs.coverage }}
                 color: green
-      check-coverage:
-          needs: test
-          runs-on: ubuntu-latest
-          name: Check Coverage
-          steps:
-              - name: checkout
-                uses: actions/checkout@v4
+    check-coverage:
+        needs: test
+        runs-on: ubuntu-latest
+        name: Check Coverage
+        steps:
+            - name: checkout
+              uses: actions/checkout@v4
 
-              - name: Download cover profile artifact
-                id: download-coverage
-                uses: actions/download-artifact@v4
-                with:
-                  name: coverage.out
+            - name: Download cover profile artifact
+              id: download-coverage
+              uses: actions/download-artifact@v4
+              with:
+                name: coverage.out
 
-              - name: Extract coverage percentage
-                id: current-coverage
-                run: |
-                  if [ -f coverage.out ]; then
-                    COVERAGE=$(go tool cover -func=coverage.out | grep total: | awk '{print $3}' | sed 's/%//')
-                    echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT
-                  else
-                    echo "coverage=0" >> $GITHUB_OUTPUT
-                  fi
-              
-              - name: download artifact (master.breakdown)
-                id: download-master-breakdown
-                uses: dawidd6/action-download-artifact@v9
-                with:
-                  branch: master
-                  workflow_conclusion: success
-                  name: master.breakdown
-                  if_no_artifact_found: warn
+            - name: Extract coverage percentage
+              id: current-coverage
+              run: |
+                if [ -f coverage.out ]; then
+                  COVERAGE=$(go tool cover -func=coverage.out | grep total: | awk '{print $3}' | sed 's/%//')
+                  echo "coverage=$COVERAGE" >> $GITHUB_OUTPUT
+                else
+                  echo "coverage=0" >> $GITHUB_OUTPUT
+                fi
+            
+            - name: download artifact (master.breakdown)
+              id: download-master-breakdown
+              uses: dawidd6/action-download-artifact@v9
+              with:
+                branch: master
+                workflow_conclusion: success
+                name: master.breakdown
+                if_no_artifact_found: warn
 
-              - name: download artifact (master-coverage.out)
-                id: download-master-coverage
-                uses: dawidd6/action-download-artifact@v9
-                with:
-                  branch: master
-                  workflow_conclusion: success
-                  name: master-coverage.out
-                  if_no_artifact_found: warn
+            - name: download artifact (master-coverage.out)
+              id: download-master-coverage
+              uses: dawidd6/action-download-artifact@v9
+              with:
+                branch: master
+                workflow_conclusion: success
+                name: master-coverage.out
+                if_no_artifact_found: warn
 
-              - name: Extract master coverage percentage
-                id: master-coverage
-                run: |
-                  if [ -f master-coverage.out ]; then
-                    MASTER_COVERAGE=$(go tool cover -func=master-coverage.out | grep total: | awk '{print $3}' | sed 's/%//')
-                    echo "coverage=$MASTER_COVERAGE" >> $GITHUB_OUTPUT
-                  else
-                    echo "coverage=0" >> $GITHUB_OUTPUT
-                  fi
+            - name: Extract master coverage percentage
+              id: master-coverage
+              run: |
+                if [ -f master-coverage.out ]; then
+                  MASTER_COVERAGE=$(go tool cover -func=master-coverage.out | grep total: | awk '{print $3}' | sed 's/%//')
+                  echo "coverage=$MASTER_COVERAGE" >> $GITHUB_OUTPUT
+                else
+                  echo "coverage=0" >> $GITHUB_OUTPUT
+                fi
 
-              - name: Generate full coverage breakdown
-                id: full_coverage_report
-                run: |
-                  if [ -f coverage.out ]; then
-                    REPORT_CONTENT=$(go tool cover -func=coverage.out) # This command outputs function-level coverage [5]
-                    echo "report<<EOF" >> $GITHUB_OUTPUT # Start HERE-doc for multi-line output [3]
-                    echo "$REPORT_CONTENT" >> $GITHUB_OUTPUT
-                    echo "EOF" >> $GITHUB_OUTPUT # End HERE-doc
-                  else
-                    echo "report=No coverage report found." >> $GITHUB_OUTPUT
-                  fi
+            - name: Generate full coverage breakdown
+              id: full_coverage_report
+              run: |
+                if [ -f coverage.out ]; then
+                  REPORT_CONTENT=$(go tool cover -func=coverage.out) # This command outputs function-level coverage [5]
+                  echo "report<<EOF" >> $GITHUB_OUTPUT # Start HERE-doc for multi-line output [3]
+                  echo "$REPORT_CONTENT" >> $GITHUB_OUTPUT
+                  echo "EOF" >> $GITHUB_OUTPUT # End HERE-doc
+                else
+                  echo "report=No coverage report found." >> $GITHUB_OUTPUT
+                fi
 
-              - name: check test coverage
-                id: coverage
-                uses: vladopajic/go-test-coverage@v2
-                continue-on-error: true
-                with:
-                  config: ./.github/.testcoverage.yml
-                  breakdown-file-name: ${{ github.ref_name == 'master' && 'master.breakdown' || '' }}
-                  diff-base-breakdown-file-name: ${{ steps.download-master-breakdown.outputs.found_artifact == 'true' && 'master.breakdown' || '' }}
-              
-              - name: upload artifact (master.breakdown)
-                uses: actions/upload-artifact@v4
-                if: github.ref_name == 'master'
-                with:
-                  name: master.breakdown
-                  path: master.breakdown
-                  if-no-files-found: error
-                  
-              - name: Previous coverage
-                run: |
-                  echo "Previous Coverage ${{ steps.master-coverage.outputs.coverage }}"
+            - name: check test coverage
+              id: coverage
+              uses: vladopajic/go-test-coverage@v2
+              continue-on-error: true
+              with:
+                config: ./.github/.testcoverage.yml
+                breakdown-file-name: ${{ github.ref_name == 'master' && 'master.breakdown' || '' }}
+                diff-base-breakdown-file-name: ${{ steps.download-master-breakdown.outputs.found_artifact == 'true' && 'master.breakdown' || '' }}
+            
+            - name: upload artifact (master.breakdown)
+              uses: actions/upload-artifact@v4
+              if: github.ref_name == 'master'
+              with:
+                name: master.breakdown
+                path: master.breakdown
+                if-no-files-found: error
+                
+            - name: Previous coverage
+              run: |
+                echo "Previous Coverage ${{ steps.master-coverage.outputs.coverage }}"
 
-              - name: Current coverage
-                run: |
-                  echo "Current Coverage ${{ steps.current-coverage.outputs.coverage }}"
+            - name: Current coverage
+              run: |
+                echo "Current Coverage ${{ steps.current-coverage.outputs.coverage }}"
 
-              - name: post coverage report
-                if: github.event_name == 'pull_request'
-                uses: thollander/actions-comment-pull-request@v3
-                with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-                  comment-tag: coverage-report
-                  pr-number: ${{ github.event.pull_request.number }}
-                  message: |
-                    ## 📊 Go Test Coverage Report
-              - name: post coverage report
-                # this has evalated permission to post back the coverage, only restricted to this step.
-                if: github.event_name == 'pull_request_target'
-                uses: thollander/actions-comment-pull-request@v3
-                with:
-                  github-token: ${{ secrets.GITHUB_TOKEN }}
-                  comment-tag: coverage-report
-                  pr-number: ${{ github.event.pull_request.number }}
-                  message: |
-                    ## 📊 Go Test Coverage Report
+            - name: post coverage report
+              if: github.event_name == 'pull_request'
+              uses: thollander/actions-comment-pull-request@v3
+              with:
+                github-token: ${{ secrets.GITHUB_TOKEN }}
+                comment-tag: coverage-report
+                pr-number: ${{ github.event.pull_request.number }}
+                message: |
+                  ## 📊 Go Test Coverage Report
+            - name: post coverage report
+              # this has evalated permission to post back the coverage, only restricted to this step.
+              if: github.event_name == 'pull_request_target'
+              uses: thollander/actions-comment-pull-request@v3
+              with:
+                github-token: ${{ secrets.GITHUB_TOKEN }}
+                comment-tag: coverage-report
+                pr-number: ${{ github.event.pull_request.number }}
+                message: |
+                  ## 📊 Go Test Coverage Report
 
-                      **🔍 Coverage Summary**
-                      - **Pull Request Coverage:** `${{ steps.current-coverage.outputs.coverage }}%`
-                      - **Main Branch Coverage:** `${{ steps.master-coverage.outputs.coverage }}%`
+                    **🔍 Coverage Summary**
+                    - **Pull Request Coverage:** `${{ steps.current-coverage.outputs.coverage }}%`
+                    - **Main Branch Coverage:** `${{ steps.master-coverage.outputs.coverage }}%`
 
-                      <details>
-                      <summary>📄 Click to expand full coverage breakdown</summary>
+                    <details>
+                    <summary>📄 Click to expand full coverage breakdown</summary>
 
-                      ```
-                      ${{ steps.full_coverage_report.outputs.report }}
-                      ```
+                    ```
+                    ${{ steps.full_coverage_report.outputs.report }}
+                    ```
 
-                      </details>
-              - name: Rename and upload master coverage
-                if: github.ref_name == 'master'
-                run: mv coverage.out master-coverage.out
+                    </details>
+            - name: Rename and upload master coverage
+              if: github.ref_name == 'master'
+              run: mv coverage.out master-coverage.out
 
-                  </details>
-              - name: Rename and upload master coverage
-                if: github.ref_name == 'master'
-                run: mv coverage.out master-coverage.out
+                </details>
+            - name: Rename and upload master coverage
+              if: github.ref_name == 'master'
+              run: mv coverage.out master-coverage.out
 
-              - name: Upload master coverage artifact
-                if: github.ref_name == 'master'
-                uses: actions/upload-artifact@v4
-                with:
-                  name: master-coverage.out
-                  path: master-coverage.out
-                  if-no-files-found: error
+            - name: Upload master coverage artifact
+              if: github.ref_name == 'master'
+              uses: actions/upload-artifact@v4
+              with:
+                name: master-coverage.out
+                path: master-coverage.out
+                if-no-files-found: error


### PR DESCRIPTION
**Type of changes**
Corrects the indentation level of the check-coverage test to allow the workflow to run again. 

- [x] Bug fix (non-breaking change which fixes an issue)

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reworked coverage checks to compute and compare current vs base coverage.
  * Generates a detailed coverage breakdown and a concise PR summary with expandable details.
  * Prints previous and current coverage values in CI logs.

* **Chores**
  * Improved artifact handling for coverage reports and breakdowns across branches.
  * Standardized workflow steps and naming for clearer execution.
  * Supports reporting on both pull_request and pull_request_target events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->