### PR TITLE
RHOAIENG-54004: add recommended-accelerators annotation and fix description key on accelerator configs

### DIFF
--- a/config/overlays/odh/accelerators/amd-rocm-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/amd-rocm-config-llm-template.yaml
@@ -4,7 +4,8 @@ metadata:
   name: kserve-config-llm-template-amd-rocm
   annotations:
     openshift.io/display-name: vLLM AMD ROCm GPU LLMInferenceServiceConfig
-    description: vLLM AMD ROCm GPU LLMInferenceServiceConfig for LLMInferenceService.
+    openshift.io/description: vLLM AMD ROCm GPU LLMInferenceServiceConfig for LLMInferenceService.
+    opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
 spec:
   template:
     containers:

--- a/config/overlays/odh/accelerators/ibm-spyre-ppc64le-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/ibm-spyre-ppc64le-config-llm-template.yaml
@@ -4,7 +4,8 @@ metadata:
   name: kserve-config-llm-template-ibm-spyre-ppc64le
   annotations:
     openshift.io/display-name: vLLM IBM Spyre ppc64le LLMInferenceServiceConfig
-    description: vLLM IBM Spyre ppc64le LLMInferenceServiceConfig for LLMInferenceService.
+    openshift.io/description: vLLM IBM Spyre ppc64le LLMInferenceServiceConfig for LLMInferenceService.
+    opendatahub.io/recommended-accelerators: '["ibm.com/spyre_pf"]'
 spec:
   template:
     containers:

--- a/config/overlays/odh/accelerators/ibm-spyre-s390x-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/ibm-spyre-s390x-config-llm-template.yaml
@@ -4,7 +4,8 @@ metadata:
   name: kserve-config-llm-template-ibm-spyre-s390x
   annotations:
     openshift.io/display-name: vLLM IBM Spyre s390x LLMInferenceServiceConfig
-    description: vLLM IBM Spyre s390x LLMInferenceServiceConfig for LLMInferenceService.
+    openshift.io/description: vLLM IBM Spyre s390x LLMInferenceServiceConfig for LLMInferenceService.
+    opendatahub.io/recommended-accelerators: '["ibm.com/spyre_vf"]'
 spec:
   template:
     schedulerName: spyre-scheduler

--- a/config/overlays/odh/accelerators/ibm-spyre-x86-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/ibm-spyre-x86-config-llm-template.yaml
@@ -4,7 +4,8 @@ metadata:
   name: kserve-config-llm-template-ibm-spyre-x86
   annotations:
     openshift.io/display-name: vLLM IBM Spyre x86 LLMInferenceServiceConfig
-    description: vLLM IBM Spyre x86 LLMInferenceServiceConfig for LLMInferenceService.
+    openshift.io/description: vLLM IBM Spyre x86 LLMInferenceServiceConfig for LLMInferenceService.
+    opendatahub.io/recommended-accelerators: '["ibm.com/spyre_pf"]'
 spec:
   template:
     containers:

--- a/config/overlays/odh/accelerators/nvidia-cuda-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/nvidia-cuda-config-llm-template.yaml
@@ -4,7 +4,8 @@ metadata:
   name: kserve-config-llm-template-nvidia-cuda
   annotations:
     openshift.io/display-name: vLLM NVIDIA CUDA GPU LLMInferenceServiceConfig
-    description: vLLM NVIDIA CUDA GPU LLMInferenceServiceConfig for LLMInferenceService.
+    openshift.io/description: vLLM NVIDIA CUDA GPU LLMInferenceServiceConfig for LLMInferenceService.
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
 spec:
   template:
     containers:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. Re-running failed tests: comment `/rerun-all` to rerun all failed workflows.
-->

**What this PR does / why we need it**:

Adds `opendatahub.io/recommended-accelerators` annotation and fixes the description annotation key on all 5 accelerator `LLMInferenceServiceConfig` templates.

The RHOAI Dashboard UI relies on `opendatahub.io/recommended-accelerators` for autoselection logic when matching configs to accelerator hardware. Without this annotation, the UI cannot auto-select the correct `LLMInferenceServiceConfig`. Additionally, the Dashboard expects `openshift.io/description` rather than the bare `description` key.

Changes per config:
| Config | `opendatahub.io/recommended-accelerators` |
|---|---|
| nvidia-cuda | `["nvidia.com/gpu"]` |
| amd-rocm | `["amd.com/gpu"]` |
| ibm-spyre-x86 | `["ibm.com/spyre_pf"]` |
| ibm-spyre-ppc64le | `["ibm.com/spyre_pf"]` |
| ibm-spyre-s390x | `["ibm.com/spyre_vf"]` |

These values are consistent with the corresponding `vllm-*-template.yaml` ServingRuntime templates in [odh-model-controller](https://github.com/opendatahub-io/odh-model-controller/tree/incubating/config/runtimes).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://redhat.atlassian.net/browse/RHOAIENG-54004

**Feature/Issue validation/testing**:

- [x] `kustomize build config/overlays/odh/accelerators/` renders all 5 configs with correct annotations and labels

- Logs

```
kustomize build output confirms:
- opendatahub.io/recommended-accelerators annotation present on all 5 configs
- openshift.io/description replaces bare description key
- opendatahub.io/config-type: accelerator label still applied via kustomization commonLabels
```

**Special notes for your reviewer**:

Annotation values sourced from the existing ServingRuntime templates in odh-model-controller to ensure consistency across the ecosystem. No Go code changes required as these are purely manifest-level annotations consumed by the Dashboard UI.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add opendatahub.io/recommended-accelerators annotation and fix description annotation key on accelerator LLMInferenceServiceConfig templates for Dashboard UI compatibility.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced metadata annotations for LLM inference service configurations to improve accelerator discovery and standardize OpenShift compatibility across AMD ROCm, IBM Spyre, and NVIDIA CUDA deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->