### PR TITLE
refactor(llmisvc): centralize test namespace lifecycle management

### DIFF
--- a/pkg/controller/llmisvc/controller_int_auth_test.go
+++ b/pkg/controller/llmisvc/controller_int_auth_test.go
@@ -21,9 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"knative.dev/pkg/kmeta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1"
 
@@ -39,21 +37,12 @@ var _ = Describe("LLMInferenceService Auth Integration Tests", func() {
 			It("should require AuthPolicyAffected condition on HTTPRoute", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-auth-enabled-default"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest,
+					WithIstioShadowService(svcName),
+				)
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha1.LLMInferenceService](nsName),
+					InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithManagedRoute(),
 					WithManagedGateway(),
@@ -64,7 +53,7 @@ var _ = Describe("LLMInferenceService Auth Integration Tests", func() {
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// then - HTTPRoute should be created
@@ -98,21 +87,12 @@ var _ = Describe("LLMInferenceService Auth Integration Tests", func() {
 			It("should be ready when AuthPolicyAffected condition is present and True", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-auth-enforced"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest,
+					WithIstioShadowService(svcName),
+				)
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha1.LLMInferenceService](nsName),
+					InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithManagedRoute(),
 					WithManagedGateway(),
@@ -122,7 +102,7 @@ var _ = Describe("LLMInferenceService Auth Integration Tests", func() {
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// then - HTTPRoute should be created
@@ -150,21 +130,12 @@ var _ = Describe("LLMInferenceService Auth Integration Tests", func() {
 			It("should not require AuthPolicyAffected condition on HTTPRoute", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-auth-disabled"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest,
+					WithIstioShadowService(svcName),
+				)
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha1.LLMInferenceService](nsName),
+					InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithManagedRoute(),
 					WithManagedGateway(),
@@ -177,7 +148,7 @@ var _ = Describe("LLMInferenceService Auth Integration Tests", func() {
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// then - HTTPRoute should be created
@@ -205,21 +176,12 @@ var _ = Describe("LLMInferenceService Auth Integration Tests", func() {
 			It("should require AuthPolicyAffected condition on HTTPRoute", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-auth-explicit-enabled"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest,
+					WithIstioShadowService(svcName),
+				)
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha1.LLMInferenceService](nsName),
+					InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithManagedRoute(),
 					WithManagedGateway(),
@@ -232,7 +194,7 @@ var _ = Describe("LLMInferenceService Auth Integration Tests", func() {
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// then - HTTPRoute should be created
@@ -267,21 +229,12 @@ var _ = Describe("LLMInferenceService Auth Integration Tests", func() {
 			It("should mark HTTPRoutes as not ready", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-auth-policy-false"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest,
+					WithIstioShadowService(svcName),
+				)
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha1.LLMInferenceService](nsName),
+					InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithManagedRoute(),
 					WithManagedGateway(),
@@ -291,7 +244,7 @@ var _ = Describe("LLMInferenceService Auth Integration Tests", func() {
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// then - HTTPRoute should be created

--- a/pkg/controller/llmisvc/controller_int_multi_node_test.go
+++ b/pkg/controller/llmisvc/controller_int_multi_node_test.go
@@ -27,7 +27,6 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/kmeta"
@@ -43,21 +42,12 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should create a basic multi-node deployment with worker spec", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-multinode"
-			nsName := kmeta.ChildName(svcName, "-test")
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest,
+				WithIstioShadowService(svcName),
+			)
 
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 				WithReplicas(2),
 				WithParallelism(ParallelismSpec(
@@ -83,7 +73,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve-mn",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedLWS)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -108,21 +98,12 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should create multi-node deployment with prefill workload", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-multinode-prefill"
-			nsName := kmeta.ChildName(svcName, "-test")
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest,
+				WithIstioShadowService(svcName),
+			)
 
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 				WithReplicas(1),
 				WithParallelism(ParallelismSpec(
@@ -145,7 +126,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			// when
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			// then - Check main workload LWS
@@ -153,7 +134,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve-mn",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedMainLWS)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -165,7 +146,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve-mn-prefill",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedPrefillLWS)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -180,21 +161,12 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should create RBAC resources when prefill and decode is used", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-multinode-rbac"
-			nsName := kmeta.ChildName(svcName, "-test")
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest,
+				WithIstioShadowService(svcName),
+			)
 
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 				WithReplicas(1),
 				WithParallelism(ParallelismSpec(
@@ -212,7 +184,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			// when
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			// then - Check ServiceAccount is created
@@ -220,7 +192,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve-mn",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedSA)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -232,7 +204,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve-mn-role",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedRole)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -244,7 +216,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve-mn-rb",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedRB)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -258,7 +230,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve-mn",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedLWS)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -270,18 +242,9 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should delete multi-node resources when worker spec is removed", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-multinode-cleanup"
-			nsName := kmeta.ChildName(svcName, "-test")
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest,
+				WithIstioShadowService(svcName),
+			)
 
 			parallelismSpec := ParallelismSpec(
 				WithDataParallelism(2),
@@ -290,7 +253,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			parallelismSpec.Expert = true
 
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 				WithParallelism(parallelismSpec),
 				WithWorker(&corev1.PodSpec{}),
@@ -300,7 +263,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			lwsName := svcName + "-kserve-mn"
@@ -310,7 +273,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 				lws := &lwsapi.LeaderWorkerSet{}
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      lwsName,
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, lws)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -329,7 +292,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 				lws := &lwsapi.LeaderWorkerSet{}
 				err := envTest.Get(ctx, types.NamespacedName{
 					Name:      lwsName,
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, lws)
 				g.Expect(err).To(HaveOccurred())
 				return nil
@@ -339,21 +302,12 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should delete prefill resources when prefill spec is removed", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-prefill-cleanup"
-			nsName := kmeta.ChildName(svcName, "-test")
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest,
+				WithIstioShadowService(svcName),
+			)
 
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 				WithPrefillParallelism(ParallelismSpec(
 					WithDataParallelism(2),
@@ -366,7 +320,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			prefillLWSName := kmeta.ChildName(svcName, "-kserve-mn-prefill")
@@ -376,7 +330,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 				lws := &lwsapi.LeaderWorkerSet{}
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      prefillLWSName,
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, lws)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -395,7 +349,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 				lws := &lwsapi.LeaderWorkerSet{}
 				err := envTest.Get(ctx, types.NamespacedName{
 					Name:      prefillLWSName,
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, lws)
 				g.Expect(err).To(HaveOccurred())
 				return nil
@@ -407,25 +361,16 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 		It("should set correct labels and annotation", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-lws-labels"
-			nsName := kmeta.ChildName(svcName, "-test")
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest,
+				WithIstioShadowService(svcName),
+			)
 
 			localQueueName := "test-local-q"
 			preemptPriority := "0"
 			testValue := "test"
 
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 				WithParallelism(ParallelismSpec(
 					WithDataParallelism(1),
@@ -453,7 +398,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			// when
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			// then
@@ -461,7 +406,7 @@ var _ = Describe("LLMInferenceService Multi-Node Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve-mn",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedLWS)
 			}).WithContext(ctx).Should(Succeed())
 

--- a/pkg/controller/llmisvc/controller_int_stop_test.go
+++ b/pkg/controller/llmisvc/controller_int_stop_test.go
@@ -55,7 +55,7 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
 			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
-				envTest.DeleteAll(namespace)
+				envTest.DeleteAll(ctx, namespace)
 			}()
 
 			llmSvc := LLMInferenceService(svcName,
@@ -165,7 +165,7 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
 			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
-				envTest.DeleteAll(namespace)
+				envTest.DeleteAll(ctx, namespace)
 			}()
 
 			llmSvc := LLMInferenceService(svcName,
@@ -224,7 +224,7 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
 			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
-				envTest.DeleteAll(namespace)
+				envTest.DeleteAll(ctx, namespace)
 			}()
 
 			llmSvc := LLMInferenceService(svcName,
@@ -361,7 +361,7 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
 			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
-				envTest.DeleteAll(namespace)
+				envTest.DeleteAll(ctx, namespace)
 			}()
 
 			llmSvc := LLMInferenceService(svcName,
@@ -438,7 +438,7 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
 			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
-				envTest.DeleteAll(namespace)
+				envTest.DeleteAll(ctx, namespace)
 			}()
 
 			llmSvc := LLMInferenceService(svcName,
@@ -505,7 +505,7 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
 			defer func() {
-				envTest.DeleteAll(namespace)
+				envTest.DeleteAll(ctx, namespace)
 			}()
 
 			// Create first service
@@ -616,7 +616,7 @@ var _ = Describe("LLMInferenceService Stop Feature", func() {
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
 			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
-				envTest.DeleteAll(namespace)
+				envTest.DeleteAll(ctx, namespace)
 			}()
 
 			llmSvc := LLMInferenceService(svcName,

--- a/pkg/controller/llmisvc/controller_int_test.go
+++ b/pkg/controller/llmisvc/controller_int_test.go
@@ -62,32 +62,23 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should create a basic single node deployment with just base refs", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm"
-			nsName := kmeta.ChildName(svcName, "-test")
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest,
+				WithIstioShadowService(svcName),
+			)
 
 			modelConfig := LLMInferenceServiceConfig("model-fb-opt-125m",
-				InNamespace[*v1alpha1.LLMInferenceServiceConfig](nsName),
+				InNamespace[*v1alpha1.LLMInferenceServiceConfig](testNs.Name),
 				WithConfigModelName("facebook/opt-125m"),
 				WithConfigModelURI("hf://facebook/opt-125m"),
 			)
 
 			routerConfig := LLMInferenceServiceConfig("router-managed",
-				InNamespace[*v1alpha1.LLMInferenceServiceConfig](nsName),
+				InNamespace[*v1alpha1.LLMInferenceServiceConfig](testNs.Name),
 				WithConfigManagedRouter(),
 			)
 
 			workloadConfig := LLMInferenceServiceConfig("workload-single-cpu",
-				InNamespace[*v1alpha1.LLMInferenceServiceConfig](nsName),
+				InNamespace[*v1alpha1.LLMInferenceServiceConfig](testNs.Name),
 				WithConfigWorkloadTemplate(&corev1.PodSpec{
 					Containers: []corev1.Container{
 						{
@@ -126,7 +117,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 			// Create LLMInferenceService using baseRefs only
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 				WithBaseRefs(
 					corev1.LocalObjectReference{Name: "model-fb-opt-125m"},
 					corev1.LocalObjectReference{Name: "router-managed"},
@@ -137,7 +128,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			// when
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			// then
@@ -145,7 +136,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedDeployment)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -180,25 +171,16 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should propagate kueue labels and annotations to the deployment", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-kueue"
-			nsName := kmeta.ChildName(svcName, "-test")
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest,
+				WithIstioShadowService(svcName),
+			)
 
 			localQueueName := "test-local-q"
 			preemptPriority := "0"
 			testValue := "test"
 
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 				WithManagedRoute(),
 				WithManagedGateway(),
@@ -218,7 +200,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			// when
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			// then
@@ -226,7 +208,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Get(ctx, types.NamespacedName{
 					Name:      svcName + "-kserve",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedDeployment)
 			}).WithContext(ctx).Should(Succeed())
 
@@ -258,20 +240,12 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should create routes pointing to the default gateway when both are managed", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-create-http-route"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest,
+					WithIstioShadowService(svcName),
+				)
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha1.LLMInferenceService](nsName),
+					InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithManagedRoute(),
 					WithManagedGateway(),
@@ -281,7 +255,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// then
@@ -322,22 +296,14 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should use referenced external InferencePool", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-create-http-route-inf-pool-ref"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest,
+					WithIstioShadowService(svcName),
+				)
 
 				infPoolName := kmeta.ChildName(svcName, "-my-inf-pool")
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha1.LLMInferenceService](nsName),
+					InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithManagedRoute(),
 					WithManagedGateway(),
@@ -345,7 +311,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				)
 
 				infPool := InferencePool(infPoolName,
-					InNamespace[*igwapi.InferencePool](nsName),
+					InNamespace[*igwapi.InferencePool](testNs.Name),
 					WithSelector("app", "workload"),
 					WithTargetPort(8000),
 					WithExtensionRef("", "Service", kmeta.ChildName(svcName, "-epp-service")),
@@ -356,8 +322,8 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				Expect(envTest.Create(ctx, infPool)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
-					Expect(envTest.Delete(ctx, infPool)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
+					testNs.DeleteAndWait(ctx, infPool)
 				}()
 
 				// then
@@ -394,20 +360,12 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should create routes pointing to workload service when no scheduler is configured", func(ctx SpecContext) {
 				// given
 				llmSvcName := "test-llm-create-http-route-no-scheduler"
-				nsName := kmeta.ChildName(llmSvcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, IstioShadowService(llmSvcName, nsName))).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest,
+					WithIstioShadowService(llmSvcName),
+				)
 
 				llmSvc := LLMInferenceService(llmSvcName,
-					InNamespace[*v1alpha1.LLMInferenceService](nsName),
+					InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithManagedRoute(),
 					WithManagedGateway(),
@@ -416,7 +374,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// then
@@ -445,7 +403,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 				Eventually(func(g Gomega, ctx context.Context) error {
 					svc := &corev1.Service{}
-					err := envTest.Client.Get(ctx, client.ObjectKey{Name: svcName, Namespace: nsName}, svc)
+					err := envTest.Client.Get(ctx, client.ObjectKey{Name: svcName, Namespace: testNs.Name}, svc)
 					g.Expect(err).ToNot(HaveOccurred())
 					g.Expect(svc.Spec.Selector).To(Equal(llmisvc.GetWorkloadLabelSelector(llmSvc.ObjectMeta, &llmSvc.Spec)))
 					return nil
@@ -469,29 +427,21 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should create HTTPRoute with defined spec", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-defined-http-route"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest,
+					WithIstioShadowService(svcName),
+				)
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha1.LLMInferenceService](nsName),
+					InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithManagedGateway(),
-					WithHTTPRouteSpec(customRouteSpec(ctx, envTest.Client, &v1alpha1.LLMInferenceService{}, nsName, "my-ingress-gateway", "my-inference-service")),
+					WithHTTPRouteSpec(customRouteSpec(ctx, envTest.Client, &v1alpha1.LLMInferenceService{}, testNs.Name, "my-ingress-gateway", "my-inference-service")),
 				)
 
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				expectedHTTPRoute := &gatewayapi.HTTPRoute{}
@@ -525,21 +475,13 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should delete managed HTTPRoute when ref is defined", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-update-http-route"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest,
+					WithIstioShadowService(svcName),
+				)
 
 				// Create the Gateway that the router-managed preset references
 				gateway := Gateway("my-ingress-gateway",
-					InNamespace[*gatewayapi.Gateway](nsName),
+					InNamespace[*gatewayapi.Gateway](testNs.Name),
 					WithListener(gatewayapi.HTTPProtocolType),
 					WithAddresses("203.0.113.1"),
 					// Don't set the condition here initially
@@ -550,11 +492,11 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				ensureGatewayReady(ctx, envTest.Client, gateway)
 
 				defer func() {
-					Expect(envTest.Delete(ctx, gateway)).To(Succeed())
+					testNs.DeleteAndWait(ctx, gateway)
 				}()
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha1.LLMInferenceService](nsName),
+					InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithManagedRoute(),
 					WithManagedGateway(),
@@ -562,7 +504,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				Eventually(func(g Gomega, ctx context.Context) error {
@@ -574,7 +516,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				}).WithContext(ctx).Should(Succeed())
 
 				customHTTPRoute := HTTPRoute("my-custom-route", []HTTPRouteOption{
-					InNamespace[*gatewayapi.HTTPRoute](nsName),
+					InNamespace[*gatewayapi.HTTPRoute](testNs.Name),
 					WithParentRef(GatewayParentRef(gateway.Name, gateway.Namespace)),
 					WithHTTPRouteRule(
 						HTTPRouteRuleWithBackendAndTimeouts(svcName+"-inference-pool", 8000, "/", "0s", "0s"),
@@ -613,29 +555,21 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should evaluate HTTPRoute readiness conditions", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-httproute-conditions"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest,
+					WithIstioShadowService(svcName),
+				)
 
-				ingressGateway := DefaultGateway(nsName)
+				ingressGateway := DefaultGateway(testNs.Name)
 				Expect(envTest.Client.Create(ctx, ingressGateway)).To(Succeed())
 				ensureGatewayReady(ctx, envTest.Client, ingressGateway)
 
 				defer func() {
-					Expect(envTest.Delete(ctx, ingressGateway)).To(Succeed())
+					testNs.DeleteAndWait(ctx, ingressGateway)
 				}()
 
 				customHTTPRoute := HTTPRoute("my-custom-route", []HTTPRouteOption{
-					InNamespace[*gatewayapi.HTTPRoute](nsName),
-					WithParentRef(GatewayParentRef("kserve-ingress-gateway", nsName)),
+					InNamespace[*gatewayapi.HTTPRoute](testNs.Name),
+					WithParentRef(GatewayParentRef("kserve-ingress-gateway", testNs.Name)),
 					WithHTTPRouteRule(
 						HTTPRouteRuleWithBackendAndTimeouts(svcName+"-inference-pool", 8000, "/", "0s", "0s"),
 					),
@@ -646,7 +580,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				ensureHTTPRouteReady(ctx, envTest.Client, &v1alpha1.LLMInferenceService{}, customHTTPRoute)
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha1.LLMInferenceService](nsName),
+					InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithHTTPRouteRefs(HTTPRouteRef("my-custom-route")),
 				)
@@ -654,7 +588,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// then - verify HTTPRoutesReady condition is set
@@ -682,20 +616,12 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				func(ctx SpecContext, testName string, initialRouterSpec *v1alpha1.RouterSpec, specMutation func(*v1alpha1.LLMInferenceService)) {
 					// given
 					svcName := "test-llm-" + testName
-					nsName := kmeta.ChildName(svcName, "-test")
-					namespace := &corev1.Namespace{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: nsName,
-						},
-					}
-					Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-					Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-					defer func() {
-						envTest.DeleteAll(namespace)
-					}()
+					testNs := NewTestNamespace(ctx, envTest,
+						WithIstioShadowService(svcName),
+					)
 
 					llmSvc := LLMInferenceService(svcName,
-						InNamespace[*v1alpha1.LLMInferenceService](nsName),
+						InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 						WithModelURI("hf://facebook/opt-125m"),
 					)
 					llmSvc.Spec.Router = initialRouterSpec
@@ -703,7 +629,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 					// when - Create LLMInferenceService
 					Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 					defer func() {
-						Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+						testNs.DeleteAndWait(ctx, llmSvc)
 					}()
 
 					// then - HTTPRoute should be created with router labels
@@ -758,28 +684,19 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should mark RouterReady condition as False with InvalidRefs reason", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-gateway-ref-not-found"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest)
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha1.LLMInferenceService](nsName),
+					InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithHTTPRouteRefs(HTTPRouteRef("non-existent-route")),
-					WithGatewayRefs(LLMGatewayRef("non-existent-gateway", nsName)),
+					WithGatewayRefs(LLMGatewayRef("non-existent-gateway", testNs.Name)),
 				)
 
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// then
@@ -792,7 +709,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 					routerCondition := updatedLLMSvc.Status.GetCondition(v1alpha1.RouterReady)
 					g.Expect(routerCondition).ToNot(BeNil())
 					g.Expect(routerCondition.Reason).To(Equal(llmisvc.RefsInvalidReason))
-					g.Expect(routerCondition.Message).To(ContainSubstring(nsName + "/non-existent-gateway does not exist"))
+					g.Expect(routerCondition.Message).To(ContainSubstring(testNs.Name + "/non-existent-gateway does not exist"))
 
 					return nil
 				}).WithContext(ctx).Should(Succeed())
@@ -803,27 +720,18 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should mark RouterReady condition as False with RefsInvalid reason", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-parent-gateway-ref-not-found"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest)
 
 				// Create HTTPRoute spec that references a non-existent gateway
 				customRouteSpec := &HTTPRoute("temp",
-					WithParentRefs(GatewayParentRef("non-existent-parent-gateway", nsName)),
+					WithParentRefs(GatewayParentRef("non-existent-parent-gateway", testNs.Name)),
 					WithHTTPRule(
 						WithBackendRefs(ServiceRef("some-backend", 8000, 1)),
 					),
 				).Spec
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha1.LLMInferenceService](nsName),
+					InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithHTTPRouteSpec(customRouteSpec),
 				)
@@ -831,7 +739,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// then
@@ -844,7 +752,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 					routerCondition := updatedLLMSvc.Status.GetCondition(v1alpha1.RouterReady)
 					g.Expect(routerCondition).ToNot(BeNil())
 					g.Expect(routerCondition.Reason).To(Equal(llmisvc.RefsInvalidReason))
-					g.Expect(routerCondition.Message).To(ContainSubstring(fmt.Sprintf("Managed HTTPRoute references non-existent Gateway %s/non-existent-parent-gateway", nsName)))
+					g.Expect(routerCondition.Message).To(ContainSubstring(fmt.Sprintf("Managed HTTPRoute references non-existent Gateway %s/non-existent-parent-gateway", testNs.Name)))
 
 					return nil
 				}).WithContext(ctx).Should(Succeed())
@@ -855,19 +763,10 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should mark RouterReady condition as False with RefsInvalid reason", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-route-ref-not-found"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest)
 
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha1.LLMInferenceService](nsName),
+					InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithHTTPRouteRefs(HTTPRouteRef("non-existent-route")),
 					WithGatewayRefs(LLMGatewayRef(constants.GatewayName, constants.KServeNamespace)),
@@ -876,7 +775,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				// when
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// then
@@ -889,7 +788,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 					routerCondition := updatedLLMSvc.Status.GetCondition(v1alpha1.RouterReady)
 					g.Expect(routerCondition).ToNot(BeNil())
 					g.Expect(routerCondition.Reason).To(Equal(llmisvc.RefsInvalidReason))
-					g.Expect(routerCondition.Message).To(ContainSubstring(fmt.Sprintf("HTTPRoute %s/non-existent-route does not exist", nsName)))
+					g.Expect(routerCondition.Message).To(ContainSubstring(fmt.Sprintf("HTTPRoute %s/non-existent-route does not exist", testNs.Name)))
 
 					return nil
 				}).WithContext(ctx).Should(Succeed())
@@ -902,38 +801,29 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should clear stale GatewaysReady condition when Gateway is created", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-stale-gateway-condition"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest)
 
 				// Create HTTPRoute first so HTTPRoute validation passes (focus on Gateway stale condition)
 				httpRoute := HTTPRoute("my-route", []HTTPRouteOption{
-					InNamespace[*gatewayapi.HTTPRoute](nsName),
+					InNamespace[*gatewayapi.HTTPRoute](testNs.Name),
 				}...)
 				Expect(envTest.Client.Create(ctx, httpRoute)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, httpRoute)).To(Succeed())
