### PR TITLE
Support for Configurable oauth-proxy Timeout

### DIFF
--- a/pkg/apis/serving/v1beta1/configmap.go
+++ b/pkg/apis/serving/v1beta1/configmap.go
@@ -129,11 +129,12 @@ type IngressConfig struct {
 
 // +kubebuilder:object:generate=false
 type OauthConfig struct {
-	Image         string `json:"image"`
-	CpuLimit      string `json:"cpuLimit"`
-	CpuRequest    string `json:"cpuRequest"`
-	MemoryLimit   string `json:"memoryLimit"`
-	MemoryRequest string `json:"memoryRequest"`
+	Image          string `json:"image"`
+	CpuLimit       string `json:"cpuLimit"`
+	CpuRequest     string `json:"cpuRequest"`
+	MemoryLimit    string `json:"memoryLimit"`
+	MemoryRequest  string `json:"memoryRequest"`
+	TimeoutSeconds string `json:"timeoutSeconds,omitempty"`
 }
 
 // +kubebuilder:object:generate=false

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -7748,6 +7748,12 @@ func schema_pkg_apis_serving_v1beta1_OauthConfig(ref common.ReferenceCallback) c
 							Format:  "",
 						},
 					},
+					"timeoutSeconds": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"image", "cpuLimit", "cpuRequest", "memoryLimit", "memoryRequest"},
 			},

--- a/pkg/openapi/swagger.json
+++ b/pkg/openapi/swagger.json
@@ -4291,6 +4291,9 @@
         "memoryRequest": {
           "type": "string",
           "default": ""
+        },
+        "timeoutSeconds": {
+          "type": "string"
         }
       }
     },

--- a/python/kserve/docs/V1beta1OauthConfig.md
+++ b/python/kserve/docs/V1beta1OauthConfig.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 **image** | **str** |  | [default to '']
 **memory_limit** | **str** |  | [default to '']
 **memory_request** | **str** |  | [default to '']
+**timeout_seconds** | **str** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/python/kserve/kserve/models/v1beta1_oauth_config.py
+++ b/python/kserve/kserve/models/v1beta1_oauth_config.py
@@ -51,7 +51,8 @@ class V1beta1OauthConfig(object):
         'cpu_request': 'str',
         'image': 'str',
         'memory_limit': 'str',
-        'memory_request': 'str'
+        'memory_request': 'str',
+        'timeout_seconds': 'str'
     }
 
     attribute_map = {
@@ -59,10 +60,11 @@ class V1beta1OauthConfig(object):
         'cpu_request': 'cpuRequest',
         'image': 'image',
         'memory_limit': 'memoryLimit',
-        'memory_request': 'memoryRequest'
+        'memory_request': 'memoryRequest',
+        'timeout_seconds': 'timeoutSeconds'
     }
 
-    def __init__(self, cpu_limit='', cpu_request='', image='', memory_limit='', memory_request='', local_vars_configuration=None):  # noqa: E501
+    def __init__(self, cpu_limit='', cpu_request='', image='', memory_limit='', memory_request='', timeout_seconds=None, local_vars_configuration=None):  # noqa: E501
         """V1beta1OauthConfig - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
@@ -73,6 +75,7 @@ class V1beta1OauthConfig(object):
         self._image = None
         self._memory_limit = None
         self._memory_request = None
+        self._timeout_seconds = None
         self.discriminator = None
 
         self.cpu_limit = cpu_limit
@@ -80,6 +83,8 @@ class V1beta1OauthConfig(object):
         self.image = image
         self.memory_limit = memory_limit
         self.memory_request = memory_request
+        if timeout_seconds is not None:
+            self.timeout_seconds = timeout_seconds
 
     @property
     def cpu_limit(self):
@@ -195,6 +200,27 @@ class V1beta1OauthConfig(object):
             raise ValueError("Invalid value for `memory_request`, must not be `None`")  # noqa: E501
 
         self._memory_request = memory_request
+
+    @property
+    def timeout_seconds(self):
+        """Gets the timeout_seconds of this V1beta1OauthConfig.  # noqa: E501
+
+
+        :return: The timeout_seconds of this V1beta1OauthConfig.  # noqa: E501
+        :rtype: str
+        """
+        return self._timeout_seconds
+
+    @timeout_seconds.setter
+    def timeout_seconds(self, timeout_seconds):
+        """Sets the timeout_seconds of this V1beta1OauthConfig.
+
+
+        :param timeout_seconds: The timeout_seconds of this V1beta1OauthConfig.  # noqa: E501
+        :type: str
+        """
+
+        self._timeout_seconds = timeout_seconds
 
     def to_dict(self):
         """Returns the model properties as a dict"""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
[RHOAIENG-34528](https://issues.redhat.com/browse/RHOAIENG-34528)
Currently, the oauth-proxy container used for ISVCs in Raw deployment mode does not support configuring the upstream timeout value. This means this value will always be set to 30s, preventing long running requests from succeeding. 

This PR adds support for configuring the upstream timeout value argument passed to the oauth-proxy container in the following ways:
1.The timeout seconds value set in the ISVC componet specs (`inferenceservice.spec.predictor.timeout`, `inferenceservice.spec.transformer.timeout`, and `inferenceservice.spec.explainer.timeout`) will be propagated to the `--upstream-timeout` arg passed to the oauth-proxy container
2. If timeout seconds is not configured for a component (i.e. `nil`) then a new optional value, `timeoutSeconds` is read from the `inferenceservice-config` configmap oauthProxy configuration and passed as the `--upstream-timeout` arg value.
3. If neither of the above are configured then no `--upstream-timeout` arg will be passed to the oauth-proxy container and the default 30s value will be used.

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Unit tests added

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support for configuring oauth-proxy upstream timeout
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.