### PR TITLE
fix: Skip validation for empty cpuModelcar and memoryModelcar fields

### DIFF
--- a/pkg/apis/serving/v1beta1/configmap.go
+++ b/pkg/apis/serving/v1beta1/configmap.go
@@ -396,13 +396,21 @@ func GetStorageInitializerConfigs(configMap *corev1.ConfigMap) (*types.StorageIn
 	}
 	// Ensure that we set proper values for CPU/Memory Limit/Request
 	resourceDefaults := map[string]string{
-		"memoryRequest":  storageInitializerConfig.MemoryRequest,
-		"memoryLimit":    storageInitializerConfig.MemoryLimit,
-		"cpuRequest":     storageInitializerConfig.CpuRequest,
-		"cpuLimit":       storageInitializerConfig.CpuLimit,
-		"cpuModelcar":    storageInitializerConfig.CpuModelcar,
-		"memoryModelcar": storageInitializerConfig.MemoryModelcar,
+		"memoryRequest": storageInitializerConfig.MemoryRequest,
+		"memoryLimit":   storageInitializerConfig.MemoryLimit,
+		"cpuRequest":    storageInitializerConfig.CpuRequest,
+		"cpuLimit":      storageInitializerConfig.CpuLimit,
 	}
+
+	// Only validate optional modelcar fields if they're set
+	if storageInitializerConfig.CpuModelcar != "" {
+		resourceDefaults["cpuModelcar"] = storageInitializerConfig.CpuModelcar
+	}
+	if storageInitializerConfig.MemoryModelcar != "" {
+		resourceDefaults["memoryModelcar"] = storageInitializerConfig.MemoryModelcar
+	}
+
+	// Perform validation
 	for key, value := range resourceDefaults {
 		_, err := resource.ParseQuantity(value)
 		if err != nil {

--- a/pkg/webhook/admission/pod/storage_initializer_injector_test.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector_test.go
@@ -1381,6 +1381,74 @@ func TestGetStorageInitializerConfigs(t *testing.T) {
 				gomega.HaveOccurred(),
 			},
 		},
+		{
+			name: "Empty Modelcar Fields Should Not Cause Validation Error",
+			configMap: &corev1.ConfigMap{
+				TypeMeta:   metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{},
+				Data: map[string]string{
+					v1beta1.StorageInitializerConfigMapKeyName: `{
+						"Image":        		 "gcr.io/kserve/storage-initializer:latest",
+						"CpuRequest":   		 "100m",
+						"CpuLimit":      		 "1",
+						"MemoryRequest": 		 "200Mi",
+						"MemoryLimit":   		 "1Gi",
+						"CpuModelcar": 			 "",
+						"MemoryModelcar": 		 "",
+						"CaBundleConfigMapName": "",
+						"CaBundleVolumeMountPath": "/etc/ssl/custom-certs"
+					}`,
+				},
+				BinaryData: map[string][]byte{},
+			},
+			matchers: []types.GomegaMatcher{
+				gomega.Equal(&kserveTypes.StorageInitializerConfig{
+					Image:                   "gcr.io/kserve/storage-initializer:latest",
+					CpuRequest:              "100m",
+					CpuLimit:                "1",
+					MemoryRequest:           "200Mi",
+					MemoryLimit:             "1Gi",
+					CpuModelcar:             "",
+					MemoryModelcar:          "",
+					CaBundleConfigMapName:   "",
+					CaBundleVolumeMountPath: "/etc/ssl/custom-certs",
+				}),
+				gomega.BeNil(),
+			},
+		},
+		{
+			name: "Missing Modelcar Fields Should Not Cause Validation Error",
+			configMap: &corev1.ConfigMap{
+				TypeMeta:   metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{},
+				Data: map[string]string{
+					v1beta1.StorageInitializerConfigMapKeyName: `{
+						"Image":        		 "gcr.io/kserve/storage-initializer:latest",
+						"CpuRequest":   		 "100m",
+						"CpuLimit":      		 "1",
+						"MemoryRequest": 		 "200Mi",
+						"MemoryLimit":   		 "1Gi",
+						"CaBundleConfigMapName": "",
+						"CaBundleVolumeMountPath": "/etc/ssl/custom-certs"
+					}`,
+				},
+				BinaryData: map[string][]byte{},
+			},
+			matchers: []types.GomegaMatcher{
+				gomega.Equal(&kserveTypes.StorageInitializerConfig{
+					Image:                   "gcr.io/kserve/storage-initializer:latest",
+					CpuRequest:              "100m",
+					CpuLimit:                "1",
+					MemoryRequest:           "200Mi",
+					MemoryLimit:             "1Gi",
+					CpuModelcar:             "",
+					MemoryModelcar:          "",
+					CaBundleConfigMapName:   "",
+					CaBundleVolumeMountPath: "/etc/ssl/custom-certs",
+				}),
+				gomega.BeNil(),
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR fixes a validation error that prevents InferenceService deployments when the `inferenceservice-config` ConfigMap doesn't include `cpuModelcar` and `memoryModelcar` fields.

**Problem:**
The `GetStorageInitializerConfigs()` function validates all resource fields including the optional `cpuModelcar` and `memoryModelcar` fields. When these fields are missing or empty in the ConfigMap, `resource.ParseQuantity("")` fails with a regex validation error, causing the admission webhook to reject pod creation:

```
Error creating: admission webhook "inferenceservice.kserve-webhook-server.pod-mutator" denied the request:
failed to parse resource configuration for "storageInitializer"."cpuModelcar":
quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
```

This affects deployments where:
- The ConfigMap uses `opendatahub.io/managed: "false"` annotation to prevent reconciliation
- The `cpuModelcar` and `memoryModelcar` fields are intentionally omitted
- These fields have runtime defaults in `CreateModelcarContainer()` and `CreateModelcarInitContainer()` functions

**Solution:**
Modified the validation logic to only validate `cpuModelcar` and `memoryModelcar` when they are non-empty, making them truly optional fields while maintaining validation for required fields (`cpuRequest`, `cpuLimit`, `memoryRequest`, `memoryLimit`).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [RHOAIENG-35716](https://issues.redhat.com/browse/RHOAIENG-35716)

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [x] **Unit Tests**: Added test cases for empty and missing modelcar fields in `pkg/webhook/admission/pod/storage_initializer_injector_test.go`
- [x] **Live Cluster Reproduction**: Reproduced the bug on OpenShift 4.16 with RHOSAI 2.24 (KServe v0.15)
- [x] **Live Cluster Validation**: Verified fix resolves the issue on live cluster

**Test Configuration:**
- Platform: OpenShift 4.16 on AWS (x86_64)
- KServe Version: v0.15 (RHOSAI 2.24)
- Deployment Mode: RawDeployment (no Service Mesh)
- ConfigMap: `inferenceservice-config` with `cpuModelcar` and `memoryModelcar` fields removed
- Annotation: `opendatahub.io/managed: "false"` to prevent reconciliation

**Reproduction Steps:**
1. Modified `inferenceservice-config` ConfigMap to remove `cpuModelcar` and `memoryModelcar` from `storageInitializer` JSON
2. Added annotation `opendatahub.io/managed: "false"` to ConfigMap
3. Created ServingRuntime and InferenceService resources
4. Observed webhook validation errors in ReplicaSet events (0 pods created)

**Before Fix - ReplicaSet Events:**
```
Type     Reason        Age                 From                   Message
----     ------        ----                ----                   -------
Warning  FailedCreate  26m (x2 over 26m)   replicaset-controller  Error creating: admission webhook "inferenceservice.kserve-webhook-server.pod-mutator" denied the request: failed to parse resource configuration for "storageInitializer"."memoryModelcar": quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
Warning  FailedCreate  10m (x18 over 26m)  replicaset-controller  Error creating: admission webhook "inferenceservice.kserve-webhook-server.pod-mutator" denied the request: failed to parse resource configuration for "storageInitializer"."cpuModelcar": quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
```
**Result:** 0 pods created - webhook blocked all pod creation

**After Fix - ReplicaSet Events:**
```
Type     Reason            Age   From                   Message
----     ------            ----  ----                   -------
Normal   SuccessfulCreate  58s   replicaset-controller  Created pod: test-sklearn-iris-predictor-b9d66f9f-nxq7z
```
**Result:** Pod successfully created - webhook validation passed ✅

**Special notes for your reviewer**:

1. This PR only modifies validation logic in `pkg/apis/serving/v1beta1/configmap.go` and adds corresponding test coverage
2. The fix maintains backward compatibility - existing ConfigMaps with these fields set will continue to be validated
3. Runtime defaults for modelcar resources are already implemented in `CreateModelcarContainer()` and `CreateModelcarInitContainer()` functions
4. This aligns with the behavior of other optional configuration fields in KServe

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix validation error for optional cpuModelcar and memoryModelcar fields in storage initializer ConfigMap. Empty or missing values no longer cause webhook admission failures.
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.
