### PR TITLE
configuring hf downloads to lower memory usage

### DIFF
--- a/config/overlays/odh/patches/patch-inferenceservice-config.yaml
+++ b/config/overlays/odh/patches/patch-inferenceservice-config.yaml
@@ -17,7 +17,7 @@ data:
     {
         "image" : "$(kserve-storage-initializer)",
         "memoryRequest": "100Mi",
-        "memoryLimit": "200Gi",
+        "memoryLimit": "1Gi",
         "cpuRequest": "100m",
         "cpuLimit": "1",
         "enableDirectPvcVolumeMount": true,

--- a/config/overlays/odh/patches/patch-inferenceservice-config.yaml
+++ b/config/overlays/odh/patches/patch-inferenceservice-config.yaml
@@ -17,7 +17,7 @@ data:
     {
         "image" : "$(kserve-storage-initializer)",
         "memoryRequest": "100Mi",
-        "memoryLimit": "1Gi",
+        "memoryLimit": "24Gi",
         "cpuRequest": "100m",
         "cpuLimit": "1",
         "enableDirectPvcVolumeMount": true,

--- a/pkg/controller/llmisvc/controller_workload_storage_int_test.go
+++ b/pkg/controller/llmisvc/controller_workload_storage_int_test.go
@@ -346,10 +346,6 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 						},
 					},
 				},
-				{
-					Name:  hf.HFTransfer,
-					Value: "1",
-				},
 			}
 			validateStorageInitializerCredentials(expectedMainDeployment, expectedEnvVars)
 			validateStorageInitializerCredentials(expectedPrefillDeployment, expectedEnvVars)
@@ -1074,10 +1070,6 @@ var _ = Describe("LLMInferenceService Controller - Storage configuration", func(
 							Key: hf.HFTokenKey,
 						},
 					},
-				},
-				{
-					Name:  hf.HFTransfer,
-					Value: "1",
 				},
 			}
 			validateStorageInitializerCredentialsForLWS(expectedMainLWS, expectedEnvVars)

--- a/pkg/credentials/hf/hf_secret.go
+++ b/pkg/credentials/hf/hf_secret.go
@@ -22,7 +22,6 @@ import (
 
 const (
 	HFTokenKey = "HF_TOKEN"
-	HFTransfer = "HF_HUB_ENABLE_HF_TRANSFER"
 )
 
 func BuildSecretEnvs(secret *corev1.Secret) []corev1.EnvVar {
@@ -40,10 +39,6 @@ func BuildSecretEnvs(secret *corev1.Secret) []corev1.EnvVar {
 						Key: HFTokenKey,
 					},
 				},
-			},
-			{
-				Name:  HFTransfer,
-				Value: "1",
 			},
 		}...)
 	}

