### PR TITLE
fix(llmisvc): compatibility with podman for container builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -399,7 +399,7 @@ docker-build-llmisvc:
 	${ENGINE} buildx build ${ARCH} -t ${KO_DOCKER_REPO}/${LLMISVC_CONTROLLER_IMG} -f llmisvc-controller.Dockerfile .
 
 docker-push-llmisvc: docker-build-llmisvc
-	${ENGINE} buildx build ${ARCH} --push -t ${KO_DOCKER_REPO}/${LLMISVC_CONTROLLER_IMG} -f llmisvc-controller.Dockerfile .
+	${ENGINE} push ${KO_DOCKER_REPO}/${LLMISVC_CONTROLLER_IMG}
 
 docker-build-localmodel:
 	${ENGINE} buildx build ${ARCH} -t ${KO_DOCKER_REPO}/${LOCALMODEL_CONTROLLER_IMG} -f localmodel.Dockerfile .

--- a/llmisvc-controller.Dockerfile
+++ b/llmisvc-controller.Dockerfile
@@ -12,6 +12,7 @@ COPY cmd/    cmd/
 COPY pkg/    pkg/
 
 # Build
+USER root
 RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager ./cmd/llmisvc
 
 # Generate third-party licenses


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds compatibility to build the llmisvc-controller with podman:
* Podman does not have the `--push` flag for `build` command. Thus, use the `push` commmand.
* In the dockerfile, use `USER root` for the build stage. Otherwise, the following error is
  emitted:

```
[1/2] STEP 8/12: RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager ./cmd/llmisvc
github.com/kserve/kserve/cmd/llmisvc: go build github.com/kserve/kserve/cmd/llmisvc: copying /tmp/go-build1108754253/b001/exe/a.out: open manager: permission denied
Error: building at STEP "RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager ./cmd/llmisvc": while running runtime: exit status 1
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

N/A


**Feature/Issue validation/testing**:

```
ENGINE=podman make docker-push-llmisvc
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the Docker image build and push workflow for the service controller, improving deployment efficiency.
  * Updated the Docker build environment configuration to ensure proper permissions during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->