### PR TITLE
Switch to official LWS operator (stable-v1.0) for OpenShift

### DIFF
--- a/pkg/controller/llmisvc/DEV.md
+++ b/pkg/controller/llmisvc/DEV.md
@@ -352,7 +352,6 @@ spec:
   name: openshift-cert-manager-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: cert-manager-operator.v1.16.1
 EOF
 
 while [ $(kubectl get pod -n cert-manager-operator  | wc -l) -le 1 ]; 
@@ -365,75 +364,20 @@ kubectl wait pod -l name=cert-manager-operator -n cert-manager-operator --for=co
 
 **Install LWS Operator**
 
-This step should be changed when official lws-operator is released.
+Install the official Leader Worker Set operator from the Red Hat Operators catalog:
 
 ```shell
-# Update PULL SECRET
-export BREW_PULL_SECRET_FILE="path/to/file"
-export REGISTRY_PULL_SECRET_FILE="path/to/file"
-
-kubectl get secret pull-secret -n openshift-config -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d > /tmp/pull-secret.json 
-jq -s '.[0].auths += .[1].auths | {auths: .[0].auths}' /tmp/pull-secret.json $BREW_PULL_SECRET_FILE > /tmp/new-pull-secret.json    
-jq -s '.[0].auths += .[1].auths | {auths: .[0].auths}' /tmp/new-pull-secret.json  $REGISTRY_PULL_SECRET_FILE > /tmp/final-pull-secret.json    
-oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=/tmp/final-pull-secret.json  
-
-# Create MirrorSet to pull prebuilt images 
-cat <<EOF| kubectl create -f -
-apiVersion: config.openshift.io/v1
-kind: ImageTagMirrorSet
-metadata:
-    name: stage-registry
-spec:
-    imageTagMirrors:
-    - mirrors:
-        - registry.stage.redhat.io/leader-worker-set/lws-operator-bundle
-      source: registry.redhat.io/leader-worker-set/lws-operator-bundle
-    - mirrors:
-        - registry.stage.redhat.io/leader-worker-set/lws-rhel9-operator
-      source: registry.redhat.io/leader-worker-set/lws-rhel9-operator
----
-apiVersion: config.openshift.io/v1
-kind: ImageDigestMirrorSet
-metadata:
-    name: stage-registry
-spec:
-    imageDigestMirrors:
-    - mirrors:
-        - registry.stage.redhat.io/leader-worker-set/lws-operator-bundle
-      source: registry.redhat.io/leader-worker-set/lws-operator-bundle
-    - mirrors:
-        - registry.stage.redhat.io/leader-worker-set/lws-rhel9-operator
-      source: registry.redhat.io/leader-worker-set/lws-rhel9-operator
-EOF
-
-
-cat <<EOF | kubectl create -f -
-apiVersion: operators.coreos.com/v1alpha1
-kind: CatalogSource
-metadata:
-  name: lws-operator
-  namespace: openshift-marketplace
-spec:
-  sourceType: grpc
-  image: brew.registry.redhat.io/rh-osbs/iib@sha256:8d69ca9a5337ba486e6a197ce24327d7bc833ebdcf993d99c90bc69a2d0e186c
-EOF
-
-sleep 10
-
-kubectl wait pod -l olm.catalogSource=lws-operator -n openshift-marketplace --for=condition=Ready --timeout=180s
-
 kubectl create ns openshift-lws-operator || true
 
 cat <<EOF | kubectl create -f -
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: openshift-lws-operator-jw944
+  name: leader-worker-set
   namespace: openshift-lws-operator
 spec:
   targetNamespaces:
   - openshift-lws-operator
-  upgradeStrategy: Default
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -441,12 +385,11 @@ metadata:
   name: leader-worker-set
   namespace: openshift-lws-operator
 spec:
-  channel: stable-v1.0                         ## This need to be updated
+  channel: stable-v1.0
   installPlanApproval: Automatic
   name: leader-worker-set
-  source: lws-operator
+  source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: leader-worker-set.v1.0.0
 EOF
 
 until kubectl get crd leaderworkersetoperators.operator.openshift.io &> /dev/null; do
@@ -461,7 +404,7 @@ kubectl wait \
   --for=condition=Established \
   --timeout=60s \
   crd/leaderworkersetoperators.operator.openshift.io
-  
+
 cat <<EOF | kubectl create -f -
 apiVersion: operator.openshift.io/v1
 kind: LeaderWorkerSetOperator

--- a/test/scripts/openshift-ci/infra/deploy.lws.sh
+++ b/test/scripts/openshift-ci/infra/deploy.lws.sh
@@ -18,18 +18,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../common.sh"
 
 echo "⏳ Installing openshift-lws-operator"
-{
-cat <<EOF | oc create -f -
-apiVersion: operators.coreos.com/v1alpha1
-kind: CatalogSource
-metadata:
-  name: lws-operator
-  namespace: openshift-marketplace
-spec:
-  sourceType: grpc
-  image: quay.io/jooholee/lws-operator-index:llmd
-EOF
-} || true
 
 oc create ns openshift-lws-operator || true
 
@@ -38,12 +26,11 @@ cat <<EOF | oc create -f -
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: openshift-lws-operator-jw944
+  name: leader-worker-set
   namespace: openshift-lws-operator
 spec:
   targetNamespaces:
   - openshift-lws-operator
-  upgradeStrategy: Default
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -51,12 +38,11 @@ metadata:
   name: leader-worker-set
   namespace: openshift-lws-operator
 spec:
-  channel: stable
+  channel: stable-v1.0
   installPlanApproval: Automatic
   name: leader-worker-set
-  source: lws-operator
+  source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: leader-worker-set.v1.0.0
 EOF
 } || true
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Migrates the LWS (Leader Worker Set) operator installation from RC/dev build to the official Red Hat `stable-v1.0` operator. This update ensures CI testing and local development use the officially supported operator from the `redhat-operators` catalog instead of custom CatalogSources.

Changes include:
  - Updated CI setup script (`test/scripts/openshift-ci/infra/deploy.lws.sh`) to use
  `redhat-operators` catalog with `stable-v1.0` channel
  - Updated dev guide (`pkg/controller/llmisvc/DEV.md`) to remove RC/brew registry configuration
  and use official operator installation
  - Removed custom CatalogSource dependency
  - Added workaround comment for cert-manager version compatibility

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #[RHOAIENG-34534](https://issues.redhat.com/browse/RHOAIENG-34534)

**Type of changes**
Please delete options that are not relevant.

- [x] This change requires a documentation update

**Feature/Issue validation/testing**:
Tested on OpenShift 4.20.0-0.nightly-2025-10-02-162542 (AWS Hypershift):

  - [x] Gateway API setup validated (openshift-ai-inference gateway programmed)
  - [x] cert-manager v1.17.0 installed successfully
  - [x] LWS operator v1.0.0 from stable-v1.0 channel installed and operational
  - [x] KServe deployed with full LWS integration (controller watches LeaderWorkerSet resources)
  - [x] Single-node LLM inference service deployed and serving requests (facebook-opt-125m-cpu)
  - [x] Multi-node LeaderWorkerSet creation validated (webhook active and validating)

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.
```bash
  # LWS operator subscription
  $ oc get subscription leader-worker-set -n openshift-lws-operator -o
  jsonpath='{.spec.channel}{"\n"}{.spec.source}{"\n"}'
  stable-v1.0
  redhat-operators

  # CSV installed
  $ oc get csv -n openshift-lws-operator
  NAME                       DISPLAY                              VERSION   PHASE
  leader-worker-set.v1.0.0   Red Hat build of Leader Worker Set   1.0.0     Succeeded

  # KServe RBAC for LWS
  $ oc auth can-i create leaderworkersets
  --as=system:serviceaccount:opendatahub:kserve-controller-manager -n opendatahub
  yes

  # LLM inference working
  $ curl "${LB_URL}/v1/completions" -H "Content-Type: application/json" -d '{"model":
  "facebook/opt-125m", "prompt": "San Francisco is a"}' | jq
  {
    "choices": [
      {
        "finish_reason": "length",
        "index": 0,
        "text": " city with its own social justice legacy..."
      }
    ],
    ...
  }
