### PR TITLE
Fix race in odh_trusted_ca_bundle_configmap in e2e tests

### DIFF
--- a/test/e2e/storagespec/test_s3_tls_storagespec.py
+++ b/test/e2e/storagespec/test_s3_tls_storagespec.py
@@ -144,9 +144,15 @@ def managed_storage_config_key(
 ODH_TRUSTED_CA_BUNDLE_CONFIGMAP_NAME = "odh-trusted-ca-bundle"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def odh_trusted_ca_bundle_configmap(kserve_client):
-    """Create empty odh-trusted-ca-bundle configmap at module level."""
+    """Create empty odh-trusted-ca-bundle configmap once per session.
+
+    Uses session scope to avoid race conditions with pytest-xdist worksteal
+    distribution, where module-scoped fixture teardown on one worker can
+    delete the ConfigMap while another worker's tests still need it.
+    The CI namespace is cleaned up after the test run.
+    """
     odh_trusted_ca_configmap = client.V1ConfigMap(
         api_version="v1",
         kind="ConfigMap",
@@ -161,18 +167,6 @@ def odh_trusted_ca_bundle_configmap(kserve_client):
         if e.status != 409:  # 409 = already exists (another worker created it)
             raise
     yield ODH_TRUSTED_CA_BUNDLE_CONFIGMAP_NAME
-    try:
-        kserve_client.core_api.delete_namespaced_config_map(
-            name=ODH_TRUSTED_CA_BUNDLE_CONFIGMAP_NAME, namespace=KSERVE_TEST_NAMESPACE
-        )
-        wait_for_resource_deletion(
-            read_func=lambda: kserve_client.core_api.read_namespaced_config_map(
-                name=ODH_TRUSTED_CA_BUNDLE_CONFIGMAP_NAME, namespace=KSERVE_TEST_NAMESPACE
-            ),
-        )
-    except client.ApiException as e:
-        if e.status != 404:  # 404 = already deleted (another worker cleaned it up)
-            raise
 
 
 @contextmanager


### PR DESCRIPTION
scope="module" → scope="session": With --dist worksteal, xdist can steal
individual tests from a module and run them on different workers.
A module-scoped fixture could be torn down on Worker A (deleting the ConfigMap)
while Worker B still has tests that
need it. Session scope ensures the ConfigMap lives for the entire worker session.

Removed teardown deletion: Eliminates the race entirely. With multiple xdist
workers each having their own session, one worker's session ending could still
delete the ConfigMap while another worker is using it.
The CI namespace (kserve-ci-e2e-test) is cleaned up after the test run anyway,
so explicit deletion is unnecessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test fixture management to improve test execution reliability and consistency in parallel testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->