### PR TITLE
Resolve LWS leader address as ZMQ doesn't always resolve it

### DIFF
--- a/config/llmisvc/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvc/config-llm-decode-worker-data-parallel.yaml
@@ -73,6 +73,9 @@ spec:
           - "-c"
         args:
           - |-
+            # In some versions, ZMQ bind doesn't resolve the address through DNS
+            DP_ADDRESS=$(getent hosts ${LWS_LEADER_ADDRESS} | cut -d' ' -f1)
+            echo "DP_ADDRESS=${DP_ADDRESS}"
             
             if [ "$KSERVE_INFER_ROCE" = "true" ]; then
               echo "Trying to infer RoCE configs ... "
@@ -205,7 +208,7 @@ spec:
               {{- if .Spec.Parallelism.Tensor -}}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
               --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
               --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
-              --data-parallel-address $(LWS_LEADER_ADDRESS) \
+              --data-parallel-address ${DP_ADDRESS} \
               --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
               --data-parallel-start-rank $START_RANK \
               ${VLLM_ADDITIONAL_ARGS} \
@@ -271,7 +274,7 @@ spec:
         name: home
       - emptyDir:
           medium: Memory
-          sizeLimit: 1Gi
+          sizeLimit: 8Gi
         name: dshm
       - emptyDir: { }
         name: model-cache
@@ -291,6 +294,9 @@ spec:
           - "-c"
         args:
           - |-
+            # In some versions, ZMQ bind doesn't resolve the address through DNS
+            DP_ADDRESS=$(getent hosts ${LWS_LEADER_ADDRESS} | cut -d' ' -f1)
+            echo "DP_ADDRESS=${DP_ADDRESS}"
             
             if [ "$KSERVE_INFER_ROCE" = "true" ]; then
               echo "Trying to infer RoCE configs ... "
@@ -422,7 +428,7 @@ spec:
               {{- if .Spec.Parallelism.Tensor }}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
               --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
               --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
-              --data-parallel-address $(LWS_LEADER_ADDRESS) \
+              --data-parallel-address ${DP_ADDRESS} \
               --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
               --data-parallel-start-rank $START_RANK \
               ${VLLM_ADDITIONAL_ARGS} \
@@ -473,7 +479,7 @@ spec:
         name: home
       - emptyDir:
           medium: Memory
-          sizeLimit: 1Gi
+          sizeLimit: 8Gi
         name: dshm
       - emptyDir: { }
         name: model-cache

--- a/config/llmisvc/config-llm-prefill-worker-data-parallel.yaml
+++ b/config/llmisvc/config-llm-prefill-worker-data-parallel.yaml
@@ -17,6 +17,9 @@ spec:
             - "-c"
           args:
             - |-
+              # In some versions, ZMQ bind doesn't resolve the address through DNS
+              DP_ADDRESS=$(getent hosts ${LWS_LEADER_ADDRESS} | cut -d' ' -f1)
+              echo "DP_ADDRESS=${DP_ADDRESS}"
 
               if [ "$KSERVE_INFER_ROCE" = "true" ]; then
                 echo "Trying to infer RoCE configs ... "
@@ -149,7 +152,7 @@ spec:
                 {{- if .Spec.Prefill.Parallelism.Tensor -}}--tensor-parallel-size {{ .Spec.Prefill.Parallelism.Tensor }}{{- end }} \
                 --data-parallel-size {{ or .Spec.Prefill.Parallelism.Data 1 }} \
                 --data-parallel-size-local {{ or .Spec.Prefill.Parallelism.DataLocal 1 }} \
