### PR TITLE
build(make): add Makefile.overrides.mk for midstream-only targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -544,8 +544,5 @@ apidocs:
 check-doc-links:
 	@python3 hack/verify-doc-links.py && echo "$@: OK"
 
-uv-update-lockfiles:
-	bash -ec 'for value in $$(find . -name uv.lock -exec dirname {} \;); do (cd "$${value}" && echo "Updating $${value}/uv.lock" && uv update --lock); done'
-
 # Optional local/downstream overrides (ignored if absent)
 -include Makefile.overrides.mk

--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -1,0 +1,23 @@
+# Midstream-only Make targets for opendatahub-io/kserve.
+# Loaded via `-include Makefile.overrides.mk` in the main Makefile.
+# This file does not exist on upstream kserve/kserve.
+
+.PHONY: deploy-dev-llm deploy-dev-llm-ocp deploy-ci uv-update-lockfiles
+
+deploy-dev-llm:
+	./hack/deploy_dev_llm.sh
+
+deploy-dev-llm-ocp:
+	./test/scripts/openshift-ci/setup-llm.sh --deploy-kuadrant
+
+deploy-ci: manifests
+	kubectl apply --server-side=true --force-conflicts -k config/crd/full
+	kubectl apply --server-side=true --force-conflicts -k config/crd/full/localmodel
+	kubectl apply --server-side=true --force-conflicts -k config/crd/full/llmisvc
+	kubectl wait --for=condition=established --timeout=60s crd/llminferenceserviceconfigs.serving.kserve.io
+	kubectl apply --server-side=true -k config/overlays/test
+	kubectl wait --for=condition=ready pod -l control-plane=kserve-controller-manager -n kserve --timeout=300s
+	kubectl apply --server-side=true -k config/overlays/test/clusterresources
+
+uv-update-lockfiles:
+	bash -ec 'for value in $$(find . -name uv.lock -exec dirname {} \;); do (cd "$${value}" && echo "Updating $${value}/uv.lock" && uv update --lock); done'


### PR DESCRIPTION
> [!NOTE]
> Upstream PR https://github.com/kserve/kserve/pull/5164

**What this PR does / why we need it**:

Introduces a `Makefile.overrides.mk` mechanism to isolate midstream-only Make targets from the main Makefile, reducing merge conflicts during upstream syncs.

`-include Makefile.overrides.mk` at the end of the Makefile. The `-` prefix makes this a silent no-op when the file is absent - zero functional change for upstream. This commit is designed to be cherry-picked directly to `kserve/kserve`.

Structured as two commits so commit 1 can be cherry-picked to upstream `kserve/kserve` as a standalone PR. The `-include` directive is idiomatic Make and widely used for optional local overrides.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build system now supports an optional overrides fragment for conditional, downstream customization without affecting standard builds.
  * Added new deployment targets to simplify setup for development and CI environments, covering multiple deployment flows and readiness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->