### PR TITLE
fix(llmisvc): enforce runAsNonRoot for LLMISvcConfig templates

### DIFF
--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -177,6 +177,49 @@ replacements:
     fieldPaths:
     - spec.template.containers.[name=main].image
 
+# Set runAsNonRoot: true for all LLMInferenceServiceConfig templates.
+# NOTE: When adding a new LLMInferenceServiceConfig template, add its container paths here.
+- source:
+    kind: LLMInferenceServiceConfig
+    name: kserve-config-llm-scheduler
+    fieldPath: spec.router.scheduler.template.containers.[name=main].securityContext.runAsNonRoot
+  targets:
+  - select:
+      kind: LLMInferenceServiceConfig
+      name: kserve-config-llm-template
+    fieldPaths:
+    - spec.template.containers.[name=main].securityContext.runAsNonRoot
+  - select:
+      kind: LLMInferenceServiceConfig
+      name: kserve-config-llm-worker-data-parallel
+    fieldPaths:
+    - spec.template.containers.[name=main].securityContext.runAsNonRoot
+    - spec.worker.containers.[name=main].securityContext.runAsNonRoot
+  - select:
+      kind: LLMInferenceServiceConfig
+      name: kserve-config-llm-decode-template
+    fieldPaths:
+    - spec.template.containers.[name=main].securityContext.runAsNonRoot
+    - spec.template.initContainers.[name=llm-d-routing-sidecar].securityContext.runAsNonRoot
+  - select:
+      kind: LLMInferenceServiceConfig
+      name: kserve-config-llm-decode-worker-data-parallel
+    fieldPaths:
+    - spec.template.containers.[name=main].securityContext.runAsNonRoot
+    - spec.template.initContainers.[name=llm-d-routing-sidecar].securityContext.runAsNonRoot
+    - spec.worker.containers.[name=main].securityContext.runAsNonRoot
+  - select:
+      kind: LLMInferenceServiceConfig
+      name: kserve-config-llm-prefill-template
+    fieldPaths:
+    - spec.prefill.template.containers.[name=main].securityContext.runAsNonRoot
+  - select:
+      kind: LLMInferenceServiceConfig
+      name: kserve-config-llm-prefill-worker-data-parallel
+    fieldPaths:
+    - spec.prefill.template.containers.[name=main].securityContext.runAsNonRoot
+    - spec.prefill.worker.containers.[name=main].securityContext.runAsNonRoot
+
 configMapGenerator:
 - envs:
   - params.env


### PR DESCRIPTION
**What this PR does / why we need it**:

Upstream LLMInferenceServiceConfig templates ship with `runAsNonRoot: false`, which is incompatible with OpenShift's restricted SCC policy. Running containers as root is unnecessary and weakens the security posture of deployed workloads.

This adds a kustomize replacement in the ODH overlay that sources `runAsNonRoot: true` from the scheduler config (which already has it set correctly) and applies it to all template, worker, prefill, and init containers across all LLMInferenceServiceConfig resources.

**Feature/Issue validation/testing**:

- [x] `kustomize build config/overlays/odh` succeeds
- [x] Verified zero `runAsNonRoot: false` in built LLMInferenceServiceConfig output (all 12 instances are `true`)

**Special notes for your reviewer**:

When adding new LLMInferenceServiceConfig templates, their container paths need to be added to the replacement block in `config/overlays/odh/kustomization.yaml` (noted with a comment).

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enforced non-root container execution across multiple service configurations to enhance system security and compliance with security best practices
  * Updated configuration management framework to support additional service parameters, improving deployment flexibility and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->