### PR TITLE
[RHOAIENG-47668] - CVE-2026-24486: Python-Multipart Arbitrary File Write

### DIFF
--- a/python/aiffairness/poetry.lock
+++ b/python/aiffairness/poetry.lock
@@ -1501,6 +1501,7 @@ protobuf = "^5.27.1"
 psutil = "^5.9.6"
 pydantic = "^2.5.0"
 python-dateutil = "^2.8.0"
+python-multipart = ">=0.0.22"
 pyyaml = "^6.0.0"
 six = "^1.16.0"
 starlette = "0.49.1"
@@ -2671,6 +2672,17 @@ files = [
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
+    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
+]
 
 [[package]]
 name = "pytz"

--- a/python/artexplainer/poetry.lock
+++ b/python/artexplainer/poetry.lock
@@ -1287,6 +1287,7 @@ protobuf = "^5.27.1"
 psutil = "^5.9.6"
 pydantic = "^2.5.0"
 python-dateutil = "^2.8.0"
+python-multipart = ">=0.0.22"
 pyyaml = "^6.0.0"
 six = "^1.16.0"
 starlette = "0.49.1"
@@ -2573,6 +2574,17 @@ files = [
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
+    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
+]
 
 [[package]]
 name = "pytz"

--- a/python/custom_model/poetry.lock
+++ b/python/custom_model/poetry.lock
@@ -1244,6 +1244,7 @@ protobuf = "^5.27.1"
 psutil = "^5.9.6"
 pydantic = "^2.5.0"
 python-dateutil = "^2.8.0"
+python-multipart = ">=0.0.22"
 pyyaml = "^6.0.0"
 ray = {version = ">=2.43.0", extras = ["serve"], optional = true}
 six = "^1.16.0"
@@ -2392,6 +2393,17 @@ files = [
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
+    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
+]
 
 [[package]]
 name = "pytz"

--- a/python/custom_tokenizer/poetry.lock
+++ b/python/custom_tokenizer/poetry.lock
@@ -1086,6 +1086,7 @@ protobuf = "^5.27.1"
 psutil = "^5.9.6"
 pydantic = "^2.5.0"
 python-dateutil = "^2.8.0"
+python-multipart = ">=0.0.22"
 pyyaml = "^6.0.0"
 six = "^1.16.0"
 starlette = "0.49.1"
@@ -2050,6 +2051,17 @@ files = [
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
+    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
+]
 
 [[package]]
 name = "pytz"

--- a/python/custom_transformer/poetry.lock
+++ b/python/custom_transformer/poetry.lock
@@ -1158,6 +1158,7 @@ protobuf = "^5.27.1"
 psutil = "^5.9.6"
 pydantic = "^2.5.0"
 python-dateutil = "^2.8.0"
+python-multipart = ">=0.0.22"
 pyyaml = "^6.0.0"
 six = "^1.16.0"
 starlette = "0.49.1"
@@ -2324,6 +2325,17 @@ files = [
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
+    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
+]
 
 [[package]]
 name = "pytz"

--- a/python/huggingfaceserver/poetry.lock
+++ b/python/huggingfaceserver/poetry.lock
@@ -2254,6 +2254,7 @@ protobuf = "^5.27.1"
 psutil = "^5.9.6"
 pydantic = "^2.5.0"
 python-dateutil = "^2.8.0"
+python-multipart = ">=0.0.22"
 pyyaml = "^6.0.0"
 requests = {version = "^2.32.2", optional = true}
 six = "^1.16.0"
@@ -4413,13 +4414,13 @@ dev = ["backports.zoneinfo", "black", "build", "freezegun", "mdx_truly_sane_list
 
 [[package]]
 name = "python-multipart"
-version = "0.0.20"
+version = "0.0.22"
 description = "A streaming multipart parser for Python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 files = [
-    {file = "python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104"},
-    {file = "python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13"},
+    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
+    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
 ]
 
 [[package]]

