### PR TITLE
[RHOAIENG-34931] - Storage Initializer can't handle versioned models storage

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -118,6 +118,7 @@ var (
 	PrometheusPortAnnotationKey                 = "prometheus.io/port"
 	PrometheusPathAnnotationKey                 = "prometheus.io/path"
 	StorageReadonlyAnnotationKey                = "storage.kserve.io/readonly"
+	OVMSAutoVersioningAnnotationKey             = "storage.kserve.io/ovms-auto-versioning"
 	DefaultPrometheusPath                       = "/metrics"
 	QueueProxyAggregatePrometheusMetricsPort    = "9088"
 	DefaultPodPrometheusPort                    = "9091"
@@ -404,8 +405,9 @@ const (
 	WorkerContainerName     = "worker-container"
 	QueueProxyContainerName = "queue-proxy"
 
-	ModelcarContainerName     = "modelcar"
-	ModelcarInitContainerName = "modelcar-init"
+	ModelcarContainerName       = "modelcar"
+	ModelcarInitContainerName   = "modelcar-init"
+	OVMSVersioningContainerName = "ovms-auto-versioning"
 )
 
 // DefaultModelLocalMountPath is where models will be mounted by the storage-initializer

--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -353,6 +354,100 @@ func (mi *StorageInitializerInjector) InjectStorageInitializer(pod *corev1.Pod) 
 		}
 	}
 
+	// Inject OVMS auto-versioning init container if annotation is present
+	if err := mi.InjectOVMSAutoVersioning(pod); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// InjectOVMSAutoVersioning injects an init container to reorganize model files
+// into OVMS-compatible versioned directory structure when the storage.kserve.io/ovms-auto-versioning
+// annotation is present. This is required because OVMS expects models in versioned directories
+// like /mnt/models/1/, /mnt/models/2/, etc.
+func (mi *StorageInitializerInjector) InjectOVMSAutoVersioning(pod *corev1.Pod) error {
+	// Check if OVMS auto-versioning annotation is present
+	versionString, ok := pod.ObjectMeta.Annotations[constants.OVMSAutoVersioningAnnotationKey]
+	if !ok {
+		return nil
+	}
+
+	// Validate the version is a positive integer
+	version, err := strconv.Atoi(versionString)
+	if err != nil || version <= 0 {
+		return fmt.Errorf("invalid OVMS auto-versioning annotation value '%s': must be a positive integer", versionString)
+	}
+
+	// Don't inject if OVMS versioning container already exists
+	for _, container := range pod.Spec.InitContainers {
+		if container.Name == constants.OVMSVersioningContainerName {
+			return nil
+		}
+	}
+
+	// Create the OVMS versioning init container
+	ovmsVersioningContainer := corev1.Container{
+		Name:    constants.OVMSVersioningContainerName,
+		Image:   "registry.redhat.io/ubi9/ubi-micro:latest",
+		Command: []string{"/bin/sh"},
+		Args: []string{
+			"-c",
+			fmt.Sprintf(`
+# OVMS Auto-Versioning Script
+# This script reorganizes model files to match OVMS expected directory structure
+
+MODEL_DIR="%s"
+VERSION="%s"
+VERSIONED_DIR="${MODEL_DIR}/${VERSION}"
+
+echo "Starting OVMS auto-versioning: organizing models for version ${VERSION}"
+
+# Check if model directory exists and has content
+if [ ! -d "${MODEL_DIR}" ] || [ -z "$(ls -A ${MODEL_DIR} 2>/dev/null)" ]; then
+  echo "No models found in ${MODEL_DIR}, skipping versioning"
+  exit 0
+fi
+
+# Check if versioned directory already exists
+if [ -d "${VERSIONED_DIR}" ]; then
+  echo "Version directory ${VERSIONED_DIR} already exists, skipping reorganization"
+  exit 0
+fi
+
+echo "Creating versioned directory: ${VERSIONED_DIR}"
+mkdir -p "${VERSIONED_DIR}"
+
+# Move all files and directories to the versioned directory by ignoring itself
+mv "${MODEL_DIR}"/* "${VERSIONED_DIR}/" 2>/dev/null || true
+
+echo "Successfully organized models into versioned directory structure"
+echo "Models are now available at: ${VERSIONED_DIR}"
+echo "Running ls -la ${VERSIONED_DIR}"
+ls -la ${VERSIONED_DIR}
+`, constants.DefaultModelLocalMountPath, versionString),
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{
+				Name:      constants.StorageInitializerVolumeName,
+				MountPath: constants.DefaultModelLocalMountPath,
+				ReadOnly:  false,
+			},
+		},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+		},
+	}
+
+	// Add the OVMS versioning init container to the pod
+	pod.Spec.InitContainers = append(pod.Spec.InitContainers, ovmsVersioningContainer)
 	return nil
 }
 

