### PR TITLE
Port TLS enablement from release-v0.15 to base LLMInferenceServiceConfig templates

### DIFF
--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -19,12 +19,11 @@ spec:
           - "{{ .Spec.Model.Name }}"
           - --port
           - "8001"
-          # BackendTLSPolicy is not implemented yet so disable SSL for now
-          #- --enable-ssl-refresh
-          #- --ssl-certfile
-          #- /var/run/kserve/tls/tls.crt
-          #- --ssl-keyfile
-          #- /var/run/kserve/tls/tls.key
+          - --enable-ssl-refresh
+          - --ssl-certfile
+          - /var/run/kserve/tls/tls.crt
+          - --ssl-keyfile
+          - /var/run/kserve/tls/tls.key
 
         env:
           - name: HOME
@@ -48,7 +47,7 @@ spec:
           httpGet:
             path: /health
             port: 8001
-            scheme: HTTP
+            scheme: HTTPS
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 3
@@ -56,7 +55,7 @@ spec:
           httpGet:
             path: /health
             port: 8001
-            scheme: HTTP
+            scheme: HTTPS
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 60
@@ -64,7 +63,7 @@ spec:
           httpGet:
             path: /health
             port: 8001
-            scheme: HTTP
+            scheme: HTTPS
           failureThreshold: 60
           periodSeconds: 10
         volumeMounts:
@@ -99,7 +98,7 @@ spec:
           httpGet:
             path: /health
             port: 8000
-            scheme: HTTP
+            scheme: HTTPS
           initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 10
@@ -108,7 +107,7 @@ spec:
           httpGet:
             path: /health
             port: 8000
-            scheme: HTTP
+            scheme: HTTPS
           initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 5
@@ -117,15 +116,12 @@ spec:
           - "--port=8000"
           - "--vllm-port=8001"
           - "--connector=nixlv2"
-          - "--secure-proxy=false"
-          # BackendTLSPolicy is not implemented yet so disable SSL for now
-          # - "--secure-proxy=true"
-          # - "--cert-path=/var/run/kserve/tls"
-          # - "--decoder-use-tls=true"
-          # - "--decoder-tls-insecure-skip-verify=true"
-          # - "--prefiller-use-tls=true"
-          # - "--prefiller-tls-insecure-skip-verify=true"
-          # - "--enable-ssrf-protection=true"
+          - "--secure-proxy=true"
+          - "--cert-path=/var/run/kserve/tls"
+          - "--decoder-use-tls=true"
+          - "--prefiller-use-tls=true"
+          - "--enable-ssrf-protection=true"
+          - "--pool-group=inference.networking.x-k8s.io"
         volumeMounts:
           - mountPath: /var/run/kserve/tls
             name: tls-certs
@@ -135,6 +131,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: SSL_CERT_DIR
+            value: "/var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs"
     terminationGracePeriodSeconds: 30
     volumes:
       - emptyDir: { }

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -27,7 +27,7 @@ spec:
           httpGet:
             path: /health
             port: 8000
-            scheme: HTTP
+            scheme: HTTPS
           initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 10
@@ -36,7 +36,7 @@ spec:
           httpGet:
             path: /health
             port: 8000
-            scheme: HTTP
+            scheme: HTTPS
           initialDelaySeconds: 10
           periodSeconds: 10
           timeoutSeconds: 5
@@ -45,14 +45,12 @@ spec:
           - "--port=8000"
           - "--vllm-port=8001"
           - "--connector=nixlv2"
-          - "--secure-proxy=false"
-          # BackendTLSPolicy is not implemented yet so disable SSL for now
-          # - "--cert-path=/var/run/kserve/tls"
-          # - "--decoder-use-tls=true"
-          # - "--decoder-tls-insecure-skip-verify=true"
-          # - "--prefiller-use-tls=true"
-          # - "--prefiller-tls-insecure-skip-verify=true"
-          # - "--enable-ssrf-protection=true"
+          - "--secure-proxy=true"
+          - "--cert-path=/var/run/kserve/tls"
+          - "--decoder-use-tls=true"
+          - "--prefiller-use-tls=true"
+          - "--enable-ssrf-protection=true"
+          - "--pool-group=inference.networking.x-k8s.io"
         volumeMounts:
           - mountPath: /var/run/kserve/tls
             name: tls-certs
@@ -62,6 +60,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: SSL_CERT_DIR
+            value: "/var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs"
     containers:
       - image: ghcr.io/llm-d/llm-d-cuda:v0.4.0
         imagePullPolicy: IfNotPresent
