### PR TITLE
port 2: Add llminferenceservices to ODH user cluster roles

### DIFF
--- a/config/overlays/odh/user-cluster-roles.yaml
+++ b/config/overlays/odh/user-cluster-roles.yaml
@@ -24,6 +24,7 @@ rules:
       - serving.kserve.io
     resources:
       - inferenceservices
+      - llminferenceservices
       - servingruntimes
     verbs:
       - create
@@ -51,6 +52,9 @@ rules:
       - inferenceservices
       - inferenceservices/status
       - inferenceservices/finalizers
+      - llminferenceservices
+      - llminferenceservices/status
+      - llminferenceservices/finalizers
     verbs:
       - get
       - list


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `llminferenceservices` to the ODH user-facing cluster roles so that users with `edit` or `view` access can interact with `LLMInferenceService` resources:

- `kserve-edit`: adds `llminferenceservices` with full CRUD verbs
- `kserve-view`: adds `llminferenceservices`, `llminferenceservices/status`, and `llminferenceservices/finalizers` with get/list/watch

This was present on release-v0.15 but missing from master after the upstream sync.

Add llminferenceservices to ODH user cluster roles (port from 0.15 cont. #1147)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Part of [RHOAIENG-38554](https://issues.redhat.com/browse/RHOAIENG-38554) (Port ODH overlay from release-v0.15 to master)

**Feature/Issue validation/testing**:

- [x] `kustomize build config/overlays/odh` succeeds - verified `llminferenceservices` appears in both `kserve-edit` and `kserve-view` ClusterRole output
- [x] `kustomize build config/overlays/odh-test` builds successfully (no regression)

**Special notes for your reviewer**:

Single file change, no image changes. Just adding the missing RBAC resources to match the release-v0.15 overlay.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note
NONE
```



