### PR TITLE
[RHOAIENG-41816] fix: watch pod init container status changes

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/cache_config.go
+++ b/pkg/controller/v1beta1/inferenceservice/cache_config.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inferenceservice
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+func NewCacheOptions() (cache.Options, error) {
+	// Build a label selector that matches pods with the InferenceService label (any value).
+	isvcPodLabelReq, err := labels.NewRequirement(constants.InferenceServicePodLabelKey, selection.Exists, nil)
+	if err != nil {
+		return cache.Options{}, err
+	}
+	isvcPodLabelSelector := labels.NewSelector().Add(*isvcPodLabelReq)
+
+	return cache.Options{
+		ByObject: map[client.Object]cache.ByObject{
+			&corev1.Pod{}: {
+				Label: isvcPodLabelSelector,
+			},
+		},
+	}, nil
+}
+
+func NewCacheOptionsWithLLMSvc(llmSvcLabelSelector labels.Selector, caSecretNamespace, caSecretName string) (cache.Options, error) {
+	// Start with base ISVC pod watch cache
+	opts, err := NewCacheOptions()
+	if err != nil {
+		return cache.Options{}, err
+	}
+
+	// Add LLMInferenceService-specific secret cache
+	opts.ByObject[&corev1.Secret{}] = cache.ByObject{
+		Namespaces: map[string]cache.Config{
+			cache.AllNamespaces: {
+				LabelSelector: llmSvcLabelSelector,
+			},
+			caSecretNamespace: {
+				FieldSelector: fields.SelectorFromSet(map[string]string{
+					"metadata.name": caSecretName,
+				}),
+			},
+		},
+	}
+
+	return opts, nil
+}

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -233,7 +233,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	// Setup reconcilers
-	r.Log.Info("Reconciling inference service", "apiVersion", isvc.APIVersion, "isvc", isvc.Name)
+	r.Log.Info("Reconciling inference service", "apiVersion", isvc.APIVersion, "isvc", isvc.Name, "namespace", isvc.Namespace)
 
 	// Reconcile cabundleConfigMap
 	caBundleConfigMapReconciler := cabundleconfigmap.NewCaBundleConfigMapReconciler(r.Client, r.Clientset)
@@ -477,15 +477,90 @@ func (r *InferenceServiceReconciler) servingRuntimeFunc(ctx context.Context, obj
 //				continue
 //			}
 //		}
-//		requests = append(requests, reconcile.Request{
-//			NamespacedName: types.NamespacedName{
-//				Namespace: isvc.Namespace,
-//				Name:      isvc.Name,
-//			},
-//		})
+//		if isvc.Status.ClusterServingRuntimeName == clusterServingRuntimeObj.Name {
+//			requests = append(requests, reconcile.Request{
+//				NamespacedName: types.NamespacedName{
+//					Namespace: isvc.Namespace,
+//					Name:      isvc.Name,
+//				},
+//			})
+//		}
 //	}
 //	return requests
-//}
+// }
+
+func (r *InferenceServiceReconciler) podInitContainersFunc(ctx context.Context, obj client.Object) []reconcile.Request {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok || pod == nil {
+		return nil
+	}
+	// Lookup by PodTemplateSpec labels
+	if isvcName, found := pod.Labels[constants.InferenceServicePodLabelKey]; found && isvcName != "" {
+		return []reconcile.Request{
+			{
+				NamespacedName: types.NamespacedName{
+					Namespace: pod.Namespace,
+					Name:      isvcName, // Reconcile the InferenceService that manages this pod
+				},
+			},
+		}
+	}
+	// If label is missing, this pod is not managed by an InferenceService
+	return nil
+}
+
+// servingRuntimesPredicate returns a predicate that filters ServingRuntime updates
+// to only include those where the Spec has changed.
+func servingRuntimesPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldServingRuntime := e.ObjectOld.(*v1alpha1.ServingRuntime)
+			newServingRuntime := e.ObjectNew.(*v1alpha1.ServingRuntime)
+			return !reflect.DeepEqual(oldServingRuntime.Spec, newServingRuntime.Spec)
+		},
+		CreateFunc:  func(e event.CreateEvent) bool { return false },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+}
+
+// ODH: clusterServingRuntimesPredicate commented out because the watch is disabled in ODH
+// func clusterServingRuntimesPredicate() predicate.Funcs {
+// 	return predicate.Funcs{
+// 		UpdateFunc: func(e event.UpdateEvent) bool {
+// 			oldClusterServingRuntime := e.ObjectOld.(*v1alpha1.ClusterServingRuntime)
+// 			newClusterServingRuntime := e.ObjectNew.(*v1alpha1.ClusterServingRuntime)
+// 			return !reflect.DeepEqual(oldClusterServingRuntime.Spec, newClusterServingRuntime.Spec)
+// 		},
+// 		CreateFunc:  func(e event.CreateEvent) bool { return false },
+// 		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+// 		GenericFunc: func(e event.GenericEvent) bool { return false },
+// 	}
+// }
+
+// podInitContainersPredicate returns a predicate that filters pod updates to only
+// include those where InitContainerStatuses have changed for pods with the InferenceService label.
+func podInitContainersPredicate() predicate.Funcs {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			// Only process pods managed by InferenceServices
+			newPod, ok := e.ObjectNew.(*corev1.Pod)
+			if !ok || newPod == nil {
+				return false
+			}
+			// Check if pod has the InferenceService label
+			if isvcName, found := newPod.Labels[constants.InferenceServicePodLabelKey]; !found || isvcName == "" {
+				return false
+			}
+			// Only watch pod status changes, not spec changes
+			oldPod := e.ObjectOld.(*corev1.Pod)
+			return !equality.Semantic.DeepEqual(oldPod.Status.InitContainerStatuses, newPod.Status.InitContainerStatuses)
+		},
+		CreateFunc:  func(e event.CreateEvent) bool { return false },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+}
 
 func (r *InferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager, deployConfig *v1beta1.DeployConfig, ingressConfig *v1beta1.IngressConfig) error {
 	r.ClientConfig = mgr.GetConfig()
@@ -526,29 +601,6 @@ func (r *InferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager, deployCo
 	}); err != nil {
 		return err
 	}
-
-	servingRuntimesPredicate := predicate.Funcs{
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			oldServingRuntime := e.ObjectOld.(*v1alpha1.ServingRuntime)
-			newServingRuntime := e.ObjectNew.(*v1alpha1.ServingRuntime)
-			return !reflect.DeepEqual(oldServingRuntime.Spec, newServingRuntime.Spec)
-		},
-		CreateFunc:  func(e event.CreateEvent) bool { return false },
-		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
-		GenericFunc: func(e event.GenericEvent) bool { return false },
-	}
-
-	// TODO: Find a way to distinguish if the ServingRuntime is a ClusterServingRuntime or not
-	// clusterServingRuntimesPredicate := predicate.Funcs{
-	//	UpdateFunc: func(e event.UpdateEvent) bool {
-	//		oldClusterServingRuntime := e.ObjectOld.(*v1alpha1.ClusterServingRuntime)
-	//		newClusterServingRuntime := e.ObjectNew.(*v1alpha1.ClusterServingRuntime)
-	//		return !reflect.DeepEqual(oldClusterServingRuntime.Spec, newClusterServingRuntime.Spec)
-	//	},
-	//	CreateFunc:  func(e event.CreateEvent) bool { return false },
-	//	DeleteFunc:  func(e event.DeleteEvent) bool { return false },
-	//	GenericFunc: func(e event.GenericEvent) bool { return false },
-	// }
 
 	ctrlBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.InferenceService{}).
