### PR TITLE
odh 3.1 release tag bump

### DIFF
--- a/.tekton/kserve-agent-push.yaml
+++ b/.tekton/kserve-agent-push.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-agent:odh-v3.1
+    value: quay.io/opendatahub/kserve-agent:odh-v3.2
   - name: dockerfile
     value: agent.Dockerfile
   - name: path-context

--- a/.tekton/kserve-controller-push.yaml
+++ b/.tekton/kserve-controller-push.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-controller:odh-v3.1
+    value: quay.io/opendatahub/kserve-controller:odh-v3.2
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/kserve-router-push.yaml
+++ b/.tekton/kserve-router-push.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-router:odh-v3.1
+    value: quay.io/opendatahub/kserve-router:odh-v3.2
   - name: dockerfile
     value: router.Dockerfile
   - name: path-context

--- a/.tekton/kserve-storage-initializer-push.yaml
+++ b/.tekton/kserve-storage-initializer-push.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-storage-initializer:odh-v3.1
+    value: quay.io/opendatahub/kserve-storage-initializer:odh-v3.2
   - name: dockerfile
     value: storage-initializer.Dockerfile
   - name: path-context


### PR DESCRIPTION
Update the tekton image to use the latest odh version (3.2)