-                --data-parallel-address $(LWS_LEADER_ADDRESS) \
+                --data-parallel-address ${DP_ADDRESS} \
                 --data-parallel-rpc-port {{ if .Spec.Prefill.Parallelism.DataRPCPort }}{{ .Spec.Prefill.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
                 --data-parallel-start-rank $START_RANK \
                 ${VLLM_ADDITIONAL_ARGS} \
@@ -215,7 +218,7 @@ spec:
           name: home
         - emptyDir:
             medium: Memory
-            sizeLimit: 1Gi
+            sizeLimit: 8Gi
           name: dshm
         - emptyDir: { }
           name: model-cache
@@ -235,6 +238,9 @@ spec:
             - "-c"
           args:
             - |-
+              # In some versions, ZMQ bind doesn't resolve the address through DNS
+              DP_ADDRESS=$(getent hosts ${LWS_LEADER_ADDRESS} | cut -d' ' -f1)
+              echo "DP_ADDRESS=${DP_ADDRESS}"
 
               if [ "$KSERVE_INFER_ROCE" = "true" ]; then
                 echo "Trying to infer RoCE configs ... "
@@ -366,7 +372,7 @@ spec:
                 {{- if .Spec.Prefill.Parallelism.Tensor }}--tensor-parallel-size {{ .Spec.Prefill.Parallelism.Tensor }}{{- end }} \
                 --data-parallel-size {{ or .Spec.Prefill.Parallelism.Data 1 }} \
                 --data-parallel-size-local {{ or .Spec.Prefill.Parallelism.DataLocal 1 }} \
-                --data-parallel-address $(LWS_LEADER_ADDRESS) \
+                --data-parallel-address ${DP_ADDRESS} \
                 --data-parallel-rpc-port {{ if .Spec.Prefill.Parallelism.DataRPCPort }}{{ .Spec.Prefill.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
                 --data-parallel-start-rank $START_RANK \
                 ${VLLM_ADDITIONAL_ARGS} \
@@ -415,7 +421,7 @@ spec:
           name: home
         - emptyDir:
             medium: Memory
-            sizeLimit: 1Gi
+            sizeLimit: 8Gi
           name: dshm
         - emptyDir: { }
           name: model-cache

--- a/config/llmisvc/config-llm-worker-data-parallel.yaml
+++ b/config/llmisvc/config-llm-worker-data-parallel.yaml
@@ -16,6 +16,9 @@ spec:
           - "-c"
         args:
           - |-
+            # In some versions, ZMP bind doesn't resolve the address through DNS
+            DP_ADDRESS=$(getent hosts ${LWS_LEADER_ADDRESS} | cut -d' ' -f1)
+            echo "DP_ADDRESS=${DP_ADDRESS}"
             
             if [ "$KSERVE_INFER_ROCE" = "true" ]; then
               echo "Trying to infer RoCE configs ... "
@@ -148,7 +151,7 @@ spec:
               {{- if .Spec.Parallelism.Tensor -}}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
               --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
               --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
-              --data-parallel-address $(LWS_LEADER_ADDRESS) \
+              --data-parallel-address ${DP_ADDRESS} \
               --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
               --data-parallel-start-rank $START_RANK \
               ${VLLM_ADDITIONAL_ARGS} \
@@ -214,7 +217,7 @@ spec:
         name: home
       - emptyDir:
           medium: Memory
-          sizeLimit: 1Gi
+          sizeLimit: 8Gi
         name: dshm
       - emptyDir: { }
         name: model-cache
@@ -234,6 +237,9 @@ spec:
           - "-c"
         args:
           - |-
+            # In some versions, ZMP bind doesn't resolve the address through DNS
+            DP_ADDRESS=$(getent hosts ${LWS_LEADER_ADDRESS} | cut -d' ' -f1)
+            echo "DP_ADDRESS=${DP_ADDRESS}"
             
             if [ "$KSERVE_INFER_ROCE" = "true" ]; then
               echo "Trying to infer RoCE configs ... "
@@ -365,7 +371,7 @@ spec:
               {{- if .Spec.Parallelism.Tensor }}--tensor-parallel-size {{ .Spec.Parallelism.Tensor }}{{- end }} \
               --data-parallel-size {{ or .Spec.Parallelism.Data 1 }} \
               --data-parallel-size-local {{ or .Spec.Parallelism.DataLocal 1 }} \
-              --data-parallel-address $(LWS_LEADER_ADDRESS) \
+              --data-parallel-address ${DP_ADDRESS} \
               --data-parallel-rpc-port {{ if .Spec.Parallelism.DataRPCPort }}{{ .Spec.Parallelism.DataRPCPort }}{{ else }}5555{{- end }} \
               --data-parallel-start-rank $START_RANK \
               ${VLLM_ADDITIONAL_ARGS} \
@@ -414,7 +420,7 @@ spec:
         name: home
       - emptyDir:
           medium: Memory
-          sizeLimit: 1Gi
+          sizeLimit: 8Gi
         name: dshm
       - emptyDir: { }
         name: model-cache

--- a/docs/samples/llmisvc/dp-ep/qwen3-nvidia/llm-inference-service-dp-ep-multi-qwen-gpu-nvshmem-deepep.yaml
+++ b/docs/samples/llmisvc/dp-ep/qwen3-nvidia/llm-inference-service-dp-ep-multi-qwen-gpu-nvshmem-deepep.yaml
@@ -119,7 +119,6 @@ spec:
               - "IPC_LOCK"
               - "SYS_RAWIO"
               - "NET_RAW"
-              - "SYS_RESOURCE"
             drop:
               - ALL
           seccompProfile:
@@ -216,7 +215,6 @@ spec:
               - "IPC_LOCK"
               - "SYS_RAWIO"
               - "NET_RAW"
-              - "SYS_RESOURCE"
             drop:
               - ALL
           seccompProfile:


### PR DESCRIPTION
With the upstream image, ZMQ was resolving the address but with the internal build of vLLM image, it's not, so we now resolve the LWS address before passing it to --data-parallel-address flag.

This also increase `/dev/shm` memory limit to be 8Gi as 1Gi turned to be too small (also only evident with the internal build)