```

**Reproducibility - YAML manifests used for testing:**

  <details>
  <summary>Click to expand YAML files</summary>

  **1. Gateway API Setup - gatewayclass.yaml**
  ```yaml
  apiVersion: gateway.networking.k8s.io/v1
  kind: GatewayClass
  metadata:
    name: openshift-default
  spec:
    controllerName: "openshift.io/gateway-controller/v1"
```
  2. Gateway API Setup - gateway.yaml
  ```yaml
  apiVersion: gateway.networking.k8s.io/v1
  kind: Gateway
  metadata:
    name: openshift-ai-inference
    namespace: openshift-ingress
  spec:
    gatewayClassName: openshift-default
    listeners:
    - name: http
      port: 80
      protocol: HTTP
      allowedRoutes:
        namespaces:
          from: All
```
  3. cert-manager Subscription - openshift-cert-manager-operator-crd.yaml
  ```yaml
  apiVersion: operators.coreos.com/v1alpha1
  kind: Subscription
  metadata:
    name: openshift-cert-manager-operator
    namespace: cert-manager-operator
  spec:
    channel: stable-v1
    installPlanApproval: Automatic
    name: openshift-cert-manager-operator
    source: redhat-operators
    sourceNamespace: openshift-marketplace
```

  5. LWS Operator CR - leaderworkersetoperator-cr.yaml
  ```yaml
  apiVersion: operator.openshift.io/v1
  kind: LeaderWorkerSetOperator
  metadata:
    name: cluster
    namespace: openshift-lws-operator
  spec:
    managementState: Managed
    logLevel: Normal
    operatorLogLevel: Normal
