### PR TITLE
fix: normalize deprec. deploymentMode annos; allow deletion

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_defaults.go
+++ b/pkg/apis/serving/v1beta1/inference_service_defaults.go
@@ -157,6 +157,18 @@ func (d *InferenceServiceDefaulter) Default(ctx context.Context, obj runtime.Obj
 func (isvc *InferenceService) DefaultInferenceService(config *InferenceServicesConfig, deployConfig *DeployConfig, securityConfig *SecurityConfig, models *v1alpha1.LocalModelCacheList) {
 	deploymentMode, ok := isvc.ObjectMeta.Annotations[constants.DeploymentMode]
 
+	// Normalize deprecated annotation values
+	if ok {
+		if deploymentMode == string(constants.LegacyRawDeployment) {
+			isvc.ObjectMeta.Annotations[constants.DeploymentMode] = string(constants.Standard)
+			deploymentMode = string(constants.Standard)
+		}
+		if deploymentMode == string(constants.LegacyServerless) {
+			isvc.ObjectMeta.Annotations[constants.DeploymentMode] = string(constants.Knative)
+			deploymentMode = string(constants.Knative)
+		}
+	}
+
 	if !ok && deployConfig != nil {
 		if deployConfig.DefaultDeploymentMode == string(constants.ModelMeshDeployment) ||
 			deployConfig.DefaultDeploymentMode == string(constants.RawDeployment) {

--- a/pkg/apis/serving/v1beta1/inference_service_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_defaults_test.go
@@ -1672,3 +1672,54 @@ func TestDefaultInferenceServiceWithLocalModel(t *testing.T) {
 	g.Expect(isvc.ObjectMeta.Annotations).To(gomega.HaveKeyWithValue(constants.LocalModelSourceUriAnnotationKey, "gs://testbucket/testmodel"))
 	g.Expect(isvc.ObjectMeta.Annotations).To(gomega.HaveKeyWithValue(constants.LocalModelPVCNameAnnotationKey, "local-model-node-group-1"))
 }
+
+func TestDefaultInferenceServiceNormalizesLegacyDeploymentMode(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	deployConfig := &DeployConfig{
+		DefaultDeploymentMode: string(constants.Knative),
+	}
+
+	// Test RawDeployment -> Standard normalization
+	isvcRaw := InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-raw",
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.DeploymentMode: string(constants.LegacyRawDeployment),
+			},
+		},
+		Spec: InferenceServiceSpec{
+			Predictor: PredictorSpec{
+				Tensorflow: &TFServingSpec{
+					PredictorExtensionSpec: PredictorExtensionSpec{
+						StorageURI: proto.String("gs://testbucket/testmodel"),
+					},
+				},
+			},
+		},
+	}
+	isvcRaw.DefaultInferenceService(nil, deployConfig, nil, nil)
+	g.Expect(isvcRaw.Annotations[constants.DeploymentMode]).To(gomega.Equal(string(constants.Standard)))
+
+	// Test Serverless -> Knative normalization
+	isvcServerless := InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-serverless",
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.DeploymentMode: string(constants.LegacyServerless),
+			},
+		},
+		Spec: InferenceServiceSpec{
+			Predictor: PredictorSpec{
+				Tensorflow: &TFServingSpec{
+					PredictorExtensionSpec: PredictorExtensionSpec{
+						StorageURI: proto.String("gs://testbucket/testmodel"),
+					},
+				},
+			},
+		},
+	}
+	isvcServerless.DefaultInferenceService(nil, deployConfig, nil, nil)
+	g.Expect(isvcServerless.Annotations[constants.DeploymentMode]).To(gomega.Equal(string(constants.Knative)))
+}

--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -87,9 +87,11 @@ func (v *InferenceServiceValidator) ValidateUpdate(ctx context.Context, oldObj, 
 		validatorLogger.Error(err, "Unable to convert object to InferenceService")
 	}
 	validatorLogger.Info("validate update", "name", isvc.Name)
-	err = validateDeploymentMode(isvc, oldIsvc)
-	if err != nil {
-		return nil, err
+	if isvc.GetDeletionTimestamp() == nil {
+		err = validateDeploymentMode(isvc, oldIsvc)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return validateInferenceService(isvc)
 }

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -1393,6 +1393,19 @@ func TestDeploymentModeUpdate(t *testing.T) {
 	// Annotation matches status, update is accepted
 	g.Expect(warnings).Should(gomega.BeEmpty())
 	g.Expect(err).Should(gomega.Succeed())
+
+	// Test: Mismatched deploymentMode should be allowed during deletion (DeletionTimestamp set)
+	// This allows finalizer cleanup when annotation differs from status
+	deletingIsvc := oldIsvc.DeepCopy()
+	deletingIsvc.Annotations = map[string]string{
+		constants.DeploymentMode: string(constants.Standard), // Mismatches status (Knative)
+	}
+	now := metav1.Now()
+	deletingIsvc.DeletionTimestamp = &now
+	warnings, err = validator.ValidateUpdate(t.Context(), &oldIsvc, deletingIsvc)
+	// During deletion, deploymentMode mismatch should be allowed
+	g.Expect(warnings).Should(gomega.BeEmpty())
+	g.Expect(err).Should(gomega.Succeed())
 }
 
 func TestValidateDelete(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry-pick of kserve/kserve#5025 (commit 93752a1) into `release-v0.15`.

Fixes InferenceService stuck in Terminating state when the `deploymentMode` annotation uses a deprecated value (`RawDeployment` or `Serverless`).

**Root Cause:** The controller normalizes deprecated annotation values when setting `status.DeploymentMode`, but the validation webhook compared the raw annotation value against the status, causing a mismatch that blocked all updates (including finalizer removal during deletion).

**This fix:**
1. **Defaulting webhook**: Normalizes deprecated annotation values at admission
2. **Validation webhook**: Skips `deploymentMode` validation during deletion to allow finalizer cleanup

**Which issue(s) this PR fixes** *(optional)*:
Upstream: Fixes kserve/kserve#5025

**Type of changes**
- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:
- [x] Unit tests added (in upstream PR); cherry-pick includes tests

**Checklist**:
- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?

**Release note**:
```release-note
Fix InferenceService stuck in Terminating when using deprecated deploymentMode annotation values (RawDeployment/Serverless)
```