### PR TITLE
[RHOAIENG-47402] fix: remove insecure TLS default in IAP sample

### DIFF
--- a/docs/samples/gcp-iap/iap_request_auth.py
+++ b/docs/samples/gcp-iap/iap_request_auth.py
@@ -103,25 +103,17 @@ def idTokenFromRefreshToken(client_id, client_secret, refresh_token, audience):
     return str(json.loads(res.text)["id_token"])
 
 
-def makeRequest(url, input_file, user_account, id_token):
+def makeRequest(url, input_file, user_account, id_token, verify=True):
+    headers = {"Authorization": "Bearer {}".format(id_token)}
     if input_file:
         with open(input_file) as f:
             data = f.read()
-        resp = requests.post(
-            url,
-            verify=False,
-            data=data,
-            headers={
-                "Authorization": "Bearer {}".format(id_token),
-                "x-goog-authenticated-user-email": "accounts.google.com:{}".format(
-                    user_account
-                ),
-            },
+        headers["x-goog-authenticated-user-email"] = "accounts.google.com:{}".format(
+            user_account
         )
+        resp = requests.post(url, verify=verify, data=data, headers=headers)
     else:
-        resp = requests.get(
-            url, verify=False, headers={"Authorization": "Bearer {}".format(id_token)}
-        )
+        resp = requests.get(url, verify=verify, headers=headers)
     if resp.status_code == 403:
         raise Exception(
             "Service account {} does not have permission to "
@@ -135,6 +127,18 @@ def makeRequest(url, input_file, user_account, id_token):
         )
     else:
         print(resp.text)
+
+
+def _tls_verify(ca_cert, insecure):
+    if insecure:
+        logging.warning(
+            "TLS certificate verification is disabled. "
+            "This is insecure and should not be used in production."
+        )
+        return False
+    if ca_cert:
+        return ca_cert
+    return True
 
 
 def main():
@@ -154,12 +158,23 @@ def main():
         help="The user email address " + "which can access the namespace",
     )
     parser.add_argument("--input", help="The input file.")
+    parser.add_argument(
+        "--ca-cert",
+        help="Path to a CA certificate bundle for TLS verification "
+        "(e.g. a self-signed CA). If omitted, the system trust store is used.",
+    )
+    parser.add_argument(
+        "--insecure",
+        action="store_true",
+        help="Disable TLS certificate verification (not recommended).",
+    )
     args = parser.parse_args()
 
+    verify = _tls_verify(args.ca_cert, args.insecure)
     id_token = getToken(
         args.iap_client_id, args.desktop_client_id, args.desktop_client_secret
     )
-    makeRequest(args.url, args.input, args.user_account, id_token)
+    makeRequest(args.url, args.input, args.user_account, id_token, verify=verify)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry-pick of kserve/kserve#5131

The GCP IAP sample hardcoded `verify=False` on all requests, disabling TLS certificate verification (CWE-295). This is the only sample in the repository that did so, and since it's the only sample making requests over the public internet (via IAP), it's also the one where TLS verification matters most.

This PR defaults to secure TLS verification (`verify=True`) and adds two opt-in flags:
- `--ca-cert` for self-signed or internal CA certificates
- `--insecure` to explicitly disable verification (with a warning)

**Feature/Issue validation/testing**:

- [x] Verified no other samples use `verify=False`
- [x] Verified production code (`kserve_storage.py`, `inference_client.py`) already follows this pattern

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```