### PR TITLE
fix: add schedulerName to IBM Spyre s390x accelerator config

### DIFF
--- a/config/overlays/odh/accelerators/ibm-spyre-s390x-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/ibm-spyre-s390x-config-llm-template.yaml
@@ -7,6 +7,7 @@ metadata:
     description: vLLM IBM Spyre s390x LLMInferenceServiceConfig for LLMInferenceService.
 spec:
   template:
+    schedulerName: spyre-scheduler
     containers:
       - name: main
         image: placeholder


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. Re-running failed tests: comment `/rerun-all` to rerun all failed workflows.
-->

**What this PR does / why we need it**:

Adds `schedulerName: spyre-scheduler` to the IBM Spyre s390x accelerator config (`ibm-spyre-s390x-config-llm-template.yaml`).

The Spyre operator on s390x enforces `schedulerName: spyre-scheduler` on all pods using `ibm.com/spyre_vf` via a `ValidatingWebhookConfiguration`. Without this field set in the accelerator config, the llmisvc-controller's generated Deployments are rejected by the admission webhook:

```
admission webhook "spyre-deployment-validator.k8s.io" denied the request:
A pod must use "schedulerName: spyre-scheduler"
```

The field is added at the pod spec level (same level as `containers` under `spec.template`), which maps to `corev1.PodSpec.SchedulerName` and gets deep-copied into the generated Deployment via the existing `DeepCopy()` path in the llmisvc controller.

This is a follow-up to #1130 which originally added the IBM Spyre accelerator configs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:

- [x] Verified YAML parses correctly into `LLMInferenceServiceConfig` (the `spec.template` field is `*corev1.PodSpec`, which includes `SchedulerName`)
- [x] Existing `config_merge_test.go` "deep merge with podspec template" test covers PodSpec-level field propagation through the strategic merge patch and `DeepCopy()` paths - `schedulerName` follows the same code path as other scalar PodSpec fields like `priorityClassName`
- [ ] s390x hardware validation: confirm the Spyre `ValidatingWebhookConfiguration` accepts the generated Deployment with `schedulerName: spyre-scheduler` set

- Reported by Deepali Kushwah during s390x testing

**Special notes for your reviewer**:

- This is a single-line YAML addition - no Go code changes required
- The accelerator overlay configs in `config/overlays/odh/accelerators/` are not covered by `TestPresetFiles` (which walks `config/llmisvcconfig/`), so no test snapshot updates are needed
- The `schedulerName` field propagation is already exercised by the existing merge/deep-copy tests for other `PodSpec` fields

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add schedulerName: spyre-scheduler to IBM Spyre s390x accelerator config to satisfy the Spyre operator's ValidatingWebhookConfiguration requirement.
```





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scheduler name configuration to IBM Spyre S390x LLM template, enabling specification of custom pod scheduler assignment for improved workload management flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->