@@ -606,8 +658,9 @@ func (r *InferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager, deployCo
 		ctrlBuilder = ctrlBuilder.Owns(&netv1.Ingress{})
 	}
 
-	return ctrlBuilder.Watches(&v1alpha1.ServingRuntime{}, handler.EnqueueRequestsFromMapFunc(r.servingRuntimeFunc), builder.WithPredicates(servingRuntimesPredicate)).
-		// Watches(&v1alpha1.ClusterServingRuntime{}, handler.EnqueueRequestsFromMapFunc(r.clusterServingRuntimeFunc), builder.WithPredicates(clusterServingRuntimesPredicate)).
+	return ctrlBuilder.Watches(&v1alpha1.ServingRuntime{}, handler.EnqueueRequestsFromMapFunc(r.servingRuntimeFunc), builder.WithPredicates(servingRuntimesPredicate())).
+		// Watches(&v1alpha1.ClusterServingRuntime{}, handler.EnqueueRequestsFromMapFunc(r.clusterServingRuntimeFunc), builder.WithPredicates(clusterServingRuntimesPredicate())).
+		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(r.podInitContainersFunc), builder.WithPredicates(podInitContainersPredicate())).
 		Complete(r)
 }
 

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -4427,11 +4427,15 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			Expect(k8sClient.Create(context.TODO(), isvc)).NotTo(HaveOccurred())
 			defer k8sClient.Delete(context.TODO(), isvc)
 
+			revisionName := serviceName + "-predictor-" + namespace + "-00001"
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      serviceName + "-predictor-" + namespace + "-00001-deployment-76464ds2zpv",
+					Name:      revisionName + "-deployment-76464ds2zpv",
 					Namespace: namespace,
