### PR TITLE
fix(kustomize): adjust manifests to work with ODH

### DIFF
--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -44,12 +44,19 @@ patches:
     kind: Service
     name: llmisvc-webhook-server-service
   path: patches/openshift-serving-cert-llmisvc-patch.yaml
+- target:
+    kind: LLMInferenceServiceConfig
+  path: patches/annotate-well-known-llmisvcconfigs.yaml
+- target:
+    kind: Deployment
+    name: llmisvc-controller-manager
+  path: patches/remove-kserve-controller-runas.yaml
 
 replacements:
 - source:
     kind: ConfigMap
     name: kserve-parameters
-    fieldpath: data.kserve-controller
+    fieldPath: data.kserve-controller
   targets:
   - select:
       kind: Deployment
@@ -122,11 +129,21 @@ replacements:
       name: kserve-config-llm-decode-worker-data-parallel
     fieldPaths:
     - spec.template.initContainers.[name=llm-d-routing-sidecar].image
+- source:
+    kind: ConfigMap
+    name: kserve-parameters
+    fieldPath: data.llmisvc-controller
+  targets:
+  - select:
+      kind: Deployment
+      name: llmisvc-controller-manager
+    fieldPaths:
+    - spec.template.spec.containers.[name=manager].image
 
 - source:
     kind: ConfigMap
     name: kserve-parameters
-    fieldpath: data.kserve-llm-d-nvidia-cuda
+    fieldPath: data.kserve-llm-d-nvidia-cuda
   targets:
   - select:
       kind: LLMInferenceServiceConfig
@@ -137,7 +154,7 @@ replacements:
 - source:
     kind: ConfigMap
     name: kserve-parameters
-    fieldpath: data.kserve-llm-d-amd-rocm
+    fieldPath: data.kserve-llm-d-amd-rocm
   targets:
   - select:
       kind: LLMInferenceServiceConfig
@@ -148,7 +165,7 @@ replacements:
 - source:
     kind: ConfigMap
     name: kserve-parameters
-    fieldpath: data.kserve-llm-d-ibm-spyre
+    fieldPath: data.kserve-llm-d-ibm-spyre
   targets:
   - select:
       kind: LLMInferenceServiceConfig

--- a/config/overlays/odh/patches/annotate-well-known-llmisvcconfigs.yaml
+++ b/config/overlays/odh/patches/annotate-well-known-llmisvcconfigs.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /metadata/annotations/serving.kserve.io~1well-known-config
+  value: "true"

--- a/config/overlays/odh/patches/inferenceservice-config-patch.yaml
+++ b/config/overlays/odh/patches/inferenceservice-config-patch.yaml
@@ -20,7 +20,6 @@ data:
         "memoryLimit": "24Gi",
         "cpuRequest": "100m",
         "cpuLimit": "1",
-        "enableDirectPvcVolumeMount": true,
         "cpuModelcar": "10m",
         "memoryModelcar": "15Mi",
         "enableModelcar": true
@@ -87,6 +86,11 @@ data:
     {
       "enableMetricAggregation": "false",
       "enablePrometheusScraping" : "false"
+    }
+
+  service: |-
+    {
+        "serviceClusterIPNone": false
     }
 
   inferenceService: |-

--- a/config/overlays/odh/patches/remove-kserve-controller-runas.yaml
+++ b/config/overlays/odh/patches/remove-kserve-controller-runas.yaml
@@ -1,0 +1,3 @@
+- op: remove
+  path: /spec/template/spec/containers/0/securityContext/runAsUser
+  value: 1000


### PR DESCRIPTION
**What this PR does / why we need it**:

* Include LLMIsvcConfigs, which are _ODH built-ins_
* Include GIE, because in ODH it is expected to be applied in the
  operator setup
* Remove `runAsUser: 1000` on the llmisvc-controller, to be compatible
  with OpenShift.
* Correctly apply llmisvc-controller image specified in params.env file.
* Port missing inferenceservice-config ConfigMap patches from `release-v0.15`
  branch.


**Which issue(s) this PR fixes**

https://issues.redhat.com/browse/RHOAIENG-52418

**Feature/Issue validation/testing**:

Manual testing: setup via custom build of odh-operator

**Special notes for your reviewer**:

Automated testing would be done via E2Es that are being fixed for `master` branch.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced new inference management APIs for model rewriting, objectives, and pool configuration.
  * Added gateway inference extension support.
  * Expanded KServe inference workload templates and configurations.

* **Configuration**
  * Enhanced service configuration settings.
  * Updated kustomization resources and patches for better deployment customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->