### PR TITLE
[cherry-pick][release-v0.17] fix(odh/rbac): add llminferenceserviceconfigs to user cluster roles (#1189)

### DIFF
--- a/config/overlays/odh/rbac/user-cluster-roles.yaml
+++ b/config/overlays/odh/rbac/user-cluster-roles.yaml
@@ -24,6 +24,7 @@ rules:
       - serving.kserve.io
     resources:
       - inferenceservices
+      - llminferenceserviceconfigs
       - llminferenceservices
       - servingruntimes
     verbs:
@@ -52,6 +53,9 @@ rules:
       - inferenceservices
       - inferenceservices/status
       - inferenceservices/finalizers
+      - llminferenceserviceconfigs
+      - llminferenceserviceconfigs/status
+      - llminferenceserviceconfigs/finalizers
       - llminferenceservices
       - llminferenceservices/status
       - llminferenceservices/finalizers


### PR DESCRIPTION
## Body
Cherry-pick of https://github.com/opendatahub-io/kserve/pull/1189

### What this PR does / why we need it
Adds llminferenceserviceconfigs to ODH user cluster roles. Already merged on midstream master but not yet on the `release-v0.17` branch.

### Conflicts resolved
None, clean cherry-pick.