### PR TITLE
chore: change default deployment mode to RawDeployment

### DIFF
--- a/config/overlays/odh/patches/patch-inferenceservice-config.yaml
+++ b/config/overlays/odh/patches/patch-inferenceservice-config.yaml
@@ -81,7 +81,7 @@ data:
     }
   deploy: |-
     {
-      "defaultDeploymentMode": "Serverless"
+      "defaultDeploymentMode": "RawDeployment"
     }
   metricsAggregator: |-
     {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR changes the default deployment mode for KServe in the ODH (OpenDataHub) overlay from "Serverless" to "RawDeployment". This aligns the default configuration with the recommended deployment mode for OpenShift AI environments where RawDeployment provides better stability and resource management without requiring Knative/Serverless components.

**Which issue(s) this PR fixes**:
Fixes [RHOAIENG-37504](https://issues.redhat.com//browse/RHOAIENG-37504)

**Type of changes**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

- [x] Ran `make test` - all unit tests pass
- [ ] E2E tests with RawDeployment mode (will be validated by CI)

**Special notes for your reviewer**:

1. This PR does not change any image versions.
2. This change only affects the default deployment mode configuration for ODH overlays (`config/overlays/odh/patches/patch-inferenceservice-config.yaml`)
3. Users can still override the deployment mode using the `serving.kserve.io/deploymentMode` annotation
4. The base KServe configmap (`config/configmap/inferenceservice.yaml`) remains unchanged with "Serverless" as the example, since that's the general KServe default for upstream
5. Note: Test configuration file `config/overlays/odh-test/dsc.yaml` still has `defaultDeploymentMode: Serverless` - please advise if this should also be updated for consistency

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
  - Unit tests pass; e2e tests for RawDeployment already exist in the codebase at `test/e2e/predictor/test_raw_deployment.py`
- [x] Has code been commented, particularly in hard-to-understand areas?
  - N/A - simple configuration change
- [x] Have you made corresponding changes to the documentation?
  - Documentation in `docs/odh/install-kserve.md` already shows RawDeployment as the default
- [x] Have you linked the JIRA issue(s) to this PR?
  - [RHOAIENG-37504](https://issues.redhat.com//browse/RHOAIENG-37504)

**Release note**:
```release-note
Change default deployment mode to RawDeployment for OpenDataHub KServe overlay
```