+					testNs.DeleteAndWait(ctx, httpRoute)
 				}()
 
 				// Create LLMInferenceService referencing a Gateway that doesn't exist yet
 				// Must use WithHTTPRouteRefs (custom gateway requires custom routes, not managed routes)
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha1.LLMInferenceService](nsName),
+					InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithHTTPRouteRefs(HTTPRouteRef("my-route")),
-					WithGatewayRefs(LLMGatewayRef("my-gateway", nsName)),
+					WithGatewayRefs(LLMGatewayRef("my-gateway", testNs.Name)),
 				)
 
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// Verify GatewaysReady is False with RefsInvalid
@@ -952,14 +842,14 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 				// when - Create the Gateway
 				gateway := Gateway("my-gateway",
-					InNamespace[*gatewayapi.Gateway](nsName),
+					InNamespace[*gatewayapi.Gateway](testNs.Name),
 					WithListener(gatewayapi.HTTPProtocolType),
 					WithAddresses("203.0.113.1"),
 				)
 				Expect(envTest.Client.Create(ctx, gateway)).To(Succeed())
 				ensureGatewayReady(ctx, envTest.Client, gateway)
 				defer func() {
-					Expect(envTest.Delete(ctx, gateway)).To(Succeed())
+					testNs.DeleteAndWait(ctx, gateway)
 				}()
 
 				// then - GatewaysReady stale condition should be cleared (no longer RefsInvalid)