--- a/pkg/credentials/hf/hf_secret_test.go
+++ b/pkg/credentials/hf/hf_secret_test.go
@@ -36,12 +36,10 @@ func TestBuildSecretEnvs_WithToken(t *testing.T) {
 
 	envs := BuildSecretEnvs(secret)
 
-	assert.Len(t, envs, 2)
+	assert.Len(t, envs, 1)
 	assert.Equal(t, HFTokenKey, envs[0].Name)
 	assert.Equal(t, HFTokenKey, envs[0].ValueFrom.SecretKeyRef.Key)
 	assert.Equal(t, secret.Name, envs[0].ValueFrom.SecretKeyRef.LocalObjectReference.Name)
-	assert.Equal(t, HFTransfer, envs[1].Name)
-	assert.Equal(t, "1", envs[1].Value)
 }
 
 func TestBuildSecretEnvs_WithoutToken(t *testing.T) {

--- a/pkg/utils/storage.go
+++ b/pkg/utils/storage.go
@@ -195,6 +195,18 @@ func AddStorageInitializerContainer(podSpec *corev1.PodSpec, mainContainerName, 
 					Name:  "HF_HOME",
 					Value: "/tmp",
 				},
+				{
+					Name:  "HF_HUB_ENABLE_HF_TRANSFER",
+					Value: "1",
+				},
+				{
+					Name:  "HF_XET_HIGH_PERFORMANCE",
+					Value: "1",
+				},
+				{
+					Name:  "HF_XET_NUM_CONCURRENT_RANGE_GETS",
+					Value: "8",
+				},
 			},
 			Resources: corev1.ResourceRequirements{
 				Limits: map[corev1.ResourceName]resource.Quantity{

--- a/pkg/webhook/admission/pod/storage_initializer_injector_test.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector_test.go
@@ -187,6 +187,9 @@ func TestStorageInitializerInjector(t *testing.T) {
 							Resources: resourceRequirement,
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
@@ -252,6 +255,9 @@ func TestStorageInitializerInjector(t *testing.T) {
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{
@@ -316,6 +322,9 @@ func TestStorageInitializerInjector(t *testing.T) {
 							Resources: resourceRequirement,
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
@@ -381,6 +390,9 @@ func TestStorageInitializerInjector(t *testing.T) {
 							Resources: resourceRequirement,
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
@@ -450,6 +462,9 @@ func TestStorageInitializerInjector(t *testing.T) {
 							Resources: resourceRequirement,
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
@@ -531,6 +546,9 @@ func TestStorageInitializerInjector(t *testing.T) {
 							Args:  []string{"s3://my-bucket/foo/bar", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name:  credentials.StorageOverrideConfigEnvKey,
 									Value: `{"bucket":"my-bucket","type":"s3"}`,
@@ -814,6 +832,9 @@ func TestCredentialInjection(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name: s3.AWSAccessKeyId,
 									ValueFrom: &corev1.EnvVarSource{
@@ -920,6 +941,9 @@ func TestCredentialInjection(t *testing.T) {
 							},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name:  gcs.GCSCredentialEnvKey,
 									Value: gcs.GCSCredentialVolumeMountPath + "gcloud-application-credentials.json",
@@ -1009,6 +1033,9 @@ func TestCredentialInjection(t *testing.T) {
 							Args:  []string{"s3://my-bucket/foo/bar", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name: credentials.StorageConfigEnvKey,
 									ValueFrom: &corev1.EnvVarSource{
@@ -1105,6 +1132,9 @@ func TestCredentialInjection(t *testing.T) {
 							Args:  []string{"s3://my-bucket/foo/bar", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name: credentials.StorageConfigEnvKey,
 									ValueFrom: &corev1.EnvVarSource{
@@ -1223,6 +1253,9 @@ func TestStorageInitializerConfigmap(t *testing.T) {
 							Resources: resourceRequirement,
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
@@ -1465,6 +1498,9 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name: s3.AWSAccessKeyId,
 									ValueFrom: &corev1.EnvVarSource{
@@ -1567,6 +1603,9 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name: s3.AWSAccessKeyId,
 									ValueFrom: &corev1.EnvVarSource{
@@ -1688,6 +1727,9 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name: s3.AWSAccessKeyId,
 									ValueFrom: &corev1.EnvVarSource{
@@ -1811,6 +1853,9 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name: s3.AWSAccessKeyId,
 									ValueFrom: &corev1.EnvVarSource{
@@ -1927,6 +1972,9 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name: s3.AWSAccessKeyId,
 									ValueFrom: &corev1.EnvVarSource{
@@ -2034,6 +2082,9 @@ func TestCaBundleConfigMapVolumeMountInStorageInitializer(t *testing.T) {
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 								{
 									Name: s3.AWSAccessKeyId,
 									ValueFrom: &corev1.EnvVarSource{
@@ -2428,6 +2479,9 @@ func TestTransformerCollocation(t *testing.T) {
 							Resources: resourceRequirement,
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
@@ -2599,6 +2653,9 @@ func TestTransformerCollocation(t *testing.T) {
 							Resources: resourceRequirement,
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
@@ -2847,6 +2904,9 @@ func TestStorageContainerCRDInjection(t *testing.T) {
 							Env: []corev1.EnvVar{
 								{Name: "name", Value: "value"},
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 						},
 					},
@@ -2903,6 +2963,9 @@ func TestStorageContainerCRDInjection(t *testing.T) {
 							Resources: resourceRequirement, // from configMap instead of the CR
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
@@ -3339,6 +3402,9 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -3414,6 +3480,9 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 							Resources: resourceRequirement,
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							TerminationMessagePolicy: "FallbackToLogsOnError",
 							VolumeMounts: []corev1.VolumeMount{
@@ -3501,6 +3570,9 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -3566,6 +3638,9 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -3643,6 +3718,9 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -3720,6 +3798,9 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -3797,6 +3878,9 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -3873,6 +3957,9 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -3949,6 +4036,9 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",
@@ -4026,6 +4116,9 @@ func TestStorageInitializerUIDForIstioCNI(t *testing.T) {
 							Args:  []string{"gs://foo", constants.DefaultModelLocalMountPath},
 							Env: []corev1.EnvVar{
 								{Name: "HF_HOME", Value: "/tmp"},
+								{Name: "HF_HUB_ENABLE_HF_TRANSFER", Value: "1"},
+								{Name: "HF_XET_HIGH_PERFORMANCE", Value: "1"},
+								{Name: "HF_XET_NUM_CONCURRENT_RANGE_GETS", Value: "8"},
 							},
 							Resources:                resourceRequirement,
 							TerminationMessagePolicy: "FallbackToLogsOnError",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
[RHOAIENG-33254](https://issues.redhat.com/browse/RHOAIENG-33254)
When downloading models form hugging face storage using the latest version of the Huggingface Hub python library `Out Of Memory (OOM)` errors are consistently encountered for large models. The cause of this issue is the way kubernetes handles memory overhead when using the `xet` package for hf downloads (discussed in this [issue](https://github.com/huggingface/huggingface_hub/issues/3300#issuecomment-3234260268)).

To lower the memory usage, the following configuration will be used:
1. To maximize download speeds for legacy git lfs storage we will enable the use of the `hf_transfer` package: https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables#hfhubenablehftransfer
2. To maximize download speeds for hf repos that support `xet` we will enable xet high performance mode: https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables#hfxethighperformance
3. To minimize the memory usage of the `xet` package we will limit the number of chunks downloaded per file:
https://huggingface.co/docs/huggingface_hub/en/package_reference/environment_variables#hfxetnumconcurrentrangegets

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

To test a simple inference service was deployed with the following configuration:
```
spec:
  predictor:
    automountServiceAccountToken: false
    maxReplicas: 1
    minReplicas: 1
    model:
      modelFormat:
        name: vLLM
      name: ''
      resources:
        limits:
          cpu: '2'
          memory: 8Gi
        requests:
          cpu: '1'
          memory: 4Gi
      runtime: hf-test
      storageUri: 'hf://deepseek-ai/DeepSeek-V2-Lite-Chat'
```

After deploying the isvc, the metrics of the storage-initalizer pod were observed. The results are captured below.

**Current Configuration**

-  hf transfer enabled

<img width="720" height="349" alt="image" src="https://github.com/user-attachments/assets/ae14709b-51cc-44bf-8f93-f22a8717c4b9" />


**New Configuration**

- hf transfer enabled
- xet high performance enabled
- xet num concurrent range gets 8

<img width="720" height="349" alt="image" src="https://github.com/user-attachments/assets/2a940445-fef7-48fd-b6fe-1c67602a8b60" />


As seen above, the new configuration lowers memory usage by 75%, while maintaining a consistent time taken to download the model.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Decrease memory usage of hf downloads in the storage initalizer container
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.