### PR TITLE
fix: comment out non-existent build-odh-kserve-llmisvc-controller taskRunSpec

### DIFF
--- a/.tekton/kserve-group-test.yaml
+++ b/.tekton/kserve-group-test.yaml
@@ -51,8 +51,8 @@ spec:
   taskRunSpecs:
     - pipelineTaskName: clone-repository
       serviceAccountName: build-pipeline-kserve-group
-    - pipelineTaskName: build-odh-kserve-llmisvc-controller
-      serviceAccountName: build-pipeline-kserve-group
+#    - pipelineTaskName: build-odh-kserve-llmisvc-controller
+#      serviceAccountName: build-pipeline-kserve-group
     - pipelineTaskName: build-sklearn-serving-runtime
       serviceAccountName: build-pipeline-kserve-group
     - pipelineTaskName: build-custom-transformer


### PR DESCRIPTION
## Summary

- The `build-odh-kserve-llmisvc-controller` task is commented out in the `odh-pr-test-kserve` Pipeline ([odh-konflux-central line 195](https://github.com/opendatahub-io/odh-konflux-central/blob/main/integration-tests/kserve/pr-group-testing-pipeline.yaml#L195)), but was left uncommented in the PipelineRun's `taskRunSpecs` when `.tekton` pipelines were added for 3.4-ea2.
- This causes Tekton to reject the entire PipelineRun before any tasks run: `pipelineRun's taskrunSpecs defined wrong taskName: "build-odh-kserve-llmisvc-controller", does not exist in Pipeline`
- Comments it out to match the `release-v0.15` pattern.

**Failing pipeline run:** https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/open-data-hub-tenant/applications/group-testing/pipelineruns/kserve-group-test-bmgkz

## Test plan

- [ ] Trigger `/group-test` on a PR targeting `release-v0.17` and verify the PipelineRun no longer fails with taskRunSpecs validation error

Made with [Cursor](https://cursor.com)