@@ -983,40 +873,31 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should clear stale HTTPRoutesReady condition when HTTPRoute is created", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-stale-httproute-condition"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest)
 
 				// Create the Gateway first so gateway validation passes
 				gateway := Gateway("my-gateway",
-					InNamespace[*gatewayapi.Gateway](nsName),
+					InNamespace[*gatewayapi.Gateway](testNs.Name),
 					WithListener(gatewayapi.HTTPProtocolType),
 					WithAddresses("203.0.113.1"),
 				)
 				Expect(envTest.Client.Create(ctx, gateway)).To(Succeed())
 				ensureGatewayReady(ctx, envTest.Client, gateway)
 				defer func() {
-					Expect(envTest.Delete(ctx, gateway)).To(Succeed())
+					testNs.DeleteAndWait(ctx, gateway)
 				}()
 
 				// Create LLMInferenceService referencing an HTTPRoute that doesn't exist yet
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha1.LLMInferenceService](nsName),
+					InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithHTTPRouteRefs(HTTPRouteRef("my-route")),
-					WithGatewayRefs(LLMGatewayRef("my-gateway", nsName)),
+					WithGatewayRefs(LLMGatewayRef("my-gateway", testNs.Name)),
 				)
 
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				// Verify HTTPRoutesReady is False with RefsInvalid
@@ -1042,8 +923,8 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 				// when - Create the HTTPRoute
 				httpRoute := HTTPRoute("my-route", []HTTPRouteOption{
-					InNamespace[*gatewayapi.HTTPRoute](nsName),
-					WithParentRef(GatewayParentRef("my-gateway", nsName)),
+					InNamespace[*gatewayapi.HTTPRoute](testNs.Name),
+					WithParentRef(GatewayParentRef("my-gateway", testNs.Name)),
 					WithHTTPRouteRule(
 						HTTPRouteRuleWithBackendAndTimeouts(svcName+"-kserve-workload-svc", 8000, "/", "0s", "0s"),
 					),
@@ -1051,7 +932,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				Expect(envTest.Client.Create(ctx, httpRoute)).To(Succeed())
 				ensureHTTPRouteReady(ctx, envTest.Client, llmSvc, httpRoute)
 				defer func() {
-					Expect(envTest.Delete(ctx, httpRoute)).To(Succeed())
+					testNs.DeleteAndWait(ctx, httpRoute)
 				}()
 
 				// then - HTTPRoutesReady stale condition should be cleared
@@ -1075,21 +956,13 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			It("should clear SchedulerWorkloadReady condition when scheduler is no longer configured", func(ctx SpecContext) {
 				// given
 				svcName := "test-llm-stale-scheduler-condition"
-				nsName := kmeta.ChildName(svcName, "-test")
-				namespace := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: nsName,
-					},
-				}
-				Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
-				defer func() {
-					envTest.DeleteAll(namespace)
-				}()
+				testNs := NewTestNamespace(ctx, envTest,
+					WithIstioShadowService(svcName),
+				)
 
 				// Create LLMInferenceService with scheduler
 				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha1.LLMInferenceService](nsName),
+					InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 					WithModelURI("hf://facebook/opt-125m"),
 					WithManagedRoute(),
 					WithManagedGateway(),
@@ -1098,7 +971,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 
 				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 				defer func() {
-					Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+					testNs.DeleteAndWait(ctx, llmSvc)
 				}()
 
 				ensureRouterManagedResourcesAreReady(ctx, envTest.Client, llmSvc)
@@ -1143,50 +1016,40 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should create monitoring resources when llmisvc is created", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-monitoring"
-			nsName := kmeta.ChildName(svcName, "-test")
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 			)
 
 			// when
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 			defer func() {
-				Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
+				testNs.DeleteAndWait(ctx, llmSvc)
 			}()
 
 			// then - verify ServiceAccount is created
