### PR TITLE
Update precise prefix routing example

### DIFF
--- a/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-qwen2-7b-gpu-kv-cache-routing.yaml
+++ b/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-qwen2-7b-gpu-kv-cache-routing.yaml
@@ -45,9 +45,10 @@ spec:
                 kind: EndpointPickerConfig
                 plugins:
                 - type: single-profile-handler
-                - type: prefix-cache-scorer
+                - type: precise-prefix-cache-scorer
                   parameters:
-                    mode: cache_tracking  # Real-time KV cache tracking via ZMQ events
+                    kvEventsConfig:
+                      zmqEndpoint: "tcp://*:5557"
                     indexerConfig:
                       tokenProcessorConfig:
                         blockSize: 64       # Must match vLLM --block-size (default is 16)


### PR DESCRIPTION
`mode: cache_tracking` has been removed in favor of top-level plugin `precise-prefix-cache-scorer`.