```
  ###Apply order
  **1. Gateway API**
```
  oc apply -f gatewayclass.yaml
  oc create namespace openshift-ingress || true
  oc apply -f gateway.yaml
```

  **2. cert-manager (note: deploy.cert-manager.sh may have version issues, use manual 
  subscription)**
 ```
 oc delete subscription openshift-cert-manager-operator -n cert-manager-operator  # if needed
  oc apply -f openshift-cert-manager-operator-crd.yaml
```

  **3. LWS operator**
```
  ./test/scripts/openshift-ci/infra/deploy.lws.sh
  oc apply -f leaderworkersetoperator-cr.yaml
```

  **4. KServe**
```
  kubectl kustomize config/crd/ | kubectl apply --server-side=true -f -
  kustomize build config/overlays/odh | kubectl apply --server-side=true --force-conflicts -f -
```

</details>

**Special notes for your reviewer**:

  1. ✅ This PR does not change any image versions.
  2. Added a workaround comment in DEV.md for cert-manager version hardcoding issue (line
  355-358) - team to review approach for fixing hardcoded startingCSV.
  5. No controller code changes - only CI scripts and documentation updates.

**Checklist**:

  - [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature
  works? *(N/A - infrastructure/documentation change, existing e2e tests validate functionality)*
  - [ ] Has code been commented, particularly in hard-to-understand areas? *(N/A - changes are 
  straightforward YAML updates)*
  - [x] Have you made corresponding changes to the documentation? *(Updated deploy.lws.sh and 
  DEV.md)*
  - [x] Have you linked the JIRA issue(s) to this PR? *([RHOAIENG-34534](https://issues.redhat.com//browse/RHOAIENG-34534))*

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.