### PR TITLE
feat(llmisvc): enhances Gateway API URL discovery

### DIFF
--- a/pkg/controller/llmisvc/config_loader.go
+++ b/pkg/controller/llmisvc/config_loader.go
@@ -35,6 +35,7 @@ type Config struct {
 	IngressGatewayName          string   `json:"ingressGatewayName,omitempty"`
 	IngressGatewayNamespace     string   `json:"ingressGatewayNamespace,omitempty"`
 	IstioGatewayControllerNames []string `json:"istioGatewayControllerNames,omitempty"`
+	UrlScheme                   string   `json:"urlScheme,omitempty"`
 
 	StorageConfig    *types.StorageInitializerConfig `json:"-"`
 	CredentialConfig *credentials.CredentialConfig   `json:"-"`
@@ -61,6 +62,7 @@ func NewConfig(ingressConfig *v1beta1.IngressConfig, storageConfig *types.Storag
 			"istio.io/unmanaged-gateway",
 			"openshift.io/gateway-controller/v1",
 		},
+		UrlScheme:        ingressConfig.UrlScheme,
 		StorageConfig:    storageConfig,
 		CredentialConfig: credentialConfig,
 	}

--- a/pkg/controller/llmisvc/fixture/required_resources.go
+++ b/pkg/controller/llmisvc/fixture/required_resources.go
@@ -136,6 +136,14 @@ func DefaultGatewayClass() *gatewayapiv1.GatewayClass {
 }
 
 func InferenceServiceCfgMap(ns string) *corev1.ConfigMap {
+	return InferenceServiceCfgMapWithUrlScheme(ns, "")
+}
+
+func InferenceServiceCfgMapWithUrlScheme(ns, urlScheme string) *corev1.ConfigMap {
+	urlSchemeConfig := ""
+	if urlScheme != "" {
+		urlSchemeConfig = `,"urlScheme": "` + urlScheme + `"`
+	}
 	configs := map[string]string{
 		"ingress": `{
 				"enableGatewayApi": true,
@@ -143,7 +151,7 @@ func InferenceServiceCfgMap(ns string) *corev1.ConfigMap {
 				"ingressGateway": "knative-serving/knative-ingress-gateway",
 				"localGateway": "knative-serving/knative-local-gateway",
 				"localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local",
-				"additionalIngressDomains": ["additional.example.com"]
+				"additionalIngressDomains": ["additional.example.com"]` + urlSchemeConfig + `
 			}`,
 		"storageInitializer": `{
 				"memoryRequest": "100Mi",

--- a/pkg/controller/llmisvc/router_discovery_filter.go
+++ b/pkg/controller/llmisvc/router_discovery_filter.go
@@ -68,3 +68,24 @@ func isInternalHostname(hostname string) bool {
 
 	return hostname == "localhost"
 }
+
+// IsClusterLocalURL returns true if the URL uses a Kubernetes cluster-local hostname
+// (e.g., service.namespace.svc.cluster.local)
+func IsClusterLocalURL(url *apis.URL) bool {
+	host := strings.ToLower(url.URL().Hostname())
+	return strings.HasSuffix(host, network.GetClusterDomainName())
+}
+
+// AddressTypeName returns the type name for a URL to be used in Addressable.Name:
+// - "gateway-external" for public addresses
+// - "gateway-internal" for cluster-local gateway service URLs
+// - "internal" for private IPs or other internal hostnames
+func AddressTypeName(url *apis.URL) string {
+	if IsClusterLocalURL(url) {
+		return "gateway-internal"
+	}
+	if IsInternalURL(url) {
+		return "internal"
+	}
+	return "gateway-external"
+}

--- a/pkg/controller/llmisvc/router_discovery_test.go
+++ b/pkg/controller/llmisvc/router_discovery_test.go
@@ -20,7 +20,9 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/apis"
@@ -33,23 +35,48 @@ import (
 	"github.com/kserve/kserve/pkg/controller/llmisvc"
 )
 
+// expectURLs returns an assert function that expects no error and exact URL match
+func expectURLs(expected ...string) func(g Gomega, urls []string, err error) {
+	return func(g Gomega, urls []string, err error) {
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(urls).To(Equal(expected))
+	}
+}
+
+// expectURLsContain returns an assert function that expects no error and URLs containing the expected elements
+func expectURLsContain(expected ...string) func(g Gomega, urls []string, err error) {
+	return func(g Gomega, urls []string, err error) {
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(urls).To(ContainElements(expected))
+	}
+}
+
+// expectError returns an assert function that expects an error matching the predicate
+func expectError(check func(error) bool) func(g Gomega, urls []string, err error) {
+	return func(g Gomega, urls []string, err error) {
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(check(err)).To(BeTrue(), "Error check failed for: %v", err)
+	}
+}
+
 func TestDiscoverURLs(t *testing.T) {
 	tests := []struct {
 		name               string
 		route              *gatewayapi.HTTPRoute
-		gateway            *gatewayapi.Gateway
-		additionalGateways []*gatewayapi.Gateway // Additional gateways for multiple parent refs test
-		expectedURLs       []string              // Always expect multiple URLs, single URL cases will have length 1
-		expectedErrorCheck func(error) bool
+		gateways           []*gatewayapi.Gateway
+		services           []*corev1.Service
+		preferredUrlScheme string
+		assert             func(g Gomega, urls []string, err error)
 	}{
+		// ===== Basic address resolution =====
 		{
 			name: "basic external address resolution",
 			route: HTTPRoute("test-route",
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway:      HTTPGateway("test-gateway", "test-ns", "203.0.113.1"),
-			expectedURLs: []string{"http://203.0.113.1/"},
+			gateways: []*gatewayapi.Gateway{HTTPGateway("test-gateway", "test-ns", "203.0.113.1")},
+			assert:   expectURLs("http://203.0.113.1/"),
 		},
 		{
 			name: "address ordering consistency - same addresses different order",
@@ -57,47 +84,35 @@ func TestDiscoverURLs(t *testing.T) {
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("consistency-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("consistency-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListener(gatewayapi.HTTPProtocolType),
-				WithAddresses([]string{"203.0.113.200", "203.0.113.100"}...),
-			),
-			expectedURLs: []string{
-				"http://203.0.113.100/",
-				"http://203.0.113.200/",
+			gateways: []*gatewayapi.Gateway{
+				Gateway("consistency-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListener(gatewayapi.HTTPProtocolType),
+					WithAddresses("203.0.113.200", "203.0.113.100"),
+				),
 			},
+			assert: expectURLs("http://203.0.113.100/", "http://203.0.113.200/"),
 		},
+		// ===== Hostname handling =====
 		{
-			name: "mixed internal and external addresses - deterministic selection",
-			route: HTTPRoute("mixed-route",
-				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("mixed-gateway", RefInNamespace("test-ns"))),
-			),
-			gateway: Gateway("mixed-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListener(gatewayapi.HTTPProtocolType),
-				WithAddresses("192.168.1.10", "203.0.113.50", "10.0.0.20", "203.0.113.25"),
-			),
-			expectedURLs: []string{
-				"http://10.0.0.20/",
-				"http://192.168.1.10/",
-				"http://203.0.113.25/",
-				"http://203.0.113.50/",
-			},
-		},
-		{
-			name: "route hostname override",
+			name: "route hostname within listener wildcard",
 			route: HTTPRoute("hostname-route",
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("hostname-gateway", RefInNamespace("test-ns"))),
 				WithHostnames("api.example.com"),
 			),
-			gateway: Gateway("hostname-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListener(gatewayapi.HTTPProtocolType),
-				WithAddresses([]string{"203.0.113.1"}...),
-			),
-			expectedURLs: []string{"http://api.example.com/"},
+			gateways: []*gatewayapi.Gateway{
+				Gateway("hostname-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(gatewayapi.Listener{
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     80,
+						Hostname: ptr.To(gatewayapi.Hostname("*.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://api.example.com/"),
 		},
 		{
 			name: "route wildcard hostname - use gateway address",
@@ -106,53 +121,69 @@ func TestDiscoverURLs(t *testing.T) {
 				WithParentRef(GatewayRef("wildcard-gateway", RefInNamespace("test-ns"))),
 				WithHostnames("*"),
 			),
-			gateway: Gateway("wildcard-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListener(gatewayapi.HTTPProtocolType),
-				WithAddresses("203.0.113.100"),
-			),
-			expectedURLs: []string{"http://203.0.113.100/"},
+			gateways: []*gatewayapi.Gateway{
+				Gateway("wildcard-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListener(gatewayapi.HTTPProtocolType),
+					WithAddresses("203.0.113.100"),
+				),
+			},
+			assert: expectURLs("http://203.0.113.100/"),
 		},
 		{
 			name: "multiple hostnames - generates multiple URLs",
 			route: HTTPRoute("multi-hostname-route",
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("multi-hostname-gateway", RefInNamespace("test-ns"))),
-				WithHostnames("*", "", "api.example.com", "alt.example.com"),
+				WithHostnames("api.example.com", "alt.example.com"),
 			),
-			gateway: Gateway("multi-hostname-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListener(gatewayapi.HTTPProtocolType),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{
-				"http://alt.example.com/",
-				"http://api.example.com/",
+			gateways: []*gatewayapi.Gateway{
+				Gateway("multi-hostname-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(gatewayapi.Listener{
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     80,
+						Hostname: ptr.To(gatewayapi.Hostname("*.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
 			},
+			assert: expectURLs("http://alt.example.com/", "http://api.example.com/"),
 		},
+
+		// ===== Path handling =====
 		{
 			name: "custom path extraction",
 			route: HTTPRoute("path-route",
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("path-gateway", RefInNamespace("test-ns"))),
-				WithPath("/api/v1/models"),
+				WithPath("/api/v1"),
 			),
-			gateway: Gateway("path-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListener(gatewayapi.HTTPProtocolType),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://203.0.113.1/api/v1/models"},
+			gateways: []*gatewayapi.Gateway{HTTPGateway("path-gateway", "test-ns", "203.0.113.1")},
+			assert:   expectURLs("http://203.0.113.1/api/v1"),
 		},
+		{
+			name: "empty route rules - default path",
+			route: HTTPRoute("empty-rules-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("empty-rules-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: []*gatewayapi.Gateway{HTTPGateway("empty-rules-gateway", "test-ns", "203.0.113.1")},
+			assert:   expectURLs("http://203.0.113.1/"),
+		},
+
+		// ===== Scheme from listener =====
 		{
 			name: "HTTPS scheme from gateway listener",
 			route: HTTPRoute("https-route",
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("https-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway:      HTTPSGateway("https-gateway", "test-ns", "203.0.113.1"),
-			expectedURLs: []string{"https://203.0.113.1/"},
+			gateways: []*gatewayapi.Gateway{HTTPSGateway("https-gateway", "test-ns", "203.0.113.1")},
+			assert:   expectURLs("https://203.0.113.1/"),
 		},
+
+		// ===== Multiple parent refs =====
 		{
 			name: "multiple parent refs - sorted selection",
 			route: HTTPRoute("multi-parent-route",
@@ -163,12 +194,12 @@ func TestDiscoverURLs(t *testing.T) {
 					GatewayRef("b-gateway", RefInNamespace("a-namespace")),
 				),
 			),
-			gateway: Gateway("a-gateway",
-				InNamespace[*gatewayapi.Gateway]("a-namespace"),
-				WithListener(gatewayapi.HTTPProtocolType),
-				WithAddresses([]string{"203.0.113.1"}...),
-			),
-			additionalGateways: []*gatewayapi.Gateway{
+			gateways: []*gatewayapi.Gateway{
+				Gateway("a-gateway",
+					InNamespace[*gatewayapi.Gateway]("a-namespace"),
+					WithListener(gatewayapi.HTTPProtocolType),
+					WithAddresses("203.0.113.1"),
+				),
 				Gateway("z-gateway",
 					InNamespace[*gatewayapi.Gateway]("z-namespace"),
 					WithListener(gatewayapi.HTTPProtocolType),
@@ -180,191 +211,182 @@ func TestDiscoverURLs(t *testing.T) {
 					WithAddresses("203.0.113.3"),
 				),
 			},
-			expectedURLs: []string{
+			assert: expectURLs(
 				"http://203.0.113.2/",
 				"http://203.0.113.1/",
 				"http://203.0.113.3/",
+			),
+		},
+		{
+			name: "route with multiple parent refs to different gateways",
+			route: HTTPRoute("multi-gateway-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRefs(
+					gatewayapi.ParentReference{
+						Name:      "gateway-a",
+						Namespace: ptr.To(gatewayapi.Namespace("gw-ns")),
+						Group:     ptr.To(gatewayapi.Group("gateway.networking.k8s.io")),
+						Kind:      ptr.To(gatewayapi.Kind("Gateway")),
+					},
+					gatewayapi.ParentReference{
+						Name:      "gateway-b",
+						Namespace: ptr.To(gatewayapi.Namespace("gw-ns")),
+						Group:     ptr.To(gatewayapi.Group("gateway.networking.k8s.io")),
+						Kind:      ptr.To(gatewayapi.Kind("Gateway")),
+					},
+				),
+			),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("gateway-a",
+					InNamespace[*gatewayapi.Gateway]("gw-ns"),
+					WithListeners(gatewayapi.Listener{
+						Name:     "https",
+						Protocol: gatewayapi.HTTPSProtocolType,
+						Port:     443,
+					}),
+					WithAddresses("gateway-a.example.com"),
+				),
+				Gateway("gateway-b",
+					InNamespace[*gatewayapi.Gateway]("gw-ns"),
+					WithListeners(gatewayapi.Listener{
+						Name:     "http",
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     8080,
+					}),
+					WithAddresses("gateway-b.example.com"),
+				),
 			},
+			assert: expectURLsContain(
+				"https://gateway-a.example.com/",
+				"http://gateway-b.example.com:8080/",
+			),
 		},
 		{
 			name: "parent ref without namespace - use route namespace",
 			route: HTTPRoute("no-ns-route",
 				InNamespace[*gatewayapi.HTTPRoute]("route-ns"),
-				WithParentRef(GatewayRefWithoutNamespace("no-ns-gateway")),
+				WithParentRef(GatewayRef("same-ns-gateway")),
 			),
-			gateway: Gateway("no-ns-gateway",
-				InNamespace[*gatewayapi.Gateway]("route-ns"),
-				WithListener(gatewayapi.HTTPProtocolType),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://203.0.113.1/"},
+			gateways: []*gatewayapi.Gateway{HTTPGateway("same-ns-gateway", "route-ns", "203.0.113.1")},
+			assert:   expectURLs("http://203.0.113.1/"),
 		},
+
+		// ===== Address types =====
 		{
-			name: "no external addresses - custom ExternalAddressNotFoundError",
-			route: HTTPRoute("no-external-route",
+			name: "private addresses only - still returns URLs",
+			route: HTTPRoute("private-route",
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("no-external-addresses-gateway", RefInNamespace("test-ns"))),
+				WithParentRef(GatewayRef("private-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("no-external-addresses-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListener(gatewayapi.HTTPProtocolType),
-				WithAddresses("192.168.1.10", "10.0.0.20"),
-			),
-			expectedURLs: []string{
-				"http://10.0.0.20/",
-				"http://192.168.1.10/",
+			gateways: []*gatewayapi.Gateway{
+				Gateway("private-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListener(gatewayapi.HTTPProtocolType),
+					WithAddresses("192.168.1.100", "10.0.0.50"),
+				),
 			},
+			assert: expectURLs("http://10.0.0.50/", "http://192.168.1.100/"),
 		},
-		{
-			name: "gateway not found should cause not found error",
-			route: HTTPRoute("missing-gw-route",
-				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("missing-gateway", RefInNamespace("test-ns"))),
-			),
-			expectedErrorCheck: apierrors.IsNotFound,
-		},
-		{
-			name: "empty route rules - default path",
-			route: HTTPRoute("empty-rules-route",
-				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("empty-rules-gateway", RefInNamespace("test-ns"))),
-				WithRules(), // Empty rules
-			),
-			gateway: Gateway("empty-rules-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListener(gatewayapi.HTTPProtocolType),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://203.0.113.1/"},
-		},
-		// Hostname address type tests
 		{
 			name: "hostname addresses - basic resolution",
-			route: HTTPRoute("hostname-route",
+			route: HTTPRoute("hostname-addr-route",
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("hostname-gateway", RefInNamespace("test-ns"))),
+				WithParentRef(GatewayRef("hostname-addr-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("hostname-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListener(gatewayapi.HTTPProtocolType),
-				WithHostnameAddresses("api.example.com"),
-			),
-			expectedURLs: []string{"http://api.example.com/"},
+			gateways: []*gatewayapi.Gateway{
+				Gateway("hostname-addr-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListener(gatewayapi.HTTPProtocolType),
+					WithHostnameAddresses("api.example.com", "lb.example.com"),
+				),
+			},
+			assert: expectURLs("http://api.example.com/", "http://lb.example.com/"),
 		},
 		{
 			name: "mixed hostname and IP addresses - deterministic selection",
-			route: HTTPRoute("mixed-types-route",
+			route: HTTPRoute("mixed-addr-route",
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("mixed-types-gateway", RefInNamespace("test-ns"))),
+				WithParentRef(GatewayRef("mixed-addr-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("mixed-types-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListener(gatewayapi.HTTPProtocolType),
-				WithMixedAddresses(
-					HostnameAddress("z.example.com"),
-					IPAddress("203.0.113.1"),
-					HostnameAddress("api.example.com"),
-					IPAddress("198.51.100.1"),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("mixed-addr-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListener(gatewayapi.HTTPProtocolType),
+					WithMixedAddresses(
+						IPAddress("203.0.113.1"),
+						HostnameAddress("api.example.com"),
+						HostnameAddress("lb.example.com"),
+					),
 				),
-			),
-			expectedURLs: []string{
-				"http://198.51.100.1/",
+			},
+			assert: expectURLs(
 				"http://203.0.113.1/",
 				"http://api.example.com/",
-				"http://z.example.com/",
-			},
+				"http://lb.example.com/",
+			),
+		},
+		// ===== Error cases =====
+		{
+			name: "gateway not found should cause not found error",
+			route: HTTPRoute("nonexistent-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("nonexistent-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: nil,
+			assert:   expectError(apierrors.IsNotFound),
 		},
 		{
-			name: "hostname addresses with internal hostnames filtered",
-			route: HTTPRoute("internal-hostname-route",
+			name: "no addresses at all - NoURLsDiscoveredError",
+			route: HTTPRoute("no-addr-route",
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("internal-hostname-gateway", RefInNamespace("test-ns"))),
+				WithParentRef(GatewayRef("no-addr-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("internal-hostname-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListener(gatewayapi.HTTPProtocolType),
-				WithMixedAddresses(
-					HostnameAddress("localhost"),
-					HostnameAddress("service.local"),
-					HostnameAddress("app.internal"),
-					HostnameAddress("api.example.com"),
-					HostnameAddress("backup.example.com"),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("no-addr-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListener(gatewayapi.HTTPProtocolType),
 				),
-			),
-			expectedURLs: []string{
-				"http://api.example.com/",
-				"http://app.internal/",
-				"http://backup.example.com/",
-				"http://localhost/",
-				"http://service.local/",
 			},
+			assert: expectError(llmisvc.IsNoURLsDiscovered),
 		},
 		{
-			name: "only internal addresses (IP + hostnames) - ExternalAddressNotFoundError",
-			route: HTTPRoute("only-internal-route",
+			name: "gateway with only TCP listeners returns error",
+			route: HTTPRoute("test-route",
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("only-internal-gateway", RefInNamespace("test-ns"))),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("only-internal-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListener(gatewayapi.HTTPProtocolType),
-				WithMixedAddresses(
-					IPAddress("192.168.1.10"),
-					IPAddress("10.0.0.20"),
-					HostnameAddress("localhost"),
-					HostnameAddress("app.local"),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("test-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(gatewayapi.Listener{
+						Name:     "tcp-listener",
+						Protocol: gatewayapi.TCPProtocolType,
+						Port:     9000,
+					}),
+					WithAddresses("203.0.113.1"),
 				),
-			),
-			expectedURLs: []string{
-				"http://10.0.0.20/",
-				"http://192.168.1.10/",
-				"http://app.local/",
-				"http://localhost/",
 			},
+			assert: expectError(func(err error) bool { return err != nil }),
 		},
-		{
-			name: "backwards compatibility - nil Type defaults to IP behavior",
-			route: HTTPRoute("nil-type-route",
-				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("nil-type-gateway", RefInNamespace("test-ns"))),
-			),
-			gateway: Gateway("nil-type-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListener(gatewayapi.HTTPProtocolType),
-				WithAddresses("203.0.113.1", "192.168.1.10"),
-			),
-			expectedURLs: []string{
-				"http://192.168.1.10/",
-				"http://203.0.113.1/",
-			},
-		},
-		{
-			name: "no addresses at all - ExternalAddressNotFoundError",
-			route: HTTPRoute("no-addresses-route",
-				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("no-addresses-gateway", RefInNamespace("test-ns"))),
-			),
-			gateway: Gateway("no-addresses-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListener(gatewayapi.HTTPProtocolType),
-			),
-			expectedErrorCheck: llmisvc.IsExternalAddressNotFound,
-		},
+
+		// ===== Port handling =====
 		{
 			name: "custom port handling - non-standard HTTP port",
 			route: HTTPRoute("custom-port-route",
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("custom-port-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("custom-port-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListeners(gatewayapi.Listener{
-					Protocol: gatewayapi.HTTPProtocolType,
-					Port:     8080,
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://203.0.113.1:8080/"},
+			gateways: []*gatewayapi.Gateway{
+				Gateway("custom-port-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(gatewayapi.Listener{
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     8080,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://203.0.113.1:8080/"),
 		},
 		{
 			name: "custom port handling - non-standard HTTPS port",
@@ -373,15 +395,17 @@ func TestDiscoverURLs(t *testing.T) {
 				WithParentRef(GatewayRef("custom-https-port-gateway", RefInNamespace("test-ns"))),
 				WithHostnames("secure.example.com"),
 			),
-			gateway: Gateway("custom-https-port-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListeners(gatewayapi.Listener{
-					Protocol: gatewayapi.HTTPSProtocolType,
-					Port:     8443,
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"https://secure.example.com:8443/"},
+			gateways: []*gatewayapi.Gateway{
+				Gateway("custom-https-port-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(gatewayapi.Listener{
+						Protocol: gatewayapi.HTTPSProtocolType,
+						Port:     8443,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("https://secure.example.com:8443/"),
 		},
 		{
 			name: "standard ports omitted - HTTP port 80",
@@ -389,206 +413,241 @@ func TestDiscoverURLs(t *testing.T) {
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("standard-http-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("standard-http-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListeners(gatewayapi.Listener{
-					Protocol: gatewayapi.HTTPProtocolType,
-					Port:     80,
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://203.0.113.1/"},
+			gateways: []*gatewayapi.Gateway{
+				Gateway("standard-http-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(gatewayapi.Listener{
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     80,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://203.0.113.1/"),
 		},
 		{
 			name: "standard ports omitted - HTTPS port 443",
 			route: HTTPRoute("standard-https-route",
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("standard-https-gateway", RefInNamespace("test-ns"))),
-				WithHostnames("secure.example.com"),
 			),
-			gateway: Gateway("standard-https-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListeners(gatewayapi.Listener{
-					Protocol: gatewayapi.HTTPSProtocolType,
-					Port:     443,
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"https://secure.example.com/"},
+			gateways: []*gatewayapi.Gateway{
+				Gateway("standard-https-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(gatewayapi.Listener{
+						Protocol: gatewayapi.HTTPSProtocolType,
+						Port:     443,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("https://203.0.113.1/"),
 		},
+
+		// ===== sectionName listener selection =====
 		{
-			name: "sectionName selects specific listener",
-			route: HTTPRoute("section-route",
+			name: "sectionName isolates to specific listener - no leakage from other listeners",
+			route: HTTPRoute("test-route",
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
 				WithParentRef(gatewayapi.ParentReference{
 					Name:        "multi-listener-gateway",
-					Namespace:   ptr.To(gatewayapi.Namespace("test-ns")),
-					SectionName: ptr.To(gatewayapi.SectionName("https-listener")),
+					Namespace:   ptr.To(gatewayapi.Namespace("gw-ns")),
+					SectionName: ptr.To(gatewayapi.SectionName("http")),
 					Group:       ptr.To(gatewayapi.Group("gateway.networking.k8s.io")),
 					Kind:        ptr.To(gatewayapi.Kind("Gateway")),
 				}),
-				WithHostnames("secure.example.com"),
 			),
-			gateway: Gateway("multi-listener-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListeners(
-					gatewayapi.Listener{
-						Name:     "http-listener",
-						Protocol: gatewayapi.HTTPProtocolType,
-						Port:     80,
-					},
-					gatewayapi.Listener{
-						Name:     "https-listener",
-						Protocol: gatewayapi.HTTPSProtocolType,
-						Port:     443,
-					},
+			gateways: []*gatewayapi.Gateway{
+				Gateway("multi-listener-gateway",
+					InNamespace[*gatewayapi.Gateway]("gw-ns"),
+					WithListeners(
+						gatewayapi.Listener{
+							Name:     "http",
+							Protocol: gatewayapi.HTTPProtocolType,
+							Port:     80,
+							Hostname: ptr.To(gatewayapi.Hostname("http.example.com")),
+						},
+						gatewayapi.Listener{
+							Name:     "https",
+							Protocol: gatewayapi.HTTPSProtocolType,
+							Port:     443,
+							Hostname: ptr.To(gatewayapi.Hostname("https.example.com")),
+						},
+						gatewayapi.Listener{
+							Name:     "internal",
+							Protocol: gatewayapi.HTTPProtocolType,
+							Port:     8080,
+							Hostname: ptr.To(gatewayapi.Hostname("internal.example.com")),
+						},
+					),
+					WithAddresses("203.0.113.1"),
 				),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"https://secure.example.com/"},
+			},
+			assert: func(g Gomega, urls []string, err error) {
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(urls).To(Equal([]string{"http://http.example.com/"}))
+				g.Expect(urls).ToNot(ContainElement(ContainSubstring("https.example.com")))
+				g.Expect(urls).ToNot(ContainElement(ContainSubstring("internal.example.com")))
+			},
 		},
+
+		// ===== Comprehensive URL generation =====
 		{
 			name: "multiple hostnames and addresses - comprehensive URL generation",
 			route: HTTPRoute("comprehensive-route",
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("comprehensive-gateway", RefInNamespace("test-ns"))),
-				WithHostnames("api.example.com", "backup.example.com", "primary.example.com"),
+				WithHostnames("api.example.com", "v2.example.com"),
 			),
-			gateway: Gateway("comprehensive-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListener(gatewayapi.HTTPProtocolType),
-				WithAddresses("203.0.113.1", "198.51.100.1"),
-			),
-			expectedURLs: []string{
-				"http://api.example.com/",
-				"http://backup.example.com/",
-				"http://primary.example.com/",
+			gateways: []*gatewayapi.Gateway{
+				Gateway("comprehensive-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListener(gatewayapi.HTTPProtocolType),
+					WithAddresses("203.0.113.1", "203.0.113.2"),
+				),
 			},
+			assert: expectURLs("http://api.example.com/", "http://v2.example.com/"),
 		},
+
+		// ===== Listener hostname fallback =====
 		{
 			name: "listener hostname fallback - no route hostnames",
 			route: HTTPRoute("listener-hostname-route",
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("listener-hostname-gateway", RefInNamespace("test-ns"))),
-				// No hostnames specified in route
 			),
-			gateway: Gateway("listener-hostname-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListeners(gatewayapi.Listener{
-					Protocol: gatewayapi.HTTPProtocolType,
-					Port:     80,
-					Hostname: ptr.To(gatewayapi.Hostname("listener.example.com")),
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://listener.example.com/"},
+			gateways: []*gatewayapi.Gateway{
+				Gateway("listener-hostname-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(gatewayapi.Listener{
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     80,
+						Hostname: ptr.To(gatewayapi.Hostname("listener.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://listener.example.com/"),
 		},
 		{
 			name: "listener hostname fallback - route has wildcard hostname",
-			route: HTTPRoute("listener-hostname-wildcard-route",
-				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("listener-hostname-wildcard-gateway", RefInNamespace("test-ns"))),
-				WithHostnames("*"), // Wildcard should be filtered out
-			),
-			gateway: Gateway("listener-hostname-wildcard-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListeners(gatewayapi.Listener{
-					Protocol: gatewayapi.HTTPProtocolType,
-					Port:     80,
-					Hostname: ptr.To(gatewayapi.Hostname("fallback.example.com")),
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://fallback.example.com/"},
-		},
-		{
-			name: "listener hostname fallback - route hostname takes precedence",
-			route: HTTPRoute("route-hostname-precedence",
-				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("route-hostname-precedence-gateway", RefInNamespace("test-ns"))),
-				WithHostnames("route.example.com"),
-			),
-			gateway: Gateway("route-hostname-precedence-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListeners(gatewayapi.Listener{
-					Protocol: gatewayapi.HTTPProtocolType,
-					Port:     80,
-					Hostname: ptr.To(gatewayapi.Hostname("listener.example.com")),
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://route.example.com/"}, // Route hostname should be used, not listener
-		},
-		{
-			name: "listener hostname fallback - empty listener hostname uses addresses",
-			route: HTTPRoute("empty-listener-hostname-route",
-				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("empty-listener-hostname-gateway", RefInNamespace("test-ns"))),
-				// No hostnames specified in route
-			),
-			gateway: Gateway("empty-listener-hostname-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListeners(gatewayapi.Listener{
-					Protocol: gatewayapi.HTTPProtocolType,
-					Port:     80,
-					Hostname: ptr.To(gatewayapi.Hostname("")), // Empty hostname
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://203.0.113.1/"}, // Should fall back to addresses
-		},
-		{
-			name: "listener wildcard hostname - basic wildcard expansion",
 			route: HTTPRoute("wildcard-listener-route",
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("wildcard-listener-gateway", RefInNamespace("test-ns"))),
-				// No hostnames specified in route
+				WithHostnames("*"),
 			),
-			gateway: Gateway("wildcard-listener-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListeners(gatewayapi.Listener{
-					Protocol: gatewayapi.HTTPProtocolType,
-					Port:     80,
-					Hostname: ptr.To(gatewayapi.Hostname("*.example.com")),
-				}),
-				WithAddresses("203.0.113.1"),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("wildcard-listener-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(gatewayapi.Listener{
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     80,
+						Hostname: ptr.To(gatewayapi.Hostname("listener.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://listener.example.com/"),
+		},
+		{
+			name: "listener hostname fallback - route hostname takes precedence",
+			route: HTTPRoute("precedence-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("precedence-gateway", RefInNamespace("test-ns"))),
+				WithHostnames("route.example.com"),
 			),
-			expectedURLs: []string{"http://inference.example.com/"}, // Should expand wildcard to inference.example.com
+			gateways: []*gatewayapi.Gateway{
+				Gateway("precedence-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(gatewayapi.Listener{
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     80,
+						Hostname: ptr.To(gatewayapi.Hostname("listener.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://route.example.com/"),
+		},
+		{
+			name: "listener hostname fallback - empty listener hostname uses addresses",
+			route: HTTPRoute("empty-listener-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("empty-listener-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("empty-listener-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(gatewayapi.Listener{
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     80,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://203.0.113.1/"),
+		},
+
+		// ===== Listener wildcard hostname =====
+		{
+			name: "listener wildcard hostname - basic wildcard expansion",
+			route: HTTPRoute("wildcard-expansion-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("wildcard-expansion-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("wildcard-expansion-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(gatewayapi.Listener{
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     80,
+						Hostname: ptr.To(gatewayapi.Hostname("*.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			// Wildcards are expanded to inference.example.com
+			assert: expectURLs("http://inference.example.com/"),
 		},
 		{
 			name: "listener wildcard hostname - wildcard with subdomain",
-			route: HTTPRoute("wildcard-subdomain-route",
+			route: HTTPRoute("subdomain-wildcard-route",
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("wildcard-subdomain-gateway", RefInNamespace("test-ns"))),
+				WithParentRef(GatewayRef("subdomain-wildcard-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("wildcard-subdomain-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListeners(gatewayapi.Listener{
-					Protocol: gatewayapi.HTTPProtocolType,
-					Port:     80,
-					Hostname: ptr.To(gatewayapi.Hostname("*.api.example.com")),
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://inference.api.example.com/"}, // Should expand to inference.api.example.com
+			gateways: []*gatewayapi.Gateway{
+				Gateway("subdomain-wildcard-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(gatewayapi.Listener{
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     80,
+						Hostname: ptr.To(gatewayapi.Hostname("*.api.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			// Wildcards are expanded to inference.api.example.com
+			assert: expectURLs("http://inference.api.example.com/"),
 		},
 		{
 			name: "listener wildcard hostname - route hostname takes precedence over wildcard",
-			route: HTTPRoute("route-over-wildcard-route",
+			route: HTTPRoute("wildcard-precedence-route",
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
-				WithParentRef(GatewayRef("route-over-wildcard-gateway", RefInNamespace("test-ns"))),
-				WithHostnames("custom.example.com"),
+				WithParentRef(GatewayRef("wildcard-precedence-gateway", RefInNamespace("test-ns"))),
+				WithHostnames("specific.example.com"),
 			),
-			gateway: Gateway("route-over-wildcard-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListeners(gatewayapi.Listener{
-					Protocol: gatewayapi.HTTPProtocolType,
-					Port:     80,
-					Hostname: ptr.To(gatewayapi.Hostname("*.example.com")),
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"http://custom.example.com/"}, // Route hostname should take precedence
+			gateways: []*gatewayapi.Gateway{
+				Gateway("wildcard-precedence-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(gatewayapi.Listener{
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     80,
+						Hostname: ptr.To(gatewayapi.Hostname("*.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("http://specific.example.com/"),
 		},
 		{
 			name: "listener wildcard hostname - HTTPS with wildcard",
@@ -596,16 +655,19 @@ func TestDiscoverURLs(t *testing.T) {
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("https-wildcard-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("https-wildcard-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListeners(gatewayapi.Listener{
-					Protocol: gatewayapi.HTTPSProtocolType,
-					Port:     443,
-					Hostname: ptr.To(gatewayapi.Hostname("*.secure.example.com")),
-				}),
-				WithAddresses("203.0.113.1"),
-			),
-			expectedURLs: []string{"https://inference.secure.example.com/"},
+			gateways: []*gatewayapi.Gateway{
+				Gateway("https-wildcard-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(gatewayapi.Listener{
+						Protocol: gatewayapi.HTTPSProtocolType,
+						Port:     443,
+						Hostname: ptr.To(gatewayapi.Hostname("*.secure.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			// HTTPS with wildcard expanded to inference.secure.example.com
+			assert: expectURLs("https://inference.secure.example.com/"),
 		},
 		{
 			name: "listener wildcard hostname - custom port with wildcard",
@@ -613,37 +675,489 @@ func TestDiscoverURLs(t *testing.T) {
 				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
 				WithParentRef(GatewayRef("custom-port-wildcard-gateway", RefInNamespace("test-ns"))),
 			),
-			gateway: Gateway("custom-port-wildcard-gateway",
-				InNamespace[*gatewayapi.Gateway]("test-ns"),
-				WithListeners(gatewayapi.Listener{
-					Protocol: gatewayapi.HTTPProtocolType,
-					Port:     8080,
-					Hostname: ptr.To(gatewayapi.Hostname("*.apps.example.com")),
-				}),
-				WithAddresses("203.0.113.1"),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("custom-port-wildcard-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(gatewayapi.Listener{
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     8080,
+						Hostname: ptr.To(gatewayapi.Hostname("*.example.com")),
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			// Custom port with wildcard expanded
+			assert: expectURLs("http://inference.example.com:8080/"),
+		},
+
+		// ===== preferredUrlScheme =====
+		{
+			name: "preferredUrlScheme=https prioritizes HTTPS listener",
+			route: HTTPRoute("test-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
 			),
-			expectedURLs: []string{"http://inference.apps.example.com:8080/"},
+			gateways: []*gatewayapi.Gateway{
+				Gateway("test-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(
+						gatewayapi.Listener{
+							Name:     "http-listener",
+							Protocol: gatewayapi.HTTPProtocolType,
+							Port:     80,
+						},
+						gatewayapi.Listener{
+							Name:     "https-listener",
+							Protocol: gatewayapi.HTTPSProtocolType,
+							Port:     443,
+						},
+					),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			preferredUrlScheme: "https",
+			assert:             expectURLs("https://203.0.113.1/", "http://203.0.113.1/"),
+		},
+		{
+			name: "preferredUrlScheme=http prioritizes HTTP listener",
+			route: HTTPRoute("test-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("test-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(
+						gatewayapi.Listener{
+							Name:     "http-listener",
+							Protocol: gatewayapi.HTTPProtocolType,
+							Port:     80,
+						},
+						gatewayapi.Listener{
+							Name:     "https-listener",
+							Protocol: gatewayapi.HTTPSProtocolType,
+							Port:     443,
+						},
+					),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			preferredUrlScheme: "http",
+			assert:             expectURLs("http://203.0.113.1/", "https://203.0.113.1/"),
+		},
+		{
+			name: "preferredUrlScheme mismatch falls back to available listener",
+			route: HTTPRoute("test-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("test-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(gatewayapi.Listener{
+						Name:     "http-listener",
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     80,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			preferredUrlScheme: "https",
+			assert:             expectURLs("http://203.0.113.1/"),
+		},
+		{
+			name: "preferredUrlScheme matching listener preserves non-standard port",
+			route: HTTPRoute("test-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("test-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(gatewayapi.Listener{
+						Name:     "https-listener",
+						Protocol: gatewayapi.HTTPSProtocolType,
+						Port:     8443,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			preferredUrlScheme: "https",
+			assert:             expectURLs("https://203.0.113.1:8443/"),
+		},
+		{
+			name: "empty preferredUrlScheme returns ALL listeners (HTTPS first)",
+			route: HTTPRoute("test-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("test-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(
+						gatewayapi.Listener{
+							Name:     "http-listener",
+							Protocol: gatewayapi.HTTPProtocolType,
+							Port:     80,
+						},
+						gatewayapi.Listener{
+							Name:     "https-listener",
+							Protocol: gatewayapi.HTTPSProtocolType,
+							Port:     443,
+						},
+					),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			preferredUrlScheme: "",
+			assert:             expectURLs("https://203.0.113.1/", "http://203.0.113.1/"),
+		},
+		{
+			name: "empty preferredUrlScheme falls back to HTTP if no HTTPS",
+			route: HTTPRoute("test-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("test-gateway", RefInNamespace("test-ns"))),
+			),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("test-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(gatewayapi.Listener{
+						Name:     "http-listener",
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     8080,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			preferredUrlScheme: "",
+			assert:             expectURLs("http://203.0.113.1:8080/"),
+		},
+		{
+			name: "sectionName takes precedence over preferredUrlScheme",
+			route: HTTPRoute("test-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(gatewayapi.ParentReference{
+					Name:        "test-gateway",
+					Namespace:   ptr.To(gatewayapi.Namespace("test-ns")),
+					SectionName: ptr.To(gatewayapi.SectionName("http-listener")),
+					Group:       ptr.To(gatewayapi.Group("gateway.networking.k8s.io")),
+					Kind:        ptr.To(gatewayapi.Kind("Gateway")),
+				}),
+			),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("test-gateway",
+					InNamespace[*gatewayapi.Gateway]("test-ns"),
+					WithListeners(
+						gatewayapi.Listener{
+							Name:     "http-listener",
+							Protocol: gatewayapi.HTTPProtocolType,
+							Port:     80,
+						},
+						gatewayapi.Listener{
+							Name:     "https-listener",
+							Protocol: gatewayapi.HTTPSProtocolType,
+							Port:     443,
+						},
+					),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			preferredUrlScheme: "https", // ignored because sectionName is set
+			assert:             expectURLs("http://203.0.113.1/"),
+		},
+		{
+			name: "gateway with multiple HTTP-capable listeners - all listeners advertised",
+			route: HTTPRoute("test-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("multi-listener-gateway", RefInNamespace("gw-ns"))),
+			),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("multi-listener-gateway",
+					InNamespace[*gatewayapi.Gateway]("gw-ns"),
+					WithListeners(
+						gatewayapi.Listener{
+							Name:     "http",
+							Protocol: gatewayapi.HTTPProtocolType,
+							Port:     80,
+							Hostname: ptr.To(gatewayapi.Hostname("api.example.com")),
+						},
+						gatewayapi.Listener{
+							Name:     "https",
+							Protocol: gatewayapi.HTTPSProtocolType,
+							Port:     443,
+							Hostname: ptr.To(gatewayapi.Hostname("api.example.com")),
+						},
+					),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			assert: expectURLs("https://api.example.com/", "http://api.example.com/"),
+		},
+
+		// ===== Internal service discovery =====
+		{
+			name: "discovers internal URL via gateway label",
+			route: HTTPRoute("test-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("my-gateway", RefInNamespace("gateway-ns"))),
+			),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("my-gateway",
+					InNamespace[*gatewayapi.Gateway]("gateway-ns"),
+					WithListeners(gatewayapi.Listener{
+						Name:     "http",
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     80,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-service",
+						Namespace: "gateway-ns",
+						Labels: map[string]string{
+							"gateway.networking.k8s.io/gateway-name": "my-gateway",
+						},
+					},
+				},
+			},
+			assert: expectURLs(
+				"http://203.0.113.1/",
+				"http://gateway-service.gateway-ns.svc.cluster.local/",
+			),
+		},
+		{
+			name: "discovers internal URL via same-name service fallback",
+			route: HTTPRoute("test-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("my-gateway", RefInNamespace("gateway-ns"))),
+			),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("my-gateway",
+					InNamespace[*gatewayapi.Gateway]("gateway-ns"),
+					WithListeners(gatewayapi.Listener{
+						Name:     "http",
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     80,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-gateway", // Same name as gateway
+						Namespace: "gateway-ns",
+					},
+				},
+			},
+			assert: expectURLs(
+				"http://203.0.113.1/",
+				"http://my-gateway.gateway-ns.svc.cluster.local/",
+			),
+		},
+		{
+			name: "internal URL includes non-standard port",
+			route: HTTPRoute("test-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("my-gateway", RefInNamespace("gateway-ns"))),
+			),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("my-gateway",
+					InNamespace[*gatewayapi.Gateway]("gateway-ns"),
+					WithListeners(gatewayapi.Listener{
+						Name:     "http-alt",
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     8080,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-service",
+						Namespace: "gateway-ns",
+						Labels: map[string]string{
+							"gateway.networking.k8s.io/gateway-name": "my-gateway",
+						},
+					},
+				},
+			},
+			assert: expectURLs(
+				"http://203.0.113.1:8080/",
+				"http://gateway-service.gateway-ns.svc.cluster.local:8080/",
+			),
+		},
+		{
+			name: "internal URL uses same scheme as gateway listener",
+			route: HTTPRoute("test-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("my-gateway", RefInNamespace("gateway-ns"))),
+			),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("my-gateway",
+					InNamespace[*gatewayapi.Gateway]("gateway-ns"),
+					WithListeners(gatewayapi.Listener{
+						Name:     "https",
+						Protocol: gatewayapi.HTTPSProtocolType,
+						Port:     443,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-service",
+						Namespace: "gateway-ns",
+						Labels: map[string]string{
+							"gateway.networking.k8s.io/gateway-name": "my-gateway",
+						},
+					},
+				},
+			},
+			// Internal URL matches the listener's scheme and port
+			assert: expectURLs(
+				"https://203.0.113.1/",
+				"https://gateway-service.gateway-ns.svc.cluster.local/",
+			),
+		},
+		{
+			name: "no internal URL without backing service",
+			route: HTTPRoute("test-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("my-gateway", RefInNamespace("gateway-ns"))),
+			),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("my-gateway",
+					InNamespace[*gatewayapi.Gateway]("gateway-ns"),
+					WithListeners(gatewayapi.Listener{
+						Name:     "http",
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     80,
+					}),
+					WithAddresses("203.0.113.1"),
+				),
+			},
+			services: nil,
+			assert:   expectURLs("http://203.0.113.1/"),
+		},
+		{
+			name: "no external addresses but backing service exists - returns internal URL only",
+			route: HTTPRoute("test-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRef(GatewayRef("my-gateway", RefInNamespace("gateway-ns"))),
+			),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("my-gateway",
+					InNamespace[*gatewayapi.Gateway]("gateway-ns"),
+					WithListeners(gatewayapi.Listener{
+						Name:     "http",
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     8080,
+					}),
+					// No addresses - LoadBalancer pending
+				),
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-service",
+						Namespace: "gateway-ns",
+						Labels: map[string]string{
+							"gateway.networking.k8s.io/gateway-name": "my-gateway",
+						},
+					},
+				},
+			},
+			assert: expectURLs("http://gateway-service.gateway-ns.svc.cluster.local:8080/"),
+		},
+		{
+			name: "multiple gateways with backing services - each gets internal URL",
+			route: HTTPRoute("test-route",
+				InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+				WithParentRefs(
+					gatewayapi.ParentReference{
+						Name:      "gateway-a",
+						Namespace: ptr.To(gatewayapi.Namespace("gw-ns")),
+						Group:     ptr.To(gatewayapi.Group("gateway.networking.k8s.io")),
+						Kind:      ptr.To(gatewayapi.Kind("Gateway")),
+					},
+					gatewayapi.ParentReference{
+						Name:      "gateway-b",
+						Namespace: ptr.To(gatewayapi.Namespace("gw-ns")),
+						Group:     ptr.To(gatewayapi.Group("gateway.networking.k8s.io")),
+						Kind:      ptr.To(gatewayapi.Kind("Gateway")),
+					},
+				),
+			),
+			gateways: []*gatewayapi.Gateway{
+				Gateway("gateway-a",
+					InNamespace[*gatewayapi.Gateway]("gw-ns"),
+					WithListeners(gatewayapi.Listener{
+						Name:     "https",
+						Protocol: gatewayapi.HTTPSProtocolType,
+						Port:     443,
+					}),
+					WithAddresses("gw-a.example.com"),
+				),
+				Gateway("gateway-b",
+					InNamespace[*gatewayapi.Gateway]("gw-ns"),
+					WithListeners(gatewayapi.Listener{
+						Name:     "http",
+						Protocol: gatewayapi.HTTPProtocolType,
+						Port:     80,
+					}),
+					WithAddresses("gw-b.example.com"),
+				),
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-a",
+						Namespace: "gw-ns",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-b-svc",
+						Namespace: "gw-ns",
+						Labels: map[string]string{
+							"gateway.networking.k8s.io/gateway-name": "gateway-b",
+						},
+					},
+				},
+			},
+			assert: expectURLsContain(
+				"https://gw-a.example.com/",
+				"https://gateway-a.gw-ns.svc.cluster.local/",
+				"http://gw-b.example.com/",
+				"http://gateway-b-svc.gw-ns.svc.cluster.local/",
+			),
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			g := NewGomegaWithT(t)
+			g := NewWithT(t)
 			ctx := t.Context()
 
 			scheme := runtime.NewScheme()
-			err := gatewayapi.Install(scheme)
-			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(gatewayapi.Install(scheme)).To(Succeed())
+			g.Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
 			var objects []client.Object
-			if tt.gateway != nil {
-				objects = append(objects, tt.gateway)
-			}
 			if tt.route != nil {
 				objects = append(objects, tt.route)
 			}
-			for _, gw := range tt.additionalGateways {
+			for _, gw := range tt.gateways {
 				objects = append(objects, gw)
+			}
+			for _, svc := range tt.services {
+				objects = append(objects, svc)
 			}
 			objects = append(objects, DefaultGatewayClass())
 
@@ -652,23 +1166,14 @@ func TestDiscoverURLs(t *testing.T) {
 				WithObjects(objects...).
 				Build()
 
-			urls, err := llmisvc.DiscoverURLs(ctx, fakeClient, tt.route)
+			urls, err := llmisvc.DiscoverURLs(ctx, fakeClient, tt.route, tt.preferredUrlScheme)
 
-			if tt.expectedErrorCheck != nil {
-				g.Expect(err).To(HaveOccurred())
-				g.Expect(tt.expectedErrorCheck(err)).To(BeTrue(), "Error check function failed for error: %v", err)
-			} else {
-				g.Expect(err).ToNot(HaveOccurred())
-				g.Expect(urls).To(HaveLen(len(tt.expectedURLs)))
-
-				// Convert to strings for easier comparison
-				var actualURLs []string
-				for _, url := range urls {
-					actualURLs = append(actualURLs, url.String())
-				}
-
-				g.Expect(actualURLs).To(Equal(tt.expectedURLs))
+			var actualURLs []string
+			for _, url := range urls {
+				actualURLs = append(actualURLs, url.String())
 			}
+
+			tt.assert(g, actualURLs, err)
 		})
 	}
 }
@@ -935,6 +1440,56 @@ func TestFilterURLs(t *testing.T) {
 			isExternal := llmisvc.IsExternalURL(url)
 
 			g.Expect(isInternal).To(Equal(!isExternal), "URL %s should be either internal or external, not both", urlStr)
+		}
+	})
+
+	t.Run("AddressTypeName", func(t *testing.T) {
+		tests := []struct {
+			name     string
+			url      string
+			expected string
+		}{
+			{
+				name:     "external hostname",
+				url:      "https://api.example.com/",
+				expected: "gateway-external",
+			},
+			{
+				name:     "external IP",
+				url:      "http://203.0.113.1/",
+				expected: "gateway-external",
+			},
+			{
+				name:     "private IP",
+				url:      "http://192.168.1.100/",
+				expected: "internal",
+			},
+			{
+				name:     "localhost",
+				url:      "http://localhost/",
+				expected: "internal",
+			},
+			{
+				name:     "cluster-local service",
+				url:      "http://my-service.default.svc.cluster.local/",
+				expected: "gateway-internal",
+			},
+			{
+				name:     "cluster-local with port",
+				url:      "http://gateway.ns.svc.cluster.local:8080/",
+				expected: "gateway-internal",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				g := NewGomegaWithT(t)
+				parsedURL, err := apis.ParseURL(tt.url)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				result := llmisvc.AddressTypeName(parsedURL)
+				g.Expect(result).To(Equal(tt.expected))
+			})
 		}
 	})
 }

--- a/pkg/controller/llmisvc/router_validation.go
+++ b/pkg/controller/llmisvc/router_validation.go
@@ -117,7 +117,7 @@ func (r *LLMInferenceServiceReconciler) validateGatewayReferences(ctx context.Co
 	logger := log.FromContext(ctx).WithName("validateGatewayReferences")
 
 	// If no router or gateway configuration, skip validation
-	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Gateway == nil || !llmSvc.Spec.Router.Gateway.HasRefs() {
+	if llmSvc.Spec.Router == nil || !llmSvc.Spec.Router.Gateway.HasRefs() {
 		return nil
 	}
 


### PR DESCRIPTION
Extends URL discovery to advertise all available endpoints from Gateway listeners.

Previously, discovery only returned a single external URL and did not take into account preferred scheme that KServe has in the ingress config.

Key improvements:
- Auto-discovers cluster-local URLs from Gateway backing services,
- Advertises all HTTP-capable listeners sorted by preference (HTTPS first)
- Distinguishes URL types: `gateway-external` for public IPs, `gateway-internal` for cluster-local service DNS

Errors only when no URLs can be discovered at all (neither external nor internal), making the system more tolerant of temporary infrastructure states.

Most of the changes went into cleaning up the tests and providing edge cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added URL scheme configuration support for enhanced routing customization.
  * Introduced hybrid URL discovery to identify both external gateway addresses and internal backing services.
  * Added support for cluster-local URL identification and classification.

* **Bug Fixes**
  * Improved error messaging for URL discovery failures, replacing generic "external address not found" with more descriptive "no URLs discovered" messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->