### PR TITLE
[cherry-pick][release-v0.17] fix(kustomize): adjust manifests to work with ODH (#1171)

### DIFF
--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -44,12 +44,19 @@ patches:
     kind: Service
     name: llmisvc-webhook-server-service
   path: patches/openshift-serving-cert-llmisvc-patch.yaml
+- target:
+    kind: LLMInferenceServiceConfig
+  path: patches/annotate-well-known-llmisvcconfigs.yaml
+- target:
+    kind: Deployment
+    name: llmisvc-controller-manager
+  path: patches/remove-kserve-controller-runas.yaml
 
 replacements:
 - source:
     kind: ConfigMap
     name: kserve-parameters
-    fieldpath: data.kserve-controller
+    fieldPath: data.kserve-controller
   targets:
   - select:
       kind: Deployment
@@ -122,11 +129,21 @@ replacements:
       name: kserve-config-llm-decode-worker-data-parallel
     fieldPaths:
     - spec.template.initContainers.[name=llm-d-routing-sidecar].image
+- source:
+    kind: ConfigMap
+    name: kserve-parameters
+    fieldPath: data.llmisvc-controller
+  targets:
+  - select:
+      kind: Deployment
+      name: llmisvc-controller-manager
+    fieldPaths:
+    - spec.template.spec.containers.[name=manager].image
 
 - source:
     kind: ConfigMap
     name: kserve-parameters
-    fieldpath: data.kserve-llm-d-nvidia-cuda
+    fieldPath: data.kserve-llm-d-nvidia-cuda
   targets:
   - select:
       kind: LLMInferenceServiceConfig
@@ -137,7 +154,7 @@ replacements:
 - source:
     kind: ConfigMap
     name: kserve-parameters
-    fieldpath: data.kserve-llm-d-amd-rocm
+    fieldPath: data.kserve-llm-d-amd-rocm
   targets:
   - select:
       kind: LLMInferenceServiceConfig
@@ -148,7 +165,7 @@ replacements:
 - source:
     kind: ConfigMap
     name: kserve-parameters
-    fieldpath: data.kserve-llm-d-ibm-spyre
+    fieldPath: data.kserve-llm-d-ibm-spyre
   targets:
   - select:
       kind: LLMInferenceServiceConfig

--- a/config/overlays/odh/patches/annotate-well-known-llmisvcconfigs.yaml
+++ b/config/overlays/odh/patches/annotate-well-known-llmisvcconfigs.yaml
@@ -1,0 +1,3 @@
+- op: add
+  path: /metadata/annotations/serving.kserve.io~1well-known-config
+  value: "true"

--- a/config/overlays/odh/patches/inferenceservice-config-patch.yaml
+++ b/config/overlays/odh/patches/inferenceservice-config-patch.yaml
@@ -20,7 +20,6 @@ data:
         "memoryLimit": "24Gi",
         "cpuRequest": "100m",
         "cpuLimit": "1",
-        "enableDirectPvcVolumeMount": true,
         "cpuModelcar": "10m",
         "memoryModelcar": "15Mi",
         "enableModelcar": true
@@ -87,6 +86,11 @@ data:
     {
       "enableMetricAggregation": "false",
       "enablePrometheusScraping" : "false"
+    }
+
+  service: |-
+    {
+        "serviceClusterIPNone": false
     }
 
   inferenceService: |-

--- a/config/overlays/odh/patches/remove-kserve-controller-runas.yaml
+++ b/config/overlays/odh/patches/remove-kserve-controller-runas.yaml
@@ -1,0 +1,3 @@
+- op: remove
+  path: /spec/template/spec/containers/0/securityContext/runAsUser
+  value: 1000


### PR DESCRIPTION
## Body
Cherry-pick of https://github.com/opendatahub-io/kserve/pull/1171

### What this PR does / why we need it
Adjusts kustomize manifests to work with ODH, including patches for well-known llmisvcconfigs annotations and removing kserve-controller runAs. Already merged on midstream master but not yet on the `release-v0.17` branch.

### Conflicts resolved
None, clean cherry-pick.