### PR TITLE
Bump Tekton push image tags to 3.4

### DIFF
--- a/.tekton/kserve-agent-push.yaml
+++ b/.tekton/kserve-agent-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-agent:odh-v3.4-EA2
+    value: quay.io/opendatahub/kserve-agent:odh-v3.4
   - name: dockerfile
     value: agent.Dockerfile
   - name: path-context

--- a/.tekton/kserve-controller-push.yaml
+++ b/.tekton/kserve-controller-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-controller:odh-v3.4-EA2
+    value: quay.io/opendatahub/kserve-controller:odh-v3.4
   - name: dockerfile
     value: Dockerfile
   - name: path-context

--- a/.tekton/kserve-router-push.yaml
+++ b/.tekton/kserve-router-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-router:odh-v3.4-EA2
+    value: quay.io/opendatahub/kserve-router:odh-v3.4
   - name: dockerfile
     value: router.Dockerfile
   - name: path-context

--- a/.tekton/kserve-storage-initializer-push.yaml
+++ b/.tekton/kserve-storage-initializer-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-storage-initializer:odh-v3.4-EA2
+    value: quay.io/opendatahub/kserve-storage-initializer:odh-v3.4
   - name: dockerfile
     value: storage-initializer.Dockerfile
   - name: path-context

--- a/.tekton/odh-kserve-llmisvc-controller-push.yaml
+++ b/.tekton/odh-kserve-llmisvc-controller-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-kserve-llmisvc-controller:odh-v3.4-EA2
+    value: quay.io/opendatahub/odh-kserve-llmisvc-controller:odh-v3.4
   - name: dockerfile
     value: llmisvc-controller.Dockerfile
   - name: path-context


### PR DESCRIPTION
## Summary
- Bump all Tekton push pipeline `output-image` tags from `odh-v3.4-EA2` to `odh-v3.4`.

## Affected files
- `.tekton/kserve-agent-push.yaml`
- `.tekton/kserve-controller-push.yaml`
- `.tekton/kserve-router-push.yaml`
- `.tekton/kserve-storage-initializer-push.yaml`
- `.tekton/odh-kserve-llmisvc-controller-push.yaml`


Made with [Cursor](https://cursor.com)