-			waitForMetricsReaderServiceAccount(ctx, nsName)
+			waitForMetricsReaderServiceAccount(ctx, testNs.Name)
 
 			// then - verify Secret is created
-			expectedSecret := waitForMetricsReaderSASecret(ctx, nsName)
+			expectedSecret := waitForMetricsReaderSASecret(ctx, testNs.Name)
 			Expect(expectedSecret.Annotations).To(HaveKeyWithValue("kubernetes.io/service-account.name", "kserve-metrics-reader-sa"))
 
 			// then - verify ClusterRoleBinding is created
-			expectedClusterRoleBinding := waitForMetricsReaderRoleBinding(ctx, nsName)
+			expectedClusterRoleBinding := waitForMetricsReaderRoleBinding(ctx, testNs.Name)
 			Expect(expectedClusterRoleBinding.Subjects).To(HaveLen(1))
 			Expect(expectedClusterRoleBinding.Subjects[0].Kind).To(Equal("ServiceAccount"))
 			Expect(expectedClusterRoleBinding.Subjects[0].Name).To(Equal("kserve-metrics-reader-sa"))
-			Expect(expectedClusterRoleBinding.Subjects[0].Namespace).To(Equal(nsName))
+			Expect(expectedClusterRoleBinding.Subjects[0].Namespace).To(Equal(testNs.Name))
 			Expect(expectedClusterRoleBinding.RoleRef.Kind).To(Equal("ClusterRole"))
 			Expect(expectedClusterRoleBinding.RoleRef.Name).To(Equal("kserve-metrics-reader-cluster-role"))
 
 			// then - verify PodMonitor is created
