### PR TITLE
[RHOAIENG-53367] fix: widen approx tolerance in flaky bert test

### DIFF
--- a/python/huggingfaceserver/tests/test_model.py
+++ b/python/huggingfaceserver/tests/test_model.py
@@ -288,8 +288,8 @@ async def test_bert_sequence_classification_return_probabilities(bert_base_retur
 
     assert response == {
         "predictions": [
-            {0: approx(-3.1508713), 1: approx(3.5892851)},
-            {0: approx(-3.1508713), 1: approx(3.589285)},
+            {0: approx(-3.1508713, rel=1e-3), 1: approx(3.5892851, rel=1e-3)},
+            {0: approx(-3.1508713, rel=1e-3), 1: approx(3.589285, rel=1e-3)},
         ]
     }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Widens the `approx()` tolerance in `test_bert_sequence_classification_return_probabilities` from the default (~1e-6 relative) to `rel=1e-3`. The test asserts raw logit values that vary across Python versions (3.9 vs 3.10/3.11/3.12), causing flaky failures on the `release-v0.15` branch.

**Which issue(s) this PR fixes**:

Fixes [RHOAIENG-53367](https://issues.redhat.com/browse/RHOAIENG-53367)

**Root cause**:

Upstream PR kserve/kserve#4566 refactored this test to assert softmax probabilities (coarse values like `0.0012`) instead of raw logits, which fixed the issue on `master`. That PR is too large to cherry-pick to `release-v0.15` (516 insertions, major `encoder_model.py` refactor with behavioral changes to `--return_probabilities`), so this applies a minimal tolerance fix instead.

**Type of changes**

- Bug fix (non-breaking change which fixes an issue)

**Checklist**:

- [x] Have you verified this fixes the flaky test? Tolerance of 1e-3 accommodates the observed variance (~1.7e-5 relative) with margin
- [x] Have you made corresponding changes to the documentation? N/A

Made with [Cursor](https://cursor.com)