### PR TITLE
Add Konflux ODH tag bump automation to our existing release workflow.

### DIFF
--- a/.github/workflows/odh-create-release-tag.yml
+++ b/.github/workflows/odh-create-release-tag.yml
@@ -4,8 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       tag_name:
-        description: 'Tag name for the new release'
+        description: 'New release tag (e.g., odh-v2.35)'
         required: true
+        type: string
+      next_odh_tag:
+        description: 'Next development tag (e.g., odh-v2.36)'
+        required: true
+        type: string
+    # Note: This workflow assumes the release tag and image tags are in sync.
+    #       'tag_name' is used to create the release and as the value to find in files.
+    #       'next_odh_tag' provides the new value to set.
 
 permissions:
   contents: write
@@ -94,4 +102,46 @@ jobs:
           files: bin/*
           generate_release_notes: true
           name: ${{ github.event.inputs.tag_name }}
+
+  bump-odh-tag:
+    name: Bump ODH Tag for Next Release
+    runs-on: ubuntu-latest
+    needs: [fetch-tag, update-params-env, changelog]
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Update KServe konflux files with next ODH tag
+        run: |
+          CURRENT_TAG="${{ github.event.inputs.tag_name }}"
+          NEXT_TAG="${{ github.event.inputs.next_odh_tag }}"
+          
+          echo "Updating ODH tag from $CURRENT_TAG to $NEXT_TAG..."
+          
+          # Using sed to replace the current ODH tag with the next one
+          # anchored to the image name for all four KServe files.
+          sed -i "s|kserve-agent:${CURRENT_TAG}|kserve-agent:${NEXT_TAG}|g" .tekton/kserve-agent-push.yaml
+          sed -i "s|kserve-controller:${CURRENT_TAG}|kserve-controller:${NEXT_TAG}|g" .tekton/kserve-controller-push.yaml
+          sed -i "s|kserve-router:${CURRENT_TAG}|kserve-router:${NEXT_TAG}|g" .tekton/kserve-router-push.yaml
+          sed -i "s|kserve-storage-initializer:${CURRENT_TAG}|kserve-storage-initializer:${NEXT_TAG}|g" .tekton/kserve-storage-initializer-push.yaml
+
+          echo "Update complete."
+          
+      - name: Commit and Push Changes
+        run: |
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git add -f .tekton/kserve-agent-push.yaml .tekton/kserve-controller-push.yaml .tekton/kserve-router-push.yaml .tekton/kserve-storage-initializer-push.yaml
+          
+          # Check for changes before committing
+          if [[ -z "$(git status --porcelain)" ]]; then
+            echo "No changes to commit. Exiting."
+          else
+            git commit -m "chore(konflux): Bump ODH release tag to ${{ github.event.inputs.next_odh_tag }}"
+            git push
+          fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR adds a new job to the `create-release.yaml` workflow to automate the process of updating ODH release tags in the KServe Tekton build files. This automation prepares the repository for the next development cycle by using the `next_odh_tag` input to update the relevant files. This ensures the correct tag is used for the next sprint, supporting both simple increments and major version bumps.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #[RHOAIENG-31952](https://issues.redhat.com/browse/RHOAIENG-31952)

**Type of changes**
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- **Test A**: Manually triggered the workflow with a `workflow_dispatch` event on the `RHOAIENG-31952-test` branch.
- **Test B**: Verified that the workflow successfully updated the image tags in the four specified `.tekton` files.

**Test Configuration:**
- Branch: `RHOAIENG-31952-test`
- Workflow inputs:
  - `tag_name`: `odh-v2.35`
  - `next_odh_tag`: `odh-v2.36`

**Test Results:**
- The workflow ran successfully without errors.
- The `kserve-agent-push.yaml`, `kserve-controller-push.yaml`, `kserve-router-push.yaml`, and `kserve-storage-initializer-push.yaml` files were all correctly updated to `odh-v2.36`.

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.