### PR TITLE
fix(test): add missing context argument in llmisvc integration test

### DIFF
--- a/pkg/controller/llmisvc/controller_int_test.go
+++ b/pkg/controller/llmisvc/controller_int_test.go
@@ -725,7 +725,7 @@ var _ = Describe("LLMInferenceService Controller", func() {
 			Expect(envTest.Client.Create(ctx, namespace)).To(Succeed())
 			Expect(envTest.Client.Create(ctx, IstioShadowService(svcName, nsName))).To(Succeed())
 			defer func() {
-				envTest.DeleteAll(namespace)
+				envTest.DeleteAll(ctx, namespace)
 			}()
 
 			customGatewayName := "my-custom-gateway"


### PR DESCRIPTION
The `envTest.DeleteAll` call was missing the required `ctx` parameter, causing `go vet` to fail with a type mismatch error.

A true mistery how #1028 passed it.

![magic](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExeHVsbmF0dHl3YnczcmUwdGx6cG1zeG9raGo1eHg3enZiY2p2YzZudSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/0jeFXrEpsI5y0ytXoL/giphy.gif)
