### PR TITLE
Add scheduler annotation for backward compatibility

### DIFF
--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -24,6 +24,7 @@ patches:
 - path: patches/inferenceservice-config-patch.yaml
 - path: patches/set-resources-manager-patch.yaml
 - path: patches/remove-auth-proxy-patch.yaml
+- path: patches/config-scheduler-patch.yaml
 - target:
     kind: ValidatingWebhookConfiguration
     annotationSelector: cert-manager.io/inject-ca-from

--- a/config/overlays/odh/patches/config-scheduler-patch.yaml
+++ b/config/overlays/odh/patches/config-scheduler-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-scheduler
+spec:
+  router:
+    scheduler:
+      annotations:
+        # This annotation is kept for compatibility with previous versions when we needed to restart the scheduler
+        # to pick the TLS certs changes. (see https://github.com/opendatahub-io/kserve/commit/3c96712ad0a28b6c89c0997475fd0fac8deb3857)
+        "certificates.kserve.io/expiration-v2": "true"


### PR DESCRIPTION
This prevents the scheduler from restarting when upgrading.

Related to https://github.com/kserve/kserve/pull/5260/changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated scheduler configuration to ensure proper handling of TLS certificate expiration during service restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->