### PR TITLE
RHOAIENG-48857: fix port conflict in multi-container probing test

### DIFF
--- a/test/e2e/predictor/test_multi_container_probing.py
+++ b/test/e2e/predictor/test_multi_container_probing.py
@@ -89,7 +89,7 @@ async def test_multi_container_probing(rest_v1_client):
             V1Container(
                 name="kserve-agent",
                 image="quay.io/opendatahub/kserve-agent:latest",
-                ports=[V1ContainerPort(container_port=8080, protocol="TCP")],
+                ports=[V1ContainerPort(container_port=9081, protocol="TCP")],
                 env=[
                     V1EnvVar(name="AGENT_TARGET_PORT", value="8080"),
                     V1EnvVar(name="AGENT_TARGET_HOST", value="localhost"),
@@ -104,14 +104,14 @@ async def test_multi_container_probing(rest_v1_client):
                 ),
                 liveness_probe=V1Probe(
                     tcp_socket=V1TCPSocketAction(
-                        port=8080,
+                        port=9081,
                     ),
                     initial_delay_seconds=60,
                     period_seconds=10,
                 ),
                 readiness_probe=V1Probe(
                     tcp_socket=V1TCPSocketAction(
-                        port=8080,
+                        port=9081,
                     ),
                     initial_delay_seconds=60,
                     period_seconds=10,


### PR DESCRIPTION
## Summary
- Fix intermittent CI failure in `test_multi_container_probing` E2E test
- The kserve-agent container was incorrectly configured to use port 8080, conflicting with the sklearn model server
- Changed kserve-agent to use port 9081 (the default agent port per `constants.InferenceServiceDefaultAgentPort`)

## Root Cause
Both the sklearn model server and the kserve-agent container were configured to bind to port 8080 in the same pod. In RawDeployment mode, containers share the same network namespace, so whichever container started second would fail to bind, causing intermittent "Deployment does not have minimum availability" errors.

## Test plan
- [ ] CI passes with `test_multi_container_probing` test

Fixes: [RHOAIENG-48857](https://issues.redhat.com/browse/RHOAIENG-48857)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated multi-container probing test suite with adjusted port configuration for improved test coverage and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->