-			waitForVLLMEnginePodMonitor(ctx, nsName)
+			waitForVLLMEnginePodMonitor(ctx, testNs.Name)
 
 			// then - verify ServiceMonitor is created
-			expectedServiceMonitor := waitForSchedulerServiceMonitor(ctx, nsName)
+			expectedServiceMonitor := waitForSchedulerServiceMonitor(ctx, testNs.Name)
 			Expect(expectedServiceMonitor.Spec.Endpoints).To(HaveLen(1))
 			Expect(expectedServiceMonitor.Spec.Endpoints[0].Port).To(Equal("metrics"))
 			Expect(expectedServiceMonitor.Spec.Endpoints[0].Authorization.Credentials.Name).To(Equal("kserve-metrics-reader-sa-secret"))
@@ -1195,27 +1058,17 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should skip cleanup when an llmisvc is deleted but other llmisvc exist in namespace", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-cleanup-skip"
-			nsName := kmeta.ChildName(svcName, "-test")
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest)
 
 			// Create first LLMInferenceService
 			llmSvc1 := LLMInferenceService(svcName+"-1",
-				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 			)
 
 			// Create second LLMInferenceService
 			llmSvc2 := LLMInferenceService(svcName+"-2",
-				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 			)
 
@@ -1224,7 +1077,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			Expect(envTest.Create(ctx, llmSvc2)).To(Succeed())
 
 			// Verify monitoring resources are created
