### PR TITLE
fix: Prevent path traversal on https.go (#4796)

### DIFF
--- a/pkg/agent/storage/https.go
+++ b/pkg/agent/storage/https.go
@@ -116,6 +116,7 @@ func (h *HTTPSDownloader) Download(client http.Client) error {
 	default:
 		paths := strings.Split(h.Uri.Path, "/")
 		fileName := paths[len(paths)-1]
+
 		fileFullName := filepath.Join(fileDirectory, fileName)
 		file, err := createNewFile(fileFullName)
 		if err != nil {
@@ -142,7 +143,25 @@ func (h *HTTPSDownloader) extractHeaders() (headers map[string]string, err error
 }
 
 func createNewFile(fileFullName string) (*os.File, error) {
+	protectedPaths := []string{"/etc", "/bin", "/dev", "/usr/bin", "/sbin", "/usr/sbin"}
 	fileFullName = filepath.Clean(fileFullName)
+
+	// Check if path starts with any protected directory
+	for _, protectedPath := range protectedPaths {
+		if strings.HasPrefix(fileFullName, protectedPath+"/") || fileFullName == protectedPath {
+			return nil, fmt.Errorf("access denied: cannot write to protected system directory %s", protectedPath)
+		}
+	}
+
+	// Reject any path containing traversal sequences upfront
+	if strings.Contains(fileFullName, "..") {
+		return nil, fmt.Errorf("path traversal detected in file path: %s", fileFullName)
+	}
+	// Reject paths that resolve to current directory or empty
+	if fileFullName == "." || fileFullName == "" {
+		return nil, fmt.Errorf("please provide the full file path. The provided path [%s] is not valid", fileFullName)
+	}
+
 	if FileExists(fileFullName) {
 		if err := os.Remove(fileFullName); err != nil {
 			return nil, fmt.Errorf("file is unable to be deleted: %w", err)

--- a/pkg/agent/storage/https_test.go
+++ b/pkg/agent/storage/https_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2023 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCreateNewFileValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		inputPath     string
+		shouldSucceed bool
+		description   string
+	}{
+		{
+			name:          "Valid absolute path",
+			inputPath:     "/tmp/test/model.bin",
+			shouldSucceed: true,
+			description:   "Should allow valid absolute paths",
+		},
+		{
+			name:          "Valid relative path",
+			inputPath:     "models/pytorch_model.bin",
+			shouldSucceed: true,
+			description:   "Should allow valid relative paths",
+		},
+		{
+			name:          "Current directory reference",
+			inputPath:     ".",
+			shouldSucceed: false,
+			description:   "Should reject current directory reference",
+		},
+		{
+			name:          "Parent directory reference",
+			inputPath:     "..",
+			shouldSucceed: false,
+			description:   "Should reject parent directory reference",
+		},
+		{
+			name:          "Empty string",
+			inputPath:     "",
+			shouldSucceed: false,
+			description:   "Should reject empty paths",
+		},
+		{
+			name:          "Path that resolves to current dir",
+			inputPath:     "./././.",
+			shouldSucceed: false,
+			description:   "Should reject paths that resolve to current directory",
+		},
+		{
+			name:          "Path that resolves to parent dir",
+			inputPath:     "../../../..",
+			shouldSucceed: false,
+			description:   "Should reject paths that resolve to parent directory",
+		},
+		{
+			name:          "Path with traversal but valid destination",
+			inputPath:     "/tmp/../model.bin",
+			shouldSucceed: false,
+			description:   "Should reject any path containing '..' even if it resolves to valid location",
+		},
+		// Protected paths test cases
+		{
+			name:          "Direct /etc path",
+			inputPath:     "/etc",
+			shouldSucceed: false,
+			description:   "Should reject direct access to /etc directory",
+		},
+		{
+			name:          "File in /etc directory",
+			inputPath:     "/etc/passwd",
+			shouldSucceed: false,
+			description:   "Should reject files in /etc directory",
+		},
+		{
+			name:          "Subdirectory in /etc",
+			inputPath:     "/etc/ssl/certs/ca-bundle.crt",
+			shouldSucceed: false,
+			description:   "Should reject files in /etc subdirectories",
+		},
+		{
+			name:          "Direct /bin path",
+			inputPath:     "/bin",
+			shouldSucceed: false,
+			description:   "Should reject direct access to /bin directory",
+		},
+		{
+			name:          "File in /bin directory",
+			inputPath:     "/bin/bash",
+			shouldSucceed: false,
+			description:   "Should reject files in /bin directory",
+		},
+		{
+			name:          "Direct /dev path",
+			inputPath:     "/dev",
+			shouldSucceed: false,
+			description:   "Should reject direct access to /dev directory",
+		},
+		{
+			name:          "File in /dev directory",
+			inputPath:     "/dev/null",
+			shouldSucceed: false,
+			description:   "Should reject files in /dev directory",
+		},
+		{
+			name:          "Direct /usr/bin path",
+			inputPath:     "/usr/bin",
+			shouldSucceed: false,
+			description:   "Should reject direct access to /usr/bin directory",
+		},
+		{
+			name:          "File in /usr/bin directory",
+			inputPath:     "/usr/bin/python",
+			shouldSucceed: false,
+			description:   "Should reject files in /usr/bin directory",
+		},
+		{
+			name:          "Direct /sbin path",
+			inputPath:     "/sbin",
+			shouldSucceed: false,
+			description:   "Should reject direct access to /sbin directory",
+		},
+		{
+			name:          "File in /sbin directory",
+			inputPath:     "/sbin/init",
+			shouldSucceed: false,
+			description:   "Should reject files in /sbin directory",
+		},
+		{
+			name:          "Direct /usr/sbin path",
+			inputPath:     "/usr/sbin",
+			shouldSucceed: false,
+			description:   "Should reject direct access to /usr/sbin directory",
+		},
+		{
+			name:          "File in /usr/sbin directory",
+			inputPath:     "/usr/sbin/nginx",
+			shouldSucceed: false,
+			description:   "Should reject files in /usr/sbin directory",
+		},
+		// Valid paths that are NOT protected
+		{
+			name:          "Valid /tmp file",
+			inputPath:     "/tmp/model.bin",
+			shouldSucceed: true,
+			description:   "Should allow files in /tmp directory",
+		},
+		{
+			name:          "Valid /tmp subdirectory file",
+			inputPath:     "/tmp/models/pytorch_model.bin",
+			shouldSucceed: true,
+			description:   "Should allow files in /tmp subdirectories",
+		},
+		{
+			name:          "Valid relative path in current working dir",
+			inputPath:     "workdir/model.bin",
+			shouldSucceed: true,
+			description:   "Should allow relative paths in working directory",
+		},
+		{
+			name:          "Valid relative path with subdirs",
+			inputPath:     "models/deep-learning/pytorch_model.bin",
+			shouldSucceed: true,
+			description:   "Should allow relative paths with subdirectories",
+		},
+		// Edge cases - paths that look similar but should be allowed
+		{
+			name:          "Path with 'etc' in middle",
+			inputPath:     "etc-backup/config.json",
+			shouldSucceed: true,
+			description:   "Should allow paths that contain 'etc' but are not in /etc",
+		},
+		{
+			name:          "Path with 'bin' in middle",
+			inputPath:     "bin-files/binary.dat",
+			shouldSucceed: true,
+			description:   "Should allow paths that contain 'bin' but are not in /bin",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test the actual createNewFile method
+			file, err := createNewFile(tt.inputPath)
+
+			if tt.shouldSucceed {
+				if err != nil {
+					t.Errorf("Test %s: expected success but got error: %v", tt.name, err)
+				} else {
+					// Clean up the created file
+					if file != nil {
+						if closeErr := file.Close(); closeErr != nil {
+							t.Logf("Failed to close file: %v", closeErr)
+						}
+						// Only remove if it was actually created
+						if _, statErr := os.Stat(tt.inputPath); statErr == nil {
+							if removeErr := os.Remove(tt.inputPath); removeErr != nil {
+								t.Logf("Failed to remove file: %v", removeErr)
+							}
+						}
+					}
+					t.Logf("Test %s: SUCCESS - %s", tt.name, tt.inputPath)
+				}
+			} else {
+				if err == nil {
+					// Clean up if file was unexpectedly created
+					if file != nil {
+						if closeErr := file.Close(); closeErr != nil {
+							t.Logf("Failed to close file: %v", closeErr)
+						}
+						if removeErr := os.Remove(tt.inputPath); removeErr != nil {
+							t.Logf("Failed to remove file: %v", removeErr)
+						}
+					}
+					t.Errorf("Test %s: expected error but file was created: %s", tt.name, tt.inputPath)
+				} else {
+					t.Logf("Test %s: REJECTED - %s (error: %v)", tt.name, tt.inputPath, err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
(cherry picked from commit fed48e6ed0636bb5d2481cf212cc6dfdf18fffbc)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. Re-running failed tests: comment `/rerun-all` to rerun all failed workflows.
-->

**What this PR does / why we need it**:

[RHOAIENG-47407](https://issues.redhat.com/browse/RHOAIENG-47407)



**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
