### PR TITLE
Configure prefix-cache-scorer for P/D

### DIFF
--- a/pkg/controller/llmisvc/scheduler.go
+++ b/pkg/controller/llmisvc/scheduler.go
@@ -358,11 +358,15 @@ schedulingProfiles:
       - pluginRef: prefill-filter
       - pluginRef: queue-scorer
         weight: 1.0
+      - pluginRef: prefix-cache-scorer
+        weight: 1.0
       - pluginRef: max-score-picker
   - name: decode
     plugins:
       - pluginRef: decode-filter
       - pluginRef: queue-scorer
+        weight: 1.0
+      - pluginRef: prefix-cache-scorer
         weight: 1.0
       - pluginRef: max-score-picker
 `


### PR DESCRIPTION
Without this change scheduler logs `failed to read prefix plugin state: not found` because the prefix-cache-scorer is not part of the `schedulingProfiles`