### PR TITLE
fix(ci): inject KSERVE_NAMESPACE into E2E test environment

### DIFF
--- a/.github/workflows/e2e-test-odh-xks-kind.yml
+++ b/.github/workflows/e2e-test-odh-xks-kind.yml
@@ -102,6 +102,7 @@ jobs:
       - name: Run E2E tests
         timeout-minutes: 40
         env:
+          KSERVE_NAMESPACE: "opendatahub"
           SKIP_DELETION_ON_FAILURE: "true"
           TOKEN_AUDIENCES: "https://kubernetes.default.svc"
           GATEWAY_CLASS_NAME: "istio"

--- a/test/e2e/common/utils.py
+++ b/test/e2e/common/utils.py
@@ -32,7 +32,7 @@ from kserve.protocol.grpc import grpc_predict_v2_pb2 as pb
 from kserve.logging import trace_logger as logger
 from .http_retry import post_with_retry
 
-KSERVE_NAMESPACE = "kserve"
+KSERVE_NAMESPACE = os.environ.get("KSERVE_NAMESPACE", "kserve")
 KSERVE_TEST_NAMESPACE = "kserve-ci-e2e-test"
 MODEL_CLASS_NAME = "modelClass"
 INFERENCESERVICE_CONTAINER = "kserve-container"

--- a/test/e2e/llmisvc/test_storage_version_migration.py
+++ b/test/e2e/llmisvc/test_storage_version_migration.py
@@ -31,6 +31,7 @@ import pytest
 from kserve import KServeClient, constants
 from kubernetes import client
 
+from ..common.utils import KSERVE_NAMESPACE
 from .fixtures import (
     inject_k8s_proxy,
     KSERVE_TEST_NAMESPACE,
@@ -40,7 +41,7 @@ from .logging import logger
 
 LLMISVC_CRD_NAME = "llminferenceservices.serving.kserve.io"
 LLMISVC_CONFIG_CRD_NAME = "llminferenceserviceconfigs.serving.kserve.io"
-CONTROLLER_NAMESPACE = os.environ.get("KSERVE_NAMESPACE", "opendatahub")
+CONTROLLER_NAMESPACE = KSERVE_NAMESPACE
 CONTROLLER_DEPLOYMENT = "llmisvc-controller-manager"
 
 

--- a/test/scripts/openshift-ci/run-e2e-tests.sh
+++ b/test/scripts/openshift-ci/run-e2e-tests.sh
@@ -27,6 +27,10 @@ export GATEWAY_CLASS_NAME=${GATEWAY_CLASS_NAME:-"openshift-default"}
 MY_PATH=$(dirname "$0")
 PROJECT_ROOT=$MY_PATH/../../../
 export CI_USE_ISVC_HOST="1"
+
+# Export the controller namespace so that E2E tests
+# (e.g. storage version migration) can find the controller.
+export KSERVE_NAMESPACE="${KSERVE_NAMESPACE:-opendatahub}"
 export GITHUB_SHA=stable # Need to use stable as this is what the CI tags the images to for success-200 and error-404
 : "${BUILD_GRAPH_IMAGES:=true}"
 : "${BUILD_KSERVE_IMAGES:=true}"


### PR DESCRIPTION
**What this PR does / why we need it**:

The storage version migration test hardcoded `opendatahub` as the fallback controller namespace. This worked by coincidence in midstream CI but breaks upstream where the controller runs in `kserve`.

This PR:
- Changes the Python test default to `kserve` (matching upstream)
- Adds `KSERVE_NAMESPACE` env var to the GH Actions xks workflow test step
- Exports `KSERVE_NAMESPACE` in the openshift-ci prow entrypoint script, where it was previously lost due to `setup-e2e-tests.sh` running in a  subshell

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end tests to use a configurable controller namespace, improving consistency across test runs and CI environments.

* **Chores**
  * Adjusted CI scripts and test utilities to propagate namespace context through the E2E pipeline, ensuring downstream test steps read the same namespace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->