### PR TITLE
Add startupProbe to vLLM config templates to prevent premature pod kills

### DIFF
--- a/config/llmisvc/config-llm-decode-template.yaml
+++ b/config/llmisvc/config-llm-decode-template.yaml
@@ -166,7 +166,6 @@ spec:
             path: /health
             port: 8001
             scheme: HTTPS
-          initialDelaySeconds: 120
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 3
@@ -175,10 +174,16 @@ spec:
             path: /health
             port: 8001
             scheme: HTTPS
-          initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 60
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8001
+            scheme: HTTPS
+          failureThreshold: 60
+          periodSeconds: 10
         volumeMounts:
           - mountPath: /home
             name: home

--- a/config/llmisvc/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvc/config-llm-decode-worker-data-parallel.yaml
@@ -261,7 +261,6 @@ spec:
             path: /health
             port: 8001
             scheme: HTTPS
-          initialDelaySeconds: 300
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 3
@@ -270,10 +269,16 @@ spec:
             path: /health
             port: 8001
             scheme: HTTPS
-          initialDelaySeconds: 200
           periodSeconds: 30
           timeoutSeconds: 5
           failureThreshold: 60
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8001
+            scheme: HTTPS
+          failureThreshold: 60
+          periodSeconds: 10
         volumeMounts:
           - mountPath: /home
             name: home

--- a/config/llmisvc/config-llm-prefill-template.yaml
+++ b/config/llmisvc/config-llm-prefill-template.yaml
@@ -167,7 +167,6 @@ spec:
               path: /health
               port: 8000
               scheme: HTTPS
-            initialDelaySeconds: 120
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 3
@@ -176,10 +175,16 @@ spec:
               path: /health
               port: 8000
               scheme: HTTPS
-            initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 60
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 60
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /home
               name: home

--- a/config/llmisvc/config-llm-prefill-worker-data-parallel.yaml
+++ b/config/llmisvc/config-llm-prefill-worker-data-parallel.yaml
@@ -204,7 +204,6 @@ spec:
               path: /health
               port: 8000
               scheme: HTTPS
-            initialDelaySeconds: 300
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 3
@@ -213,10 +212,16 @@ spec:
               path: /health
               port: 8000
               scheme: HTTPS
-            initialDelaySeconds: 200
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 60
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+              scheme: HTTPS
+            failureThreshold: 60
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /home
               name: home

--- a/config/llmisvc/config-llm-template.yaml
+++ b/config/llmisvc/config-llm-template.yaml
@@ -166,7 +166,6 @@ spec:
             path: /health
             port: 8000
             scheme: HTTPS
-          initialDelaySeconds: 120
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 3
@@ -175,10 +174,16 @@ spec:
             path: /health
             port: 8000
             scheme: HTTPS
-          initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 60
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: HTTPS
+          failureThreshold: 60
+          periodSeconds: 10
         volumeMounts:
           - mountPath: /home
             name: home

--- a/config/llmisvc/config-llm-worker-data-parallel.yaml
+++ b/config/llmisvc/config-llm-worker-data-parallel.yaml
@@ -203,7 +203,6 @@ spec:
             path: /health
             port: 8000
             scheme: HTTPS
-          initialDelaySeconds: 300
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 3
@@ -212,10 +211,16 @@ spec:
             path: /health
             port: 8000
             scheme: HTTPS
-          initialDelaySeconds: 200
           periodSeconds: 30
           timeoutSeconds: 5
           failureThreshold: 60
+        startupProbe:
+          httpGet:
+            path: /health
+            port: 8000
+            scheme: HTTPS
+          failureThreshold: 60
+          periodSeconds: 10
         volumeMounts:
           - mountPath: /home
             name: home

--- a/pkg/controller/llmisvc/config_presets_test.go
+++ b/pkg/controller/llmisvc/config_presets_test.go
@@ -223,10 +223,9 @@ func TestPresetFiles(t *testing.T) {
 												Scheme: corev1.URISchemeHTTPS,
 											},
 										},
-										InitialDelaySeconds: 300,
-										TimeoutSeconds:      10,
-										PeriodSeconds:       10,
-										FailureThreshold:    3,
+										TimeoutSeconds:   10,
+										PeriodSeconds:    10,
+										FailureThreshold: 3,
 									},
 									ReadinessProbe: &corev1.Probe{
 										ProbeHandler: corev1.ProbeHandler{
@@ -236,10 +235,20 @@ func TestPresetFiles(t *testing.T) {
 												Scheme: corev1.URISchemeHTTPS,
 											},
 										},
-										InitialDelaySeconds: 200,
-										TimeoutSeconds:      5,
-										PeriodSeconds:       30,
-										FailureThreshold:    60,
+										TimeoutSeconds:   5,
+										PeriodSeconds:    30,
+										FailureThreshold: 60,
+									},
+									StartupProbe: &corev1.Probe{
+										ProbeHandler: corev1.ProbeHandler{
+											HTTPGet: &corev1.HTTPGetAction{
+												Path:   "/health",
+												Port:   intstr.FromInt32(8001),
+												Scheme: corev1.URISchemeHTTPS,
+											},
+										},
+										FailureThreshold: 60,
+										PeriodSeconds:    10,
 									},
 									TerminationMessagePath:   "/dev/termination-log",
 									TerminationMessagePolicy: "FallbackToLogsOnError",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. Re-running failed tests: comment `/rerun-all` to rerun all failed workflows.
-->


**What this PR does / why we need it**:

Ports the startupProbe changes from upstream kserve/kserve PR #5063 to release-v0.15.

vLLM pods are consistently killed by liveness probes before model loading completes, causing 100% failure rate on `test_llm_auth_enabled_requires_token` in odh-model-controller e2e CI (see opendatahub-io/odh-model-controller#698). The root cause is that liveness probes (with `initialDelaySeconds`) begin checking before vLLM finishes loading models, and with TLS cert rotation happening during startup, the probes never pass in time.

This PR:
- Adds a `startupProbe` to all 6 vLLM config templates, giving vLLM up to 600s (failureThreshold: 60 × periodSeconds: 10) to start before liveness/readiness probes kick in
- Removes `initialDelaySeconds` from liveness and readiness probes on the main vLLM container (no longer needed with startupProbe gating)
- Adapts the upstream change for release-v0.15 (uses `scheme: HTTPS` since TLS is enabled on this branch)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:

- [x] `go test ./pkg/controller/llmisvc/... -run TestPresetFiles -v` - all 8 subtests pass
- [x] Verified no `initialDelaySeconds` remains on main vLLM containers (only sidecar containers retain theirs)
- [x] Verified `startupProbe` present in all 6 config templates
- [ ] e2e: `test_llm_auth_enabled_requires_token` should pass with this change (previously failing 100% due to liveness probe killing vLLM before ready)

**Special notes for your reviewer**:

- This is a manual port of upstream PR kserve/kserve#5063 - a clean cherry-pick was not possible due to branch divergence (different directory structure, API version, TLS enabled vs disabled, command structure, no Helm charts on release-v0.15)
- Only the main vLLM container probes are modified. Sidecar containers (`llm-d-routing-sidecar`) and headless worker containers are untouched
- The `make precommit` poetry-lock step fails due to local Python version (3.14 vs required <3.13) - this is a pre-existing environment issue unrelated to this change. All Go targets (vet, codegen, tests) pass

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note
Add startupProbe to vLLM containers in LLMInferenceService config templates, preventing liveness probes from killing pods during model loading. Removes initialDelaySeconds from liveness/readiness probes in favor of startupProbe gating.
```

