### PR TITLE
Update minio image to use what upstream uses

### DIFF
--- a/config/overlays/test/minio/minio-deployment.yaml
+++ b/config/overlays/test/minio/minio-deployment.yaml
@@ -30,7 +30,7 @@ spec:
             secretKeyRef:
               name: mlpipeline-minio-artifact
               key: secretkey
-        image: gcr.io/ml-pipeline/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance
+        image: minio/minio:RELEASE.2021-04-22T15-44-28Z
         name: minio
         ports:
         - containerPort: 9000


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend service image to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->