--- a/python/kserve/poetry.lock
+++ b/python/kserve/poetry.lock
@@ -4837,13 +4837,13 @@ dev = ["backports.zoneinfo", "black", "build", "freezegun", "mdx_truly_sane_list
 
 [[package]]
 name = "python-multipart"
-version = "0.0.20"
+version = "0.0.22"
 description = "A streaming multipart parser for Python"
-optional = true
-python-versions = ">=3.8"
+optional = false
+python-versions = ">=3.10"
 files = [
-    {file = "python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104"},
-    {file = "python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13"},
+    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
+    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
 ]
 
 [[package]]
@@ -7071,4 +7071,4 @@ storage = ["azure-identity", "azure-storage-blob", "azure-storage-file-share", "
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "d91bf00fca52778b310a11b3c659e0e09769647e80ed93c304d84e756510ac6c"
+content-hash = "8ac0917c46399d17f66b5c513068ae2a280b6229cb5fd8803a71c0205fae43ed"

--- a/python/kserve/pyproject.toml
+++ b/python/kserve/pyproject.toml
@@ -59,6 +59,9 @@ aiohttp = ">=3.13.3"
 # CVE-2026-26007 cryptography Subgroup Attack Due to Missing Subgroup Validation for SECT Curves
 # Pinning because it is a transitive dependency.
 cryptography = ">=46.0.5"
+# CVE-2026-24486 Python-Multipart has Arbitrary File Write via Non-Default Configuration
+# Pinning because it is a transitive dependency.
+python-multipart = ">=0.0.22"
 
 # Storage dependencies. They can be opted into by apps.
 requests = { version = "^2.32.2", optional = true }

--- a/python/lgbserver/poetry.lock
+++ b/python/lgbserver/poetry.lock
@@ -1617,6 +1617,7 @@ protobuf = "^5.27.1"
 psutil = "^5.9.6"
 pydantic = "^2.5.0"
 python-dateutil = "^2.8.0"
+python-multipart = ">=0.0.22"
 pyyaml = "^6.0.0"
 requests = {version = "^2.32.2", optional = true}
 six = "^1.16.0"
@@ -2717,6 +2718,17 @@ files = [
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
+    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
+]
 
 [[package]]
 name = "pytz"

--- a/python/paddleserver/poetry.lock
+++ b/python/paddleserver/poetry.lock
@@ -1628,6 +1628,7 @@ protobuf = "^5.27.1"
 psutil = "^5.9.6"
 pydantic = "^2.5.0"
 python-dateutil = "^2.8.0"
+python-multipart = ">=0.0.22"
 pyyaml = "^6.0.0"
 requests = {version = "^2.32.2", optional = true}
 six = "^1.16.0"
@@ -2868,6 +2869,17 @@ files = [
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
+    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
+]
 
 [[package]]
 name = "pytz"

--- a/python/pmmlserver/poetry.lock
+++ b/python/pmmlserver/poetry.lock
@@ -1672,6 +1672,7 @@ protobuf = "^5.27.1"
 psutil = "^5.9.6"
 pydantic = "^2.5.0"
 python-dateutil = "^2.8.0"
+python-multipart = ">=0.0.22"
 pyyaml = "^6.0.0"
 requests = {version = "^2.32.2", optional = true}
 six = "^1.16.0"
@@ -2822,6 +2823,17 @@ files = [
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
+    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
+]
 
 [[package]]
 name = "pytz"

--- a/python/sklearnserver/poetry.lock
+++ b/python/sklearnserver/poetry.lock
@@ -1617,6 +1617,7 @@ protobuf = "^5.27.1"
 psutil = "^5.9.6"
 pydantic = "^2.5.0"
 python-dateutil = "^2.8.0"
+python-multipart = ">=0.0.22"
 pyyaml = "^6.0.0"
 requests = {version = "^2.32.2", optional = true}
 six = "^1.16.0"
@@ -2691,6 +2692,17 @@ files = [
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
+    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
+]
 
 [[package]]
 name = "pytz"

--- a/python/test_resources/graph/error_404_isvc/poetry.lock
+++ b/python/test_resources/graph/error_404_isvc/poetry.lock
@@ -1075,6 +1075,7 @@ protobuf = "^5.27.1"
 psutil = "^5.9.6"
 pydantic = "^2.5.0"
 python-dateutil = "^2.8.0"
+python-multipart = ">=0.0.22"
 pyyaml = "^6.0.0"
 six = "^1.16.0"
 starlette = "0.49.1"
@@ -1952,6 +1953,17 @@ files = [
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
+    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
+]
 
 [[package]]
 name = "pytz"

--- a/python/test_resources/graph/success_200_isvc/poetry.lock
+++ b/python/test_resources/graph/success_200_isvc/poetry.lock
@@ -1075,6 +1075,7 @@ protobuf = "^5.27.1"
 psutil = "^5.9.6"
 pydantic = "^2.5.0"
 python-dateutil = "^2.8.0"
+python-multipart = ">=0.0.22"
 pyyaml = "^6.0.0"
 six = "^1.16.0"
 starlette = "0.49.1"
@@ -1952,6 +1953,17 @@ files = [
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
+    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
+]
 
 [[package]]
 name = "pytz"

--- a/python/xgbserver/poetry.lock
+++ b/python/xgbserver/poetry.lock
@@ -1617,6 +1617,7 @@ protobuf = "^5.27.1"
 psutil = "^5.9.6"
 pydantic = "^2.5.0"
 python-dateutil = "^2.8.0"
+python-multipart = ">=0.0.22"
 pyyaml = "^6.0.0"
 requests = {version = "^2.32.2", optional = true}
 six = "^1.16.0"
@@ -2702,6 +2703,17 @@ files = [
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155"},
+    {file = "python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58"},
+]
 
 [[package]]
 name = "pytz"


### PR DESCRIPTION
## Summary
- Pin `python-multipart>=0.0.22` in `python/kserve/pyproject.toml` to fix CVE-2026-24486 (Arbitrary File Write via Non-Default Configuration)
- Pinning because it is a transitive dependency (pulled in by fastapi/starlette)
- Updated all 14 poetry.lock files via `make precommit`

## Verification
- All 172 kserve Python unit tests pass
- Storage-initializer container builds successfully
- Confirmed `python-multipart==0.0.22` is installed in the storage-initializer container image

## Test plan
- [x] `make precommit` completed successfully
- [x] Python unit tests pass (172/172)
- [x] Storage-initializer container image builds successfully
- [x] `python-multipart 0.0.22` confirmed installed in the container

Jira: https://issues.redhat.com/browse/RHOAIENG-47668