-			waitForAllMonitoringResources(ctx, nsName)
+			waitForAllMonitoringResources(ctx, testNs.Name)
 
 			// when - delete only the first service
 			Expect(envTest.Delete(ctx, llmSvc1)).To(Succeed())
@@ -1239,26 +1092,26 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			Consistently(func(g Gomega, ctx context.Context) {
 				g.Expect(envTest.Get(ctx, types.NamespacedName{
 					Name:      "kserve-metrics-reader-sa",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedServiceAccount)).To(Succeed())
 
 				g.Expect(envTest.Get(ctx, types.NamespacedName{
 					Name:      "kserve-metrics-reader-sa-secret",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedSecret)).To(Succeed())
 
 				g.Expect(envTest.Get(ctx, types.NamespacedName{
-					Name: "kserve-metrics-reader-role-binding-" + nsName,
+					Name: kmeta.ChildName("kserve-metrics-reader-role-binding-", testNs.Name),
 				}, expectedClusterRoleBinding)).Should(Succeed())
 
 				g.Expect(envTest.Get(ctx, types.NamespacedName{
 					Name:      "kserve-llm-isvc-vllm-engine",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedPodMonitor)).Should(Succeed())
 
 				g.Expect(envTest.Get(ctx, types.NamespacedName{
 					Name:      "kserve-llm-isvc-scheduler",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, expectedServiceMonitor)).Should(Succeed())
 			}).WithContext(ctx).Should(Succeed())
 		})
@@ -1266,20 +1119,10 @@ var _ = Describe("LLMInferenceService Controller", func() {
 		It("should perform cleanup when the last llmisvc is deleted", func(ctx SpecContext) {
 			// given
 			svcName := "test-llm-cleanup-last"
-			nsName := kmeta.ChildName(svcName, "-test")
-			namespace := &corev1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: nsName,
-				},
-			}
-
-			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
-			defer func() {
-				envTest.DeleteAll(namespace)
-			}()
+			testNs := NewTestNamespace(ctx, envTest)
 
 			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha1.LLMInferenceService](nsName),
+				InNamespace[*v1alpha1.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 			)
 
@@ -1287,7 +1130,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
 
 			// Verify monitoring resources are created
-			waitForAllMonitoringResources(ctx, nsName)
+			waitForAllMonitoringResources(ctx, testNs.Name)
 
 			// when - delete the last (and only) service
 			Expect(envTest.Delete(ctx, llmSvc)).To(Succeed())
@@ -1297,7 +1140,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				serviceAccount := &corev1.ServiceAccount{}
 				err := envTest.Get(ctx, types.NamespacedName{
 					Name:      "kserve-metrics-reader-sa",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, serviceAccount)
 				return err != nil && errors.IsNotFound(err)
 			}).WithContext(ctx).Should(BeTrue(), "monitoring ServiceAccount should be deleted")
@@ -1306,7 +1149,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				secret := &corev1.Secret{}
 				err := envTest.Get(ctx, types.NamespacedName{
 					Name:      "kserve-metrics-reader-sa-secret",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, secret)
 				return err != nil && errors.IsNotFound(err)
 			}).WithContext(ctx).Should(BeTrue(), "monitoring Secret should be deleted")
@@ -1314,7 +1157,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			Eventually(func(g Gomega, ctx context.Context) bool {
 				clusterRoleBinding := &rbacv1.ClusterRoleBinding{}
 				err := envTest.Get(ctx, types.NamespacedName{
-					Name: "kserve-metrics-reader-role-binding-" + nsName,
+					Name: kmeta.ChildName("kserve-metrics-reader-role-binding-", testNs.Name),
 				}, clusterRoleBinding)
 				return err != nil && errors.IsNotFound(err)
 			}).WithContext(ctx).Should(BeTrue(), "monitoring ClusterRoleBinding should be deleted")
@@ -1323,7 +1166,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				podMonitor := &monitoringv1.PodMonitor{}
 				err := envTest.Get(ctx, types.NamespacedName{
 					Name:      "kserve-llm-isvc-vllm-engine",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, podMonitor)
 				return err != nil && errors.IsNotFound(err)
 			}).WithContext(ctx).Should(BeTrue(), "monitoring PodMonitor should be deleted")
