### PR TITLE
Add zmq port to scheduler service for precise prefix cache routing

### DIFF
--- a/config/llmisvc/config-llm-scheduler.yaml
+++ b/config/llmisvc/config-llm-scheduler.yaml
@@ -27,6 +27,9 @@ spec:
               - containerPort: 9090
                 name: metrics
                 protocol: TCP
+              - containerPort: 5557
+                name: zmq
+                protocol: TCP
             image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.2.0
             imagePullPolicy: IfNotPresent
             livenessProbe:

--- a/pkg/controller/llmisvc/controller_int_test.go
+++ b/pkg/controller/llmisvc/controller_int_test.go
@@ -287,6 +287,26 @@ var _ = Describe("LLMInferenceService Controller", func() {
 					return envTest.Client.Get(ctx, client.ObjectKey{Name: svcName + "-inference-pool", Namespace: llmSvc.GetNamespace()}, &ip)
 				}).WithContext(ctx).Should(Succeed())
 
+				// Verify the scheduler service (EPP service) has the expected ports including zmq
+				Eventually(func(g Gomega, ctx context.Context) error {
+					eppSvc := &corev1.Service{}
+					g.Expect(envTest.Client.Get(ctx, client.ObjectKey{Name: svcName + "-epp-service", Namespace: llmSvc.GetNamespace()}, eppSvc)).To(Succeed())
+
+					// Verify all expected ports are present (grpc, grpc-health, metrics, zmq)
+					portNames := make(map[string]int32)
+					for _, port := range eppSvc.Spec.Ports {
+						portNames[port.Name] = port.Port
+					}
+
+					g.Expect(portNames).To(HaveKeyWithValue("grpc", int32(9002)))
+					g.Expect(portNames).To(HaveKeyWithValue("grpc-health", int32(9003)))
+					g.Expect(portNames).To(HaveKeyWithValue("metrics", int32(9090)))
+					g.Expect(portNames).To(HaveKeyWithValue("zmq", int32(5557)))
+					g.Expect(eppSvc.Spec.Ports).To(HaveLen(4))
+
+					return nil
+				}).WithContext(ctx).Should(Succeed())
+
 				Eventually(LLMInferenceServiceIsReady(llmSvc, func(g Gomega, current *v1alpha1.LLMInferenceService) {
 					g.Expect(current.Status).To(HaveCondition(string(v1alpha1.HTTPRoutesReady), "True"))
 					g.Expect(current.Status).To(HaveCondition(string(v1alpha1.InferencePoolReady), "True"))

--- a/pkg/controller/llmisvc/sample.go
+++ b/pkg/controller/llmisvc/sample.go
@@ -198,6 +198,11 @@ func LLMInferenceServiceSample() *v1alpha1.LLMInferenceService {
 										Name:          "grpc-health",
 										Protocol:      corev1.ProtocolTCP,
 									},
+									{
+										ContainerPort: 5557,
+										Name:          "zmq",
+										Protocol:      corev1.ProtocolTCP,
+									},
 								},
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{

--- a/pkg/controller/llmisvc/scheduler.go
+++ b/pkg/controller/llmisvc/scheduler.go
@@ -205,7 +205,7 @@ func (r *LLMInferenceServiceReconciler) expectedSchedulerService(ctx context.Con
 	if llmSvc.Spec.Router != nil && llmSvc.Spec.Router.Scheduler != nil && llmSvc.Spec.Router.Scheduler.Template != nil {
 		podSpec := llmSvc.Spec.Router.Scheduler.Template.DeepCopy()
 
-		desiredPorts := sets.New("grpc", "grpc-health", "metrics")
+		desiredPorts := sets.New("grpc", "grpc-health", "metrics", "zmq")
 
 		actualPorts := make(map[string]*corev1.ContainerPort)
 		for _, container := range podSpec.Containers {


### PR DESCRIPTION
Add 5557 as the (default) port for the zmq enpoint for kv-events.