### PR TITLE
RHOAIENG-38972: Allow stopping LLMInferenceService

### DIFF
--- a/pkg/apis/serving/v1alpha1/llm_inference_service_lifecycle.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_lifecycle.go
@@ -65,12 +65,20 @@ func (in *LLMInferenceService) MarkMainWorkloadNotReady(reason, messageFormat st
 	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(MainWorkloadReady, reason, messageFormat, messageA...)
 }
 
+func (in *LLMInferenceService) MarkMainWorkloadUnset() {
+	_ = in.GetConditionSet().Manage(in.GetStatus()).ClearCondition(MainWorkloadReady)
+}
+
 func (in *LLMInferenceService) MarkWorkerWorkloadReady() {
 	in.GetConditionSet().Manage(in.GetStatus()).MarkTrue(WorkerWorkloadReady)
 }
 
 func (in *LLMInferenceService) MarkWorkerWorkloadNotReady(reason, messageFormat string, messageA ...interface{}) {
 	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(WorkerWorkloadReady, reason, messageFormat, messageA...)
+}
+
+func (in *LLMInferenceService) MarkWorkerWorkloadUnset() {
+	_ = in.GetConditionSet().Manage(in.GetStatus()).ClearCondition(WorkerWorkloadReady)
 }
 
 func (in *LLMInferenceService) MarkPrefillWorkloadReady() {
@@ -81,12 +89,20 @@ func (in *LLMInferenceService) MarkPrefillWorkloadNotReady(reason, messageFormat
 	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(PrefillWorkloadReady, reason, messageFormat, messageA...)
 }
 
+func (in *LLMInferenceService) MarkPrefillWorkloadUnset() {
+	_ = in.GetConditionSet().Manage(in.GetStatus()).ClearCondition(PrefillWorkloadReady)
+}
+
 func (in *LLMInferenceService) MarkPrefillWorkerWorkloadReady() {
 	in.GetConditionSet().Manage(in.GetStatus()).MarkTrue(PrefillWorkerWorkloadReady)
 }
 
 func (in *LLMInferenceService) MarkPrefillWorkerWorkloadNotReady(reason, messageFormat string, messageA ...interface{}) {
 	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(PrefillWorkerWorkloadReady, reason, messageFormat, messageA...)
+}
+
+func (in *LLMInferenceService) MarkPrefillWorkerWorkloadUnset() {
+	_ = in.GetConditionSet().Manage(in.GetStatus()).ClearCondition(PrefillWorkerWorkloadReady)
 }
 
 func (in *LLMInferenceService) DetermineWorkloadReadiness() {
@@ -129,6 +145,10 @@ func (in *LLMInferenceService) MarkGatewaysReady() {
 	in.GetConditionSet().Manage(in.GetStatus()).MarkTrue(GatewaysReady)
 }
 
+func (in *LLMInferenceService) MarkGatewaysReadyUnset() {
+	_ = in.GetConditionSet().Manage(in.GetStatus()).ClearCondition(GatewaysReady)
+}
+
 func (in *LLMInferenceService) MarkGatewaysNotReady(reason, messageFormat string, messageA ...interface{}) {
 	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(GatewaysReady, reason, messageFormat, messageA...)
 }
@@ -141,12 +161,20 @@ func (in *LLMInferenceService) MarkHTTPRoutesNotReady(reason, messageFormat stri
 	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(HTTPRoutesReady, reason, messageFormat, messageA...)
 }
 
+func (in *LLMInferenceService) MarkHTTPRoutesReadyUnset() {
+	_ = in.GetConditionSet().Manage(in.GetStatus()).ClearCondition(HTTPRoutesReady)
+}
+
 func (in *LLMInferenceService) MarkInferencePoolReady() {
 	in.GetConditionSet().Manage(in.GetStatus()).MarkTrue(InferencePoolReady)
 }
 
 func (in *LLMInferenceService) MarkInferencePoolNotReady(reason, messageFormat string, messageA ...interface{}) {
 	in.GetConditionSet().Manage(in.GetStatus()).MarkFalse(InferencePoolReady, reason, messageFormat, messageA...)
+}
+
+func (in *LLMInferenceService) MarkInferencePoolReadyUnset() {
+	_ = in.GetConditionSet().Manage(in.GetStatus()).ClearCondition(InferencePoolReady)
 }
 
 func (in *LLMInferenceService) DetermineRouterReadiness() {

--- a/pkg/controller/llmisvc/controller_int_stop_test.go
+++ b/pkg/controller/llmisvc/controller_int_stop_test.go
@@ -1,0 +1,687 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/kmeta"
+	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
+	leaderworkerset "sigs.k8s.io/lws/api/leaderworkerset/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kserve/kserve/pkg/constants"
+	. "github.com/kserve/kserve/pkg/controller/llmisvc/fixture"
+)
+
+var _ = Describe("LLMInferenceService Stop Feature", func() {
+	Context("When service is stopped", func() {
+		It("should delete workload resources when stop annotation is set", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-stop-workload"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(namespace)
+			}()
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				WithModelURI("hf://facebook/opt-125m"),
+			)
+
+			// when - Create LLMInferenceService without stop annotation
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			// then - verify deployment is created
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, expectedDeployment)
+			}).WithContext(ctx).Should(Succeed())
+
+			// verify workload service is created
+			workloadService := &corev1.Service{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-workload-svc",
+					Namespace: nsName,
+				}, workloadService)
+			}).WithContext(ctx).Should(Succeed())
+
+			// verify TLS secret is created
+			tlsSecret := &corev1.Secret{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-self-signed-certs",
+					Namespace: nsName,
+				}, tlsSecret)
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - Update LLMInferenceService with stop annotation
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					if llmSvc.Annotations == nil {
+						llmSvc.Annotations = make(map[string]string)
+					}
+					llmSvc.Annotations[constants.StopAnnotationKey] = "true"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// then - verify the service is marked as stopped
+			Eventually(func(g Gomega, ctx context.Context) error {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName,
+					Namespace: nsName,
+				}, llmSvc)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				mainWorkloadCondition := llmSvc.Status.GetCondition(v1alpha1.MainWorkloadReady)
+				g.Expect(mainWorkloadCondition).ToNot(BeNil())
+				g.Expect(mainWorkloadCondition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(mainWorkloadCondition.Reason).To(Equal("Stopped"))
+				return nil
+			}).WithContext(ctx).Should(Succeed(), "service should be marked as stopped")
+
+			// verify deployment is deleted
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, expectedDeployment)
+				return err != nil && errors.IsNotFound(err)
+			}).WithContext(ctx).Should(BeTrue(), "deployment should be deleted when service is stopped")
+
+			// verify workload service is deleted
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-workload-svc",
+					Namespace: nsName,
+				}, workloadService)
+				return err != nil && errors.IsNotFound(err)
+			}).WithContext(ctx).Should(BeTrue(), "workload service should be deleted when service is stopped")
+
+			// verify TLS secret is deleted
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-self-signed-certs",
+					Namespace: nsName,
+				}, tlsSecret)
+				return err != nil && errors.IsNotFound(err)
+			}).WithContext(ctx).Should(BeTrue(), "TLS secret should be deleted when service is stopped")
+		})
+
+		It("should delete router resources when stop annotation is set", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-stop-router"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(namespace)
+			}()
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+			)
+
+			// when - Create LLMInferenceService without stop annotation
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			// then - verify HTTPRoute is created
+			Eventually(func(g Gomega, ctx context.Context) error {
+				routes, errList := managedRoutes(ctx, llmSvc)
+				g.Expect(errList).ToNot(HaveOccurred())
+				g.Expect(routes).To(HaveLen(1))
+				return nil
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - Update LLMInferenceService with stop annotation
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					if llmSvc.Annotations == nil {
+						llmSvc.Annotations = make(map[string]string)
+					}
+					llmSvc.Annotations[constants.StopAnnotationKey] = "true"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// then - verify HTTPRoute is deleted
+			Eventually(func(g Gomega, ctx context.Context) error {
+				routes, errList := managedRoutes(ctx, llmSvc)
+				g.Expect(errList).ToNot(HaveOccurred())
+				g.Expect(routes).To(BeEmpty())
+				return nil
+			}).WithContext(ctx).Should(Succeed(), "HTTPRoute should be deleted when service is stopped")
+		})
+
+		It("should delete scheduler resources when stop annotation is set", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-stop-scheduler"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(namespace)
+			}()
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+			)
+
+			// when - Create LLMInferenceService without stop annotation
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			// Ensure router and scheduler resources are ready (required for envTest)
+			ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvc)
+
+			// then - verify scheduler deployment is created
+			schedulerDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-router-scheduler",
+					Namespace: nsName,
+				}, schedulerDeployment)
+			}).WithContext(ctx).Should(Succeed())
+
+			// verify scheduler service is created
+			schedulerService := &corev1.Service{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-epp-service",
+					Namespace: nsName,
+				}, schedulerService)
+			}).WithContext(ctx).Should(Succeed())
+
+			// verify InferencePool is created
+			inferencePool := &igwapi.InferencePool{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-inference-pool",
+					Namespace: nsName,
+				}, inferencePool)
+			}).WithContext(ctx).Should(Succeed())
+
+			// verify InferenceModel is created
+			inferenceModel := &igwapi.InferenceModel{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-inference-model",
+					Namespace: nsName,
+				}, inferenceModel)
+			}).WithContext(ctx).Should(Succeed())
+
+			// verify scheduler ServiceAccount is created
+			schedulerSA := &corev1.ServiceAccount{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-epp-sa",
+					Namespace: nsName,
+				}, schedulerSA)
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - Update LLMInferenceService with stop annotation
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					if llmSvc.Annotations == nil {
+						llmSvc.Annotations = make(map[string]string)
+					}
+					llmSvc.Annotations[constants.StopAnnotationKey] = "true"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// then - verify scheduler deployment is deleted
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-epp",
+					Namespace: nsName,
+				}, schedulerDeployment)
+				return err != nil && errors.IsNotFound(err)
+			}).WithContext(ctx).Should(BeTrue(), "scheduler deployment should be deleted when service is stopped")
+
+			// verify scheduler service is deleted
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-epp-service",
+					Namespace: nsName,
+				}, schedulerService)
+				return err != nil && errors.IsNotFound(err)
+			}).WithContext(ctx).Should(BeTrue(), "scheduler service should be deleted when service is stopped")
+
+			// verify InferencePool is deleted
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-inference-pool",
+					Namespace: nsName,
+				}, inferencePool)
+				return err != nil && errors.IsNotFound(err)
+			}).WithContext(ctx).Should(BeTrue(), "InferencePool should be deleted when service is stopped")
+
+			// verify InferenceModel is deleted
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-inference-model",
+					Namespace: nsName,
+				}, inferenceModel)
+				return err != nil && errors.IsNotFound(err)
+			}).WithContext(ctx).Should(BeTrue(), "InferenceModel should be deleted when service is stopped")
+
+			// verify scheduler ServiceAccount is deleted
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-epp-sa",
+					Namespace: nsName,
+				}, schedulerSA)
+				return err != nil && errors.IsNotFound(err)
+			}).WithContext(ctx).Should(BeTrue(), "scheduler ServiceAccount should be deleted when service is stopped")
+		})
+
+		It("should recreate resources when stop annotation is removed", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-stop-restart"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(namespace)
+			}()
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				WithModelURI("hf://facebook/opt-125m"),
+			)
+
+			// when - Create LLMInferenceService without stop annotation
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			// then - verify deployment is created
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, expectedDeployment)
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - Update LLMInferenceService with stop annotation
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					if llmSvc.Annotations == nil {
+						llmSvc.Annotations = make(map[string]string)
+					}
+					llmSvc.Annotations[constants.StopAnnotationKey] = "true"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// then - verify deployment is deleted
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, expectedDeployment)
+				return err != nil && errors.IsNotFound(err)
+			}).WithContext(ctx).Should(BeTrue(), "deployment should be deleted when service is stopped")
+
+			// when - Remove stop annotation to restart the service
+			errRetry = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					delete(llmSvc.Annotations, constants.StopAnnotationKey)
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// then - verify deployment is recreated
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve",
+					Namespace: nsName,
+				}, expectedDeployment)
+			}).WithContext(ctx).Should(Succeed(), "deployment should be recreated when stop annotation is removed")
+		})
+
+		It("should not delete monitoring resources when service is stopped (shared namespace resources)", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-stop-monitoring"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(namespace)
+			}()
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				WithModelURI("hf://facebook/opt-125m"),
+			)
+
+			// when - Create LLMInferenceService without stop annotation
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			// then - verify monitoring resources are created
+			waitForAllMonitoringResources(ctx, nsName)
+
+			// when - Update LLMInferenceService with stop annotation
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					if llmSvc.Annotations == nil {
+						llmSvc.Annotations = make(map[string]string)
+					}
+					llmSvc.Annotations[constants.StopAnnotationKey] = "true"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// then - verify monitoring resources still exist (because they are shared namespace resources)
+			expectedServiceAccount := &corev1.ServiceAccount{}
+			expectedSecret := &corev1.Secret{}
+			expectedClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+
+			Consistently(func(g Gomega, ctx context.Context) {
+				g.Expect(envTest.Get(ctx, types.NamespacedName{
+					Name:      "kserve-metrics-reader-sa",
+					Namespace: nsName,
+				}, expectedServiceAccount)).To(Succeed(), "monitoring ServiceAccount should still exist when service is stopped")
+
+				g.Expect(envTest.Get(ctx, types.NamespacedName{
+					Name:      "kserve-metrics-reader-sa-secret",
+					Namespace: nsName,
+				}, expectedSecret)).To(Succeed(), "monitoring Secret should still exist when service is stopped")
+
+				g.Expect(envTest.Get(ctx, types.NamespacedName{
+					Name: kmeta.ChildName("kserve-metrics-reader-role-binding-", nsName),
+				}, expectedClusterRoleBinding)).Should(Succeed(), "monitoring ClusterRoleBinding should still exist when service is stopped")
+			}).WithContext(ctx).
+				WithTimeout(2*time.Second).
+				WithPolling(300*time.Millisecond).
+				Should(Succeed(), "monitoring resources should persist when a single service is stopped")
+		})
+
+		It("should handle multiple services with mixed stop states", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-stop-multi"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(namespace)
+			}()
+
+			// Create first service
+			llmSvc1 := LLMInferenceService(svcName+"-1",
+				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				WithModelURI("hf://facebook/opt-125m"),
+			)
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName+"-1", nsName))).To(Succeed())
+			Expect(envTest.Create(ctx, llmSvc1)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc1)).To(Succeed())
+			}()
+
+			// Create second service
+			llmSvc2 := LLMInferenceService(svcName+"-2",
+				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				WithModelURI("hf://facebook/opt-125m"),
+			)
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName+"-2", nsName))).To(Succeed())
+			Expect(envTest.Create(ctx, llmSvc2)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc2)).To(Succeed())
+			}()
+
+			// Verify both deployments are created
+			deployment1 := &appsv1.Deployment{}
+			deployment2 := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				g.Expect(envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-1-kserve",
+					Namespace: nsName,
+				}, deployment1)).To(Succeed())
+				g.Expect(envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-2-kserve",
+					Namespace: nsName,
+				}, deployment2)).To(Succeed())
+				return nil
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - Stop only the first service
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc1, func() error {
+					if llmSvc1.Annotations == nil {
+						llmSvc1.Annotations = make(map[string]string)
+					}
+					llmSvc1.Annotations[constants.StopAnnotationKey] = "true"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// then - first deployment should be deleted
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-1-kserve",
+					Namespace: nsName,
+				}, deployment1)
+				return err != nil && errors.IsNotFound(err)
+			}).WithContext(ctx).Should(BeTrue(), "first deployment should be deleted when stopped")
+
+			// but second deployment should still exist
+			Consistently(func(g Gomega, ctx context.Context) {
+				g.Expect(envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-2-kserve",
+					Namespace: nsName,
+				}, deployment2)).To(Succeed(), "second deployment should still exist")
+			}).WithContext(ctx).
+				WithTimeout(2 * time.Second).
+				WithPolling(300 * time.Millisecond).
+				Should(Succeed())
+
+			// verify monitoring resources still exist (shared namespace resources)
+			expectedServiceAccount := &corev1.ServiceAccount{}
+			expectedSecret := &corev1.Secret{}
+			expectedClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
+
+			Consistently(func(g Gomega, ctx context.Context) {
+				g.Expect(envTest.Get(ctx, types.NamespacedName{
+					Name:      "kserve-metrics-reader-sa",
+					Namespace: nsName,
+				}, expectedServiceAccount)).To(Succeed(), "monitoring ServiceAccount should still exist when one service is stopped")
+
+				g.Expect(envTest.Get(ctx, types.NamespacedName{
+					Name:      "kserve-metrics-reader-sa-secret",
+					Namespace: nsName,
+				}, expectedSecret)).To(Succeed(), "monitoring Secret should still exist when one service is stopped")
+
+				g.Expect(envTest.Get(ctx, types.NamespacedName{
+					Name: "kserve-metrics-reader-role-binding-" + nsName,
+				}, expectedClusterRoleBinding)).Should(Succeed(), "monitoring ClusterRoleBinding should still exist when one service is stopped")
+			}).WithContext(ctx).
+				WithTimeout(2*time.Second).
+				WithPolling(300*time.Millisecond).
+				Should(Succeed(), "monitoring resources should persist when multiple services exist in namespace")
+		})
+
+		It("should delete multi-node LeaderWorkerSet resources when stop annotation is set", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-stop-multinode"
+			nsName := kmeta.ChildName(svcName, "-test")
+			namespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+
+			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
+			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
+			defer func() {
+				envTest.DeleteAll(namespace)
+			}()
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithReplicas(1),
+				WithParallelism(ParallelismSpec(
+					WithDataParallelism(2),
+					WithDataLocalParallelism(1),
+					WithTensorParallelism(1),
+				)),
+				WithWorker(SimpleWorkerPodSpec()),
+			)
+
+			// when - Create LLMInferenceService with worker (multi-node)
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+			}()
+
+			// then - verify LeaderWorkerSet is created
+			expectedLWS := &leaderworkerset.LeaderWorkerSet{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-mn",
+					Namespace: nsName,
+				}, expectedLWS)
+			}).WithContext(ctx).Should(Succeed())
+
+			// when - Update LLMInferenceService with stop annotation
+			errRetry := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, errUpdate := ctrl.CreateOrUpdate(ctx, envTest.Client, llmSvc, func() error {
+					if llmSvc.Annotations == nil {
+						llmSvc.Annotations = make(map[string]string)
+					}
+					llmSvc.Annotations[constants.StopAnnotationKey] = "true"
+					return nil
+				})
+				return errUpdate
+			})
+			Expect(errRetry).ToNot(HaveOccurred())
+
+			// then - verify the service is marked as stopped
+			Eventually(func(g Gomega, ctx context.Context) error {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName,
+					Namespace: nsName,
+				}, llmSvc)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				mainWorkloadCondition := llmSvc.Status.GetCondition(v1alpha1.MainWorkloadReady)
+				g.Expect(mainWorkloadCondition).ToNot(BeNil())
+				g.Expect(mainWorkloadCondition.Status).To(Equal(corev1.ConditionFalse))
+				g.Expect(mainWorkloadCondition.Reason).To(Equal("Stopped"))
+				return nil
+			}).WithContext(ctx).Should(Succeed(), "service should be marked as stopped")
+
+			// verify LeaderWorkerSet is deleted
+			Eventually(func(g Gomega, ctx context.Context) bool {
+				err := envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-mn",
+					Namespace: nsName,
+				}, expectedLWS)
+				return err != nil && errors.IsNotFound(err)
+			}).WithContext(ctx).Should(BeTrue(), "LeaderWorkerSet should be deleted when service is stopped")
+		})
+	})
+})