@@ -214,13 +214,12 @@ spec:
               --data-parallel-start-rank $START_RANK \
               ${VLLM_ADDITIONAL_ARGS} \
               $@ \
-              --trust-remote-code"
-              # BackendTLSPolicy is not implemented yet so disable SSL for now
-              # --enable-ssl-refresh \
-              # --ssl-certfile \
-              # /var/run/kserve/tls/tls.crt \
-              # --ssl-keyfile \
-              # /var/run/kserve/tls/tls.key"
+              --trust-remote-code \
+              --enable-ssl-refresh \
+              --ssl-certfile \
+              /var/run/kserve/tls/tls.crt \
+              --ssl-keyfile \
+              /var/run/kserve/tls/tls.key"
           # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
           - "--"
 
@@ -250,7 +249,7 @@ spec:
           httpGet:
             path: /health
             port: 8001
-            scheme: HTTP
+            scheme: HTTPS
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 3
@@ -258,7 +257,7 @@ spec:
           httpGet:
             path: /health
             port: 8001
-            scheme: HTTP
+            scheme: HTTPS
           periodSeconds: 30
           timeoutSeconds: 5
           failureThreshold: 60
@@ -266,7 +265,7 @@ spec:
           httpGet:
             path: /health
             port: 8001
-            scheme: HTTP
+            scheme: HTTPS
           failureThreshold: 60
           periodSeconds: 10
         volumeMounts:
@@ -445,13 +444,12 @@ spec:
               ${VLLM_ADDITIONAL_ARGS} \
               $@ \
               --trust-remote-code \
-              --headless"
-              # BackendTLSPolicy is not implemented yet so disable SSL for now
-              # --enable-ssl-refresh \
-              # --ssl-certfile \
-              # /var/run/kserve/tls/tls.crt \
-              # --ssl-keyfile \
-              # /var/run/kserve/tls/tls.key"
+              --headless \
+              --enable-ssl-refresh \
+              --ssl-certfile \
+              /var/run/kserve/tls/tls.crt \
+              --ssl-keyfile \
+              /var/run/kserve/tls/tls.key"
           # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
           - "--"
 

--- a/config/llmisvcconfig/config-llm-prefill-template.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-template.yaml
@@ -20,12 +20,11 @@ spec:
             - "{{ .Spec.Model.Name }}"
             - --port
             - "8000"
-            # BackendTLSPolicy is not implemented yet so disable SSL for now
-            # - --enable-ssl-refresh
-            # - --ssl-certfile
-            # - /var/run/kserve/tls/tls.crt
-            # - --ssl-keyfile
-            # - /var/run/kserve/tls/tls.key
+            - --enable-ssl-refresh
+            - --ssl-certfile
+            - /var/run/kserve/tls/tls.crt
+            - --ssl-keyfile
+            - /var/run/kserve/tls/tls.key
 
           env:
             - name: HOME
@@ -49,7 +48,7 @@ spec:
             httpGet:
               path: /health
               port: 8000
-              scheme: HTTP
+              scheme: HTTPS
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 3
@@ -57,7 +56,7 @@ spec:
             httpGet:
               path: /health
               port: 8000
-              scheme: HTTP
+              scheme: HTTPS
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 60
@@ -65,7 +64,7 @@ spec:
             httpGet:
               path: /health
               port: 8000
-              scheme: HTTP
+              scheme: HTTPS
             failureThreshold: 60
             periodSeconds: 10
           volumeMounts:

--- a/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
@@ -157,13 +157,12 @@ spec:
                 --data-parallel-start-rank $START_RANK \
                 ${VLLM_ADDITIONAL_ARGS} \
                 $@ \
-                --trust-remote-code"
-                # BackendTLSPolicy is not implemented yet so disable SSL for now
-                # --enable-ssl-refresh \
-                # --ssl-certfile \
-                # /var/run/kserve/tls/tls.crt \
-                # --ssl-keyfile \
-                # /var/run/kserve/tls/tls.key"
+                --trust-remote-code \
+                --enable-ssl-refresh \
+                --ssl-certfile \
+                /var/run/kserve/tls/tls.crt \
+                --ssl-keyfile \
+                /var/run/kserve/tls/tls.key"
             # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
             - "--"
 
@@ -193,7 +192,7 @@ spec:
             httpGet:
               path: /health
               port: 8000
-              scheme: HTTP
+              scheme: HTTPS
             periodSeconds: 10
             timeoutSeconds: 10
             failureThreshold: 3
@@ -201,7 +200,7 @@ spec:
             httpGet:
               path: /health
               port: 8000
-              scheme: HTTP
+              scheme: HTTPS
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 60
@@ -209,7 +208,7 @@ spec:
             httpGet:
               path: /health
               port: 8000