@@ -1332,7 +1175,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 				serviceMonitor := &monitoringv1.ServiceMonitor{}
 				err := envTest.Get(ctx, types.NamespacedName{
 					Name:      "kserve-llm-isvc-scheduler",
-					Namespace: nsName,
+					Namespace: testNs.Name,
 				}, serviceMonitor)
 				return err != nil && errors.IsNotFound(err)
 			}).WithContext(ctx).Should(BeTrue(), "monitoring ServiceMonitor should be deleted")

--- a/pkg/controller/llmisvc/fixture/test_namespace.go
+++ b/pkg/controller/llmisvc/fixture/test_namespace.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fixture
+
+import (
+	"context"
+	"fmt"
+	"hash/crc32"
+	"regexp"
+	"strings"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	pkgtest "github.com/kserve/kserve/pkg/testing"
+)
+
+// TestNamespace encapsulates a test namespace with its lifecycle management.
+// It ensures proper setup and cleanup ordering.
+type TestNamespace struct {
+	Name      string
+	Namespace *corev1.Namespace
+	client    *pkgtest.Client
+	// resources tracks all resources created via options for cleanup
+	resources []client.Object
+}
+
+// TestNamespaceOption configures a TestNamespace during creation
+type TestNamespaceOption func(ctx context.Context, tn *TestNamespace)
+
+// WithIstioShadowService creates an Istio shadow service in the namespace.
+// This is required for tests that verify Istio integration.
+func WithIstioShadowService(svcName string) TestNamespaceOption {
+	return func(ctx context.Context, tn *TestNamespace) {
+		svc := IstioShadowService(svcName, tn.Name)
+		gomega.Expect(tn.client.Create(ctx, svc)).To(gomega.Succeed())
+		tn.resources = append(tn.resources, svc)
+	}
+}
+
+// WithDefaultServiceAccount creates the default ServiceAccount.
+// This is automatically applied but can be explicitly added for clarity.
+// Note: envtest doesn't run kube-controller-manager, so default SA isn't auto-created.
+func WithDefaultServiceAccount() TestNamespaceOption {
+	return func(ctx context.Context, tn *TestNamespace) {
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "default",
+				Namespace: tn.Name,
+			},
+		}
+		err := tn.client.Create(ctx, sa)
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		if err == nil {
+			tn.resources = append(tn.resources, sa)
+		}
+	}
+}
+
+// WithServiceAccount creates a custom ServiceAccount in the namespace.
+func WithServiceAccount(name string) TestNamespaceOption {
+	return func(ctx context.Context, tn *TestNamespace) {
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: tn.Name,
+			},
+		}
+		err := tn.client.Create(ctx, sa)
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		}
+		if err == nil {
+			tn.resources = append(tn.resources, sa)
+		}
+	}
+}
+
+// NewTestNamespace creates a namespace for testing with proper cleanup registered.
+//
+// It automatically:
+//   - Creates the namespace with name derived from current Ginkgo test info
+//   - Creates default ServiceAccount when using envtest (real clusters auto-create it)
+//   - Registers cleanup via DeferCleanup (ensures proper ordering)
+//
+// Example usage:
+//
+//	testNs := NewTestNamespace(ctx, envTest,
+//	    WithIstioShadowService("my-service"),
+//	)
+func NewTestNamespace(ctx context.Context, c *pkgtest.Client, opts ...TestNamespaceOption) *TestNamespace {
+	nsName := generateNamespaceName(ginkgo.CurrentSpecReport())
+
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: nsName,
+		},
+	}
+
+	gomega.Expect(c.Create(ctx, namespace)).To(gomega.Succeed())
+
+	tn := &TestNamespace{
+		Name:      nsName,
+		Namespace: namespace,
+		client:    c,
+	}
+
+	// Create default ServiceAccount only for envtest (real clusters auto-create it)
+	if !c.UsingExistingCluster() {
+		WithDefaultServiceAccount()(ctx, tn)
+	}
+
+	// Apply additional options
+	for _, opt := range opts {
+		opt(ctx, tn)
+	}
+
+	// Register cleanup via DeferCleanup - this ensures it runs AFTER any
+	// inline defers registered after this call (LIFO order)
+	// Note: envtest has no GC, so we must explicitly delete all resources
+	ginkgo.DeferCleanup(func(ctx context.Context) {
+		// Delete tracked resources in reverse order (LIFO)
+		for i := len(tn.resources) - 1; i >= 0; i-- {
+			if err := c.Delete(ctx, tn.resources[i]); err != nil && !apierrors.IsNotFound(err) {
+				// Log but don't fail - cleanup should be best-effort
+				fmt.Fprintf(ginkgo.GinkgoWriter, "Warning: failed to delete resource %v: %v\n",
+					client.ObjectKeyFromObject(tn.resources[i]), err)
+			}
+		}
+		c.DeleteAll(ctx, namespace)
+	})
+
+	return tn
+}
+
+// DeleteAndWait deletes the given object and waits for it to be fully removed.
+// This should be called for objects with finalizers (like LLMInferenceService)
+// before namespace cleanup to avoid race conditions.
+func (tn *TestNamespace) DeleteAndWait(ctx context.Context, obj client.Object) {
+	err := tn.client.Delete(ctx, obj)
+	if apierrors.IsNotFound(err) {
+		return
+	}
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	// Wait for the object to be fully deleted (including finalizer processing)
+	gomega.Eventually(func(g gomega.Gomega) {
+		getErr := tn.client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+		g.Expect(apierrors.IsNotFound(getErr)).To(gomega.BeTrue(),
+			"expected object to be deleted, got: %v", getErr)
+	}).WithContext(ctx).Should(gomega.Succeed())
+}
+
+// generateNamespaceName creates a DNS-safe namespace name from test info.
+// Uses full test hierarchy (Describe/Context/It) for stable namespace name.
+//
+// Example: Describe("Controller") > Context("Reconciliation") > It("should create")
+// becomes: "test-controller-reconciliation-should-create"
+// (or "test-controller-reconci-a1b2c3d4" if exceeds 63 chars)
+func generateNamespaceName(spec ginkgo.SpecReport) string {
+	fullPath := strings.Join(append(spec.ContainerHierarchyTexts, spec.LeafNodeText), "-")
+	return truncateWithHash("test-"+sanitizeForDNS(fullPath), 63)
+}
+
+var nonDNSChars = regexp.MustCompile(`[^a-z0-9]+`)
+
+func sanitizeForDNS(s string) string {
+	return strings.Trim(nonDNSChars.ReplaceAllString(strings.ToLower(s), "-"), "-")
+}
+
+// truncateWithHash returns name as-is if it fits in maxLen,
+// otherwise truncates and appends a hash suffix for uniqueness.
+func truncateWithHash(name string, maxLen int) string {
+	if len(name) <= maxLen {
+		return name
+	}
+	hash := fmt.Sprintf("%08x", crc32.ChecksumIEEE([]byte(name)))
+	truncateAt := maxLen - 9
+	return strings.TrimRight(name[:truncateAt], "-") + "-" + hash
+}

