### PR TITLE
fix(ci): pins odh-model-controller

### DIFF
--- a/test/scripts/openshift-ci/kustomization.yaml
+++ b/test/scripts/openshift-ci/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - github.com/opendatahub-io/odh-model-controller/config/base?ref=incubating
+  - github.com/opendatahub-io/odh-model-controller/config/base?ref=4f38095b9dfd24cc02843b78dddb69f942ed4ee7 # pinned to commit pre v1alpha2 API update
 
 namespace: opendatahub


### PR DESCRIPTION

**What this PR does / why we need it**:

Locks odh-model-controller prior to v1alpha2 update to unblock release-v0.15 tests, as this version does not support v1alpha2 LLMInferenceService.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