-					Labels:    map[string]string{"serving.knative.dev/revision": serviceName + "-predictor-" + namespace + "-00001"},
+					Labels: map[string]string{
+						constants.InferenceServicePodLabelKey: serviceName,
+						constants.RevisionLabel:               revisionName,
+					},
 				},
 				Spec: corev1.PodSpec{
 					InitContainers: []corev1.Container{

--- a/pkg/controller/v1beta1/inferenceservice/pod_watch_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/pod_watch_test.go
@@ -1,0 +1,926 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inferenceservice
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	knativeapis "knative.dev/pkg/apis"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+var _ = Describe("Pod InitContainers Watch", func() {
+	// Test the mapper function that maps pods to InferenceService reconcile requests
+	Describe("podInitContainersFunc", func() {
+		var reconciler *InferenceServiceReconciler
+
+		BeforeEach(func() {
+			// Note: Client is not needed for the podInitContainersFunc mapper
+			// as it only reads labels from the pod object passed directly
+			reconciler = &InferenceServiceReconciler{}
+		})
+
+		Context("when pod has the InferenceService label", func() {
+			It("should return a reconcile request for the owning InferenceService", func() {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+						Labels: map[string]string{
+							constants.InferenceServicePodLabelKey: "my-isvc",
+						},
+					},
+				}
+
+				requests := reconciler.podInitContainersFunc(context.Background(), pod)
+
+				Expect(requests).To(HaveLen(1))
+				Expect(requests[0]).To(Equal(reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Namespace: "default",
+						Name:      "my-isvc",
+					},
+				}))
+			})
+
+			It("should use the correct namespace from the pod", func() {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "custom-namespace",
+						Labels: map[string]string{
+							constants.InferenceServicePodLabelKey: "my-isvc",
+						},
+					},
+				}
+
+				requests := reconciler.podInitContainersFunc(context.Background(), pod)
+
+				Expect(requests).To(HaveLen(1))
+				Expect(requests[0].NamespacedName.Namespace).To(Equal("custom-namespace"))
+				Expect(requests[0].NamespacedName.Name).To(Equal("my-isvc"))
+			})
+		})
+
+		Context("when pod does not have the InferenceService label", func() {
+			It("should return nil for pods without the label", func() {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+						Labels:    map[string]string{},
+					},
+				}
+
+				requests := reconciler.podInitContainersFunc(context.Background(), pod)
+
+				Expect(requests).To(BeNil())
+			})
+
+			It("should return nil for pods with empty label value", func() {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+						Labels: map[string]string{
+							constants.InferenceServicePodLabelKey: "",
+						},
+					},
+				}
+
+				requests := reconciler.podInitContainersFunc(context.Background(), pod)
+
+				Expect(requests).To(BeNil())
+			})
+
+			It("should return nil for pods with nil labels", func() {
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "default",
+					},
+				}
+
+				requests := reconciler.podInitContainersFunc(context.Background(), pod)
+
+				Expect(requests).To(BeNil())
+			})
+		})
+
+		Context("when object is not a pod", func() {
+			It("should return nil for non-pod objects", func() {
+				configMap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-configmap",
+						Namespace: "default",
+					},
+				}
+
+				requests := reconciler.podInitContainersFunc(context.Background(), configMap)
+
+				Expect(requests).To(BeNil())
+			})
+
+			It("should return nil for nil object", func() {
+				requests := reconciler.podInitContainersFunc(context.Background(), nil)
+
+				Expect(requests).To(BeNil())
+			})
+		})
+	})
+
+	// Test the predicate that filters pod updates
+	Describe("podInitContainersPredicate", func() {
+		var pred predicate.Funcs
+
+		BeforeEach(func() {
+			pred = podInitContainersPredicate()
+		})
+
+		Describe("UpdateFunc", func() {
+			Context("when pod has InferenceService label and InitContainerStatuses change", func() {
+				It("should return true when InitContainerStatuses change from empty to waiting", func() {
+					oldPod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "default",
+							Labels: map[string]string{
+								constants.InferenceServicePodLabelKey: "my-isvc",
+							},
+						},
+						Status: corev1.PodStatus{
+							InitContainerStatuses: []corev1.ContainerStatus{},
+						},
+					}
+
+					newPod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "default",
+							Labels: map[string]string{
+								constants.InferenceServicePodLabelKey: "my-isvc",
+							},
+						},
+						Status: corev1.PodStatus{
+							InitContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name: "storage-initializer",
+									State: corev1.ContainerState{
+										Waiting: &corev1.ContainerStateWaiting{
+											Reason:  "PodInitializing",
+											Message: "Initializing",
+										},
+									},
+								},
+							},
+						},
+					}
+
+					result := pred.Update(event.UpdateEvent{
+						ObjectOld: oldPod,
+						ObjectNew: newPod,
+					})
+
+					Expect(result).To(BeTrue())
+				})
+
+				It("should return true when InitContainerStatuses change from waiting to terminated with error", func() {
+					oldPod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "default",
+							Labels: map[string]string{
+								constants.InferenceServicePodLabelKey: "my-isvc",
+							},
+						},
+						Status: corev1.PodStatus{
+							InitContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name: "storage-initializer",
+									State: corev1.ContainerState{
+										Waiting: &corev1.ContainerStateWaiting{
+											Reason: "PodInitializing",
+										},
+									},
+								},
+							},
+						},
+					}
+
+					newPod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "default",
+							Labels: map[string]string{
+								constants.InferenceServicePodLabelKey: "my-isvc",
+							},
+						},
+						Status: corev1.PodStatus{
+							InitContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name: "storage-initializer",
+									State: corev1.ContainerState{
+										Terminated: &corev1.ContainerStateTerminated{
+											ExitCode: 1,
+											Reason:   "Error",
+											Message:  "Failed to download model: certificate verify failed",
+										},
+									},
+								},
+							},
+						},
+					}
+
+					result := pred.Update(event.UpdateEvent{
+						ObjectOld: oldPod,
+						ObjectNew: newPod,
+					})
+
+					Expect(result).To(BeTrue())
+				})
+
+				It("should return true when InitContainerStatuses change from waiting to running", func() {
+					oldPod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "default",
+							Labels: map[string]string{
+								constants.InferenceServicePodLabelKey: "my-isvc",
+							},
+						},
+						Status: corev1.PodStatus{
+							InitContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name: "storage-initializer",
+									State: corev1.ContainerState{
+										Waiting: &corev1.ContainerStateWaiting{
+											Reason: "PodInitializing",
+										},
+									},
+								},
+							},
+						},
+					}
+
+					newPod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "default",
+							Labels: map[string]string{
+								constants.InferenceServicePodLabelKey: "my-isvc",
+							},
+						},
+						Status: corev1.PodStatus{
+							InitContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name: "storage-initializer",
+									State: corev1.ContainerState{
+										Running: &corev1.ContainerStateRunning{},
+									},
+								},
+							},
+						},
+					}
+
+					result := pred.Update(event.UpdateEvent{
+						ObjectOld: oldPod,
+						ObjectNew: newPod,
+					})
+
+					Expect(result).To(BeTrue())
+				})
+			})
+
+			Context("when InitContainerStatuses do not change", func() {
+				It("should return false when only other status fields change", func() {
+					initStatus := []corev1.ContainerStatus{
+						{
+							Name: "storage-initializer",
+							State: corev1.ContainerState{
+								Waiting: &corev1.ContainerStateWaiting{
+									Reason: "PodInitializing",
+								},
+							},
+						},
+					}
+
+					oldPod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "default",
+							Labels: map[string]string{
+								constants.InferenceServicePodLabelKey: "my-isvc",
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase:                 corev1.PodPending,
+							InitContainerStatuses: initStatus,
+						},
+					}
+
+					newPod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "default",
+							Labels: map[string]string{
+								constants.InferenceServicePodLabelKey: "my-isvc",
+							},
+						},
+						Status: corev1.PodStatus{
+							Phase:                 corev1.PodRunning, // Phase changed
+							InitContainerStatuses: initStatus,        // But InitContainerStatuses unchanged
+						},
+					}
+
+					result := pred.Update(event.UpdateEvent{
+						ObjectOld: oldPod,
+						ObjectNew: newPod,
+					})
+
+					Expect(result).To(BeFalse())
+				})
+
+				It("should return false when only ContainerStatuses change (not InitContainerStatuses)", func() {
+					// This is critical for preventing event storms - main containers constantly
+					// update their status but we only care about init container changes
+					initStatus := []corev1.ContainerStatus{
+						{
+							Name: "storage-initializer",
+							State: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{
+									ExitCode: 0,
+								},
+							},
+						},
+					}
+
+					oldPod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "default",
+							Labels: map[string]string{
+								constants.InferenceServicePodLabelKey: "my-isvc",
+							},
+						},
+						Status: corev1.PodStatus{
+							InitContainerStatuses: initStatus,
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name:         "kserve-container",
+									Ready:        false,
+									RestartCount: 0,
+								},
+							},
+						},
+					}
+
+					newPod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "default",
+							Labels: map[string]string{
+								constants.InferenceServicePodLabelKey: "my-isvc",
+							},
+						},
+						Status: corev1.PodStatus{
+							InitContainerStatuses: initStatus, // Unchanged
+							ContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name:         "kserve-container",
+									Ready:        true, // Changed
+									RestartCount: 1,    // Changed
+								},
+							},
+						},
+					}
+
+					result := pred.Update(event.UpdateEvent{
+						ObjectOld: oldPod,
+						ObjectNew: newPod,
+					})
+
+					Expect(result).To(BeFalse())
+				})
+
+				It("should return false when InitContainerStatuses are identical", func() {
+					oldPod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-pod",
+							Namespace: "default",
+							Labels: map[string]string{
+								constants.InferenceServicePodLabelKey: "my-isvc",
+							},
+						},
+						Status: corev1.PodStatus{
+							InitContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name: "storage-initializer",
+									State: corev1.ContainerState{
+										Terminated: &corev1.ContainerStateTerminated{
+											ExitCode: 0,
+										},
+									},
+								},
+							},
+						},
+					}
+
+					newPod := oldPod.DeepCopy()
+
+					result := pred.Update(event.UpdateEvent{
+						ObjectOld: oldPod,
+						ObjectNew: newPod,
+					})
+
+					Expect(result).To(BeFalse())
+				})
+			})
+
+			Context("when pod does not have InferenceService label", func() {
+				It("should return false for pods without the label", func() {
+					oldPod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "unrelated-pod",
+							Namespace: "default",
+							Labels:    map[string]string{},
+						},
+						Status: corev1.PodStatus{
+							InitContainerStatuses: []corev1.ContainerStatus{},
+						},
+					}
+
+					newPod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "unrelated-pod",
+							Namespace: "default",
+							Labels:    map[string]string{},
+						},
+						Status: corev1.PodStatus{
+							InitContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name: "init",
+									State: corev1.ContainerState{
+										Terminated: &corev1.ContainerStateTerminated{
+											ExitCode: 1,
+										},
+									},
+								},
+							},
+						},
+					}
+
+					result := pred.Update(event.UpdateEvent{
+						ObjectOld: oldPod,
+						ObjectNew: newPod,
+					})
+
+					Expect(result).To(BeFalse())
+				})
+
+				It("should return false for pods with other labels but not InferenceService label", func() {
+					oldPod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "other-pod",
+							Namespace: "default",
+							Labels: map[string]string{
+								"app": "some-other-app",
+							},
+						},
+						Status: corev1.PodStatus{
+							InitContainerStatuses: []corev1.ContainerStatus{},
+						},
+					}
+
+					newPod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "other-pod",
+							Namespace: "default",
+							Labels: map[string]string{
+								"app": "some-other-app",
+							},
+						},
+						Status: corev1.PodStatus{
+							InitContainerStatuses: []corev1.ContainerStatus{
+								{
+									Name: "init",
+									State: corev1.ContainerState{
+										Terminated: &corev1.ContainerStateTerminated{
+											ExitCode: 1,
+										},
+									},
+								},
+							},
+						},
+					}
+
+					result := pred.Update(event.UpdateEvent{
+						ObjectOld: oldPod,
+						ObjectNew: newPod,
+					})
+
+					Expect(result).To(BeFalse())
+				})
+			})
+
+			Context("when object is not a pod", func() {
+				It("should return false for non-pod objects", func() {
+					result := pred.Update(event.UpdateEvent{
+						ObjectOld: &corev1.ConfigMap{},
+						ObjectNew: &corev1.ConfigMap{},
+					})
+
+					Expect(result).To(BeFalse())
+				})
+			})
+		})
+	})
+
+	// Integration-style tests that verify the mapper doesn't cause "event storms"
+	Describe("Event Storm Prevention", func() {
+		Context("when multiple pods exist for different InferenceServices", func() {
+			It("should only return reconcile request for the specific InferenceService", func() {
+				reconciler := &InferenceServiceReconciler{}
+
+				pod1 := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "isvc1-predictor-pod",
+						Namespace: "default",
+						Labels: map[string]string{
+							constants.InferenceServicePodLabelKey: "isvc1",
+						},
+					},
+				}
+
+				pod2 := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "isvc2-predictor-pod",
+						Namespace: "default",
+						Labels: map[string]string{
+							constants.InferenceServicePodLabelKey: "isvc2",
+						},
+					},
+				}
+
+				// Pod1 change should only reconcile isvc1
+				requests1 := reconciler.podInitContainersFunc(context.Background(), pod1)
+				Expect(requests1).To(HaveLen(1))
+				Expect(requests1[0].Name).To(Equal("isvc1"))
+
+				// Pod2 change should only reconcile isvc2
+				requests2 := reconciler.podInitContainersFunc(context.Background(), pod2)
+				Expect(requests2).To(HaveLen(1))
+				Expect(requests2[0].Name).To(Equal("isvc2"))
+			})
+		})
+
+		Context("when pod is not managed by any InferenceService", func() {
+			It("should not trigger any reconciliation", func() {
+				reconciler := &InferenceServiceReconciler{}
+
+				// A regular pod without the InferenceService label
+				regularPod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "regular-pod",
+						Namespace: "default",
+						Labels: map[string]string{
+							"app": "some-other-app",
+						},
+					},
+				}
+
+				requests := reconciler.podInitContainersFunc(context.Background(), regularPod)
+				Expect(requests).To(BeNil())
+			})
+		})
+	})
+})
+
+var _ = Describe("ServingRuntime Watch", func() {
+	var reconciler *InferenceServiceReconciler
+	var testNamespace string
+
+	BeforeEach(func() {
+		testNamespace = "runtime-watch-test"
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testNamespace,
+			},
+		}
+		err := k8sClient.Create(context.Background(), ns)
+		if err != nil {
+			// Namespace might already exist, ignore error
+			_ = k8sClient.Get(context.Background(), types.NamespacedName{Name: testNamespace}, ns)
+		}
+
+		reconciler = &InferenceServiceReconciler{
+			Client: k8sClient,
+		}
+	})
+
+	AfterEach(func() {
+		// Clean up ISVCs created during tests
+		var isvcList v1beta1.InferenceServiceList
+		_ = k8sClient.List(context.Background(), &isvcList, client.InNamespace(testNamespace))
+		for _, isvc := range isvcList.Items {
+			_ = k8sClient.Delete(context.Background(), &isvc)
+		}
+	})
+
+	// ODH: clusterServingRuntimeFunc tests commented out because the watch is disabled in ODH
+	// Describe("clusterServingRuntimeFunc", func() {
+	// 	It("should only reconcile ISVCs that use the specific ClusterServingRuntime", func() {
+	// 		// Create ISVC using clusterRuntime1
+	// 		isvc1 := &v1beta1.InferenceService{
+	// 			ObjectMeta: metav1.ObjectMeta{
+	// 				Name:      "isvc-cluster-runtime-1",
+	// 				Namespace: testNamespace,
+	// 			},
+	// 			Spec: v1beta1.InferenceServiceSpec{
+	// 				Predictor: v1beta1.PredictorSpec{
+	// 					SKLearn: &v1beta1.SKLearnSpec{},
+	// 				},
+	// 			},
+	// 		}
+	// 		Expect(k8sClient.Create(context.Background(), isvc1)).To(Succeed())
+	//
+	// 		// Set the ClusterServingRuntimeName in status
+	// 		isvc1.Status.ClusterServingRuntimeName = "cluster-runtime-1"
+	// 		Expect(k8sClient.Status().Update(context.Background(), isvc1)).To(Succeed())
+	//
+	// 		// Create ISVC using clusterRuntime2
+	// 		isvc2 := &v1beta1.InferenceService{
+	// 			ObjectMeta: metav1.ObjectMeta{
+	// 				Name:      "isvc-cluster-runtime-2",
+	// 				Namespace: testNamespace,
+	// 			},
+	// 			Spec: v1beta1.InferenceServiceSpec{
+	// 				Predictor: v1beta1.PredictorSpec{
+	// 					SKLearn: &v1beta1.SKLearnSpec{},
+	// 				},
+	// 			},
+	// 		}
+	// 		Expect(k8sClient.Create(context.Background(), isvc2)).To(Succeed())
+	//
+	// 		// Set the ClusterServingRuntimeName in status
+	// 		isvc2.Status.ClusterServingRuntimeName = "cluster-runtime-2"
+	// 		Expect(k8sClient.Status().Update(context.Background(), isvc2)).To(Succeed())
+	//
+	// 		// Create a ClusterServingRuntime object (only need metadata for the mapper)
+	// 		csr := &v1alpha1.ClusterServingRuntime{
+	// 			ObjectMeta: metav1.ObjectMeta{
+	// 				Name: "cluster-runtime-1",
+	// 			},
+	// 		}
+	//
+	// 		// Wait for the cache to sync and verify the mapper returns the correct request.
+	// 		// The cached client may not immediately reflect status updates.
+	// 		Eventually(func() []reconcile.Request {
+	// 			return reconciler.clusterServingRuntimeFunc(context.Background(), csr)
+	// 		}).Should(HaveLen(1))
+	//
+	// 		requests := reconciler.clusterServingRuntimeFunc(context.Background(), csr)
+	// 		Expect(requests[0].Name).To(Equal("isvc-cluster-runtime-1"))
+	// 		Expect(requests[0].Namespace).To(Equal(testNamespace))
+	// 	})
+	//
+	// 	It("should not reconcile ISVCs that use a different ClusterServingRuntime", func() {
+	// 		// Create ISVC using a different runtime
+	// 		isvc := &v1beta1.InferenceService{
+	// 			ObjectMeta: metav1.ObjectMeta{
+	// 				Name:      "isvc-different-runtime",
+	// 				Namespace: testNamespace,
+	// 			},
+	// 			Spec: v1beta1.InferenceServiceSpec{
+	// 				Predictor: v1beta1.PredictorSpec{
+	// 					SKLearn: &v1beta1.SKLearnSpec{},
+	// 				},
+	// 			},
+	// 		}
+	// 		Expect(k8sClient.Create(context.Background(), isvc)).To(Succeed())
+	//
+	// 		// Set the ClusterServingRuntimeName in status to a different runtime
+	// 		isvc.Status.ClusterServingRuntimeName = "cluster-runtime-other"
+	// 		Expect(k8sClient.Status().Update(context.Background(), isvc)).To(Succeed())
+	//
+	// 		// Create a ClusterServingRuntime object with a unique name not used by any ISVC
+	// 		csr := &v1alpha1.ClusterServingRuntime{
+	// 			ObjectMeta: metav1.ObjectMeta{
+	// 				Name: "cluster-runtime-unused",
+	// 			},
+	// 		}
+	//
+	// 		// Call the mapper function
+	// 		requests := reconciler.clusterServingRuntimeFunc(context.Background(), csr)
+	//
+	// 		// Should return empty since no ISVC uses cluster-runtime-unused
+	// 		Expect(requests).To(BeEmpty())
+	// 	})
+	//
+	// 	It("should not reconcile ISVCs with auto-update disabled when ready", func() {
+	// 		// Create ISVC with auto-update disabled
+	// 		isvc := &v1beta1.InferenceService{
+	// 			ObjectMeta: metav1.ObjectMeta{
+	// 				Name:      "isvc-auto-update-disabled",
+	// 				Namespace: testNamespace,
+	// 				Annotations: map[string]string{
+	// 					constants.DisableAutoUpdateAnnotationKey: "true",
+	// 				},
+	// 			},
+	// 			Spec: v1beta1.InferenceServiceSpec{
+	// 				Predictor: v1beta1.PredictorSpec{
+	// 					SKLearn: &v1beta1.SKLearnSpec{},
+	// 				},
+	// 			},
+	// 		}
+	// 		Expect(k8sClient.Create(context.Background(), isvc)).To(Succeed())
+	//
+	// 		// Set the ClusterServingRuntimeName and make it ready
+	// 		isvc.Status.ClusterServingRuntimeName = "cluster-runtime-auto-update"
+	// 		isvc.Status.SetCondition(v1beta1.PredictorReady, &knativeapis.Condition{
+	// 			Type:   v1beta1.PredictorReady,
+	// 			Status: corev1.ConditionTrue,
+	// 		})
+	// 		isvc.Status.SetCondition(v1beta1.IngressReady, &knativeapis.Condition{
+	// 			Type:   v1beta1.IngressReady,
+	// 			Status: corev1.ConditionTrue,
+	// 		})
+	// 		Expect(k8sClient.Status().Update(context.Background(), isvc)).To(Succeed())
+	//
+	// 		// Create a ClusterServingRuntime object
+	// 		csr := &v1alpha1.ClusterServingRuntime{
+	// 			ObjectMeta: metav1.ObjectMeta{
+	// 				Name: "cluster-runtime-auto-update",
+	// 			},
+	// 		}
+	//
+	// 		// Call the mapper function
+	// 		requests := reconciler.clusterServingRuntimeFunc(context.Background(), csr)
+	//
+	// 		// Should not reconcile the ISVC because auto-update is disabled and it's ready
+	// 		Expect(requests).To(BeEmpty())
+	// 	})
+	// })
+
+	Describe("servingRuntimeFunc", func() {
+		It("should only reconcile ISVCs that use the specific ServingRuntime", func() {
+			// Create ISVC using runtime1
+			isvc1 := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "isvc-serving-runtime-1",
+					Namespace: testNamespace,
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						SKLearn: &v1beta1.SKLearnSpec{},
+					},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), isvc1)).To(Succeed())
+
+			// Set the ServingRuntimeName in status
+			isvc1.Status.ServingRuntimeName = "serving-runtime-1"
+			Expect(k8sClient.Status().Update(context.Background(), isvc1)).To(Succeed())
+
+			// Create ISVC using runtime2
+			isvc2 := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "isvc-serving-runtime-2",
+					Namespace: testNamespace,
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						SKLearn: &v1beta1.SKLearnSpec{},
+					},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), isvc2)).To(Succeed())
+
+			// Set the ServingRuntimeName in status
+			isvc2.Status.ServingRuntimeName = "serving-runtime-2"
+			Expect(k8sClient.Status().Update(context.Background(), isvc2)).To(Succeed())
+
+			// Create a ServingRuntime object
+			sr := &v1alpha1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "serving-runtime-1",
+					Namespace: testNamespace,
+				},
+			}
+
+			// Wait for the cache to sync and verify the mapper returns the correct request.
+			// The cached client may not immediately reflect status updates.
+			Eventually(func() []reconcile.Request {
+				return reconciler.servingRuntimeFunc(context.Background(), sr)
+			}).Should(HaveLen(1))
+
+			requests := reconciler.servingRuntimeFunc(context.Background(), sr)
+			Expect(requests[0].Name).To(Equal("isvc-serving-runtime-1"))
+			Expect(requests[0].Namespace).To(Equal(testNamespace))
+		})
+
+		It("should not reconcile ISVCs that use a different ServingRuntime", func() {
+			// Create ISVC using a different runtime
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "isvc-different-serving-runtime",
+					Namespace: testNamespace,
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						SKLearn: &v1beta1.SKLearnSpec{},
+					},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), isvc)).To(Succeed())
+
+			// Set the ServingRuntimeName in status to a different runtime
+			isvc.Status.ServingRuntimeName = "serving-runtime-other"
+			Expect(k8sClient.Status().Update(context.Background(), isvc)).To(Succeed())
+
+			// Create a ServingRuntime object with a unique name not used by any ISVC
+			sr := &v1alpha1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "serving-runtime-unused",
+					Namespace: testNamespace,
+				},
+			}
+
+			// Call the mapper function
+			requests := reconciler.servingRuntimeFunc(context.Background(), sr)
+
+			// Should return empty since no ISVC uses serving-runtime-unused
+			Expect(requests).To(BeEmpty())
+		})
+
+		It("should not reconcile ISVCs with auto-update disabled when ready", func() {
+			// Create ISVC with auto-update disabled
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "isvc-serving-auto-update-disabled",
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						constants.DisableAutoUpdateAnnotationKey: "true",
+					},
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						SKLearn: &v1beta1.SKLearnSpec{},
+					},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), isvc)).To(Succeed())
+
+			// Set the ServingRuntimeName and make it ready
+			isvc.Status.ServingRuntimeName = "serving-runtime-auto-update"
+			isvc.Status.SetCondition(v1beta1.PredictorReady, &knativeapis.Condition{
+				Type:   v1beta1.PredictorReady,
+				Status: corev1.ConditionTrue,
+			})
+			isvc.Status.SetCondition(v1beta1.IngressReady, &knativeapis.Condition{
+				Type:   v1beta1.IngressReady,
+				Status: corev1.ConditionTrue,
+			})
+			Expect(k8sClient.Status().Update(context.Background(), isvc)).To(Succeed())
+
+			// Create a ServingRuntime object
+			sr := &v1alpha1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "serving-runtime-auto-update",
+					Namespace: testNamespace,
+				},
+			}
+
+			// Call the mapper function
+			requests := reconciler.servingRuntimeFunc(context.Background(), sr)
+
+			// Should not reconcile the ISVC because auto-update is disabled and it's ready
+			Expect(requests).To(BeEmpty())
+		})
+	})
+})