--- a/pkg/webhook/admission/pod/storage_initializer_injector_test.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector_test.go
@@ -4121,3 +4121,335 @@ func TestLocalModelPVC(t *testing.T) {
 		}
 	}
 }
+
+func TestOVMSAutoVersioning(t *testing.T) {
+	scenarios := map[string]struct {
+		original *corev1.Pod
+		expected *corev1.Pod
+	}{
+		"OVMS auto-versioning annotation not present": {
+			original: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.StorageInitializerSourceUriInternalAnnotationKey: "gs://foo",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: constants.InferenceServiceContainerName,
+						},
+					},
+				},
+			},
+			expected: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.StorageInitializerSourceUriInternalAnnotationKey: "gs://foo",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: constants.InferenceServiceContainerName,
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      constants.StorageInitializerVolumeName,
+									MountPath: constants.DefaultModelLocalMountPath,
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name:                     constants.StorageInitializerContainerName,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
+							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
+							Resources:                resourceRequirement,
+							TerminationMessagePolicy: "FallbackToLogsOnError",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      constants.StorageInitializerVolumeName,
+									MountPath: constants.DefaultModelLocalMountPath,
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: constants.StorageInitializerVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+		},
+		"OVMS auto-versioning annotation present with valid version": {
+			original: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.StorageInitializerSourceUriInternalAnnotationKey: "gs://foo",
+						constants.OVMSAutoVersioningAnnotationKey:                  "1",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: constants.InferenceServiceContainerName,
+						},
+					},
+				},
+			},
+			expected: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.StorageInitializerSourceUriInternalAnnotationKey: "gs://foo",
+						constants.OVMSAutoVersioningAnnotationKey:                  "1",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: constants.InferenceServiceContainerName,
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      constants.StorageInitializerVolumeName,
+									MountPath: constants.DefaultModelLocalMountPath,
+									ReadOnly:  true,
+								},
+							},
+						},
+					},
+					InitContainers: []corev1.Container{
+						{
+							Name:                     constants.StorageInitializerContainerName,
+							Image:                    constants.StorageInitializerContainerImage + ":" + constants.StorageInitializerContainerImageVersion,
+							Args:                     []string{"gs://foo", constants.DefaultModelLocalMountPath},
+							Resources:                resourceRequirement,
+							TerminationMessagePolicy: "FallbackToLogsOnError",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      constants.StorageInitializerVolumeName,
+									MountPath: constants.DefaultModelLocalMountPath,
+								},
+							},
+						},
+						{
+							Name:    constants.OVMSVersioningContainerName,
+							Image:   "registry.redhat.io/ubi9/ubi-micro:latest",
+							Command: []string{"/bin/sh"},
+							Args: []string{
+								"-c",
+								`
+# OVMS Auto-Versioning Script
+# This script reorganizes model files to match OVMS expected directory structure
+
+MODEL_DIR="/mnt/models"
+VERSION="1"
+VERSIONED_DIR="${MODEL_DIR}/${VERSION}"
+
+echo "Starting OVMS auto-versioning: organizing models for version ${VERSION}"
+
+# Check if model directory exists and has content
+if [ ! -d "${MODEL_DIR}" ] || [ -z "$(ls -A ${MODEL_DIR} 2>/dev/null)" ]; then
+  echo "No models found in ${MODEL_DIR}, skipping versioning"
+  exit 0
+fi
+
+# Check if versioned directory already exists
+if [ -d "${VERSIONED_DIR}" ]; then
+  echo "Version directory ${VERSIONED_DIR} already exists, skipping reorganization"
+  exit 0
+fi
+
+echo "Creating versioned directory: ${VERSIONED_DIR}"
+mkdir -p "${VERSIONED_DIR}"
+
+# Move all files and directories to the versioned directory by ignoring itself
+mv "${MODEL_DIR}"/* "${VERSIONED_DIR}/" 2>/dev/null || true
+
+echo "Successfully organized models into versioned directory structure"
+echo "Models are now available at: ${VERSIONED_DIR}"
+echo "Running ls -la ${VERSIONED_DIR}"
+ls -la ${VERSIONED_DIR}
+`,
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      constants.StorageInitializerVolumeName,
+									MountPath: constants.DefaultModelLocalMountPath,
+									ReadOnly:  false,
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: constants.StorageInitializerVolumeName,
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for name, scenario := range scenarios {
+		injector := &StorageInitializerInjector{
+			credentialBuilder: credentials.NewCredentialBuilder(c, clientset, &corev1.ConfigMap{
+				Data: map[string]string{},
+			}),
+			config: storageInitializerConfig,
+			client: c,
+		}
+		if err := injector.InjectStorageInitializer(scenario.original); err != nil {
+			t.Errorf("Test %q unexpected result: %s", name, err)
+		}
+		if diff, _ := kmp.SafeDiff(scenario.expected.Spec, scenario.original.Spec); diff != "" {
+			t.Errorf("Test %q unexpected result (-want +got): %v", name, diff)
+		}
+	}
+}
+
+func TestOVMSAutoVersioningInvalidValues(t *testing.T) {
+	scenarios := []struct {
+		name            string
+		annotationValue string
+		expectError     bool
+	}{
+		{
+			name:            "invalid value - not a number",
+			annotationValue: "invalid",
+			expectError:     true,
+		},
+		{
+			name:            "invalid value - zero",
+			annotationValue: "0",
+			expectError:     true,
+		},
+		{
+			name:            "invalid value - negative",
+			annotationValue: "-1",
+			expectError:     true,
+		},
+		{
+			name:            "valid value - positive integer",
+			annotationValue: "1",
+			expectError:     false,
+		},
+		{
+			name:            "valid value - larger positive integer",
+			annotationValue: "10",
+			expectError:     false,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						constants.StorageInitializerSourceUriInternalAnnotationKey: "gs://foo",
+						constants.OVMSAutoVersioningAnnotationKey:                  scenario.annotationValue,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: constants.InferenceServiceContainerName,
+						},
+					},
+				},
+			}
+
+			injector := &StorageInitializerInjector{
+				credentialBuilder: credentials.NewCredentialBuilder(c, clientset, &corev1.ConfigMap{
+					Data: map[string]string{},
+				}),
+				config: storageInitializerConfig,
+				client: c,
+			}
+
+			err := injector.InjectStorageInitializer(pod)
+			if scenario.expectError && err == nil {
+				t.Errorf("Expected error but got none")
+			}
+			if !scenario.expectError && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestOVMSAutoVersioningIdempotency(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				constants.StorageInitializerSourceUriInternalAnnotationKey: "gs://foo",
+				constants.OVMSAutoVersioningAnnotationKey:                  "1",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: constants.InferenceServiceContainerName,
+				},
+			},
+		},
+	}
+
+	injector := &StorageInitializerInjector{
+		credentialBuilder: credentials.NewCredentialBuilder(c, clientset, &corev1.ConfigMap{
+			Data: map[string]string{},
+		}),
+		config: storageInitializerConfig,
+		client: c,
+	}
+
+	// First injection
+	err := injector.InjectStorageInitializer(pod)
+	if err != nil {
+		t.Fatalf("First injection failed: %v", err)
+	}
+
+	// Count init containers after first injection
+	firstInjectionCount := len(pod.Spec.InitContainers)
+
+	// Second injection should be idempotent
+	err = injector.InjectStorageInitializer(pod)
+	if err != nil {
+		t.Fatalf("Second injection failed: %v", err)
+	}
+
+	// Count should be the same
+	if len(pod.Spec.InitContainers) != firstInjectionCount {
+		t.Errorf("Expected %d init containers after second injection, got %d", firstInjectionCount, len(pod.Spec.InitContainers))
+	}
+
+	// Verify OVMS versioning container exists and is present only once
+	ovmsContainerCount := 0
+	for _, container := range pod.Spec.InitContainers {
+		if container.Name == constants.OVMSVersioningContainerName {
+			ovmsContainerCount++
+		}
+	}
+
+	if ovmsContainerCount != 1 {
+		t.Errorf("Expected exactly 1 OVMS versioning container, got %d", ovmsContainerCount)
+	}
+}


