### PR TITLE
Add service key to inferenceservice-config overlay patch

### DIFF
--- a/config/overlays/odh/patches/patch-inferenceservice-config.yaml
+++ b/config/overlays/odh/patches/patch-inferenceservice-config.yaml
@@ -104,6 +104,10 @@ data:
       ]
      }
 
+  service: |-
+    {
+        "serviceClusterIPNone": true
+    }
   security: |-
     {
       "autoMountServiceAccountToken": false


### PR DESCRIPTION
## Summary

The ODH overlay patch for `inferenceservice-config` is missing the `service` data key that the opendatahub-operator requires. This key was present in the base ConfigMap on `release-v0.15` but has been removed upstream, so it no longer exists on `release-v0.17` or any newer branch.

**Impact:**
- **RHOAI e2e: broken now** -- 100% failure rate since March 13 (33+ consecutive failures across 15+ PRs). The `rhoai-3.4` branch picked up the missing key via a merge from upstream on March 13.
- **ODH e2e: will break** when opendatahub-io/opendatahub-operator#3265 merges (bumps kserve from `release-v0.15` to `release-v0.17`).

**Root cause:** The operator's `updateInferenceCM` function (`kserve_support.go:107`) reads `configMap.Data["service"]` and calls `json.Unmarshal` on it. When the key is absent, Go returns an empty string, and `json.Unmarshal("")` fails with:
```
error retrieving value for key 'service' from configmap inferenceservice-config. unexpected end of JSON input
```
This prevents `KserveReady` from ever becoming `True`, causing the `Validate component enabled` test to time out after 600s on every retry.

**This fix needs to be applied to all branches/forks** that have the `config/overlays/odh/patches/` directory, including:
- `release-v0.15` (this PR)
- `release-v0.17` (needed before opendatahub-operator#3265 can merge)
- `red-hat-data-services/kserve:rhoai-3.4` (needed to unblock RHOAI CI immediately)

## Change

Adds the `service` key to the overlay patch, matching what the `release-v0.15` base ConfigMap provided:
```yaml
  service: |-
    {
        "serviceClusterIPNone": true
    }
```

## Test plan

- [ ] RHOAI e2e tests pass (kserve `Validate component enabled` no longer times out)
- [ ] ODH e2e tests continue to pass (no behavioral change on `release-v0.15` since the key already exists via the base)