--- a/pkg/controller/v1beta1/inferenceservice/suite_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/suite_test.go
@@ -112,11 +112,15 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(clientset).ToNot(BeNil())
 
+	cacheOpts, err := NewCacheOptions()
+	Expect(err).ToNot(HaveOccurred())
+
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: "0",
 		},
+		Cache: cacheOpts,
 	})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/test/e2e/predictor/test_pod_watch.py
+++ b/test/e2e/predictor/test_pod_watch.py
@@ -1,0 +1,535 @@
+# Copyright 2025 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import json
+import os
+import time
+import uuid
+from contextlib import contextmanager
+
+import pytest
+from kubernetes import client
+from kubernetes.client import V1ResourceRequirements
+
+from kserve import (
+    KServeClient,
+    V1beta1InferenceService,
+    V1beta1InferenceServiceSpec,
+    V1beta1PredictorSpec,
+    V1beta1SKLearnSpec,
+    constants,
+)
+from kserve.logging import trace_logger as logger
+
+from ..common.utils import KSERVE_TEST_NAMESPACE
+
+
+def get_isvc_data(kserve_client: KServeClient, name: str, namespace: str):
+    """Get ISVC resource data for debugging."""
+    try:
+        return kserve_client.get(name, namespace=namespace)
+    except Exception as e:
+        return {"error": f"Failed to get ISVC {name}: {e}"}
+
+
+def get_deployments_for_isvc(name: str, namespace: str) -> list[dict]:
+    """Get deployments matching the ISVC."""
+    apps_api = client.AppsV1Api()
+    try:
+        deployments = apps_api.list_namespaced_deployment(
+            namespace=namespace,
+            label_selector=f"serving.kserve.io/inferenceservice={name}",
+        )
+        return [dep.to_dict() for dep in deployments.items]
+    except Exception as e:
+        return [{"error": f"Failed to list deployments for ISVC {name}: {e}"}]
+
+
+def get_pods_for_isvc(name: str, namespace: str) -> list[dict]:
+    """Get pods matching the ISVC."""
+    core_api = client.CoreV1Api()
+    try:
+        pods = core_api.list_namespaced_pod(
+            namespace=namespace,
+            label_selector=f"serving.kserve.io/inferenceservice={name}",
+        )
+        return [pod.to_dict() for pod in pods.items]
+    except Exception as e:
+        return [{"error": f"Failed to list pods for ISVC {name}: {e}"}]
+
+
+def get_controller_logs_for_isvc(name: str, namespace: str) -> list[dict]:
+    """Get controller log entries for a specific ISVC."""
+    try:
+        logs = get_controller_logs(since_seconds=300)  # Last 5 minutes
+        entries = []
+        for line in logs.strip().split("\n"):
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+                if entry.get("isvc") == name and entry.get("namespace") == namespace:
+                    entries.append(entry)
+            except json.JSONDecodeError:
+                if name in line and namespace in line:
+                    entries.append({"raw": line})
+        return entries
+    except Exception as e:
+        return [{"error": f"Failed to get controller logs: {e}"}]
+
+
+def dump_debug_info(
+    kserve_client: KServeClient, isvc_names: list[str], namespace: str
+) -> None:
+    """Dump debug info for the given ISVCs, their deployments, pods, and logs as compact JSON."""
+    for isvc_name in isvc_names:
+        debug_data = {
+            "isvc": get_isvc_data(kserve_client, isvc_name, namespace),
+            "deployments": get_deployments_for_isvc(isvc_name, namespace),
+            "pods": get_pods_for_isvc(isvc_name, namespace),
+            "controller_logs": get_controller_logs_for_isvc(isvc_name, namespace),
+        }
+        logger.info(
+            "DEBUG DUMP %s/%s:\n%s",
+            namespace,
+            isvc_name,
+            json.dumps(debug_data, separators=(",", ":"), default=str),
+        )
+
+
+@contextmanager
+def managed_isvc(kserve_client: KServeClient, isvc: V1beta1InferenceService):
+    """
+    Context manager that handles ISVC lifecycle: creation, error dumping, and cleanup.
+
+    Usage:
+        with managed_isvc(kserve_client, isvc):
+            # ISVC is already created
+            # ... test logic ...
+            # On any exception: dumps debug info for the ISVC
+            # On exit: deletes the ISVC
+    """
+    assert isvc.metadata is not None, "ISVC must have metadata"
+    assert isvc.metadata.name is not None, "ISVC must have a name"
+    assert isvc.metadata.namespace is not None, "ISVC must have a namespace"
+    name = isvc.metadata.name
+    namespace = isvc.metadata.namespace
+    error_occurred = False
+    try:
+        kserve_client.create(isvc)
+        yield
+    except Exception:
+        error_occurred = True
+        dump_debug_info(kserve_client, [name], namespace)
+        raise
+    finally:
+        try:
+            kserve_client.delete(name, namespace)
+        except Exception as e:
+            if not error_occurred:
+                logger.warning("Failed to delete ISVC %s: %s", name, e)
+
+
+def get_isvc_resource_version(
+    kserve_client: KServeClient, name: str, namespace: str = KSERVE_TEST_NAMESPACE
+) -> str:
+    isvc = kserve_client.get(name, namespace=namespace)
+    metadata = isvc.get("metadata") if isinstance(isvc, dict) else {}
+    if isinstance(metadata, dict):
+        return str(metadata.get("resourceVersion", ""))
+    return ""
+
+
+def get_isvc_model_status(
+    kserve_client: KServeClient, name: str, namespace: str = KSERVE_TEST_NAMESPACE
+) -> dict:
+    isvc = kserve_client.get(name, namespace=namespace)
+    status = isvc.get("status") if isinstance(isvc, dict) else {}
+    if isinstance(status, dict):
+        model_status = status.get("modelStatus")
+        return model_status if isinstance(model_status, dict) else {}
+    return {}
+
+
+def get_isvc_conditions(
+    kserve_client: KServeClient, name: str, namespace: str = KSERVE_TEST_NAMESPACE
+) -> list:
+    isvc = kserve_client.get(name, namespace=namespace)
+    status = isvc.get("status") if isinstance(isvc, dict) else {}
+    if isinstance(status, dict):
+        conditions = status.get("conditions")
+        return conditions if isinstance(conditions, list) else []
+    return []
+
+
+def create_invalid_s3_secret(namespace: str, secret_name: str):
+    core_api = client.CoreV1Api()
+    secret = client.V1Secret(
+        api_version="v1",
+        kind="Secret",
+        metadata=client.V1ObjectMeta(
+            name=secret_name,
+            namespace=namespace,
+            annotations={
+                "serving.kserve.io/s3-endpoint": "s3.amazonaws.com",
+                "serving.kserve.io/s3-region": "us-east-1",
+                "serving.kserve.io/s3-usehttps": "1",
+                "serving.kserve.io/s3-verifyssl": "1",
+            },
+        ),
+        type="Opaque",
+        string_data={
+            "AWS_ACCESS_KEY_ID": "INVALID_ACCESS_KEY_ID_12345",
+            "AWS_SECRET_ACCESS_KEY": "INVALID_SECRET_ACCESS_KEY_67890",
+        },
+    )
+
+    try:
+        core_api.delete_namespaced_secret(secret_name, namespace)
+    except client.ApiException:
+        pass
+
+    return core_api.create_namespaced_secret(namespace, secret)
+
+
+def create_service_account_with_secret(namespace: str, sa_name: str, secret_name: str):
+    core_api = client.CoreV1Api()
+
+    sa = client.V1ServiceAccount(
+        api_version="v1",
+        kind="ServiceAccount",
+        metadata=client.V1ObjectMeta(name=sa_name, namespace=namespace),
+        secrets=[client.V1ObjectReference(name=secret_name)],
+    )
+
+    try:
+        core_api.delete_namespaced_service_account(sa_name, namespace)
+    except client.ApiException:
+        pass
+
+    return core_api.create_namespaced_service_account(namespace, sa)
+
+
+def delete_secret(namespace: str, secret_name: str):
+    core_api = client.CoreV1Api()
+    try:
+        core_api.delete_namespaced_secret(secret_name, namespace)
+    except client.ApiException:
+        pass
+
+
+def delete_service_account(namespace: str, sa_name: str):
+    core_api = client.CoreV1Api()
+    try:
+        core_api.delete_namespaced_service_account(sa_name, namespace)
+    except client.ApiException:
+        pass
+
+
+def wait_for_isvc_failure_status(
+    kserve_client: KServeClient,
+    name: str,
+    namespace: str = KSERVE_TEST_NAMESPACE,
+    timeout_seconds: int = 120,
+    poll_interval: float = 2.0,
+) -> dict | None:
+    start_time = time.time()
+    while time.time() - start_time < timeout_seconds:
+        try:
+            model_status = get_isvc_model_status(kserve_client, name, namespace)
+            last_failure = model_status.get("lastFailureInfo")
+            if last_failure is not None:
+                logger.info(
+                    "ISVC %s reported failure: %s",
+                    name,
+                    last_failure,
+                )
+                return model_status
+        except Exception as e:
+            logger.warning("Error checking ISVC status: %s", e)
+        time.sleep(poll_interval)
+    return None
+
+
+def get_controller_logs(since_seconds: int) -> str:
+    core_api = client.CoreV1Api()
+    pods = core_api.list_namespaced_pod(
+        namespace="kserve",
+        label_selector="control-plane=kserve-controller-manager",
+    )
+    if not pods.items:
+        raise RuntimeError(
+            "No controller manager pod found in kserve namespace. "
+            "Cannot perform log analysis for reconciliation detection."
+        )
+    pod = pods.items[0]
+    try:
+        return core_api.read_namespaced_pod_log(
+            name=pod.metadata.name,
+            namespace="kserve",
+            container="manager",
+            since_seconds=since_seconds,
+        )
+    except client.ApiException as e:
+        raise RuntimeError(
+            f"Failed to read controller logs from pod {pod.metadata.name}: {e}"
+        ) from e
+
+
+@pytest.mark.predictor
+@pytest.mark.raw
+@pytest.mark.asyncio(scope="session")
+async def test_event_storm_prevention_init_container_isolation(rest_v1_client):
+    """
+    Test that init container status changes on one ISVC don't cause unwanted modifications
+    to unrelated ISVCs (event storm prevention).
+
+    The controller may reconcile an ISVC for legitimate reasons (e.g.,
+    HTTPRoute status updates from Istio, deployment status changes) without making any
+    changes. This is acceptable. The real concern is if the secondary ISVC's events
+    cause the primary ISVC to be MODIFIED (resourceVersion change).
+
+    Test flow:
+    1. Creates a "primary" ISVC that will successfully load a model from GCS
+    2. Waits for the primary ISVC to become ready
+    3. Records baseline resourceVersion
+    4. Creates a "secondary" ISVC with invalid S3 credentials that will fail
+    5. Waits for the secondary ISVC to show failure status
+    6. Verifies the primary ISVC's resourceVersion is unchanged
+    """
+    suffix = str(uuid.uuid4())[:6]
+    primary_name = f"isvc-primary-{suffix}"
+    secondary_name = f"isvc-secondary-{suffix}"
+    invalid_sa_name = f"invalid-s3-sa-{suffix}"
+    invalid_secret_name = f"invalid-s3-secret-{suffix}"
+
+    kserve_client = KServeClient(
+        config_file=os.environ.get("KUBECONFIG", "~/.kube/config")
+    )
+
+    # Create primary ISVC with a valid GCS storage URI (no credentials needed)
+    primary_predictor = V1beta1PredictorSpec(
+        min_replicas=1,
+        sklearn=V1beta1SKLearnSpec(
+            storage_uri="gs://kfserving-examples/models/sklearn/1.0/model",
+            resources=V1ResourceRequirements(
+                requests={"cpu": "50m", "memory": "128Mi"},
+                limits={"cpu": "100m", "memory": "256Mi"},
+            ),
+        ),
+    )
+
+    primary_isvc = V1beta1InferenceService(
+        api_version=constants.KSERVE_V1BETA1,
+        kind=constants.KSERVE_KIND_INFERENCESERVICE,
+        metadata=client.V1ObjectMeta(
+            name=primary_name, namespace=KSERVE_TEST_NAMESPACE
+        ),
+        spec=V1beta1InferenceServiceSpec(predictor=primary_predictor),
+    )
+
+    with managed_isvc(kserve_client, primary_isvc):
+        # Step 1: Wait for primary ISVC to be ready (created by managed_isvc)
+        logger.info("Created primary ISVC: %s", primary_name)
+        kserve_client.wait_isvc_ready(primary_name, namespace=KSERVE_TEST_NAMESPACE)
+        logger.info("Primary ISVC is ready")
+
+        # Record baseline resourceVersion
+        primary_rv_before = get_isvc_resource_version(kserve_client, primary_name)
+        logger.info("Baseline recorded - resourceVersion: %s", primary_rv_before)
+
+        # Step 2: Create invalid S3 credentials
+        logger.info("Creating invalid S3 secret and service account")
+        create_invalid_s3_secret(KSERVE_TEST_NAMESPACE, invalid_secret_name)
+        create_service_account_with_secret(
+            KSERVE_TEST_NAMESPACE, invalid_sa_name, invalid_secret_name
+        )
+
+        # Step 3: Create secondary ISVC with invalid S3 credentials
+        secondary_predictor = V1beta1PredictorSpec(
+            min_replicas=1,
+            service_account_name=invalid_sa_name,
+            sklearn=V1beta1SKLearnSpec(
+                storage_uri="s3://nonexistent-bucket-12345/invalid/path/model",
+                resources=V1ResourceRequirements(
+                    requests={"cpu": "50m", "memory": "128Mi"},
+                    limits={"cpu": "100m", "memory": "256Mi"},
+                ),
+            ),
+        )
+
+        secondary_isvc = V1beta1InferenceService(
+            api_version=constants.KSERVE_V1BETA1,
+            kind=constants.KSERVE_KIND_INFERENCESERVICE,
+            metadata=client.V1ObjectMeta(
+                name=secondary_name, namespace=KSERVE_TEST_NAMESPACE
+            ),
+            spec=V1beta1InferenceServiceSpec(predictor=secondary_predictor),
+        )
+
+        with managed_isvc(kserve_client, secondary_isvc):
+            # Step 4: Wait for secondary ISVC to report failure (created by managed_isvc)
+            logger.info(
+                "Created secondary ISVC %s, waiting for failure status...",
+                secondary_name,
+            )
+            secondary_failure = wait_for_isvc_failure_status(
+                kserve_client, secondary_name, timeout_seconds=180
+            )
+            if secondary_failure:
+                logger.info("Secondary ISVC failure detected: %s", secondary_failure)
+
+            # Give time for any potential event storms to propagate
+            await asyncio.sleep(10)
+
+            # Step 5: Verify primary ISVC was not modified
+            # The controller may reconcile the primary ISVC for legitimate reasons
+            # (e.g., HTTPRoute status updates from Istio), but no-op reconciliations
+            # are fine. Only fail if resourceVersion changed (actual modification).
+            primary_rv_after = get_isvc_resource_version(kserve_client, primary_name)
+            logger.info(
+                "Primary ISVC resourceVersion: before=%s, after=%s",
+                primary_rv_before,
+                primary_rv_after,
+            )
+
+            assert primary_rv_before == primary_rv_after, (
+                f"Primary ISVC '{primary_name}' was modified during secondary ISVC failure. "
+                f"ResourceVersion changed from {primary_rv_before} to {primary_rv_after}. "
+                "This indicates potential event storm - init container status changes "
+                "on secondary ISVC may have triggered modification of unrelated primary ISVC."
+            )
+
+            logger.info(
+                "Event storm prevention validated: Primary ISVC was not modified "
+                "during secondary ISVC init container failures"
+            )
+
+
+@pytest.mark.predictor
+@pytest.mark.raw
+@pytest.mark.asyncio(scope="session")
+async def test_quick_reconciliation_on_init_container_failure():
+    """
+    Test that when an init container fails (e.g., invalid storage credentials),
+    the owning InferenceService quickly reconciles and reflects the failure in its status.
+
+    This test:
+    1. Creates an ISVC with invalid S3 credentials
+    2. Monitors the ISVC status for failure detection
+    3. Validates that failure status is populated within a reasonable timeframe
+    4. Verifies the failure message contains relevant error information
+    """
+    suffix = str(uuid.uuid4())[:6]
+    isvc_name = f"isvc-init-fail-{suffix}"
+    invalid_sa_name = f"fail-s3-sa-{suffix}"
+    invalid_secret_name = f"fail-s3-secret-{suffix}"
+
+    kserve_client = KServeClient(
+        config_file=os.environ.get("KUBECONFIG", "~/.kube/config")
+    )
+
+    try:
+        # Create invalid S3 credentials
+        logger.info("Creating invalid S3 secret and service account")
+        create_invalid_s3_secret(KSERVE_TEST_NAMESPACE, invalid_secret_name)
+        create_service_account_with_secret(
+            KSERVE_TEST_NAMESPACE, invalid_sa_name, invalid_secret_name
+        )
+
+        # Create ISVC with invalid S3 credentials
+        predictor = V1beta1PredictorSpec(
+            min_replicas=1,
+            service_account_name=invalid_sa_name,
+            sklearn=V1beta1SKLearnSpec(
+                storage_uri="s3://nonexistent-bucket-xyz123/invalid/model",
+                resources=V1ResourceRequirements(
+                    requests={"cpu": "50m", "memory": "128Mi"},
+                    limits={"cpu": "100m", "memory": "256Mi"},
+                ),
+            ),
+        )
+
+        isvc = V1beta1InferenceService(
+            api_version=constants.KSERVE_V1BETA1,
+            kind=constants.KSERVE_KIND_INFERENCESERVICE,
+            metadata=client.V1ObjectMeta(
+                name=isvc_name, namespace=KSERVE_TEST_NAMESPACE
+            ),
+            spec=V1beta1InferenceServiceSpec(predictor=predictor),
+        )
+
+        creation_time = time.time()
+        with managed_isvc(kserve_client, isvc):
+            # Wait for failure status to be populated
+            logger.info("Created ISVC %s, waiting for failure status...", isvc_name)
+            failure_status = wait_for_isvc_failure_status(
+                kserve_client, isvc_name, timeout_seconds=180, poll_interval=5.0
+            )
+
+            failure_detection_time = time.time()
+            time_to_failure = failure_detection_time - creation_time
+
+            # Validate failure was detected
+            assert failure_status is not None, (
+                f"ISVC {isvc_name} did not report failure status within timeout. "
+                f"The init container failure should trigger quick reconciliation and status update."
+            )
+
+            logger.info(
+                "Failure status detected in %.2f seconds: %s",
+                time_to_failure,
+                failure_status,
+            )
+
+            # Validate failure info contains expected fields
+            last_failure = failure_status.get("lastFailureInfo", {})
+            assert (
+                last_failure.get("reason") is not None
+            ), "lastFailureInfo.reason should be populated"
+
+            # The transition status should indicate blocked by failed load
+            transition_status = failure_status.get("transitionStatus")
+            logger.info("Transition status: %s", transition_status)
+
+            # Check conditions for failure indication
+            conditions = get_isvc_conditions(kserve_client, isvc_name)
+            ready_condition = next(
+                (c for c in conditions if c.get("type") == "Ready"), None
+            )
+
+            if ready_condition:
+                logger.info("Ready condition: %s", ready_condition)
+                # The service should not be ready due to init container failure
+                assert (
+                    ready_condition.get("status") != "True"
+                ), "ISVC should not be Ready when init container fails"
+
+            # Validate reasonable time to failure detection
+            # The pod watch should trigger reconciliation quickly when init container status changes
+            assert time_to_failure < 180, (
+                f"Failure detection took too long ({time_to_failure:.2f}s). "
+                f"Pod watch should trigger quick reconciliation on init container failure."
+            )
+
+            logger.info(
+                "Quick reconciliation validated: Failure detected in %.2f seconds",
+                time_to_failure,
+            )
+
+    finally:
+        # Cleanup non-ISVC resources (ISVCs are cleaned up by managed_isvc)
+        delete_service_account(KSERVE_TEST_NAMESPACE, invalid_sa_name)
+        delete_secret(KSERVE_TEST_NAMESPACE, invalid_secret_name)


### PR DESCRIPTION
Cherry-pick of kserve/kserve#4910

**What this PR does / why we need it**:

Init container errors (e.g., invalid S3 credentials) take 10 minutes to propagate to the InferenceService status. This is because the controller watches the Deployment, but Deployment status doesn't update until `progressDeadlineSeconds` expires (default 600s).

This PR adds a pod watch to the InferenceService controller to react immediately when init container status changes, dramatically reducing the time to surface common errors such as invalid S3 credentials to users, tests, and other components.

**Changes:**
- Add `podInitContainersFunc` mapper to route pod events to the owning InferenceService based on the `serving.kserve.io/inferenceservice` label
- Add `podInitContainersPredicate` to filter pod updates to only process init container status changes
- Add `.Watches` on pods with the above mapper and filter
- Refactor `servingRuntimesPredicate` from inline variable to standalone function
- Consolidate cache configuration into `cache_config.go`

**Type of changes**

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

- [x] Unit tests for `podInitContainersFunc` mapper function
- [x] Unit tests for `podInitContainersPredicate` predicate function
- [x] E2E tests to verify overall functionality

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?

```release-note
Fix slow propagation of init container errors (e.g., storage-initializer failures) to InferenceService status by watching pod init container status changes directly
```