### PR TITLE
[stable-2.x][RHOAIENG-38328] Set correct schema in .status.address.url when auth is disabled

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
@@ -143,12 +143,8 @@ func (r *RawIngressReconciler) Reconcile(ctx context.Context, isvc *v1beta1.Infe
 	internalHost := getRawServiceHost(isvc)
 	url := &apis.URL{
 		Host:   internalHost,
-		Scheme: r.ingressConfig.UrlScheme,
+		Scheme: "http", // odh specific change, scheme is decided based on auth annotation
 		Path:   "",
-	}
-
-	isvc.Status.Address = &duckv1.Addressable{
-		URL: url,
 	}
 
 	if authEnabled {


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry-pick of https://github.com/opendatahub-io/kserve/pull/942 to stable-2.x

This reverts an incorrect merge conflict resolution causing a bug where the `schema` in `.status.address.url` is `https` when auth is disabled when the correct value is `http`.

https://issues.redhat.com/browse/RHOAIENG-38328

**Type of changes**

- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.