### PR TITLE
update kserve image tags to stable-2.x

### DIFF
--- a/.tekton/kserve-agent-push.yaml
+++ b/.tekton/kserve-agent-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-agent:odh-v2.35
+    value: quay.io/opendatahub/kserve-agent:stable-2.x
   - name: dockerfile
     value: agent.Dockerfile
   - name: path-context

--- a/.tekton/kserve-controller-push.yaml
+++ b/.tekton/kserve-controller-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-controller:odh-v2.35
+    value: quay.io/opendatahub/kserve-controller:stable-2.x
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/kserve-router-push.yaml
+++ b/.tekton/kserve-router-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-router:odh-v2.35
+    value: quay.io/opendatahub/kserve-router:stable-2.x
   - name: dockerfile
     value: router.Dockerfile
   - name: path-context

--- a/.tekton/kserve-storage-initializer-push.yaml
+++ b/.tekton/kserve-storage-initializer-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-storage-initializer:odh-v2.35
+    value: quay.io/opendatahub/kserve-storage-initializer:stable-2.x
   - name: dockerfile
     value: storage-initializer.Dockerfile
   - name: path-context

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -1,7 +1,7 @@
-kserve-controller=quay.io/opendatahub/kserve-controller:v0.15-latest
-kserve-agent=quay.io/opendatahub/kserve-agent:v0.15-latest
-kserve-router=quay.io/opendatahub/kserve-router:v0.15-latest
-kserve-storage-initializer=quay.io/opendatahub/kserve-storage-initializer:v0.15-latest
+kserve-controller=quay.io/opendatahub/kserve-controller:stable-2.x
+kserve-agent=quay.io/opendatahub/kserve-agent:stable-2.x
+kserve-router=quay.io/opendatahub/kserve-router:stable-2.x
+kserve-storage-initializer=quay.io/opendatahub/kserve-storage-initializer:stable-2.x
 kserve-llm-d=ghcr.io/llm-d/llm-d-dev:sha-b3f0b0d
 kserve-llm-d-inference-scheduler=quay.io/opendatahub/llm-d-inference-scheduler:odh-v2.33
 kserve-llm-d-routing-sidecar=quay.io/opendatahub/llm-d-routing-sidecar:odh-v2.33


### PR DESCRIPTION
Update Kserve image tags (non llm-d) to `stable-2.x` in params.env and tekton files 