-              scheme: HTTP
+              scheme: HTTPS
             failureThreshold: 60
             periodSeconds: 10
           volumeMounts:
@@ -388,13 +387,12 @@ spec:
                 ${VLLM_ADDITIONAL_ARGS} \
                 $@ \
                 --trust-remote-code \
-                --headless"
-                # BackendTLSPolicy is not implemented yet so disable SSL for now
-                # --enable-ssl-refresh \
-                # --ssl-certfile \
-                # /var/run/kserve/tls/tls.crt \
-                # --ssl-keyfile \
-                # /var/run/kserve/tls/tls.key"
+                --headless \
+                --enable-ssl-refresh \
+                --ssl-certfile \
+                /var/run/kserve/tls/tls.crt \
+                --ssl-keyfile \
+                /var/run/kserve/tls/tls.key"
             # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
             - "--"
 

--- a/config/llmisvcconfig/config-llm-scheduler.yaml
+++ b/config/llmisvcconfig/config-llm-scheduler.yaml
@@ -71,13 +71,14 @@ spec:
               - "9003"
               - --kv-cache-usage-percentage-metric
               - "vllm:kv_cache_usage_perc"
-              # BackendTLSPolicy is not implemented yet so disable SSL for now
-              # - --secure-serving
-              # - --model-server-metrics-scheme
-              # - "https"
-              # - --model-server-metrics-https-insecure-skip-verify
-              # - --cert-path
-              # - "/var/run/kserve/tls"
+              - --secure-serving
+              - --model-server-metrics-scheme
+              - "https"
+              - --cert-path
+              - "/var/run/kserve/tls"
+            env:
+              - name: SSL_CERT_DIR
+                value: "/var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs"
             resources:
               requests:
                 cpu: 256m

--- a/config/llmisvcconfig/config-llm-template.yaml
+++ b/config/llmisvcconfig/config-llm-template.yaml
@@ -19,12 +19,11 @@ spec:
           - "{{ .Spec.Model.Name }}"
           - --port
           - "8000"
-          # BackendTLSPolicy is not implemented yet so disable SSL for now
-          # - --enable-ssl-refresh
-          # - --ssl-certfile
-          # - /var/run/kserve/tls/tls.crt
-          # - --ssl-keyfile
-          # - /var/run/kserve/tls/tls.key
+          - --enable-ssl-refresh
+          - --ssl-certfile
+          - /var/run/kserve/tls/tls.crt
+          - --ssl-keyfile
+          - /var/run/kserve/tls/tls.key
 
         env:
           - name: HOME
@@ -48,7 +47,7 @@ spec:
           httpGet:
             path: /health
             port: 8000
-            scheme: HTTP
+            scheme: HTTPS
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 3
@@ -56,7 +55,7 @@ spec:
           httpGet:
             path: /health
             port: 8000
-            scheme: HTTP
+            scheme: HTTPS
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 60
@@ -64,7 +63,7 @@ spec:
           httpGet:
             path: /health
             port: 8000
-            scheme: HTTP
+            scheme: HTTPS
           failureThreshold: 60
           periodSeconds: 10
         volumeMounts:

--- a/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
@@ -156,13 +156,12 @@ spec:
               --data-parallel-start-rank $START_RANK \
               ${VLLM_ADDITIONAL_ARGS} \
               $@ \
-              --trust-remote-code"
-              # BackendTLSPolicy is not implemented yet so disable SSL for now
-              # --enable-ssl-refresh \
-              # --ssl-certfile \
-              # /var/run/kserve/tls/tls.crt \
-              # --ssl-keyfile \
-              # /var/run/kserve/tls/tls.key"
+              --trust-remote-code \
+              --enable-ssl-refresh \
+              --ssl-certfile \
+              /var/run/kserve/tls/tls.crt \
+              --ssl-keyfile \
+              /var/run/kserve/tls/tls.key"
           # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
           - "--"
 
@@ -192,7 +191,7 @@ spec:
           httpGet:
             path: /health
             port: 8000
-            scheme: HTTP
+            scheme: HTTPS
           periodSeconds: 10
           timeoutSeconds: 10
           failureThreshold: 3
@@ -200,7 +199,7 @@ spec:
           httpGet:
             path: /health
             port: 8000
-            scheme: HTTP
+            scheme: HTTPS
           periodSeconds: 30
           timeoutSeconds: 5
           failureThreshold: 60
@@ -208,7 +207,7 @@ spec:
           httpGet:
             path: /health
             port: 8000
-            scheme: HTTP
+            scheme: HTTPS
           failureThreshold: 60
           periodSeconds: 10
         volumeMounts:
@@ -387,13 +386,12 @@ spec:
               ${VLLM_ADDITIONAL_ARGS} \
               $@ \
               --trust-remote-code \
-              --headless"
-              # BackendTLSPolicy is not implemented yet so disable SSL for now
-              # --enable-ssl-refresh \
-              # --ssl-certfile \
-              # /var/run/kserve/tls/tls.crt \
-              # --ssl-keyfile \
-              # /var/run/kserve/tls/tls.key
+              --headless \
+              --enable-ssl-refresh \
+              --ssl-certfile \
+              /var/run/kserve/tls/tls.crt \
+              --ssl-keyfile \
+              /var/run/kserve/tls/tls.key"
           # "--" ends bash options; subsequent args become positional params ($@) forwarded to vllm serve
           - "--"
 

--- a/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
@@ -99,7 +99,12 @@ func TestPresetFiles(t *testing.T) {
 										"--port=8000",
 										"--vllm-port=8001",
 										"--connector=nixlv2",
-										"--secure-proxy=false",
+										"--secure-proxy=true",
+										"--cert-path=/var/run/kserve/tls",
+										"--decoder-use-tls=true",
+										"--prefiller-use-tls=true",
+										"--enable-ssrf-protection=true",
+										"--pool-group=inference.networking.x-k8s.io",
 									},
 									Env: []corev1.EnvVar{
 										{
@@ -109,6 +114,10 @@ func TestPresetFiles(t *testing.T) {
 													FieldPath: "metadata.namespace",
 												},
 											},
+										},
+										{
+											Name:  "SSL_CERT_DIR",
+											Value: "/var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs",
 										},
 									},
 									Ports: []corev1.ContainerPort{
@@ -144,7 +153,7 @@ func TestPresetFiles(t *testing.T) {
 											HTTPGet: &corev1.HTTPGetAction{
 												Path:   "/health",
 												Port:   intstr.FromInt32(8000),
-												Scheme: corev1.URISchemeHTTP,
+												Scheme: corev1.URISchemeHTTPS,
 											},
 										},
 										InitialDelaySeconds: 10,
@@ -157,7 +166,7 @@ func TestPresetFiles(t *testing.T) {
 											HTTPGet: &corev1.HTTPGetAction{
 												Path:   "/health",
 												Port:   intstr.FromInt32(8000),
-												Scheme: corev1.URISchemeHTTP,
+												Scheme: corev1.URISchemeHTTPS,
 											},
 										},
 										InitialDelaySeconds: 10,
@@ -216,7 +225,7 @@ func TestPresetFiles(t *testing.T) {
 											HTTPGet: &corev1.HTTPGetAction{
 												Path:   "/health",
 												Port:   intstr.FromInt32(8001),
-												Scheme: corev1.URISchemeHTTP,
+												Scheme: corev1.URISchemeHTTPS,
 											},
 										},
 
@@ -229,7 +238,7 @@ func TestPresetFiles(t *testing.T) {
 											HTTPGet: &corev1.HTTPGetAction{
 												Path:   "/health",
 												Port:   intstr.FromInt32(8001),
-												Scheme: corev1.URISchemeHTTP,
+												Scheme: corev1.URISchemeHTTPS,
 											},
 										},
 
@@ -242,7 +251,7 @@ func TestPresetFiles(t *testing.T) {
 											HTTPGet: &corev1.HTTPGetAction{
 												Path:   "/health",
 												Port:   intstr.FromInt32(8001),
-												Scheme: corev1.URISchemeHTTP,
+												Scheme: corev1.URISchemeHTTPS,
 											},
 										},
 										FailureThreshold: 60,
@@ -417,7 +426,7 @@ func TestPresetFiles(t *testing.T) {
 								{
 									Name:    "main",
 									Image:   "ghcr.io/llm-d/llm-d-cuda:v0.4.0",
-									Command: []string{"vllm", "serve", "/mnt/models", "--served-model-name", "llama", "--port", "8000"},
+									Command: []string{"vllm", "serve", "/mnt/models", "--served-model-name", "llama", "--port", "8000", "--enable-ssl-refresh", "--ssl-certfile", "/var/run/kserve/tls/tls.crt", "--ssl-keyfile", "/var/run/kserve/tls/tls.key"},
 									Ports: []corev1.ContainerPort{
 										{
 											ContainerPort: 8000,
@@ -462,7 +471,7 @@ func TestPresetFiles(t *testing.T) {
 											HTTPGet: &corev1.HTTPGetAction{
 												Path:   "/health",
 												Port:   intstr.FromInt32(8000),
-												Scheme: corev1.URISchemeHTTP,
+												Scheme: corev1.URISchemeHTTPS,
 											},
 										},
 
@@ -475,7 +484,7 @@ func TestPresetFiles(t *testing.T) {
 											HTTPGet: &corev1.HTTPGetAction{
 												Path:   "/health",
 												Port:   intstr.FromInt32(8000),
-												Scheme: corev1.URISchemeHTTP,
+												Scheme: corev1.URISchemeHTTPS,
 											},
 										},
 
@@ -488,7 +497,7 @@ func TestPresetFiles(t *testing.T) {
 											HTTPGet: &corev1.HTTPGetAction{
 												Path:   "/health",
 												Port:   intstr.FromInt32(8000),
-												Scheme: corev1.URISchemeHTTP,
+												Scheme: corev1.URISchemeHTTPS,
 											},
 										},
 										FailureThreshold: 60,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. Re-running failed tests: comment `/rerun-all` to rerun all failed workflows.
-->

**What this PR does / why we need it**:

Ports TLS enablement from `release-v0.15` to `master` for all 7 base `LLMInferenceServiceConfig` templates.

Rather than using overlay patches (which rely on fragile index-based container references like `containers/0` that break when upstream adds containers - e.g. kserve#5121 tokenizer sidecar), this PR enables TLS directly in the base templates as agreed with @pierDipi and @spolti.

**Changes across all 7 templates:**
- Uncomment SSL command flags (`--enable-ssl-refresh`, `--ssl-certfile`, `--ssl-keyfile`)
- Switch all HTTP health probes to HTTPS (22 probes total)
- Enable `--secure-proxy=true`, `--cert-path`, `--decoder-use-tls`, `--prefiller-use-tls` on routing sidecars
- Add `--pool-group=inference.networking.x-k8s.io` to sidecars
- Add `SSL_CERT_DIR` env to sidecars and scheduler (3 total)
- Enable `--secure-serving` and `--model-server-metrics-scheme https` on scheduler
- Intentionally skip `--*-insecure-skip-verify` flags (not on v0.15)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:

- [x] `kustomize build config/overlays/odh` - succeeds, output verified:
  - `ssl-certfile`: 9 occurrences
  - `secure-proxy=true`: 2 (decode-template + decode-worker-data-parallel sidecars)
  - `scheme: HTTPS`: 22 (all probes)
  - `insecure-skip-verify`: 0 (intentionally excluded)
  - `pool-group`: 2 (both sidecars)
  - `SSL_CERT_DIR`: 3 (2 sidecars + scheduler)
  - `secure-serving`: 1 (scheduler)
  - `INFERENCE_POOL_NAMESPACE`: 2 (both sidecars retained)
- [x] `kustomize build config/overlays/odh-test` - succeeds
- [x] `go test ./pkg/controller/v1alpha2/llmisvc/... -run TestPresetFiles` - all 8 sub-tests pass

- Logs

<details><summary>TestPresetFiles output</summary>

--- PASS: TestPresetFiles (0.01s)
--- PASS: TestPresetFiles/config-llm-decode-template.yaml (0.00s)
--- PASS: TestPresetFiles/config-llm-decode-worker-data-parallel.yaml (0.00s)
--- PASS: TestPresetFiles/config-llm-prefill-template.yaml (0.00s)
--- PASS: TestPresetFiles/config-llm-prefill-worker-data-parallel.yaml (0.00s)
--- PASS: TestPresetFiles/config-llm-router-route.yaml (0.00s)
--- PASS: TestPresetFiles/config-llm-scheduler.yaml (0.00s)
--- PASS: TestPresetFiles/config-llm-template.yaml (0.00s)
--- PASS: TestPresetFiles/config-llm-worker-data-parallel.yaml (0.00s)
PASS

</details>

**Special notes for your reviewer**:

This replaces the previous overlay-patch approach in #1161. Enabling TLS directly in the base templates is simpler, avoids index-based patching fragility, and doesn't require overlay maintenance when upstream adds/reorders containers.

The data-parallel templates use bash heredoc scripts with `$@` forwarding (from kserve#5049) - TLS flags are placed inside the `eval` command string before the closing quote, preserving the `$@` mechanism.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note
Enable TLS directly in base LLMInferenceServiceConfig templates (ported from release-v0.15)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled TLS/SSL encryption across LLM services for secure communication.
  * Updated health check protocols from HTTP to HTTPS for enhanced security.
  * Added SSL certificate configuration and secure proxy settings for improved service protection.

* **Tests**
  * Updated test configurations to reflect TLS/SSL security enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->