### PR DESCRIPTION
chore:	Add a initi-container that will be initialized if the annotation
	`storage.kserve.io/ovms-auto-versioning` is present with any numerical value.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

To test:
- Create any InferenceService using OpenVINO ServingRuntime with this annotation: `storage.kserve.io/ovms-auto-versioning: 1`
- Use a model that is not compliant with the OVMS versioned directory.

It should create the `` initContainer, an example of its output:
```bash
Starting OVMS auto-versioning: organizing models for version 1
Creating versioned directory: /mnt/models/1
Successfully organized models into versioned directory structure
Models are now available at: /mnt/models/1
Running ls -la /mnt/models/1
total 28
drwxr-sr-x. 2 1000840000 1000840000    24 Nov  5 18:30 .
drwxrwsrwx. 3 root       1000840000    15 Nov  5 18:30 ..
-rw-r--r--. 1 1000840000 1000840000 26454 Nov  5 18:30 mnist.onnx
```

- Also, the model will be correctly copied to the versioned directory.


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic model versioning via the storage.kserve.io/ovms-auto-versioning annotation: when set to a positive integer, an init step reorganizes models into a versioned layout during storage initialization; invalid or absent values leave the pod unchanged.

* **Tests**
  * Added tests covering validation, error handling, and idempotency of the auto-versioning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->