--- a/pkg/controller/llmisvc/controller_int_test.go
+++ b/pkg/controller/llmisvc/controller_int_test.go
@@ -727,9 +727,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 						return nil
 					}).WithContext(ctx).Should(Succeed(), "Should have no managed HTTPRoutes with router when ")
 
-					Eventually(LLMInferenceServiceIsReady(llmSvc, func(g Gomega, current *v1alpha1.LLMInferenceService) {
-						g.Expect(current.Status).To(HaveCondition(string(v1alpha1.HTTPRoutesReady), "True"))
-					})).WithContext(ctx).Should(Succeed())
+					Eventually(LLMInferenceServiceIsReady(llmSvc)).WithContext(ctx).Should(Succeed())
 				},
 				Entry("should delete HTTPRoutes when spec.Router is set to nil",
 					"router-spec-nil",
@@ -1411,7 +1409,7 @@ func waitForMetricsReaderRoleBinding(ctx context.Context, nsName string) *rbacv1
 	expectedClusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 	Eventually(func(_ Gomega, ctx context.Context) error {
 		return envTest.Get(ctx, types.NamespacedName{
-			Name: "kserve-metrics-reader-role-binding-" + nsName,
+			Name: kmeta.ChildName("kserve-metrics-reader-role-binding-", nsName),
 		}, expectedClusterRoleBinding)
 	}).WithContext(ctx).Should(Succeed())
 

--- a/pkg/controller/llmisvc/fixture/required_resources.go
+++ b/pkg/controller/llmisvc/fixture/required_resources.go
@@ -81,7 +81,7 @@ func RequiredResources(ctx context.Context, c client.Client, ns string) {
 func IstioShadowService(name, ns string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "istio-shadow",
+			Name:      kmeta.ChildName(name, "istio-shadow"),
 			Namespace: ns,
 			Labels: map[string]string{
 				"istio.io/inferencepool-name": kmeta.ChildName(name, "-inference-pool"),

--- a/pkg/controller/llmisvc/router_gateway_conditions_test.go
+++ b/pkg/controller/llmisvc/router_gateway_conditions_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package llmisvc_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -588,7 +589,6 @@ func assertRouterNotReadyWithReason(routerCondition, gatewayCondition *apis.Cond
 func assertHTTPRouteConditionUnset(routerCondition, httpRouteCondition *apis.Condition) assertConditionsFunc {
 	return func(g *WithT) {
 		g.Expect(routerCondition.IsTrue()).To(BeTrue(), "Router should be ready")
-		g.Expect(httpRouteCondition).ToNot(BeNil(), "HTTPRoute condition should be set")
-		g.Expect(httpRouteCondition.IsTrue()).To(BeTrue(), "HTTPRoute condition should be ready when no HTTPRoute refs")
+		g.Expect(httpRouteCondition).To(BeNil(), fmt.Sprintf("HTTPRoute condition should be unset %#v", httpRouteCondition))
 	}
 }

--- a/pkg/controller/llmisvc/workload.go
+++ b/pkg/controller/llmisvc/workload.go
@@ -31,6 +31,7 @@ import (
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/credentials"
 	kserveTypes "github.com/kserve/kserve/pkg/types"
+	"github.com/kserve/kserve/pkg/utils"
 )
 
 const (
@@ -52,6 +53,10 @@ func (r *LLMInferenceServiceReconciler) reconcileWorkload(ctx context.Context, l
 
 	defer llmSvc.DetermineWorkloadReadiness()
 
+	if utils.GetForceStopRuntime(llmSvc) {
+		llmSvc.MarkMainWorkloadNotReady("Stopped", "Service is stopped")
+	}
+
 	if err := r.reconcileSelfSignedCertsSecret(ctx, llmSvc); err != nil {
 		llmSvc.MarkMainWorkloadNotReady("ReconcileCertsError", err.Error())
 		return fmt.Errorf("failed to reconcile self-signed certificates secret: %w", err)
@@ -61,7 +66,7 @@ func (r *LLMInferenceServiceReconciler) reconcileWorkload(ctx context.Context, l
 	// finalizing superfluous workloads).
 
 	if err := r.reconcileMultiNodeWorkload(ctx, llmSvc, storageConfig, credentialConfig); err != nil {
-		llmSvc.MarkMainWorkloadNotReady("ReconcileMultiNodeWorkloadError", err.Error())
+		llmSvc.MarkWorkerWorkloadNotReady("ReconcileMultiNodeWorkloadError", err.Error())
 		return fmt.Errorf("failed to reconcile multi node workload: %w", err)
 	}
 
@@ -108,6 +113,10 @@ func (r *LLMInferenceServiceReconciler) reconcileWorkloadService(ctx context.Con
 			Selector: GetWorkloadLabelSelector(llmSvc.ObjectMeta, &llmSvc.Spec),
 			Type:     corev1.ServiceTypeClusterIP,
 		},
+	}
+
+	if utils.GetForceStopRuntime(llmSvc) {
+		return Delete(ctx, r, llmSvc, expected)
 	}
 
 	return Reconcile(ctx, r, llmSvc, &corev1.Service{}, expected, semanticServiceIsEqual)

--- a/pkg/controller/llmisvc/workload_single_node.go
+++ b/pkg/controller/llmisvc/workload_single_node.go
@@ -62,7 +62,12 @@ func (r *LLMInferenceServiceReconciler) reconcileSingleNodeMainWorkload(ctx cont
 	if err != nil {
 		return fmt.Errorf("failed to get expected main deployment: %w", err)
 	}
-	if llmSvc.Spec.Worker != nil {
+	if isStopped := utils.GetForceStopRuntime(llmSvc); isStopped || llmSvc.Spec.Worker != nil {
+		if isStopped {
+			llmSvc.MarkMainWorkloadNotReady("Stopped", "Service is stopped")
+		} else {
+			llmSvc.MarkMainWorkloadUnset()
+		}
 		return Delete(ctx, r, llmSvc, expected)
 	}
 	if err := Reconcile(ctx, r, llmSvc, &appsv1.Deployment{}, expected, semanticDeploymentIsEqual); err != nil {
@@ -149,7 +154,13 @@ func (r *LLMInferenceServiceReconciler) reconcileSingleNodePrefill(ctx context.C
 	if err != nil {
 		return fmt.Errorf("failed to get expected prefill deployment: %w", err)
 	}
-	if llmSvc.Spec.Prefill == nil || llmSvc.Spec.Prefill.Worker != nil {
+	if isStopped := utils.GetForceStopRuntime(llmSvc); isStopped || llmSvc.Spec.Prefill == nil || llmSvc.Spec.Prefill.Worker != nil {
+		if isStopped {
+			llmSvc.MarkPrefillWorkloadNotReady("Stopped", "Service is stopped")
+		} else {
+			llmSvc.MarkPrefillWorkloadUnset()
+		}
+
 		if err := Delete(ctx, r, llmSvc, prefill); err != nil {
 			return fmt.Errorf("failed to delete prefill main deployment: %w", err)
 		}
@@ -277,7 +288,7 @@ func (r *LLMInferenceServiceReconciler) reconcileSingleNodeMainServiceAccount(ct
 	if err != nil {
 		return fmt.Errorf("failed to created expected single node service account: %w", err)
 	}
-	if !hasRoutingSidecar(expectedDeployment.Spec.Template.Spec) {
+	if utils.GetForceStopRuntime(llmSvc) || !hasRoutingSidecar(expectedDeployment.Spec.Template.Spec) {
 		return Delete(ctx, r, llmSvc, serviceAccount)
 	}
 
@@ -299,7 +310,7 @@ func (r *LLMInferenceServiceReconciler) reconcileSingleNodeMainRole(ctx context.
 	}
 
 	role := r.expectedSingleNodeRole(llmSvc)
-	if !hasRoutingSidecar(expectedDeployment.Spec.Template.Spec) {
+	if utils.GetForceStopRuntime(llmSvc) || !hasRoutingSidecar(expectedDeployment.Spec.Template.Spec) {
 		return Delete(ctx, r, llmSvc, role)
 	}
 
@@ -317,7 +328,7 @@ func (r *LLMInferenceServiceReconciler) reconcileSingleNodeMainRoleBinding(ctx c
 	}
 
 	roleBinding := r.expectedSingleNodeRoleBinding(llmSvc, sa)
-	if !hasRoutingSidecar(expectedDeployment.Spec.Template.Spec) {
+	if utils.GetForceStopRuntime(llmSvc) || !hasRoutingSidecar(expectedDeployment.Spec.Template.Spec) {
 		return Delete(ctx, r, llmSvc, roleBinding)
 	}
 

--- a/pkg/controller/llmisvc/workload_tls_self_signed.go
+++ b/pkg/controller/llmisvc/workload_tls_self_signed.go
@@ -44,6 +44,7 @@ import (
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
 	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/utils"
 )
 
 const (
@@ -80,6 +81,11 @@ func (r *LLMInferenceServiceReconciler) reconcileSelfSignedCertsSecret(ctx conte
 	if err != nil {
 		return fmt.Errorf("failed to get expected self-signed certificate secret: %w", err)
 	}
+
+	if utils.GetForceStopRuntime(llmSvc) {
+		return Delete(ctx, r, llmSvc, expected)
+	}
+
 	if err := Reconcile(ctx, r, llmSvc, &corev1.Secret{}, expected, semanticCertificateSecretIsEqual); err != nil {
 		return fmt.Errorf("failed to reconcile self-signed TLS certificate: %w", err)
 	}

--- a/pkg/controller/llmisvc/workload_tls_self_signed_istio.go
+++ b/pkg/controller/llmisvc/workload_tls_self_signed_istio.go
@@ -35,6 +35,7 @@ import (
 	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kserve/kserve/pkg/utils"
 )
 
 const (
@@ -105,7 +106,7 @@ func (r *LLMInferenceServiceReconciler) reconcileIstioDestinationRuleForShadowSe
 	if err != nil {
 		return fmt.Errorf("failed to get expected Istio destination rule for workload: %w", err)
 	}
-	if llmSvc.Spec.Router == nil {
+	if utils.GetForceStopRuntime(llmSvc) || llmSvc.Spec.Router == nil {
 		return Delete(ctx, r, llmSvc, expected)
 	}
 	if expected.Spec.GetHost() == "" {
@@ -120,7 +121,7 @@ func (r *LLMInferenceServiceReconciler) reconcileIstioDestinationRuleForShadowSe
 
 func (r *LLMInferenceServiceReconciler) reconcileIstioDestinationRuleForWorkload(ctx context.Context, llmSvc *v1alpha1.LLMInferenceService) error {
 	expected := r.expectedIstioDestinationRuleForWorkload(ctx, llmSvc)
-	if llmSvc.Spec.Router == nil {
+	if utils.GetForceStopRuntime(llmSvc) || llmSvc.Spec.Router == nil {
 		return Delete(ctx, r, llmSvc, expected)
 	}
 	return Reconcile(ctx, r, llmSvc, &istioapi.DestinationRule{}, expected, semanticDestinationRuleIsEqual)
@@ -131,7 +132,7 @@ func (r *LLMInferenceServiceReconciler) reconcileIstioDestinationRuleForSchedule
 	if err != nil {
 		return fmt.Errorf("failed to get expected Istio destination rule for scheduler: %w", err)
 	}
-	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil {
+	if utils.GetForceStopRuntime(llmSvc) || llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil {
 		return Delete(ctx, r, llmSvc, expected)
 	}
 	return Reconcile(ctx, r, llmSvc, &istioapi.DestinationRule{}, expected, semanticDestinationRuleIsEqual)

--- a/test/e2e/llmisvc/test_llm_inference_service_stop.py
+++ b/test/e2e/llmisvc/test_llm_inference_service_stop.py
@@ -1,0 +1,356 @@
+# Copyright 2025 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import os
+import pytest
+from kserve import KServeClient, V1alpha1LLMInferenceService, constants
+from kubernetes import client
+
+from .fixtures import (
+    generate_test_id,
+    inject_k8s_proxy,
+    test_case,  # noqa: F401,F811
+)
+from .logging import log_execution
+from .test_llm_inference_service import (
+    TestCase,
+    create_llmisvc,
+    delete_llmisvc,
+    get_llmisvc,
+    wait_for,
+    wait_for_llm_isvc_ready,
+)
+
+KSERVE_PLURAL_LLMINFERENCESERVICE = "llminferenceservices"
+STOP_ANNOTATION_KEY = "serving.kserve.io/stop"
+
+
+@pytest.mark.llminferenceservice
+@pytest.mark.asyncio(loop_scope="session")
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        pytest.param(
+            TestCase(
+                base_refs=[
+                    "router-managed",
+                    "workload-single-cpu",
+                    "model-fb-opt-125m",
+                ],
+                service_name="stop-feature-test",
+            ),
+            marks=[pytest.mark.cluster_cpu, pytest.mark.cluster_single_node],
+        ),
+    ],
+    indirect=["test_case"],
+    ids=generate_test_id,
+)
+@log_execution
+def test_llm_stop_feature(test_case: TestCase):
+    """Test that stopping an LLMInferenceService sets the Ready condition to False with reason Stopped."""
+    inject_k8s_proxy()
+
+    kserve_client = KServeClient(
+        config_file=os.environ.get("KUBECONFIG", "~/.kube/config"),
+        client_configuration=client.Configuration(),
+    )
+
+    service_name = test_case.llm_service.metadata.name
+    test_failed = False
+
+    # Disable auth for this test
+    if not test_case.llm_service.metadata.annotations:
+        test_case.llm_service.metadata.annotations = {}
+    test_case.llm_service.metadata.annotations[
+        "security.opendatahub.io/enable-auth"
+    ] = "false"
+
+    try:
+        # Create the service
+        print(f"Creating LLMInferenceService {service_name}")
+        create_llmisvc(kserve_client, test_case.llm_service)
+
+        # Wait for the service to be ready
+        print(f"Waiting for LLMInferenceService {service_name} to be ready")
+        wait_for_llm_isvc_ready(
+            kserve_client, test_case.llm_service, test_case.wait_timeout
+        )
+        print(f"✅ LLMInferenceService {service_name} is ready")
+
+        # Stop the service by adding the stop annotation
+        print(f"Stopping LLMInferenceService {service_name}")
+        stop_llmisvc(kserve_client, test_case.llm_service)
+
+        # Wait for the service to be marked as stopped
+        print(f"Waiting for LLMInferenceService {service_name} to be stopped")
+        wait_for_llm_isvc_stopped(
+            kserve_client, test_case.llm_service, timeout_seconds=120
+        )
+        print(f"✅ LLMInferenceService {service_name} is stopped")
+
+        # Verify the workload resources are deleted
+        print(f"Verifying workload resources are deleted for {service_name}")
+        verify_workload_resources_deleted(
+            kserve_client, test_case.llm_service, timeout_seconds=120
+        )
+        print(f"✅ Workload resources deleted for {service_name}")
+
+        # Restart the service by removing the stop annotation
+        print(f"Restarting LLMInferenceService {service_name}")
+        restart_llmisvc(kserve_client, test_case.llm_service)
+
+        # Wait for the service to be ready again
+        print(f"Waiting for LLMInferenceService {service_name} to be ready again")
+        wait_for_llm_isvc_ready(
+            kserve_client, test_case.llm_service, test_case.wait_timeout
+        )
+        print(f"✅ LLMInferenceService {service_name} is ready again after restart")
+
+    except Exception as e:
+        test_failed = True
+        print(f"❌ ERROR: Stop feature test failed for {service_name}: {e}")
+        raise
+    finally:
+        try:
+            skip_all_deletion = os.getenv(
+                "SKIP_RESOURCE_DELETION", "False"
+            ).lower() in (
+                "true",
+                "1",
+                "t",
+            )
+            skip_deletion_on_failure = os.getenv(
+                "SKIP_DELETION_ON_FAILURE", "False"
+            ).lower() in (
+                "true",
+                "1",
+                "t",
+            )
+
+            should_skip_deletion = skip_all_deletion or (
+                skip_deletion_on_failure and test_failed
+            )
+
+            if not should_skip_deletion:
+                delete_llmisvc(kserve_client, test_case.llm_service)
+            elif test_failed and skip_deletion_on_failure:
+                print(
+                    f"⏭️  Skipping deletion of {service_name} due to test failure (SKIP_DELETION_ON_FAILURE=True)"
+                )
+        except Exception as e:
+            print(f"⚠️ Warning: Failed to cleanup service {service_name}: {e}")
+
+
+@log_execution
+def stop_llmisvc(kserve_client: KServeClient, llm_isvc: V1alpha1LLMInferenceService):
+    """Add the stop annotation to the LLMInferenceService."""
+    try:
+        # Get the current service
+        current = kserve_client.api_instance.get_namespaced_custom_object(
+            constants.KSERVE_GROUP,
+            llm_isvc.api_version.split("/")[1],
+            llm_isvc.metadata.namespace,
+            KSERVE_PLURAL_LLMINFERENCESERVICE,
+            llm_isvc.metadata.name,
+        )
+
+        # Add the stop annotation
+        if "metadata" not in current:
+            current["metadata"] = {}
+        if "annotations" not in current["metadata"]:
+            current["metadata"]["annotations"] = {}
+        current["metadata"]["annotations"][STOP_ANNOTATION_KEY] = "true"
+
+        # Patch the service
+        result = kserve_client.api_instance.patch_namespaced_custom_object(
+            constants.KSERVE_GROUP,
+            llm_isvc.api_version.split("/")[1],
+            llm_isvc.metadata.namespace,
+            KSERVE_PLURAL_LLMINFERENCESERVICE,
+            llm_isvc.metadata.name,
+            current,
+        )
+        print(f"✅ LLM inference service {llm_isvc.metadata.name} stopped successfully")
+        return result
+    except client.rest.ApiException as e:
+        raise RuntimeError(
+            f"❌ Exception when calling CustomObjectsApi->"
+            f"patch_namespaced_custom_object for LLMInferenceService: {e}"
+        ) from e
+
+
+@log_execution
+def restart_llmisvc(kserve_client: KServeClient, llm_isvc: V1alpha1LLMInferenceService):
+    """Remove the stop annotation from the LLMInferenceService."""
+    try:
+        # Get the current service
+        current = kserve_client.api_instance.get_namespaced_custom_object(
+            constants.KSERVE_GROUP,
+            llm_isvc.api_version.split("/")[1],
+            llm_isvc.metadata.namespace,
+            KSERVE_PLURAL_LLMINFERENCESERVICE,
+            llm_isvc.metadata.name,
+        )
+
+        # Set the stop annotation to 'false'
+        if "metadata" not in current:
+            current["metadata"] = {}
+        if "annotations" not in current["metadata"]:
+            current["metadata"]["annotations"] = {}
+        current["metadata"]["annotations"][STOP_ANNOTATION_KEY] = "false"
+
+        # Patch the service
+        result = kserve_client.api_instance.patch_namespaced_custom_object(
+            constants.KSERVE_GROUP,
+            llm_isvc.api_version.split("/")[1],
+            llm_isvc.metadata.namespace,
+            KSERVE_PLURAL_LLMINFERENCESERVICE,
+            llm_isvc.metadata.name,
+            current,
+        )
+        print(
+            f"✅ LLM inference service {llm_isvc.metadata.name} restarted successfully"
+        )
+        return result
+    except client.rest.ApiException as e:
+        raise RuntimeError(
+            f"❌ Exception when calling CustomObjectsApi->"
+            f"patch_namespaced_custom_object for LLMInferenceService: {e}"
+        ) from e
+
+
+@log_execution
+def wait_for_llm_isvc_stopped(
+    kserve_client: KServeClient,
+    given: V1alpha1LLMInferenceService,
+    timeout_seconds: int = 120,
+) -> bool:
+    """Wait for the LLMInferenceService to be marked as stopped."""
+
+    def assert_llm_isvc_stopped():
+        out = get_llmisvc(
+            kserve_client,
+            given.metadata.name,
+            given.metadata.namespace,
+            given.api_version.split("/")[1],
+        )
+
+        if "status" not in out:
+            raise AssertionError("No status found in LLM inference service")
+
+        status = out["status"]
+        if "conditions" not in status:
+            raise AssertionError("No conditions found in status")
+
+        conditions = status["conditions"]
+
+        # Find the Ready condition
+        ready_condition = None
+        workload_ready_condition = None
+        router_ready_condition = None
+        main_workload_ready_condition = None
+
+        for condition in conditions:
+            cond_type = condition.get("type")
+            if cond_type == "Ready":
+                ready_condition = condition
+            elif cond_type == "WorkloadsReady":
+                workload_ready_condition = condition
+            elif cond_type == "RouterReady":
+                router_ready_condition = condition
+            elif cond_type == "MainWorkloadReady":
+                main_workload_ready_condition = condition
+
+        # Verify Ready condition is False
+        if ready_condition is None:
+            raise AssertionError("Ready condition not found")
+
+        if ready_condition.get("status") != "False":
+            raise AssertionError(
+                f"Ready condition status is not False: {ready_condition.get('status')}"
+            )
+
+        # Verify at least one of the workload conditions has reason "Stopped"
+        stopped_conditions = []
+        for cond in [
+            workload_ready_condition,
+            router_ready_condition,
+            main_workload_ready_condition,
+        ]:
+            if cond and cond.get("reason") == "Stopped":
+                stopped_conditions.append(cond.get("type"))
+
+        if not stopped_conditions:
+            raise AssertionError(
+                f"None of the workload conditions have reason 'Stopped'. Conditions: {conditions}"
+            )
+
+        print(
+            f"✅ Service is stopped. Conditions with reason 'Stopped': {stopped_conditions}"
+        )
+        return True
+
+    return wait_for(assert_llm_isvc_stopped, timeout=timeout_seconds, interval=2.0)
+
+
+@log_execution
+def verify_workload_resources_deleted(
+    kserve_client: KServeClient,
+    llm_isvc: V1alpha1LLMInferenceService,
+    timeout_seconds: int = 120,
+) -> bool:
+    """Verify that workload resources (deployments) are deleted when service is stopped."""
+
+    def assert_deployment_deleted():
+        core_v1 = client.CoreV1Api()
+        apps_v1 = client.AppsV1Api()
+
+        namespace = llm_isvc.metadata.namespace
+        service_name = llm_isvc.metadata.name
+
+        # Check if the main deployment is deleted
+        deployment_name = f"{service_name}-kserve"
+        try:
+            apps_v1.read_namespaced_deployment(deployment_name, namespace)
+            raise AssertionError(
+                f"Deployment {deployment_name} still exists but should be deleted"
+            )
+        except client.rest.ApiException as e:
+            if e.status != 404:
+                raise AssertionError(
+                    f"Unexpected error checking deployment {deployment_name}: {e}"
+                )
+            # 404 is expected - deployment is deleted
+            print(f"✅ Deployment {deployment_name} is deleted")
+
+        # Check if the workload service is deleted
+        workload_service_name = f"{service_name}-kserve-workload-svc"
+        try:
+            core_v1.read_namespaced_service(workload_service_name, namespace)
+            raise AssertionError(
+                f"Service {workload_service_name} still exists but should be deleted"
+            )
+        except client.rest.ApiException as e:
+            if e.status != 404:
+                raise AssertionError(
+                    f"Unexpected error checking service {workload_service_name}: {e}"
+                )
+            # 404 is expected - service is deleted
+            print(f"✅ Service {workload_service_name} is deleted")
+
+        return True
+
+    return wait_for(assert_deployment_deleted, timeout=timeout_seconds, interval=2.0)


### PR DESCRIPTION
Allow stopping llm-d services just like any other model runtime (upstream follow up in progress)