### PR TITLE
fix(odh/rbac): adds missing `list` verb for DRs

### DIFF
--- a/config/overlays/odh/rbac/llmisvc/role.yaml
+++ b/config/overlays/odh/rbac/llmisvc/role.yaml
@@ -12,6 +12,7 @@ rules:
   - create
   - delete
   - get
+  - list
   - update
   - watch
 - apiGroups:

--- a/pkg/controller/v1alpha2/llmisvc/distro/controller_rbac_ocp.go
+++ b/pkg/controller/v1alpha2/llmisvc/distro/controller_rbac_ocp.go
@@ -20,5 +20,5 @@ package distro
 // Processed by a separate controller-gen invocation (see Makefile.overrides.mk)
 // to generate a dedicated ClusterRole included only in distro overlays.
 
-//+kubebuilder:rbac:groups=networking.istio.io,resources=destinationrules,verbs=get;watch;create;update;delete
+//+kubebuilder:rbac:groups=networking.istio.io,resources=destinationrules,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=openshift-ai-llminferenceservice-scc,verbs=use


### PR DESCRIPTION
**What this PR does / why we need it**:

In contrary to code-rabbit suggestion it is needed, otherwise:

```
E0312 11:35:50.514639       1 reflector.go:205] "Failed to watch" err="failed to list *v1.DestinationRule: destinationrules.networking.istio.io is forbidden: User \"system:serviceaccount:opendatahub:llmisvc-controller-manager\" cannot list resource \"destinationrules\" in API group \"networking.istio.io\" at the cluster scope" logger="UnhandledError" reflector="go/pkg/mod/k8s.io/client-go@v0.34.3/tools/cache/reflector.go:290" type="*v1.DestinationRule"
```

**Release note**:
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended system permissions to enable listing of networking resources within the platform's authorization configuration. This ensures the service has the necessary access to properly enumerate and manage related infrastructure components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->