### PR TITLE
Fix S3 CA Bundle Configuration

### DIFF
--- a/config/overlays/odh/patches/patch-inferenceservice-config.yaml
+++ b/config/overlays/odh/patches/patch-inferenceservice-config.yaml
@@ -125,6 +125,6 @@ data:
            "s3UseAccelerate": "",
            "s3UseAnonymousCredential": "",
            "s3CABundleConfigMap": "odh-kserve-custom-ca-bundle",
-           "s3CABundle": "/etc/ssl/custom-certs"
+           "s3CABundle": "/etc/ssl/custom-certs/cabundle.crt"
        }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
[RHOAIENG-41626](https://issues.redhat.com/browse/RHOAIENG-41626)
Add expected ca bundle filename to s3 config `s3CABundle` value

The currently configured s3 config `s3CABundle` value present in the ODH inferenceservice-config [patch](https://github.com/red-hat-data-services/kserve/blob/rhoai-3.2/config/overlays/odh/patches/patch-inferenceservice-config.yaml#L128) is leading to the following error when s3 storage is configured via a service account attached to an isvc:
```
 "/kserve/kserve/storage/storage.py", line 231, in _download_s3 raise RuntimeError( RuntimeError: Failed to find ca bundle file(/etc/ssl/custom-certs).
```

 Unlike other fields used to configure ca bundle path, this field will assume the path ends with a filename and will take the [dir structure](https://github.com/opendatahub-io/kserve/blob/release-v0.15/pkg/webhook/admission/pod/storage_initializer_injector.go#L308) of the path, dropping the last part - this will lead to failures, like the one captured above, when looking for the ca bundles in the storage init container.

**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration.

- Deploy isvc with s3 storage configured via an attached service account
- Ran the [tests](https://github.com/tarukumar/model-serving-tests/blob/cpu_raw/model_serving_tests/tests/model_deployment/test_tinyllama_1B_chat_v1.py) that originally flagged the issue which now pass


**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix bug in s3 config s3CABundle path
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.