--- a/pkg/controller/llmisvc/validation/llminferenceservice_validator_int_test.go
+++ b/pkg/controller/llmisvc/validation/llminferenceservice_validator_int_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validation_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -65,11 +66,11 @@ var _ = Describe("LLMInferenceService webhook validation", func() {
 		)
 		Expect(envTest.Client.Create(ctx, httpRoute)).To(Succeed())
 
-		DeferCleanup(func() {
+		DeferCleanup(func(ctx context.Context) {
 			httpRoute := httpRoute
 			gateway := gateway
 			ns := ns
-			envTest.DeleteAll(httpRoute, gateway, ns)
+			envTest.DeleteAll(ctx, httpRoute, gateway, ns)
 		})
 	})
 
@@ -381,9 +382,9 @@ var _ = Describe("LLMInferenceService API validation", func() {
 		}
 		Expect(envTest.Client.Create(ctx, ns)).To(Succeed())
 
-		DeferCleanup(func() {
+		DeferCleanup(func(ctx context.Context) {
 			ns := ns
-			envTest.DeleteAll(ns)
+			envTest.DeleteAll(ctx, ns)
 		})
 	})
 	Context("Integer value validation", func() {


### PR DESCRIPTION
Integration tests repeated the same namespace setup and cleanup pattern, leading to code duplication and inconsistent behavior.

The existing approach had several issues with envtest: missing garbage collection meant resources weren't cleaned up when the namespace was deleted, and the default ServiceAccount wasn't auto-created, causing noisy error logs.

```
2025-12-29T14:28:09+01:00       ERROR   LLMInferenceService.reconcile.reconcileWorkload Failed to find default service account     {"controller": "llminferenceservice", "controllerGroup": "serving.kserve.io", "controllerKind": "LLMInferenceService", "LLMInferenceService": {"name":"test-llm-lws-labels","namespace":"test-llm-lws-labels-test"}, "namespace": "test-llm-lws-labels-test", "name": "test-llm-lws-labels", "reconcileID": "376d6481-c47b-412a-92a9-6de510a592cd", "namespace": "test-llm-lws-labels-test", "error": "ServiceAccount \"default\" not found"}
```


This PR introduces a `TestNamespace` fixture that standardizes namespace lifecycle management. It tracks all created resources for explicit cleanup via `ginkgo.DeferCleanup`, and automatically provisions the `default` `ServiceAccount` that envtest doesn't provide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test namespace setup and teardown across multiple test suites for improved maintainability.
  * Introduced centralized test namespace helper utilities to standardize namespace lifecycle management.
  * Updated test resource cleanup logic for consistency across test suites.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->