### PR TITLE
RHOAIENG-50812: replace CI_USE_ISVC_HOST with openshift-route network layer

### DIFF
--- a/test/e2e/batcher/test_batcher.py
+++ b/test/e2e/batcher/test_batcher.py
@@ -30,7 +30,7 @@ kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/c
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_batcher(rest_v1_client):
+async def test_batcher(rest_v1_client, network_layer):
     service_name = "isvc-sklearn-batcher"
 
     predictor = V1beta1PredictorSpec(
@@ -81,7 +81,11 @@ async def test_batcher(rest_v1_client):
             print(pod)
         raise e
     results = await predict_isvc(
-        rest_v1_client, service_name, "./data/iris_batch_input.json", is_batch=True
+        rest_v1_client,
+        service_name,
+        "./data/iris_batch_input.json",
+        is_batch=True,
+        network_layer=network_layer,
     )
     assert all(x == results[0] for x in results)
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/batcher/test_batcher_custom_port.py
+++ b/test/e2e/batcher/test_batcher_custom_port.py
@@ -32,7 +32,7 @@ kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/c
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_batcher_custom_port(rest_v1_client):
+async def test_batcher_custom_port(rest_v1_client, network_layer):
     service_name = "isvc-sklearn-batcher-custom"
 
     predictor = V1beta1PredictorSpec(
@@ -85,7 +85,11 @@ async def test_batcher_custom_port(rest_v1_client):
             print(pod)
         raise e
     results = await predict_isvc(
-        rest_v1_client, service_name, "./data/iris_batch_input.json", is_batch=True
+        rest_v1_client,
+        service_name,
+        "./data/iris_batch_input.json",
+        is_batch=True,
+        network_layer=network_layer,
     )
     assert all(x == results[0] for x in results)
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/common/utils.py
+++ b/test/e2e/common/utils.py
@@ -327,20 +327,43 @@ async def predict_modelmesh(
         return response
 
 
+def _get_gateway_namespace_from_config():
+    """Read the gateway namespace from kserveIngressGateway in the inferenceservice-config ConfigMap.
+
+    The controller stores the gateway reference as "namespace/name" in the ingress config.
+    This follows the same parsing logic used by the Go controller in configmap.go.
+    """
+    api = k8s_client.CoreV1Api(k8s_client.ApiClient())
+    cm = api.read_namespaced_config_map(
+        name="inferenceservice-config", namespace=KSERVE_NAMESPACE
+    )
+    ingress_config = json.loads(cm.data.get("ingress", "{}"))
+    gateway = ingress_config.get("kserveIngressGateway", "")
+    parts = gateway.split("/")
+    if len(parts) == 2:
+        return parts[0]
+    return KSERVE_NAMESPACE
+
+
 def get_isvc_endpoint(isvc, network_layer: str = "istio"):
     scheme = urlparse(isvc["status"]["url"]).scheme
     host = urlparse(isvc["status"]["url"]).netloc
     path = urlparse(isvc["status"]["url"]).path
-    ci_use_isvc_host = os.environ.get("CI_USE_ISVC_HOST")
-    logger.info(f"CI_USE_ISVC_HOST = {ci_use_isvc_host}")
     logger.info(f"Host from isvc status URL = {host}")
     logger.info(f"Network layer = {network_layer}")
-    if ci_use_isvc_host == "1":
+    if network_layer == "openshift-route":
         cluster_ip = host
         logger.info(f"Using external route host: {cluster_ip}")
     elif network_layer == "istio" or network_layer == "istio-ingress":
         cluster_ip = get_cluster_ip()
         logger.info(f"Using internal cluster IP: {cluster_ip}")
+    elif network_layer == "gateway-api":
+        gw_ns = _get_gateway_namespace_from_config()
+        logger.info(f"Using gateway namespace from config: {gw_ns}")
+        cluster_ip = get_cluster_ip(
+            namespace=gw_ns,
+            labels={"serving.kserve.io/gateway": "kserve-ingress-gateway"},
+        )
     elif network_layer == "envoy-gatewayapi":
         cluster_ip = get_cluster_ip(
             namespace="envoy-gateway-system",

--- a/test/e2e/common/utils.py
+++ b/test/e2e/common/utils.py
@@ -327,11 +327,12 @@ async def predict_modelmesh(
         return response
 
 
-def _get_gateway_namespace_from_config():
-    """Read the gateway namespace from kserveIngressGateway in the inferenceservice-config ConfigMap.
+def _get_gateway_from_config():
+    """Read the gateway namespace and name from kserveIngressGateway in the inferenceservice-config ConfigMap.
 
     The controller stores the gateway reference as "namespace/name" in the ingress config.
     This follows the same parsing logic used by the Go controller in configmap.go.
+    Returns (namespace, name).
     """
     api = k8s_client.CoreV1Api(k8s_client.ApiClient())
     cm = api.read_namespaced_config_map(
@@ -341,8 +342,8 @@ def _get_gateway_namespace_from_config():
     gateway = ingress_config.get("kserveIngressGateway", "")
     parts = gateway.split("/")
     if len(parts) == 2:
-        return parts[0]
-    return KSERVE_NAMESPACE
+        return parts[0], parts[1]
+    return KSERVE_NAMESPACE, "kserve-ingress-gateway"
 
 
 def get_isvc_endpoint(isvc, network_layer: str = "istio"):
@@ -358,11 +359,11 @@ def get_isvc_endpoint(isvc, network_layer: str = "istio"):
         cluster_ip = get_cluster_ip()
         logger.info(f"Using internal cluster IP: {cluster_ip}")
     elif network_layer == "gateway-api":
-        gw_ns = _get_gateway_namespace_from_config()
-        logger.info(f"Using gateway namespace from config: {gw_ns}")
+        gw_ns, gw_name = _get_gateway_from_config()
+        logger.info(f"Using gateway from config: {gw_ns}/{gw_name}")
         cluster_ip = get_cluster_ip(
             namespace=gw_ns,
-            labels={"serving.kserve.io/gateway": "kserve-ingress-gateway"},
+            labels={"serving.kserve.io/gateway": gw_name},
         )
     elif network_layer == "envoy-gatewayapi":
         cluster_ip = get_cluster_ip(
@@ -384,9 +385,12 @@ def generate(
     input_json,
     version=constants.KSERVE_V1BETA1_VERSION,
     chat_completions=True,
+    network_layer: str = "istio",
 ):
     url_suffix = "v1/chat/completions" if chat_completions else "v1/completions"
-    res = _openai_request(service_name, input_json, version, url_suffix)
+    res = _openai_request(
+        service_name, input_json, version, url_suffix, network_layer=network_layer
+    )
     return _process_non_streaming_response(res)
 
 
@@ -394,8 +398,11 @@ def embed(
     service_name,
     input_json,
     version=constants.KSERVE_V1BETA1_VERSION,
+    network_layer: str = "istio",
 ):
-    res = _openai_request(service_name, input_json, version, "v1/embeddings")
+    res = _openai_request(
+        service_name, input_json, version, "v1/embeddings", network_layer=network_layer
+    )
     return _process_non_streaming_response(res)
 
 
@@ -403,13 +410,19 @@ def rerank(
     service_name,
     input_json,
     version=constants.KSERVE_V1BETA1_VERSION,
+    network_layer: str = "istio",
 ):
-    res = _openai_request(service_name, input_json, version, "v1/rerank")
+    res = _openai_request(
+        service_name, input_json, version, "v1/rerank", network_layer=network_layer
+    )
     return _process_non_streaming_response(res)
 
 
 def _get_openai_endpoint_and_host(
-    service_name, url_suffix, version=constants.KSERVE_V1BETA1_VERSION
+    service_name,
+    url_suffix,
+    version=constants.KSERVE_V1BETA1_VERSION,
+    network_layer: str = "istio",
 ):
     """
     Get the OpenAI endpoint for the given service name.
@@ -417,6 +430,7 @@ def _get_openai_endpoint_and_host(
         service_name: The name of the inference service
         url_suffix: The suffix for the OpenAI endpoint (e.g., "v1/chat/completions")
         version: The version of the inference service. Defaults to v1beta1
+        network_layer: The network layer to use for endpoint resolution
     Returns:
         A tuple containing the OpenAI endpoint URL and the host name
     """
@@ -426,7 +440,7 @@ def _get_openai_endpoint_and_host(
     isvc = kfs_client.get(
         service_name, namespace=KSERVE_TEST_NAMESPACE, version=version
     )
-    scheme, cluster_ip, host, path = get_isvc_endpoint(isvc)
+    scheme, cluster_ip, host, path = get_isvc_endpoint(isvc, network_layer)
     return f"{scheme}://{cluster_ip}{path}/openai/{url_suffix}", host
 
 
@@ -436,11 +450,14 @@ def _openai_request(
     version=constants.KSERVE_V1BETA1_VERSION,
     url_suffix="",
     stream=False,
+    network_layer: str = "istio",
 ):
     with open(input_json) as json_file:
         data = json.load(json_file)
 
-        url, host = _get_openai_endpoint_and_host(service_name, url_suffix, version)
+        url, host = _get_openai_endpoint_and_host(
+            service_name, url_suffix, version, network_layer
+        )
         headers = {"Host": host, "Content-Type": "application/json"}
 
         logger.info("Sending Header = %s", headers)
@@ -468,13 +485,19 @@ def chat_completion_stream(
     service_name,
     input_json,
     version=constants.KSERVE_V1BETA1_VERSION,
+    network_layer: str = "istio",
 ):
     """
     Make a chat completion streaming request to the inference service and collect all chunks.
     Returns a tuple containing full response text and all chunks received.
     """
     res = _openai_request(
-        service_name, input_json, version, "v1/chat/completions", stream=True
+        service_name,
+        input_json,
+        version,
+        "v1/chat/completions",
+        stream=True,
+        network_layer=network_layer,
     )
 
     chunks = []
@@ -499,13 +522,19 @@ def completion_stream(
     service_name,
     input_json,
     version=constants.KSERVE_V1BETA1_VERSION,
+    network_layer: str = "istio",
 ):
     """
     Make a streaming request to the text completion inference service and collect all chunks.
     Returns a tuple containing full response text and all chunks received.
     """
     res = _openai_request(
-        service_name, input_json, version, "v1/completions", stream=True
+        service_name,
+        input_json,
+        version,
+        "v1/completions",
+        stream=True,
+        network_layer=network_layer,
     )
     chunks = []
     full_content = ""

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -115,9 +115,9 @@ async def rest_v2_client():
 def pytest_addoption(parser):
     parser.addoption(
         "--network-layer",
-        default="istio",
+        default="openshift-route",
         type=str,
-        help="Network layer to used for testing. Default is istio. Allowed values are istio-ingress, envoy-gatewayapi, istio-gatewayapi",
+        help="Network layer to used for testing. Default is openshift-route. Allowed values are istio, istio-ingress, envoy-gatewayapi, istio-gatewayapi, openshift-route, gateway-api",
     )
 
 

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -115,9 +115,9 @@ async def rest_v2_client():
 def pytest_addoption(parser):
     parser.addoption(
         "--network-layer",
-        default="openshift-route",
+        default="istio",
         type=str,
-        help="Network layer to used for testing. Default is openshift-route. Allowed values are istio, istio-ingress, envoy-gatewayapi, istio-gatewayapi, openshift-route, gateway-api",
+        help="Network layer to used for testing. Default is istio. Allowed values are istio, istio-ingress, envoy-gatewayapi, istio-gatewayapi, openshift-route, gateway-api",
     )
 
 

--- a/test/e2e/custom/test_custom_model_grpc.py
+++ b/test/e2e/custom/test_custom_model_grpc.py
@@ -282,7 +282,7 @@ async def test_predictor_grpc_with_transformer_http(rest_v2_client):
 
 @pytest.mark.transformer
 @pytest.mark.asyncio(scope="session")
-async def test_predictor_rest_with_transformer_rest(rest_v2_client):
+async def test_predictor_rest_with_transformer_rest(rest_v2_client, network_layer):
     service_name = "model-rest-trans-rest"
     model_name = "custom-model"
 
@@ -344,6 +344,7 @@ async def test_predictor_rest_with_transformer_rest(rest_v2_client):
         service_name,
         "./data/custom_model_input_v2.json",
         model_name=model_name,
+        network_layer=network_layer,
     )
     points = ["%.3f" % point for point in list(res.outputs[0].data)]
     assert points == ["14.976", "14.037", "13.966", "12.252", "12.086"]
@@ -368,6 +369,7 @@ async def test_predictor_rest_with_transformer_rest(rest_v2_client):
         service_name,
         infer_request,
         model_name=model_name,
+        network_layer=network_layer,
     )
     points = ["%.3f" % point for point in list(res.outputs[0].data)]
     assert points == ["14.976", "14.037", "13.966", "12.252", "12.086"]

--- a/test/e2e/graph/test_inference_graph.py
+++ b/test/e2e/graph/test_inference_graph.py
@@ -39,7 +39,7 @@ IG_TEST_RESOURCES_BASE_LOCATION = "graph/test-resources"
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_inference_graph(rest_v1_client):
+async def test_inference_graph(rest_v1_client, network_layer):
     logger.info("Starting test test_inference_graph")
     sklearn_name_1 = "isvc-sklearn-graph-1"
     sklearn_name_2 = "isvc-sklearn-graph-2"
@@ -150,6 +150,7 @@ async def test_inference_graph(rest_v1_client):
         rest_v1_client,
         graph_name,
         os.path.join(IG_TEST_RESOURCES_BASE_LOCATION, "iris_input.json"),
+        network_layer=network_layer,
     )
     assert res["predictions"] == [1, 1]
 
@@ -225,7 +226,7 @@ def setup_isvcs_for_test(suffix):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario1(rest_v1_client):
+async def test_ig_scenario1(rest_v1_client, network_layer):
     """
     Scenario: Sequence graph with 2 steps that are both soft dependencies.
      success_isvc(soft) -> error_isvc (soft)
@@ -289,6 +290,7 @@ async def test_ig_scenario1(rest_v1_client):
             os.path.join(
                 IG_TEST_RESOURCES_BASE_LOCATION, "custom_predictor_input.json"
             ),
+            network_layer=network_layer,
         )
 
     assert exc_info.value.response.json() == {"detail": "Intentional 404 code"}
@@ -302,7 +304,7 @@ async def test_ig_scenario1(rest_v1_client):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario2(rest_v1_client):
+async def test_ig_scenario2(rest_v1_client, network_layer):
     """
     Scenario: Sequence graph with 2 steps that are both soft dependencies.
        error_isvc (soft) -> success_isvc(soft)
@@ -361,6 +363,7 @@ async def test_ig_scenario2(rest_v1_client):
         rest_v1_client,
         graph_name,
         os.path.join(IG_TEST_RESOURCES_BASE_LOCATION, "custom_predictor_input.json"),
+        network_layer=network_layer,
     )
     assert response == {"predictions": [{"message": "SUCCESS"}]}
 
@@ -372,7 +375,7 @@ async def test_ig_scenario2(rest_v1_client):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario3(rest_v1_client):
+async def test_ig_scenario3(rest_v1_client, network_layer):
     """
      Scenario: Sequence graph with 2 steps - first is hard (and returns non-200) and second is soft dependency.
      error_isvc(hard) -> success_isvc (soft)
@@ -427,6 +430,7 @@ async def test_ig_scenario3(rest_v1_client):
             os.path.join(
                 IG_TEST_RESOURCES_BASE_LOCATION, "custom_predictor_input.json"
             ),
+            network_layer=network_layer,
         )
 
     assert exc_info.value.response.json() == {"detail": "Intentional 404 code"}
@@ -440,7 +444,7 @@ async def test_ig_scenario3(rest_v1_client):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario4(rest_v1_client):
+async def test_ig_scenario4(rest_v1_client, network_layer):
     """
     Scenario: Switch graph with 1 step as hard dependency and other one as soft dependency.
     Will be testing 3 cases in this test case:
@@ -501,6 +505,7 @@ async def test_ig_scenario4(rest_v1_client):
             os.path.join(
                 IG_TEST_RESOURCES_BASE_LOCATION, "switch_call_error_picker_input.json"
             ),
+            network_layer=network_layer,
         )
 
     assert exc_info.value.response.json() == {"detail": "Intentional 404 code"}
@@ -513,6 +518,7 @@ async def test_ig_scenario4(rest_v1_client):
         os.path.join(
             IG_TEST_RESOURCES_BASE_LOCATION, "switch_call_success_picker_input.json"
         ),
+        network_layer=network_layer,
     )
     assert response == {"predictions": [{"message": "SUCCESS"}]}
 
@@ -524,6 +530,7 @@ async def test_ig_scenario4(rest_v1_client):
             os.path.join(
                 IG_TEST_RESOURCES_BASE_LOCATION, "switch_call_no_match_input.json"
             ),
+            network_layer=network_layer,
         )
 
     assert exc_info.value.response.json() == {
@@ -540,7 +547,7 @@ async def test_ig_scenario4(rest_v1_client):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario5(rest_v1_client):
+async def test_ig_scenario5(rest_v1_client, network_layer):
     """
     Scenario: Switch graph where a match would happen for error node and then error would return but IG will continue
     execution and call the next step in the flow as error step will be a soft dependency.
@@ -593,6 +600,7 @@ async def test_ig_scenario5(rest_v1_client):
         os.path.join(
             IG_TEST_RESOURCES_BASE_LOCATION, "switch_call_error_picker_input.json"
         ),
+        network_layer=network_layer,
     )
     assert response == {"predictions": [{"message": "SUCCESS"}]}
 
@@ -604,7 +612,7 @@ async def test_ig_scenario5(rest_v1_client):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario6(rest_v1_client):
+async def test_ig_scenario6(rest_v1_client, network_layer):
     """
     Scenario: Switch graph where a match would happen for error node and then error would return and IG will NOT
     continue execution and call the next step in the flow as error step will be a HARD dependency.
@@ -658,6 +666,7 @@ async def test_ig_scenario6(rest_v1_client):
             os.path.join(
                 IG_TEST_RESOURCES_BASE_LOCATION, "switch_call_error_picker_input.json"
             ),
+            network_layer=network_layer,
         )
 
     assert exc_info.value.response.json() == {"detail": "Intentional 404 code"}
@@ -671,7 +680,7 @@ async def test_ig_scenario6(rest_v1_client):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario7(rest_v1_client):
+async def test_ig_scenario7(rest_v1_client, network_layer):
     """
     Scenario: Ensemble graph with 2 steps, where both the steps are soft deps.
 
@@ -724,6 +733,7 @@ async def test_ig_scenario7(rest_v1_client):
         os.path.join(
             IG_TEST_RESOURCES_BASE_LOCATION, "switch_call_success_picker_input.json"
         ),
+        network_layer=network_layer,
     )
     assert response == {
         "rootStep1": {"predictions": [{"message": "SUCCESS"}]},
@@ -738,7 +748,7 @@ async def test_ig_scenario7(rest_v1_client):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario8(rest_v1_client):
+async def test_ig_scenario8(rest_v1_client, network_layer):
     """
     Scenario: Ensemble graph with 3 steps, where 2 steps are soft and 1 step is hard and returns non-200
 
@@ -792,6 +802,7 @@ async def test_ig_scenario8(rest_v1_client):
             os.path.join(
                 IG_TEST_RESOURCES_BASE_LOCATION, "switch_call_success_picker_input.json"
             ),
+            network_layer=network_layer,
         )
 
     assert exc_info.value.response.json() == {"detail": "Intentional 404 code"}
@@ -804,7 +815,7 @@ async def test_ig_scenario8(rest_v1_client):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario9(rest_v1_client):
+async def test_ig_scenario9(rest_v1_client, network_layer):
     """
     Scenario: Splitter graph where a match would happen for error node and then error would return but IG will continue
     execution and call the next step in the flow as error step will be a soft dependency.
@@ -855,6 +866,7 @@ async def test_ig_scenario9(rest_v1_client):
         rest_v1_client,
         graph_name,
         os.path.join(IG_TEST_RESOURCES_BASE_LOCATION, "iris_input.json"),
+        network_layer=network_layer,
     )
     assert response == {"predictions": [{"message": "SUCCESS"}]}
 
@@ -866,7 +878,7 @@ async def test_ig_scenario9(rest_v1_client):
 @pytest.mark.graph
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_ig_scenario10(rest_v1_client):
+async def test_ig_scenario10(rest_v1_client, network_layer):
     """
     Scenario: Splitter graph where a match would happen for error node and then error would return and IG will NOT
     continue execution and call the next step in the flow as error step will be a HARD dependency.
@@ -918,6 +930,7 @@ async def test_ig_scenario10(rest_v1_client):
             rest_v1_client,
             graph_name,
             os.path.join(IG_TEST_RESOURCES_BASE_LOCATION, "iris_input.json"),
+            network_layer=network_layer,
         )
 
     assert exc_info.value.response.json() == {"detail": "Intentional 404 code"}

--- a/test/e2e/helm/test_kserve_sklearn.py
+++ b/test/e2e/helm/test_kserve_sklearn.py
@@ -33,7 +33,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE, predict_isvc
 
 @pytest.mark.helm
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_kserve(rest_v2_client):
+async def test_sklearn_kserve(rest_v2_client, network_layer):
     service_name = "isvc-sklearn-helm"
     protocol_version = "v2"
 
@@ -78,6 +78,7 @@ async def test_sklearn_kserve(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1, 1]
 

--- a/test/e2e/logger/test_logger.py
+++ b/test/e2e/logger/test_logger.py
@@ -34,7 +34,7 @@ kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/c
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_kserve_logger(rest_v1_client):
+async def test_kserve_logger(rest_v1_client, network_layer):
     msg_dumper = "message-dumper"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -108,7 +108,12 @@ async def test_kserve_logger(rest_v1_client):
         for pod in pods.items:
             print(pod)
 
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [1, 1]
     pods = kserve_client.core_api.list_namespaced_pod(
         KSERVE_TEST_NAMESPACE,

--- a/test/e2e/logger/test_marshaller.py
+++ b/test/e2e/logger/test_marshaller.py
@@ -40,7 +40,7 @@ kserve_client = KServeClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/c
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_json_immediate(rest_v1_client):
+async def test_json_immediate(rest_v1_client, network_layer):
     """JSON marshaller with immediate batching (batch_size=1).
 
     Send 1 prediction. Expect 2 S3 objects (request + response),
@@ -55,7 +55,12 @@ async def test_json_immediate(rest_v1_client):
         kserve_client.create(isvc)
         kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
-        res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+        res = await predict_isvc(
+            rest_v1_client,
+            service_name,
+            "./data/iris_input.json",
+            network_layer=network_layer,
+        )
         assert res["predictions"] == [1, 1]
 
         objects = wait_for_s3_objects(s3, LOGGER_BUCKET, prefix, 2, timeout=60)
@@ -84,7 +89,7 @@ async def test_json_immediate(rest_v1_client):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_json_size_batch(rest_v1_client):
+async def test_json_size_batch(rest_v1_client, network_layer):
     """JSON marshaller with size-based batching (batch_size=5).
 
     Send 5 predictions. Expect 2 S3 objects: one batch of 5 request
@@ -101,7 +106,10 @@ async def test_json_size_batch(rest_v1_client):
 
         for _ in range(5):
             res = await predict_isvc(
-                rest_v1_client, service_name, "./data/iris_input.json"
+                rest_v1_client,
+                service_name,
+                "./data/iris_input.json",
+                network_layer=network_layer,
             )
             assert res["predictions"] == [1, 1]
 
@@ -118,7 +126,7 @@ async def test_json_size_batch(rest_v1_client):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_json_timed_batch(rest_v1_client):
+async def test_json_timed_batch(rest_v1_client, network_layer):
     """JSON marshaller with timed batching (batch_size=2, interval=5s).
 
     Phase 1: Send 2 requests to fill the batch. Verify 2 objects with 2 records.
@@ -138,7 +146,10 @@ async def test_json_timed_batch(rest_v1_client):
         # Phase 1: fill the batch
         for _ in range(2):
             res = await predict_isvc(
-                rest_v1_client, service_name, "./data/iris_input.json"
+                rest_v1_client,
+                service_name,
+                "./data/iris_input.json",
+                network_layer=network_layer,
             )
             assert res["predictions"] == [1, 1]
 
@@ -148,7 +159,12 @@ async def test_json_timed_batch(rest_v1_client):
             verify_json_object(body, expected_records=2)
 
         # Phase 2: partial batch flushed by timer
-        res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+        res = await predict_isvc(
+            rest_v1_client,
+            service_name,
+            "./data/iris_input.json",
+            network_layer=network_layer,
+        )
         assert res["predictions"] == [1, 1]
 
         objects = wait_for_s3_objects(
@@ -168,7 +184,7 @@ async def test_json_timed_batch(rest_v1_client):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_csv_immediate(rest_v1_client):
+async def test_csv_immediate(rest_v1_client, network_layer):
     """CSV marshaller with immediate batching (batch_size=1).
 
     Send 1 prediction. Expect 2 S3 objects (request + response),
@@ -183,7 +199,12 @@ async def test_csv_immediate(rest_v1_client):
         kserve_client.create(isvc)
         kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
-        res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+        res = await predict_isvc(
+            rest_v1_client,
+            service_name,
+            "./data/iris_input.json",
+            network_layer=network_layer,
+        )
         assert res["predictions"] == [1, 1]
 
         objects = wait_for_s3_objects(s3, LOGGER_BUCKET, prefix, 2, timeout=60)
@@ -206,7 +227,7 @@ async def test_csv_immediate(rest_v1_client):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_csv_size_batch(rest_v1_client):
+async def test_csv_size_batch(rest_v1_client, network_layer):
     """CSV marshaller with size-based batching (batch_size=5).
 
     Send 5 predictions. Expect 2 S3 objects: one batch of 5 request
@@ -223,7 +244,10 @@ async def test_csv_size_batch(rest_v1_client):
 
         for _ in range(5):
             res = await predict_isvc(
-                rest_v1_client, service_name, "./data/iris_input.json"
+                rest_v1_client,
+                service_name,
+                "./data/iris_input.json",
+                network_layer=network_layer,
             )
             assert res["predictions"] == [1, 1]
 
@@ -240,7 +264,7 @@ async def test_csv_size_batch(rest_v1_client):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_csv_timed_batch(rest_v1_client):
+async def test_csv_timed_batch(rest_v1_client, network_layer):
     """CSV marshaller with timed batching (batch_size=2, interval=5s).
 
     Phase 1: Send 2 requests to fill the batch. Verify 2 objects with 2 rows.
@@ -259,7 +283,10 @@ async def test_csv_timed_batch(rest_v1_client):
 
         for _ in range(2):
             res = await predict_isvc(
-                rest_v1_client, service_name, "./data/iris_input.json"
+                rest_v1_client,
+                service_name,
+                "./data/iris_input.json",
+                network_layer=network_layer,
             )
             assert res["predictions"] == [1, 1]
 
@@ -268,7 +295,12 @@ async def test_csv_timed_batch(rest_v1_client):
             body = get_s3_object_body(s3, LOGGER_BUCKET, obj["Key"])
             verify_csv_object(body, expected_records=2)
 
-        res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+        res = await predict_isvc(
+            rest_v1_client,
+            service_name,
+            "./data/iris_input.json",
+            network_layer=network_layer,
+        )
         assert res["predictions"] == [1, 1]
 
         objects = wait_for_s3_objects(
@@ -288,7 +320,7 @@ async def test_csv_timed_batch(rest_v1_client):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_parquet_immediate(rest_v1_client):
+async def test_parquet_immediate(rest_v1_client, network_layer):
     """Parquet marshaller with immediate batching (batch_size=1).
 
     Send 1 prediction. Expect 2 S3 objects (request + response),
@@ -303,7 +335,12 @@ async def test_parquet_immediate(rest_v1_client):
         kserve_client.create(isvc)
         kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
-        res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+        res = await predict_isvc(
+            rest_v1_client,
+            service_name,
+            "./data/iris_input.json",
+            network_layer=network_layer,
+        )
         assert res["predictions"] == [1, 1]
 
         objects = wait_for_s3_objects(s3, LOGGER_BUCKET, prefix, 2, timeout=60)
@@ -326,7 +363,7 @@ async def test_parquet_immediate(rest_v1_client):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_parquet_size_batch(rest_v1_client):
+async def test_parquet_size_batch(rest_v1_client, network_layer):
     """Parquet marshaller with size-based batching (batch_size=5).
 
     Send 5 predictions. Expect 2 S3 objects: one batch of 5 request
@@ -343,7 +380,10 @@ async def test_parquet_size_batch(rest_v1_client):
 
         for _ in range(5):
             res = await predict_isvc(
-                rest_v1_client, service_name, "./data/iris_input.json"
+                rest_v1_client,
+                service_name,
+                "./data/iris_input.json",
+                network_layer=network_layer,
             )
             assert res["predictions"] == [1, 1]
 
@@ -360,7 +400,7 @@ async def test_parquet_size_batch(rest_v1_client):
 
 @pytest.mark.marshaller
 @pytest.mark.asyncio(scope="session")
-async def test_parquet_timed_batch(rest_v1_client):
+async def test_parquet_timed_batch(rest_v1_client, network_layer):
     """Parquet marshaller with timed batching (batch_size=2, interval=5s).
 
     Phase 1: Send 2 requests to fill the batch. Verify 2 objects with 2 rows.
@@ -379,7 +419,10 @@ async def test_parquet_timed_batch(rest_v1_client):
 
         for _ in range(2):
             res = await predict_isvc(
-                rest_v1_client, service_name, "./data/iris_input.json"
+                rest_v1_client,
+                service_name,
+                "./data/iris_input.json",
+                network_layer=network_layer,
             )
             assert res["predictions"] == [1, 1]
 
@@ -388,7 +431,12 @@ async def test_parquet_timed_batch(rest_v1_client):
             body = get_s3_object_body(s3, LOGGER_BUCKET, obj["Key"])
             verify_parquet_object(body, expected_records=2)
 
-        res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+        res = await predict_isvc(
+            rest_v1_client,
+            service_name,
+            "./data/iris_input.json",
+            network_layer=network_layer,
+        )
         assert res["predictions"] == [1, 1]
 
         objects = wait_for_s3_objects(

--- a/test/e2e/modelcache/test_localmodelcache_sklearn.py
+++ b/test/e2e/modelcache/test_localmodelcache_sklearn.py
@@ -44,7 +44,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE, predict_isvc
 
 @pytest.mark.modelcache
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_modelcache(rest_v1_client):
+async def test_sklearn_modelcache(rest_v1_client, network_layer):
     """
     Test LocalModelCache with sklearn predictor.
     This test is ARM64 compatible as sklearn server has multi-arch images.
@@ -174,7 +174,12 @@ async def test_sklearn_modelcache(rest_v1_client):
         )
 
     # Test inference with the cached model
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [1, 1]
 
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/modelcache/test_localmodelnamespacecache.py
+++ b/test/e2e/modelcache/test_localmodelnamespacecache.py
@@ -48,7 +48,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE, predict_isvc
 
 @pytest.mark.modelcache
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_modelnamespacecache(rest_v1_client):
+async def test_sklearn_modelnamespacecache(rest_v1_client, network_layer):
     service_name = "sklearn-modelnamespacecache-worker1"
     storage_uri = "gs://kfserving-examples/models/sklearn/1.0/model"
     nodes = ["minikube-m02", "minikube-m03"]
@@ -174,7 +174,12 @@ async def test_sklearn_modelnamespacecache(rest_v1_client):
             "aks-agentpool-27350515-vmss000000",
         )
 
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [1, 1]
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
     # Wait for the isvc to be deleted to avoid modelcache still in use error when deleting the model cache

--- a/test/e2e/predictor/test_huggingface.py
+++ b/test/e2e/predictor/test_huggingface.py
@@ -251,7 +251,7 @@ def test_huggingface_openai_text_completion_streaming():
 
 @pytest.mark.llm
 @pytest.mark.asyncio(scope="session")
-async def test_huggingface_v2_sequence_classification(rest_v2_client):
+async def test_huggingface_v2_sequence_classification(rest_v2_client, network_layer):
     service_name = "hf-bert-sequence-v2"
     protocol_version = "v2"
     predictor = V1beta1PredictorSpec(
@@ -297,6 +297,7 @@ async def test_huggingface_v2_sequence_classification(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/bert_sequence_classification_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1]
 
@@ -305,7 +306,7 @@ async def test_huggingface_v2_sequence_classification(rest_v2_client):
 
 @pytest.mark.llm
 @pytest.mark.asyncio(scope="session")
-async def test_huggingface_v1_fill_mask(rest_v1_client):
+async def test_huggingface_v1_fill_mask(rest_v1_client, network_layer):
     service_name = "hf-bert-fill-mask-v1"
     protocol_version = "v1"
     predictor = V1beta1PredictorSpec(
@@ -345,6 +346,7 @@ async def test_huggingface_v1_fill_mask(rest_v1_client):
         rest_v1_client,
         service_name,
         "./data/bert_fill_mask_v1.json",
+        network_layer=network_layer,
     )
     assert res["predictions"] == ["paris", "france"]
 
@@ -353,7 +355,7 @@ async def test_huggingface_v1_fill_mask(rest_v1_client):
 
 @pytest.mark.llm
 @pytest.mark.asyncio(scope="session")
-async def test_huggingface_v2_token_classification(rest_v2_client):
+async def test_huggingface_v2_token_classification(rest_v2_client, network_layer):
     service_name = "hf-bert-token-classification-v2"
     protocol_version = "v2"
     predictor = V1beta1PredictorSpec(
@@ -400,6 +402,7 @@ async def test_huggingface_v2_token_classification(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/bert_token_classification_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
 
@@ -455,7 +458,7 @@ def test_huggingface_openai_text_2_text():
 
 @pytest.mark.llm
 @pytest.mark.asyncio(scope="session")
-async def test_huggingface_v2_text_embedding(rest_v2_client):
+async def test_huggingface_v2_text_embedding(rest_v2_client, network_layer):
     service_name = "hf-text-embedding-v2"
     protocol_version = "v2"
     predictor = V1beta1PredictorSpec(
@@ -502,7 +505,10 @@ async def test_huggingface_v2_text_embedding(rest_v2_client):
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
     res = await predict_isvc(
-        rest_v2_client, service_name, "./data/text_embedding_input_v2.json"
+        rest_v2_client,
+        service_name,
+        "./data/text_embedding_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == huggingface_text_embedding_expected_output
 
@@ -578,6 +584,7 @@ async def test_huggingface_openai_text_embedding():
 @pytest.mark.asyncio(scope="session")
 async def test_huggingface_v2_sequence_classification_with_raw_logits(
     rest_v2_client,
+    network_layer,
 ):
     service_name = "hf-bert-sequence-v2-prob"
     protocol_version = "v2"
@@ -625,6 +632,7 @@ async def test_huggingface_v2_sequence_classification_with_raw_logits(
         rest_v2_client,
         service_name,
         "./data/bert_sequence_classification_v2.json",
+        network_layer=network_layer,
     )
 
     result = res.outputs[0].data[0]
@@ -645,6 +653,7 @@ async def test_huggingface_v2_sequence_classification_with_raw_logits(
 @pytest.mark.asyncio(scope="session")
 async def test_huggingface_v2_sequence_classification_with_probabilities(
     rest_v2_client,
+    network_layer,
 ):
     service_name = "hf-bert-sequence-v2-logits"
     protocol_version = "v2"
@@ -692,6 +701,7 @@ async def test_huggingface_v2_sequence_classification_with_probabilities(
         rest_v2_client,
         service_name,
         "./data/bert_sequence_classification_v2.json",
+        network_layer=network_layer,
     )
     output = ast.literal_eval(res.outputs[0].data[0])
     assert output == {0: 0.0094, 1: 0.9906}

--- a/test/e2e/predictor/test_lightgbm.py
+++ b/test/e2e/predictor/test_lightgbm.py
@@ -37,7 +37,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE, predict_isvc, predict_grpc
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_lightgbm_kserve(rest_v1_client):
+async def test_lightgbm_kserve(rest_v1_client, network_layer):
     service_name = "isvc-lightgbm"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -69,7 +69,12 @@ async def test_lightgbm_kserve(rest_v1_client):
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input_v3.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input_v3.json",
+        network_layer=network_layer,
+    )
     assert numpy.argmax(res["predictions"][0]) == 0
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
@@ -77,7 +82,7 @@ async def test_lightgbm_kserve(rest_v1_client):
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_lightgbm_runtime_kserve(rest_v1_client):
+async def test_lightgbm_runtime_kserve(rest_v1_client, network_layer):
     service_name = "isvc-lightgbm-runtime"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -112,13 +117,28 @@ async def test_lightgbm_runtime_kserve(rest_v1_client):
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input_v3.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input_v3.json",
+        network_layer=network_layer,
+    )
     assert numpy.argmax(res["predictions"][0]) == 0
 
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input_v4.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input_v4.json",
+        network_layer=network_layer,
+    )
     assert numpy.argmax(res["predictions"][0]) == 0
 
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input_v5.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input_v5.json",
+        network_layer=network_layer,
+    )
     assert numpy.argmax(res["predictions"][0]) == 0
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
@@ -126,7 +146,7 @@ async def test_lightgbm_runtime_kserve(rest_v1_client):
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_lightgbm_v2_runtime_mlserver(rest_v2_client):
+async def test_lightgbm_v2_runtime_mlserver(rest_v2_client, network_layer):
     service_name = "isvc-lightgbm-v2-runtime"
     protocol_version = "v2"
 
@@ -175,6 +195,7 @@ async def test_lightgbm_v2_runtime_mlserver(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [
         8.796664107010673e-06,
@@ -191,7 +212,7 @@ async def test_lightgbm_v2_runtime_mlserver(rest_v2_client):
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_lightgbm_v2_kserve(rest_v2_client):
+async def test_lightgbm_v2_kserve(rest_v2_client, network_layer):
     service_name = "isvc-lightgbm-v2-kserve"
 
     predictor = V1beta1PredictorSpec(
@@ -232,6 +253,7 @@ async def test_lightgbm_v2_kserve(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [
         8.796664107010673e-06,

--- a/test/e2e/predictor/test_mlflow.py
+++ b/test/e2e/predictor/test_mlflow.py
@@ -32,7 +32,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_mlflow_v2_runtime_kserve(rest_v2_client):
+async def test_mlflow_v2_runtime_kserve(rest_v2_client, network_layer):
     service_name = "isvc-mlflow-v2-runtime"
     protocol_version = "v2"
 
@@ -79,6 +79,7 @@ async def test_mlflow_v2_runtime_kserve(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/mlflow_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [5.576883936610762]
 

--- a/test/e2e/predictor/test_multi_model_serving.py
+++ b/test/e2e/predictor/test_multi_model_serving.py
@@ -49,7 +49,11 @@ from ..common.utils import KSERVE_TEST_NAMESPACE
 @pytest.mark.mms
 @pytest.mark.asyncio(scope="session")
 async def test_mms_sklearn_kserve(
-    protocol_version: str, storage_uri: str, rest_v1_client, rest_v2_client
+    protocol_version: str,
+    storage_uri: str,
+    rest_v1_client,
+    rest_v2_client,
+    network_layer,
 ):
     service_name = f"isvc-sklearn-mms-{protocol_version}"
     # Define an inference service
@@ -124,6 +128,7 @@ async def test_mms_sklearn_kserve(
                 service_name,
                 "./data/iris_input.json",
                 model_name=model_name,
+                network_layer=network_layer,
             )
             for model_name in model_names
         ]
@@ -136,6 +141,7 @@ async def test_mms_sklearn_kserve(
                 service_name,
                 "./data/iris_input_v2.json",
                 model_name=model_name,
+                network_layer=network_layer,
             )
             for model_name in model_names
         ]
@@ -164,7 +170,11 @@ async def test_mms_sklearn_kserve(
 @pytest.mark.mms
 @pytest.mark.asyncio(scope="session")
 async def test_mms_xgboost_kserve(
-    protocol_version: str, storage_uri: str, rest_v1_client, rest_v2_client
+    protocol_version: str,
+    storage_uri: str,
+    rest_v1_client,
+    rest_v2_client,
+    network_layer,
 ):
     service_name = f"isvc-xgboost-mms-{protocol_version}"
     # Define an inference service
@@ -240,6 +250,7 @@ async def test_mms_xgboost_kserve(
                 service_name,
                 "./data/iris_input.json",
                 model_name=model_name,
+                network_layer=network_layer,
             )
             for model_name in model_names
         ]
@@ -252,6 +263,7 @@ async def test_mms_xgboost_kserve(
                 service_name,
                 "./data/iris_input_v2.json",
                 model_name=model_name,
+                network_layer=network_layer,
             )
             for model_name in model_names
         ]

--- a/test/e2e/predictor/test_paddle.py
+++ b/test/e2e/predictor/test_paddle.py
@@ -36,7 +36,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE, predict_isvc, predict_grpc
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_paddle(rest_v1_client):
+async def test_paddle(rest_v1_client, network_layer):
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
         paddle=V1beta1PaddleServerSpec(
@@ -79,7 +79,9 @@ async def test_paddle(rest_v1_client):
             logging.info(pod)
         raise e
 
-    res = await predict_isvc(rest_v1_client, service_name, "./data/jay.json")
+    res = await predict_isvc(
+        rest_v1_client, service_name, "./data/jay.json", network_layer=network_layer
+    )
     assert np.argmax(res["predictions"][0]) == 17
 
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
@@ -87,7 +89,7 @@ async def test_paddle(rest_v1_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_paddle_runtime(rest_v1_client):
+async def test_paddle_runtime(rest_v1_client, network_layer):
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
         model=V1beta1ModelSpec(
@@ -133,7 +135,9 @@ async def test_paddle_runtime(rest_v1_client):
             logging.info(pod)
         raise e
 
-    res = await predict_isvc(rest_v1_client, service_name, "./data/jay.json")
+    res = await predict_isvc(
+        rest_v1_client, service_name, "./data/jay.json", network_layer=network_layer
+    )
     assert np.argmax(res["predictions"][0]) == 17
 
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
@@ -141,7 +145,7 @@ async def test_paddle_runtime(rest_v1_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_paddle_v2_kserve(rest_v2_client):
+async def test_paddle_v2_kserve(rest_v2_client, network_layer):
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
         model=V1beta1ModelSpec(
@@ -192,6 +196,7 @@ async def test_paddle_v2_kserve(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/jay-v2.json",
+        network_layer=network_layer,
     )
     assert np.argmax(res.outputs[0].data) == 17
 
@@ -201,7 +206,7 @@ async def test_paddle_v2_kserve(rest_v2_client):
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
 @pytest.mark.skip("GRPC tests are failing in ODH at the moment")
-async def test_paddle_v2_grpc():
+async def test_paddle_v2_grpc(network_layer):
     service_name = "isvc-paddle-v2-grpc"
     model_name = "paddle"
     predictor = V1beta1PredictorSpec(
@@ -248,7 +253,10 @@ async def test_paddle_v2_grpc():
     json_file = open("./data/jay-v2-grpc.json")
     payload = json.load(json_file)["inputs"]
     response = await predict_grpc(
-        service_name=service_name, payload=payload, model_name=model_name
+        service_name=service_name,
+        payload=payload,
+        model_name=model_name,
+        network_layer=network_layer,
     )
     prediction = response.outputs[0].data
     assert np.argmax(prediction) == 17

--- a/test/e2e/predictor/test_pmml.py
+++ b/test/e2e/predictor/test_pmml.py
@@ -34,7 +34,7 @@ from ..common.utils import predict_isvc
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_pmml_kserve(rest_v1_client):
+async def test_pmml_kserve(rest_v1_client, network_layer):
     service_name = "isvc-pmml"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -66,7 +66,12 @@ async def test_pmml_kserve(rest_v1_client):
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
     start = time.perf_counter()
-    res = await predict_isvc(rest_v1_client, service_name, "./data/pmml_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/pmml_input.json",
+        network_layer=network_layer,
+    )
     end = time.perf_counter()
     print(f"Time taken: {end - start}")
     logger.info(f"Time taken: {end - start}")
@@ -84,7 +89,7 @@ async def test_pmml_kserve(rest_v1_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_pmml_runtime_kserve(rest_v1_client):
+async def test_pmml_runtime_kserve(rest_v1_client, network_layer):
     service_name = "isvc-pmml-runtime"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -118,7 +123,12 @@ async def test_pmml_runtime_kserve(rest_v1_client):
     )
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
-    res = await predict_isvc(rest_v1_client, service_name, "./data/pmml_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/pmml_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [
         {
             "Species": "setosa",
@@ -133,7 +143,7 @@ async def test_pmml_runtime_kserve(rest_v1_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_pmml_v2_kserve(rest_v2_client):
+async def test_pmml_v2_kserve(rest_v2_client, network_layer):
     service_name = "isvc-pmml-v2-kserve"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -172,6 +182,7 @@ async def test_pmml_v2_kserve(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/pmml-input-v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs == [
         InferOutput(

--- a/test/e2e/predictor/test_predictive.py
+++ b/test/e2e/predictor/test_predictive.py
@@ -34,7 +34,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE, predict_isvc
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_predictive_sklearn_v1(rest_v1_client):
+async def test_predictive_sklearn_v1(rest_v1_client, network_layer):
     service_name = "isvc-predictive-sklearn"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -67,14 +67,19 @@ async def test_predictive_sklearn_v1(rest_v1_client):
     )
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [1, 1]
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_predictive_xgboost_v1(rest_v1_client):
+async def test_predictive_xgboost_v1(rest_v1_client, network_layer):
     service_name = "isvc-predictive-xgboost"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -107,14 +112,19 @@ async def test_predictive_xgboost_v1(rest_v1_client):
     )
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [1, 1]
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_predictive_lightgbm_v1(rest_v1_client):
+async def test_predictive_lightgbm_v1(rest_v1_client, network_layer):
     service_name = "isvc-predictive-lightgbm"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -148,14 +158,19 @@ async def test_predictive_lightgbm_v1(rest_v1_client):
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input_v3.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input_v3.json",
+        network_layer=network_layer,
+    )
     assert numpy.argmax(res["predictions"][0]) == 0
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_predictive_sklearn_v2(rest_v2_client):
+async def test_predictive_sklearn_v2(rest_v2_client, network_layer):
     service_name = "isvc-predictive-sklearn-v2"
     protocol_version = "v2"
     predictor = V1beta1PredictorSpec(
@@ -201,6 +216,7 @@ async def test_predictive_sklearn_v2(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1, 1]
 
@@ -209,7 +225,7 @@ async def test_predictive_sklearn_v2(rest_v2_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_predictive_xgboost_v2(rest_v2_client):
+async def test_predictive_xgboost_v2(rest_v2_client, network_layer):
     service_name = "isvc-predictive-xgboost-v2"
     protocol_version = "v2"
     predictor = V1beta1PredictorSpec(
@@ -255,6 +271,7 @@ async def test_predictive_xgboost_v2(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1, 1]
 
@@ -263,7 +280,7 @@ async def test_predictive_xgboost_v2(rest_v2_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_predictive_lightgbm_v2(rest_v2_client):
+async def test_predictive_lightgbm_v2(rest_v2_client, network_layer):
     service_name = "isvc-predictive-lightgbm-v2"
     protocol_version = "v2"
     predictor = V1beta1PredictorSpec(
@@ -309,6 +326,7 @@ async def test_predictive_lightgbm_v2(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     # LightGBM returns probability predictions in v2 format
     # We verify the highest probability class matches expected result

--- a/test/e2e/predictor/test_sklearn.py
+++ b/test/e2e/predictor/test_sklearn.py
@@ -42,7 +42,7 @@ from ..common.utils import (
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_kserve(rest_v1_client):
+async def test_sklearn_kserve(rest_v1_client, network_layer):
     service_name = "isvc-sklearn"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -73,14 +73,19 @@ async def test_sklearn_kserve(rest_v1_client):
     )
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [1, 1]
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_v2_mlserver(rest_v2_client):
+async def test_sklearn_v2_mlserver(rest_v2_client, network_layer):
     service_name = "sklearn-v2-mlserver"
     protocol_version = "v2"
     predictor = V1beta1PredictorSpec(
@@ -124,6 +129,7 @@ async def test_sklearn_v2_mlserver(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1, 1]
 
@@ -133,7 +139,7 @@ async def test_sklearn_v2_mlserver(rest_v2_client):
 @pytest.mark.predictor
 @pytest.mark.kourier
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_runtime_kserve(rest_v1_client):
+async def test_sklearn_runtime_kserve(rest_v1_client, network_layer):
     service_name = "isvc-sklearn-runtime"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -170,7 +176,12 @@ async def test_sklearn_runtime_kserve(rest_v1_client):
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
     tasks = [
-        predict_isvc(rest_v1_client, service_name, "./data/news_grouping_input_v1.json")
+        predict_isvc(
+            rest_v1_client,
+            service_name,
+            "./data/news_grouping_input_v1.json",
+            network_layer=network_layer,
+        )
         for _ in range(25)
     ]
     responses = await asyncio.gather(*tasks)
@@ -195,7 +206,7 @@ async def test_sklearn_runtime_kserve(rest_v1_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_v2_runtime_mlserver(rest_v2_client):
+async def test_sklearn_v2_runtime_mlserver(rest_v2_client, network_layer):
     service_name = "isvc-sklearn-v2-runtime"
     protocol_version = "v2"
 
@@ -244,6 +255,7 @@ async def test_sklearn_v2_runtime_mlserver(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1, 1]
 
@@ -252,7 +264,7 @@ async def test_sklearn_v2_runtime_mlserver(rest_v2_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_v2(rest_v2_client):
+async def test_sklearn_v2(rest_v2_client, network_layer):
     service_name = "isvc-sklearn-v2"
 
     predictor = V1beta1PredictorSpec(
@@ -293,6 +305,7 @@ async def test_sklearn_v2(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1, 1]
 
@@ -300,6 +313,7 @@ async def test_sklearn_v2(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2_binary.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1, 1]
 
@@ -307,6 +321,7 @@ async def test_sklearn_v2(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2_all_binary.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1, 1]
 
@@ -370,7 +385,7 @@ async def test_sklearn_v2_grpc():
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_v2_mixed(rest_v2_client):
+async def test_sklearn_v2_mixed(rest_v2_client, network_layer):
     service_name = "isvc-sklearn-v2-mixed"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -410,6 +425,7 @@ async def test_sklearn_v2_mixed(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/sklearn_mixed_v2.json",
+        network_layer=network_layer,
     )
     assert response.outputs[0].data == [12.202832815138274]
 

--- a/test/e2e/predictor/test_tensorflow.py
+++ b/test/e2e/predictor/test_tensorflow.py
@@ -31,7 +31,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_tensorflow_kserve(rest_v1_client):
+async def test_tensorflow_kserve(rest_v1_client, network_layer):
     service_name = "isvc-tensorflow"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -62,7 +62,12 @@ async def test_tensorflow_kserve(rest_v1_client):
     )
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
-    res = await predict_isvc(rest_v1_client, service_name, "./data/flower_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/flower_input.json",
+        network_layer=network_layer,
+    )
     assert np.argmax(res["predictions"][0].get("scores")) == 0
 
     # Delete the InferenceService
@@ -71,7 +76,7 @@ async def test_tensorflow_kserve(rest_v1_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_tensorflow_runtime_kserve(rest_v1_client):
+async def test_tensorflow_runtime_kserve(rest_v1_client, network_layer):
     service_name = "isvc-tensorflow-runtime"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -105,7 +110,12 @@ async def test_tensorflow_runtime_kserve(rest_v1_client):
     )
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
-    res = await predict_isvc(rest_v1_client, service_name, "./data/flower_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/flower_input.json",
+        network_layer=network_layer,
+    )
     assert np.argmax(res["predictions"][0].get("scores")) == 0
 
     # Delete the InferenceService

--- a/test/e2e/predictor/test_torchserve.py
+++ b/test/e2e/predictor/test_torchserve.py
@@ -36,7 +36,7 @@ pytest.skip("ODH does not support torchserve at the moment", allow_module_level=
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_torchserve_kserve(rest_v1_client):
+async def test_torchserve_kserve(rest_v1_client, network_layer):
     service_name = "mnist"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -66,7 +66,10 @@ async def test_torchserve_kserve(rest_v1_client):
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
     res = await predict_isvc(
-        rest_v1_client, service_name, "./data/torchserve_input.json"
+        rest_v1_client,
+        service_name,
+        "./data/torchserve_input.json",
+        network_layer=network_layer,
     )
     assert res["predictions"][0] == 2
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
@@ -74,7 +77,7 @@ async def test_torchserve_kserve(rest_v1_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_torchserve_v2_kserve(rest_v2_client):
+async def test_torchserve_v2_kserve(rest_v2_client, network_layer):
     service_name = "mnist-v2"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -108,6 +111,7 @@ async def test_torchserve_v2_kserve(rest_v2_client):
         service_name,
         "./data/torchserve_input_v2.json",
         model_name="mnist",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1]
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
@@ -169,7 +173,7 @@ async def test_torchserve_grpc_v2():
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_torchserve_runtime_kserve(rest_v1_client):
+async def test_torchserve_runtime_kserve(rest_v1_client, network_layer):
     service_name = "mnist-runtime"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -202,7 +206,11 @@ async def test_torchserve_runtime_kserve(rest_v1_client):
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
 
     res = await predict_isvc(
-        rest_v1_client, service_name, "./data/torchserve_input.json", model_name="mnist"
+        rest_v1_client,
+        service_name,
+        "./data/torchserve_input.json",
+        model_name="mnist",
+        network_layer=network_layer,
     )
     assert res["predictions"][0] == 2
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/predictor/test_triton.py
+++ b/test/e2e/predictor/test_triton.py
@@ -33,7 +33,7 @@ from ..common.utils import predict_isvc
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_triton(rest_v2_client):
+async def test_triton(rest_v2_client, network_layer):
     service_name = "isvc-triton"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -86,6 +86,7 @@ async def test_triton(rest_v2_client):
         service_name,
         "./data/cifar10_input_v2.json",
         model_name="cifar10",
+        network_layer=network_layer,
     )
     assert np.argmax(res.outputs[0].data) == 3
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
@@ -94,7 +95,7 @@ async def test_triton(rest_v2_client):
 @pytest.mark.transformer
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_triton_runtime_with_transformer(rest_v1_client):
+async def test_triton_runtime_with_transformer(rest_v1_client, network_layer):
     service_name = "isvc-triton-runtime"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -173,7 +174,11 @@ async def test_triton_runtime_with_transformer(rest_v1_client):
         raise e
 
     res = await predict_isvc(
-        rest_v1_client, service_name, "./data/image.json", model_name="cifar10"
+        rest_v1_client,
+        service_name,
+        "./data/image.json",
+        model_name="cifar10",
+        network_layer=network_layer,
     )
     assert np.argmax(res["predictions"][0]) == 5
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/predictor/test_xgboost.py
+++ b/test/e2e/predictor/test_xgboost.py
@@ -36,7 +36,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE, predict_isvc, predict_grpc
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_xgboost_kserve(rest_v1_client):
+async def test_xgboost_kserve(rest_v1_client, network_layer):
     service_name = "isvc-xgboost"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -67,7 +67,12 @@ async def test_xgboost_kserve(rest_v1_client):
     )
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [1, 1]
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
@@ -75,7 +80,7 @@ async def test_xgboost_kserve(rest_v1_client):
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_xgboost_v2_mlserver(rest_v2_client):
+async def test_xgboost_v2_mlserver(rest_v2_client, network_layer):
     service_name = "isvc-xgboost-v2-mlserver"
     protocol_version = "v2"
 
@@ -121,6 +126,7 @@ async def test_xgboost_v2_mlserver(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1.0, 1.0]
 
@@ -130,7 +136,7 @@ async def test_xgboost_v2_mlserver(rest_v2_client):
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_xgboost_single_model_file(rest_v2_client):
+async def test_xgboost_single_model_file(rest_v2_client, network_layer):
     service_name = "xgboost-v2-mlserver"
     protocol_version = "v2"
 
@@ -176,6 +182,7 @@ async def test_xgboost_single_model_file(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1.0, 1.0]
 
@@ -185,7 +192,7 @@ async def test_xgboost_single_model_file(rest_v2_client):
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_xgboost_runtime_kserve(rest_v1_client):
+async def test_xgboost_runtime_kserve(rest_v1_client, network_layer):
     service_name = "isvc-xgboost-runtime"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -219,7 +226,12 @@ async def test_xgboost_runtime_kserve(rest_v1_client):
     )
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [1, 1]
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
@@ -227,7 +239,7 @@ async def test_xgboost_runtime_kserve(rest_v1_client):
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_xgboost_v2_runtime_mlserver(rest_v2_client):
+async def test_xgboost_v2_runtime_mlserver(rest_v2_client, network_layer):
     service_name = "isvc-xgboost-v2-runtime"
     protocol_version = "v2"
 
@@ -276,6 +288,7 @@ async def test_xgboost_v2_runtime_mlserver(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1.0, 1.0]
 
@@ -285,7 +298,7 @@ async def test_xgboost_v2_runtime_mlserver(rest_v2_client):
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_xgboost_v2(rest_v2_client):
+async def test_xgboost_v2(rest_v2_client, network_layer):
     service_name = "isvc-xgboost-v2"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -325,6 +338,7 @@ async def test_xgboost_v2(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1.0, 1.0]
 

--- a/test/e2e/qpext/test_qpext.py
+++ b/test/e2e/qpext/test_qpext.py
@@ -39,7 +39,7 @@ METRICS_PATH = "metrics"
 
 
 @pytest.mark.asyncio(scope="session")
-async def test_qpext_kserve(rest_v2_client):
+async def test_qpext_kserve(rest_v2_client, network_layer):
     # test the qpext using the sklearn predictor
     service_name = "sklearn-v2-metrics"
     protocol_version = "v2"
@@ -91,6 +91,7 @@ async def test_qpext_kserve(rest_v2_client):
         rest_v2_client,
         service_name,
         "./data/iris_input_v2.json",
+        network_layer=network_layer,
     )
     assert res.outputs[0].data == [1, 1]
 

--- a/test/e2e/storagespec/test_s3_storagespec.py
+++ b/test/e2e/storagespec/test_s3_storagespec.py
@@ -32,7 +32,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE
 @pytest.mark.predictor
 @pytest.mark.path_based_routing
 @pytest.mark.asyncio(scope="session")
-async def test_sklearn_s3_storagespec_kserve(rest_v1_client):
+async def test_sklearn_s3_storagespec_kserve(rest_v1_client, network_layer):
     service_name = "isvc-sklearn-s3"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -67,6 +67,11 @@ async def test_sklearn_s3_storagespec_kserve(rest_v1_client):
     )
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
-    res = await predict_isvc(rest_v1_client, service_name, "./data/iris_input.json")
+    res = await predict_isvc(
+        rest_v1_client,
+        service_name,
+        "./data/iris_input.json",
+        network_layer=network_layer,
+    )
     assert res["predictions"] == [1, 1]
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/transformer/test_collocation.py
+++ b/test/e2e/transformer/test_collocation.py
@@ -40,7 +40,7 @@ from ..common.utils import (
 
 @pytest.mark.collocation
 @pytest.mark.asyncio(scope="session")
-async def test_transformer_collocation(rest_v1_client):
+async def test_transformer_collocation(rest_v1_client, network_layer):
     service_name = "custom-model-transformer-collocation"
     model_name = "mnist"
     predictor = V1beta1PredictorSpec(
@@ -126,7 +126,11 @@ async def test_transformer_collocation(rest_v1_client):
     is_ready = await is_model_ready(rest_v1_client, service_name, model_name) is True
     assert is_ready is True
     res = await predict_isvc(
-        rest_v1_client, service_name, "./data/transformer.json", model_name=model_name
+        rest_v1_client,
+        service_name,
+        "./data/transformer.json",
+        model_name=model_name,
+        network_layer=network_layer,
     )
     assert res["predictions"][0] == 2
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
@@ -134,7 +138,7 @@ async def test_transformer_collocation(rest_v1_client):
 
 @pytest.mark.collocation
 @pytest.mark.asyncio(scope="session")
-async def test_transformer_collocation_runtime(rest_v1_client):
+async def test_transformer_collocation_runtime(rest_v1_client, network_layer):
     service_name = "custom-model-trans-collocation-runtime"
     model_name = "mnist"
     predictor = V1beta1PredictorSpec(
@@ -210,7 +214,11 @@ async def test_transformer_collocation_runtime(rest_v1_client):
     is_ready = await is_model_ready(rest_v1_client, service_name, model_name) is True
     assert is_ready is True
     res = await predict_isvc(
-        rest_v1_client, service_name, "./data/transformer.json", model_name=model_name
+        rest_v1_client,
+        service_name,
+        "./data/transformer.json",
+        model_name=model_name,
+        network_layer=network_layer,
     )
     assert res["predictions"][0] == 2
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/transformer/test_transformer.py
+++ b/test/e2e/transformer/test_transformer.py
@@ -31,7 +31,7 @@ from ..common.utils import KSERVE_TEST_NAMESPACE
 
 @pytest.mark.transformer
 @pytest.mark.asyncio(scope="session")
-async def test_transformer(rest_v1_client):
+async def test_transformer(rest_v1_client, network_layer):
     service_name = "isvc-transformer"
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -98,7 +98,11 @@ async def test_transformer(rest_v1_client):
             print(pod)
         raise e
     res = await predict_isvc(
-        rest_v1_client, service_name, "./data/transformer.json", model_name="mnist"
+        rest_v1_client,
+        service_name,
+        "./data/transformer.json",
+        model_name="mnist",
+        network_layer=network_layer,
     )
     assert res["predictions"][0] == 2
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/scripts/gh-actions/run-e2e-tests.sh
+++ b/test/scripts/gh-actions/run-e2e-tests.sh
@@ -40,7 +40,10 @@ export GITHUB_SHA="${TAG:-latest}"
 echo "Starting E2E functional tests ..."
 MARKER="${1:-}"
 PARALLELISM="${2:-1}"
-NETWORK_LAYER="${3:-'istio'}"
+NETWORK_LAYER="${3:-'openshift-route'}"
+
+: "${SKIP_DELETION_ON_FAILURE:=true}"
+export SKIP_DELETION_ON_FAILURE
 
 echo "Parallelism requested for pytest is ${PARALLELISM}"
 

--- a/test/scripts/gh-actions/run-e2e-tests.sh
+++ b/test/scripts/gh-actions/run-e2e-tests.sh
@@ -40,7 +40,7 @@ export GITHUB_SHA="${TAG:-latest}"
 echo "Starting E2E functional tests ..."
 MARKER="${1:-}"
 PARALLELISM="${2:-1}"
-NETWORK_LAYER="${3:-'openshift-route'}"
+NETWORK_LAYER="${3:-'istio'}"
 
 : "${SKIP_DELETION_ON_FAILURE:=true}"
 export SKIP_DELETION_ON_FAILURE

--- a/test/scripts/openshift-ci/common.sh
+++ b/test/scripts/openshift-ci/common.sh
@@ -1,3 +1,18 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
 
 # find_project_root [start_dir] [marker]
 #   start_dir : directory to begin the search (defaults to this script’s dir)
@@ -186,5 +201,30 @@ wait_for_subscription_csv() {
   oc get catalogsource -n openshift-marketplace 2>/dev/null || true
   echo "CSVs in namespace ${namespace}:"
   oc get csv -n "$namespace" 2>/dev/null || true
+  return 1
+}
+
+readonly VALID_DEPLOYMENT_PROFILES=(raw serverless llm-d)
+# validate_deployment_profile [value]
+validate_deployment_profile() {
+  local profile="$1"
+  if [[ ! " ${VALID_DEPLOYMENT_PROFILES[*]} " =~ " ${profile} " ]]; then
+    echo "Error: '$profile' is not a valid deployment profile." >&2
+    echo "Allowed values: ${VALID_DEPLOYMENT_PROFILES[*]}" >&2
+    exit 1
+  fi
+}
+
+# Define deployment types that skip serverless installation
+MARKERS_SKIP_SERVERLESS=("raw" "graph" "predictor" "path_based_routing" "kserve_on_openshift" "llminferenceservice")
+
+# Helper function to check if deployment type should skip serverless
+skip_serverless() {
+  local deployment_type="$1"
+  for type in "${MARKERS_SKIP_SERVERLESS[@]}"; do
+    if [[ "$deployment_type" =~ $type ]]; then
+      return 0
+    fi
+  done
   return 1
 }

--- a/test/scripts/openshift-ci/run-e2e-tests.sh
+++ b/test/scripts/openshift-ci/run-e2e-tests.sh
@@ -34,9 +34,9 @@ validate_deployment_profile "${DEPLOYMENT_PROFILE}"
 
 # Map deployment profile to network layer for pytest
 case "${DEPLOYMENT_PROFILE}" in
-  raw)        NETWORK_LAYER="openshift-route" ;;
   serverless) NETWORK_LAYER="istio" ;;
   llm-d)      NETWORK_LAYER="gateway-api" ;;
+  *)          NETWORK_LAYER="openshift-route" ;;
 esac
 
 export GATEWAY_CLASS_NAME=${GATEWAY_CLASS_NAME:-"openshift-default"}
@@ -82,6 +82,7 @@ fi
 # For Raw: setup-e2e-tests.sh
 if [ ! -s "/tmp/ca.crt" ]; then
   echo "Failed to extract CA certificate, using system defaults... early failing..."
+  unset REQUESTS_CA_BUNDLE
 else
   echo "CA certificate extracted"
   export REQUESTS_CA_BUNDLE="/tmp/ca.crt"

--- a/test/scripts/openshift-ci/run-e2e-tests.sh
+++ b/test/scripts/openshift-ci/run-e2e-tests.sh
@@ -22,53 +22,73 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+PROJECT_ROOT="$(find_project_root "$SCRIPT_DIR")"
+
+readonly MARKERS="${1:-raw}"
+readonly PARALLELISM="${2:-1}"
+
+readonly DEPLOYMENT_PROFILE="${3:-raw}"
+validate_deployment_profile "${DEPLOYMENT_PROFILE}"
+
+# Map deployment profile to network layer for pytest
+case "${DEPLOYMENT_PROFILE}" in
+  raw)        NETWORK_LAYER="openshift-route" ;;
+  serverless) NETWORK_LAYER="istio" ;;
+  llm-d)      NETWORK_LAYER="gateway-api" ;;
+esac
+
 export GATEWAY_CLASS_NAME=${GATEWAY_CLASS_NAME:-"openshift-default"}
 export INFERENCE_POOL_GROUP="${INFERENCE_POOL_GROUP:-inference.networking.x-k8s.io}"
 export RUN_AS_NON_ROOT="${RUN_AS_NON_ROOT:-true}"
-export SKIP_DELETION_ON_FAILURE=${SKIP_DELETION_ON_FAILURE:-true}
 export KUBE_CLI=${KUBE_CLI_COMMAND:-oc}
-export KSERVE_NAMESPACE=${KSERVE_NAMESPACE:-"kserve"}
 
-MY_PATH=$(dirname "$0")
-PROJECT_ROOT=$MY_PATH/../../../
-export CI_USE_ISVC_HOST="1"
+export GITHUB_SHA=stable # Need to use stable as this is what the CI tags the images to for success-200 and error-404
+: "${BUILD_GRAPH_IMAGES:=true}"
+: "${RUNNING_LOCAL:=false}"
+: "${SKIP_DELETION_ON_FAILURE:=true}"
+export SKIP_DELETION_ON_FAILURE
 
 # Export the controller namespace so that E2E tests
 # (e.g. storage version migration) can find the controller.
 export KSERVE_NAMESPACE="${KSERVE_NAMESPACE:-opendatahub}"
-: "${RUNNING_LOCAL:=false}"
-export GITHUB_SHA=stable # CI tags images to "stable" for success-200 and error-404
 
 if [[ "$RUNNING_LOCAL" == "true" ]]; then
   export CUSTOM_MODEL_GRPC_IMG_TAG=kserve/custom-model-grpc:latest
   export IMAGE_TRANSFORMER_IMG_TAG=kserve/image-transformer:latest
   export GITHUB_SHA=master
+
+  if [[ "${MARKERS}" = *"graph"*  && "$BUILD_GRAPH_IMAGES" = "true" ]]; then
+    pushd $PROJECT_ROOT >/dev/null
+    ./test/scripts/gh-actions/build-graph-tests-images.sh | tee 2>&1 ./test/scripts/openshift-ci/build-graph-tests-images.log
+    popd
+  fi
 fi
 
 cp ./test/e2e/conftest.py ./test/e2e/conftest.py.bak
 trap 'mv ./test/e2e/conftest.py.bak ./test/e2e/conftest.py 2>/dev/null || true' EXIT
 
 : "${SETUP_E2E:=true}"
-
 if [ "$SETUP_E2E" = "true" ]; then
   echo "Installing on cluster"
   pushd $PROJECT_ROOT >/dev/null
-  ./test/scripts/openshift-ci/setup-e2e-tests.sh "$1" | tee 2>&1 "./test/scripts/openshift-ci/setup-e2e-tests-${1// /-}.log"
+  ./test/scripts/openshift-ci/setup-e2e-tests.sh "${MARKERS}" "${PARALLELISM}" "${DEPLOYMENT_PROFILE}" | tee 2>&1 ./test/scripts/openshift-ci/setup-e2e-tests-"${MARKERS// /_}".log
   popd
 fi
 
-PARALLELISM="${2:-1}"
-
 # Use certify go module to get the CA certs
-if [ ! -f "/tmp/ca.crt" ]; then
-  echo "❌ Error: CA certificate file '/tmp/ca.crt' not found. Please ensure the setup script ran successfully."
-  exit 1
+# For serverless it is configured here: infra/deploy.serverless.sh
+# For Raw: setup-e2e-tests.sh
+if [ ! -s "/tmp/ca.crt" ]; then
+  echo "Failed to extract CA certificate, using system defaults... early failing..."
+else
+  echo "CA certificate extracted"
+  export REQUESTS_CA_BUNDLE="/tmp/ca.crt"
+  echo "REQUESTS_CA_BUNDLE=$(cat ${REQUESTS_CA_BUNDLE})"
 fi
 
-export REQUESTS_CA_BUNDLE="/tmp/ca.crt"
-echo "REQUESTS_CA_BUNDLE=$(cat ${REQUESTS_CA_BUNDLE})"
-
-echo "Run E2E tests: $1"
+echo "Run E2E tests: ${MARKERS}"
 pushd $PROJECT_ROOT >/dev/null
-./test/scripts/gh-actions/run-e2e-tests.sh "$1" $PARALLELISM | tee 2>&1 "./test/scripts/openshift-ci/run-e2e-tests-${1// /-}.log"
+./test/scripts/gh-actions/run-e2e-tests.sh "${MARKERS}" "${PARALLELISM}" "${NETWORK_LAYER}" | tee 2>&1 ./test/scripts/openshift-ci/run-e2e-tests-"${MARKERS// /_}".log
 popd

--- a/test/scripts/openshift-ci/run-e2e-tests.sh
+++ b/test/scripts/openshift-ci/run-e2e-tests.sh
@@ -52,18 +52,12 @@ export SKIP_DELETION_ON_FAILURE
 
 # Export the controller namespace so that E2E tests
 # (e.g. storage version migration) can find the controller.
-export KSERVE_NAMESPACE="${KSERVE_NAMESPACE:-opendatahub}"
+export KSERVE_NAMESPACE=${KSERVE_NAMESPACE:-"kserve"}
 
 if [[ "$RUNNING_LOCAL" == "true" ]]; then
   export CUSTOM_MODEL_GRPC_IMG_TAG=kserve/custom-model-grpc:latest
   export IMAGE_TRANSFORMER_IMG_TAG=kserve/image-transformer:latest
   export GITHUB_SHA=master
-
-  if [[ "${MARKERS}" = *"graph"*  && "$BUILD_GRAPH_IMAGES" = "true" ]]; then
-    pushd $PROJECT_ROOT >/dev/null
-    ./test/scripts/gh-actions/build-graph-tests-images.sh | tee 2>&1 ./test/scripts/openshift-ci/build-graph-tests-images.log
-    popd
-  fi
 fi
 
 cp ./test/e2e/conftest.py ./test/e2e/conftest.py.bak


### PR DESCRIPTION
## Summary
- Removes `CI_USE_ISVC_HOST` env var and replaces it with `openshift-route` as a `--network-layer` pytest parameter
- Adds deployment profile validation (`raw`, `serverless`, `llm-d`) with a mapping to network layers in the CI scripts
- Adds `gateway-api` network layer that reads the gateway namespace from the `inferenceservice-config` ConfigMap
- Ports CI script improvements from release-v0.15: `SKIP_DELETION_ON_FAILURE`, improved CA cert handling, diagnostic dump on test failure

Jira: https://redhat.atlassian.net/browse/RHOAIENG-50812

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `gateway-api` and improved network-layer handling in end-to-end tests; tests now accept an explicit network-layer parameter.
  * Endpoint selection updated to better handle OpenShift route and gateway scenarios.

* **Bug Fixes**
  * Changed default network layer from `istio` to `openshift-route`.
  * Improved failure diagnostics to capture additional cluster state on test failures.

* **Chores**
  * Added deployment-profile validation, stricter CI script behavior, safer CA-bundle handling, and a skip-deletion-on-failure option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->