### PR TITLE
fix(llmisvc): TLS certificate verification on DestinationRules

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -10,10 +10,6 @@ spec:
       - /bin/bash
       - -c
       - |-
-        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-          source /etc/profile.d/ibm-aiu-setup.sh
-        fi
-
         if [ "$KSERVE_INFER_ROCE" = "true" ]; then
           echo "Trying to infer RoCE configs ... "
           grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
@@ -151,7 +147,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -178,8 +174,8 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       startupProbe:
@@ -194,8 +190,6 @@ spec:
       volumeMounts:
       - mountPath: /home
         name: home
-      - mountPath: /tmp
-        name: tmp-dir
       - mountPath: /dev/shm
         name: dshm
       - mountPath: /models
@@ -208,7 +202,7 @@ spec:
       - /app/pd-sidecar
       - --port=8000
       - --vllm-port=8001
-      - --kv-connector=nixlv2
+      - --connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
@@ -223,7 +217,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.6.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -254,8 +248,8 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
       terminationMessagePath: /dev/termination-log
       terminationMessagePolicy: FallbackToLogsOnError
       volumeMounts:
@@ -266,8 +260,6 @@ spec:
     volumes:
     - emptyDir: {}
       name: home
-    - emptyDir: {}
-      name: tmp-dir
     - emptyDir:
         medium: Memory
         sizeLimit: 1Gi
@@ -290,10 +282,6 @@ spec:
       - /bin/bash
       - -c
       - |-
-        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-          source /etc/profile.d/ibm-aiu-setup.sh
-        fi
-
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -461,7 +449,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -492,8 +480,8 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       startupProbe:
@@ -508,8 +496,6 @@ spec:
       volumeMounts:
       - mountPath: /home
         name: home
-      - mountPath: /tmp
-        name: tmp-dir
       - mountPath: /dev/shm
         name: dshm
       - mountPath: /models
@@ -522,7 +508,7 @@ spec:
       - /app/pd-sidecar
       - --port=8000
       - --vllm-port=8001
-      - --kv-connector=nixlv2
+      - --connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
@@ -537,7 +523,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.6.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -568,7 +554,7 @@ spec:
           drop:
           - ALL
         readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       terminationMessagePath: /dev/termination-log
@@ -581,8 +567,6 @@ spec:
     volumes:
     - emptyDir: {}
       name: home
-    - emptyDir: {}
-      name: tmp-dir
     - emptyDir:
         medium: Memory
         sizeLimit: 8Gi
@@ -598,10 +582,6 @@ spec:
       - /bin/bash
       - -c
       - |-
-        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-          source /etc/profile.d/ibm-aiu-setup.sh
-        fi
-
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -771,7 +751,7 @@ spec:
         value: /models
       - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
         value: "1"
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
       imagePullPolicy: IfNotPresent
       name: main
       ports:
@@ -786,8 +766,8 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       terminationMessagePath: /dev/termination-log
@@ -795,8 +775,6 @@ spec:
       volumeMounts:
       - mountPath: /home
         name: home
-      - mountPath: /tmp
-        name: tmp-dir
       - mountPath: /dev/shm
         name: dshm
       - mountPath: /models
@@ -808,8 +786,6 @@ spec:
     volumes:
     - emptyDir: {}
       name: home
-    - emptyDir: {}
-      name: tmp-dir
     - emptyDir:
         medium: Memory
         sizeLimit: 8Gi
@@ -833,10 +809,6 @@ spec:
         - /bin/bash
         - -c
         - |-
-          if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-            source /etc/profile.d/ibm-aiu-setup.sh
-          fi
-
           if [ "$KSERVE_INFER_ROCE" = "true" ]; then
             echo "Trying to infer RoCE configs ... "
             grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
@@ -974,7 +946,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1001,8 +973,8 @@ spec:
           capabilities:
             drop:
             - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
+          readOnlyRootFilesystem: false
+          runAsNonRoot: false
           seccompProfile:
             type: RuntimeDefault
         startupProbe:
@@ -1017,8 +989,6 @@ spec:
         volumeMounts:
         - mountPath: /home
           name: home
-        - mountPath: /tmp
-          name: tmp-dir
         - mountPath: /dev/shm
           name: dshm
         - mountPath: /models
@@ -1030,8 +1000,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: home
-      - emptyDir: {}
-        name: tmp-dir
       - emptyDir:
           medium: Memory
           sizeLimit: 1Gi
@@ -1055,10 +1023,6 @@ spec:
         - /bin/bash
         - -c
         - |-
-          if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-            source /etc/profile.d/ibm-aiu-setup.sh
-          fi
-
           # In some versions, ZMQ bind doesn't resolve the address through DNS
           # Retry DP_ADDRESS resolution (configurable attempts, default 30)
           RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -1226,7 +1190,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1257,8 +1221,8 @@ spec:
             - NET_RAW
             drop:
             - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
+          readOnlyRootFilesystem: false
+          runAsNonRoot: false
           seccompProfile:
             type: RuntimeDefault
         startupProbe:
@@ -1273,8 +1237,6 @@ spec:
         volumeMounts:
         - mountPath: /home
           name: home
-        - mountPath: /tmp
-          name: tmp-dir
         - mountPath: /dev/shm
           name: dshm
         - mountPath: /models
@@ -1286,8 +1248,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: home
-      - emptyDir: {}
-        name: tmp-dir
       - emptyDir:
           medium: Memory
           sizeLimit: 8Gi
@@ -1303,10 +1263,6 @@ spec:
         - /bin/bash
         - -c
         - |-
-          if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-            source /etc/profile.d/ibm-aiu-setup.sh
-          fi
-
           # In some versions, ZMQ bind doesn't resolve the address through DNS
           # Retry DP_ADDRESS resolution (configurable attempts, default 30)
           RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -1474,7 +1430,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
         imagePullPolicy: IfNotPresent
         name: main
         ports:
@@ -1489,8 +1445,8 @@ spec:
             - NET_RAW
             drop:
             - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
+          readOnlyRootFilesystem: false
+          runAsNonRoot: false
           seccompProfile:
             type: RuntimeDefault
         terminationMessagePath: /dev/termination-log
@@ -1498,8 +1454,6 @@ spec:
         volumeMounts:
         - mountPath: /home
           name: home
-        - mountPath: /tmp
-          name: tmp-dir
         - mountPath: /dev/shm
           name: dshm
         - mountPath: /models
@@ -1511,8 +1465,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: home
-      - emptyDir: {}
-        name: tmp-dir
       - emptyDir:
           medium: Memory
           sizeLimit: 8Gi
@@ -1578,25 +1530,6 @@ spec:
               backendRequest: 0s
               request: 0s
           - backendRefs:
-            - group: inference.networking.k8s.io
-              kind: InferencePool
-              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
-              port: 8000
-              weight: 1
-            filters:
-            - type: URLRewrite
-              urlRewrite:
-                path:
-                  replacePrefixMatch: /v1/responses
-                  type: ReplacePrefixMatch
-            matches:
-            - path:
-                type: PathPrefix
-                value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/responses
-            timeouts:
-              backendRequest: 0s
-              request: 0s
-          - backendRefs:
             - kind: Service
               name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
               port: 8000
@@ -1623,8 +1556,6 @@ metadata:
 spec:
   router:
     scheduler:
-      annotations:
-        app.kubernetes.io/version: 0.7.0
       pool:
         spec:
           endpointPickerRef:
@@ -1654,6 +1585,8 @@ spec:
           - "9002"
           - --grpc-health-port
           - "9003"
+          - --kv-cache-usage-percentage-metric
+          - vllm:kv_cache_usage_perc
           - '{{ if .GlobalConfig.EnableTLS }}--enable-cert-reload=true{{- end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--secure-serving=true{{- end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--model-server-metrics-scheme=https{{-
@@ -1663,7 +1596,7 @@ spec:
           env:
           - name: SSL_CERT_DIR
             value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-          image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.1
+          image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.6.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -1721,12 +1654,12 @@ spec:
         - env:
           - name: TOKENIZERS_DIR
             value: /mnt/models
-          image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.1
+          image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.6.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
             httpGet:
-              path: /healthz
+              path: /health
               port: 8082
             periodSeconds: 15
             timeoutSeconds: 5
@@ -1738,7 +1671,7 @@ spec:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /healthz
+              path: /health
               port: 8082
             periodSeconds: 10
             timeoutSeconds: 5
@@ -1758,7 +1691,7 @@ spec:
           startupProbe:
             failureThreshold: 60
             httpGet:
-              path: /healthz
+              path: /health
               port: 8082
             initialDelaySeconds: 5
             periodSeconds: 10
@@ -1766,10 +1699,6 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
-          - mountPath: /tmp
-            name: tokenizer-tmp
-          - mountPath: /.cache
-            name: tokenizer-cache
           - mountPath: /tmp/tokenizer
             name: tokenizer-uds
           workingDir: /mnt/models
@@ -1783,10 +1712,6 @@ spec:
               }}'
         - emptyDir: {}
           name: tokenizer-uds
-        - emptyDir: {}
-          name: tokenizer-tmp
-        - emptyDir: {}
-          name: tokenizer-cache
 ---
 apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
@@ -1800,10 +1725,6 @@ spec:
       - /bin/bash
       - -c
       - |-
-        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-          source /etc/profile.d/ibm-aiu-setup.sh
-        fi
-
         if [ "$KSERVE_INFER_ROCE" = "true" ]; then
           echo "Trying to infer RoCE configs ... "
           grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
@@ -1941,7 +1862,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -1968,8 +1889,8 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       startupProbe:
@@ -1984,8 +1905,6 @@ spec:
       volumeMounts:
       - mountPath: /home
         name: home
-      - mountPath: /tmp
-        name: tmp-dir
       - mountPath: /dev/shm
         name: dshm
       - mountPath: /models
@@ -2003,8 +1922,6 @@ spec:
       name: dshm
     - emptyDir: {}
       name: model-cache
-    - emptyDir: {}
-      name: tmp-dir
     - name: tls-certs
       secret:
         secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
@@ -2021,10 +1938,6 @@ spec:
       - /bin/bash
       - -c
       - |-
-        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-          source /etc/profile.d/ibm-aiu-setup.sh
-        fi
-
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -2192,7 +2105,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -2223,8 +2136,8 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       startupProbe:
@@ -2239,8 +2152,6 @@ spec:
       volumeMounts:
       - mountPath: /home
         name: home
-      - mountPath: /tmp
-        name: tmp-dir
       - mountPath: /dev/shm
         name: dshm
       - mountPath: /models
@@ -2252,8 +2163,6 @@ spec:
     volumes:
     - emptyDir: {}
       name: home
-    - emptyDir: {}
-      name: tmp-dir
     - emptyDir:
         medium: Memory
         sizeLimit: 8Gi
@@ -2269,10 +2178,6 @@ spec:
       - /bin/bash
       - -c
       - |-
-        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-          source /etc/profile.d/ibm-aiu-setup.sh
-        fi
-
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -2440,7 +2345,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
       imagePullPolicy: IfNotPresent
       name: main
       ports:
@@ -2455,8 +2360,8 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       terminationMessagePath: /dev/termination-log
@@ -2464,8 +2369,6 @@ spec:
       volumeMounts:
       - mountPath: /home
         name: home
-      - mountPath: /tmp
-        name: tmp-dir
       - mountPath: /dev/shm
         name: dshm
       - mountPath: /models
@@ -2477,8 +2380,6 @@ spec:
     volumes:
     - emptyDir: {}
       name: home
-    - emptyDir: {}
-      name: tmp-dir
     - emptyDir:
         medium: Memory
         sizeLimit: 8Gi

--- a/config/llmisvcconfig/config-llm-scheduler.yaml
+++ b/config/llmisvcconfig/config-llm-scheduler.yaml
@@ -22,8 +22,6 @@ spec:
               kserve.io/component: workload
           targetPorts:
             - number: 8000
-      annotations:
-        "app.kubernetes.io/version": "0.7.0"
       template:
         containers:
           - name: main
@@ -40,7 +38,7 @@ spec:
               - containerPort: 5557
                 name: zmq
                 protocol: TCP
-            image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.1
+            image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.6.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 3
@@ -72,6 +70,8 @@ spec:
               - "9002"
               - --grpc-health-port
               - "9003"
+              - --kv-cache-usage-percentage-metric
+              - "vllm:kv_cache_usage_perc"
               - '{{ if .GlobalConfig.EnableTLS }}--enable-cert-reload=true{{- end }}'
               - '{{ if .GlobalConfig.EnableTLS }}--secure-serving=true{{- end }}'
               - '{{ if .GlobalConfig.EnableTLS }}--model-server-metrics-scheme=https{{- end }}'
@@ -105,7 +105,7 @@ spec:
               - containerPort: 8082
                 name: health
                 protocol: TCP
-            image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.1
+            image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.6.0
             imagePullPolicy: IfNotPresent
             workingDir: /mnt/models
             env:
@@ -113,21 +113,21 @@ spec:
                 value: /mnt/models
             livenessProbe:
               httpGet:
-                path: /healthz
+                path: /health
                 port: 8082
               periodSeconds: 15
               timeoutSeconds: 5
               failureThreshold: 3
             readinessProbe:
               httpGet:
-                path: /healthz
+                path: /health
                 port: 8082
               periodSeconds: 10
               timeoutSeconds: 5
               failureThreshold: 3
             startupProbe:
               httpGet:
-                path: /healthz
+                path: /health
                 port: 8082
               periodSeconds: 10
               initialDelaySeconds: 5
@@ -149,14 +149,6 @@ spec:
               seccompProfile:
                 type: RuntimeDefault
             volumeMounts:
-              # The tokenizer image imports torch/dill which requires a writable
-              # /tmp at import time (tempfile.gettempdir()). Without this mount,
-              # readOnlyRootFilesystem causes the container to crash on startup.
-              - mountPath: /tmp
-                name: tokenizer-tmp
-              # vllm writes model info cache to /.cache/vllm/modelinfos.
-              - mountPath: /.cache
-                name: tokenizer-cache
               - mountPath: /tmp/tokenizer
                 name: tokenizer-uds
         volumes:
@@ -164,12 +156,6 @@ spec:
             secret:
               secretName: "{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}"
           - name: tokenizer-uds
-            emptyDir: {}
-          # Writable /tmp for the tokenizer container (see volumeMounts comment above).
-          - name: tokenizer-tmp
-            emptyDir: {}
-          # Writable /.cache for vllm model info cache.
-          - name: tokenizer-cache
             emptyDir: {}
         dnsPolicy: ClusterFirst
         restartPolicy: Always

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -628,15 +628,15 @@ export RELEASE
 
 GOLANGCI_LINT_VERSION=v2.9.0
 CONTROLLER_TOOLS_VERSION=v0.19.0
-ENVTEST_VERSION=release-0.19
+ENVTEST_VERSION=latest
 YQ_VERSION=v4.52.1
 HELM_VERSION=v3.16.3
-KUSTOMIZE_VERSION=v5.8.1
+KUSTOMIZE_VERSION=v5.8.0
 HELM_DOCS_VERSION=v1.12.0
+BLACK_FMT_VERSION=24.3
 POETRY_VERSION=1.8.3
 UV_VERSION=0.7.8
 RUFF_VERSION=0.14.13
-PINACT_VERSION=v3.9.0
 KIND_VERSION=v0.30.0
 CERT_MANAGER_VERSION=v1.17.0
 ENVOY_GATEWAY_VERSION=v1.6.3
@@ -644,16 +644,14 @@ ENVOY_AI_GATEWAY_VERSION=v0.5.0
 KNATIVE_OPERATOR_VERSION=v1.21.1
 KNATIVE_SERVING_VERSION=1.21.1
 KEDA_OTEL_ADDON_VERSION=v0.0.6
-PROMETHEUS_VERSION=83.4.0
-PROMETHEUS_ADAPTER_VERSION=5.3.0
-KSERVE_VERSION=v0.18.0-rc1
+KSERVE_VERSION=v0.17.0
 ISTIO_VERSION=1.27.1
 KEDA_VERSION=2.17.3
 OPENTELEMETRY_OPERATOR_VERSION=0.74.3
-LWS_VERSION=v0.8.0
+LWS_VERSION=v0.7.0
 GATEWAY_API_VERSION=v1.4.1
-GIE_VERSION=v1.3.1
-WVA_VERSION=v0.6.0
+GIE_VERSION=v1.3.0
+WVA_VERSION=v0.5.1
 
 #================================================
 # Global Variables (from global-vars.env)
@@ -663,9 +661,6 @@ WVA_VERSION=v0.6.0
 
 KEDA_NAMESPACE="${KEDA_NAMESPACE:-keda}"
 KSERVE_NAMESPACE="${KSERVE_NAMESPACE:-kserve}"
-PROMETHEUS_NAMESPACE="${PROMETHEUS_NAMESPACE:-monitoring}"
-PROMETHEUS_ADAPTER_NAMESPACE="${PROMETHEUS_ADAPTER_NAMESPACE:-monitoring}"
-WVA_NAMESPACE="${WVA_NAMESPACE:-wva-system}"
 OTEL_NAMESPACE="${OTEL_NAMESPACE:-opentelemetry-operator}"
 OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-knative-operator}"
 SERVING_NAMESPACE="${SERVING_NAMESPACE:-knative-serving}"
@@ -974,7 +969,7 @@ install_helm() {
     rm -rf "${temp_dir}"
 
     log_success "Successfully installed Helm ${HELM_VERSION} to ${BIN_DIR}/helm"
-    "${BIN_DIR}/helm" version
+    helm version
 }
 
 # ----------------------------------------
@@ -991,10 +986,10 @@ install_kustomize() {
 
     log_info "Installing Kustomize ${KUSTOMIZE_VERSION} for ${os}/${arch}..."
 
-    if [[ -x "${BIN_DIR}/kustomize" ]]; then
-        local current_version=$("${BIN_DIR}/kustomize" version 2>/dev/null | awk 'match($0, /v[0-9.]+/) {print substr($0, RSTART, RLENGTH)}')
+    if command -v kustomize &>/dev/null; then
+        local current_version=$(kustomize version --short 2>/dev/null | grep -oP 'v[0-9.]+')
         if [[ -n "$current_version" ]] && version_gte "$current_version" "$KUSTOMIZE_VERSION"; then
-            log_info "Kustomize ${current_version} is already installed in ${BIN_DIR} (>= ${KUSTOMIZE_VERSION})"
+            log_info "Kustomize ${current_version} is already installed (>= ${KUSTOMIZE_VERSION})"
             return 0
         fi
         [[ -n "$current_version" ]] && log_info "Upgrading Kustomize from ${current_version} to ${KUSTOMIZE_VERSION}..."
@@ -1034,7 +1029,7 @@ install_kustomize() {
     rm -rf "${temp_dir}"
 
     log_success "Successfully installed Kustomize ${KUSTOMIZE_VERSION} to ${BIN_DIR}/kustomize"
-    "${BIN_DIR}/kustomize" version
+    kustomize version
 }
 
 # ----------------------------------------
@@ -1052,7 +1047,7 @@ install_yq() {
     log_info "Installing yq ${YQ_VERSION} for ${os}/${arch}..."
 
     if [[ -x "${BIN_DIR}/yq" ]]; then
-        local current_version=$("${BIN_DIR}/yq" --version 2>&1 | awk 'match($0, /v[0-9.]+/) {print substr($0, RSTART, RLENGTH)}')
+        local current_version=$("${BIN_DIR}/yq" --version 2>&1 | grep -oP 'version \K[v0-9.]+')
         # Normalize version format (add 'v' prefix if missing)
         [[ -n "$current_version" && "$current_version" != v* ]] && current_version="v${current_version}"
         if [[ -n "$current_version" ]] && version_gte "$current_version" "$YQ_VERSION"; then
@@ -1362,13 +1357,13 @@ uninstall_kserve_kustomize() {
         # Uninstall overlay resources in reverse order
         for ((i=${#TARGET_OVERLAY_DIRS[@]}-1; i>=0; i--)); do
             log_info "Uninstalling resources from ${TARGET_OVERLAY_DIRS[$i]}..."
-            kustomize build "${TARGET_OVERLAY_DIRS[$i]}" | kubectl delete -f - --force --grace-period=0 2>/dev/null || true
+            kubectl kustomize "${TARGET_OVERLAY_DIRS[$i]}" | kubectl delete -f - --force --grace-period=0 2>/dev/null || true
         done
 
         # Uninstall CRDs in reverse order
         for ((i=${#TARGET_CRD_DIRS[@]}-1; i>=0; i--)); do
             log_info "Uninstalling CRDs from ${TARGET_CRD_DIRS[$i]}..."
-            kustomize build "${TARGET_CRD_DIRS[$i]}" | kubectl delete -f - --force --grace-period=0 2>/dev/null || true
+            kubectl kustomize "${TARGET_CRD_DIRS[$i]}" | kubectl delete -f - --force --grace-period=0 2>/dev/null || true
         done
     fi
 
@@ -2030,7 +2025,7 @@ spec:
       value: "8080"
     - name: MLSERVER_GRPC_PORT
       value: "9000"
-    image: docker.io/seldonio/mlserver:1.7.1
+    image: docker.io/seldonio/mlserver:1.5.0
     name: kserve-container
     resources:
       limits:
@@ -2471,10 +2466,6 @@ spec:
       - /bin/bash
       - -c
       - |-
-        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-          source /etc/profile.d/ibm-aiu-setup.sh
-        fi
-
         if [ "$KSERVE_INFER_ROCE" = "true" ]; then
           echo "Trying to infer RoCE configs ... "
           grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
@@ -2612,7 +2603,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -2639,8 +2630,8 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       startupProbe:
@@ -2655,8 +2646,6 @@ spec:
       volumeMounts:
       - mountPath: /home
         name: home
-      - mountPath: /tmp
-        name: tmp-dir
       - mountPath: /dev/shm
         name: dshm
       - mountPath: /models
@@ -2669,7 +2658,7 @@ spec:
       - /app/pd-sidecar
       - --port=8000
       - --vllm-port=8001
-      - --kv-connector=nixlv2
+      - --connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
@@ -2684,7 +2673,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.6.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -2715,8 +2704,8 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
       terminationMessagePath: /dev/termination-log
       terminationMessagePolicy: FallbackToLogsOnError
       volumeMounts:
@@ -2727,8 +2716,6 @@ spec:
     volumes:
     - emptyDir: {}
       name: home
-    - emptyDir: {}
-      name: tmp-dir
     - emptyDir:
         medium: Memory
         sizeLimit: 1Gi
@@ -2751,10 +2738,6 @@ spec:
       - /bin/bash
       - -c
       - |-
-        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-          source /etc/profile.d/ibm-aiu-setup.sh
-        fi
-
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -2922,7 +2905,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -2953,8 +2936,8 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       startupProbe:
@@ -2969,8 +2952,6 @@ spec:
       volumeMounts:
       - mountPath: /home
         name: home
-      - mountPath: /tmp
-        name: tmp-dir
       - mountPath: /dev/shm
         name: dshm
       - mountPath: /models
@@ -2983,7 +2964,7 @@ spec:
       - /app/pd-sidecar
       - --port=8000
       - --vllm-port=8001
-      - --kv-connector=nixlv2
+      - --connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
@@ -2998,7 +2979,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.6.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -3029,7 +3010,7 @@ spec:
           drop:
           - ALL
         readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       terminationMessagePath: /dev/termination-log
@@ -3042,8 +3023,6 @@ spec:
     volumes:
     - emptyDir: {}
       name: home
-    - emptyDir: {}
-      name: tmp-dir
     - emptyDir:
         medium: Memory
         sizeLimit: 8Gi
@@ -3059,10 +3038,6 @@ spec:
       - /bin/bash
       - -c
       - |-
-        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-          source /etc/profile.d/ibm-aiu-setup.sh
-        fi
-
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -3232,7 +3207,7 @@ spec:
         value: /models
       - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
         value: "1"
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
       imagePullPolicy: IfNotPresent
       name: main
       ports:
@@ -3247,8 +3222,8 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       terminationMessagePath: /dev/termination-log
@@ -3256,8 +3231,6 @@ spec:
       volumeMounts:
       - mountPath: /home
         name: home
-      - mountPath: /tmp
-        name: tmp-dir
       - mountPath: /dev/shm
         name: dshm
       - mountPath: /models
@@ -3269,8 +3242,6 @@ spec:
     volumes:
     - emptyDir: {}
       name: home
-    - emptyDir: {}
-      name: tmp-dir
     - emptyDir:
         medium: Memory
         sizeLimit: 8Gi
@@ -3294,10 +3265,6 @@ spec:
         - /bin/bash
         - -c
         - |-
-          if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-            source /etc/profile.d/ibm-aiu-setup.sh
-          fi
-
           if [ "$KSERVE_INFER_ROCE" = "true" ]; then
             echo "Trying to infer RoCE configs ... "
             grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
@@ -3435,7 +3402,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -3462,8 +3429,8 @@ spec:
           capabilities:
             drop:
             - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
+          readOnlyRootFilesystem: false
+          runAsNonRoot: false
           seccompProfile:
             type: RuntimeDefault
         startupProbe:
@@ -3478,8 +3445,6 @@ spec:
         volumeMounts:
         - mountPath: /home
           name: home
-        - mountPath: /tmp
-          name: tmp-dir
         - mountPath: /dev/shm
           name: dshm
         - mountPath: /models
@@ -3491,8 +3456,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: home
-      - emptyDir: {}
-        name: tmp-dir
       - emptyDir:
           medium: Memory
           sizeLimit: 1Gi
@@ -3516,10 +3479,6 @@ spec:
         - /bin/bash
         - -c
         - |-
-          if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-            source /etc/profile.d/ibm-aiu-setup.sh
-          fi
-
           # In some versions, ZMQ bind doesn't resolve the address through DNS
           # Retry DP_ADDRESS resolution (configurable attempts, default 30)
           RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -3687,7 +3646,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -3718,8 +3677,8 @@ spec:
             - NET_RAW
             drop:
             - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
+          readOnlyRootFilesystem: false
+          runAsNonRoot: false
           seccompProfile:
             type: RuntimeDefault
         startupProbe:
@@ -3734,8 +3693,6 @@ spec:
         volumeMounts:
         - mountPath: /home
           name: home
-        - mountPath: /tmp
-          name: tmp-dir
         - mountPath: /dev/shm
           name: dshm
         - mountPath: /models
@@ -3747,8 +3704,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: home
-      - emptyDir: {}
-        name: tmp-dir
       - emptyDir:
           medium: Memory
           sizeLimit: 8Gi
@@ -3764,10 +3719,6 @@ spec:
         - /bin/bash
         - -c
         - |-
-          if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-            source /etc/profile.d/ibm-aiu-setup.sh
-          fi
-
           # In some versions, ZMQ bind doesn't resolve the address through DNS
           # Retry DP_ADDRESS resolution (configurable attempts, default 30)
           RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -3935,7 +3886,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
         imagePullPolicy: IfNotPresent
         name: main
         ports:
@@ -3950,8 +3901,8 @@ spec:
             - NET_RAW
             drop:
             - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
+          readOnlyRootFilesystem: false
+          runAsNonRoot: false
           seccompProfile:
             type: RuntimeDefault
         terminationMessagePath: /dev/termination-log
@@ -3959,8 +3910,6 @@ spec:
         volumeMounts:
         - mountPath: /home
           name: home
-        - mountPath: /tmp
-          name: tmp-dir
         - mountPath: /dev/shm
           name: dshm
         - mountPath: /models
@@ -3972,8 +3921,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: home
-      - emptyDir: {}
-        name: tmp-dir
       - emptyDir:
           medium: Memory
           sizeLimit: 8Gi
@@ -4039,25 +3986,6 @@ spec:
               backendRequest: 0s
               request: 0s
           - backendRefs:
-            - group: inference.networking.k8s.io
-              kind: InferencePool
-              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
-              port: 8000
-              weight: 1
-            filters:
-            - type: URLRewrite
-              urlRewrite:
-                path:
-                  replacePrefixMatch: /v1/responses
-                  type: ReplacePrefixMatch
-            matches:
-            - path:
-                type: PathPrefix
-                value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/responses
-            timeouts:
-              backendRequest: 0s
-              request: 0s
-          - backendRefs:
             - kind: Service
               name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
               port: 8000
@@ -4084,8 +4012,6 @@ metadata:
 spec:
   router:
     scheduler:
-      annotations:
-        app.kubernetes.io/version: 0.7.0
       pool:
         spec:
           endpointPickerRef:
@@ -4115,6 +4041,8 @@ spec:
           - "9002"
           - --grpc-health-port
           - "9003"
+          - --kv-cache-usage-percentage-metric
+          - vllm:kv_cache_usage_perc
           - '{{ if .GlobalConfig.EnableTLS }}--enable-cert-reload=true{{- end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--secure-serving=true{{- end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--model-server-metrics-scheme=https{{-
@@ -4124,7 +4052,7 @@ spec:
           env:
           - name: SSL_CERT_DIR
             value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-          image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.1
+          image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.6.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -4182,12 +4110,12 @@ spec:
         - env:
           - name: TOKENIZERS_DIR
             value: /mnt/models
-          image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.1
+          image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.6.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
             httpGet:
-              path: /healthz
+              path: /health
               port: 8082
             periodSeconds: 15
             timeoutSeconds: 5
@@ -4199,7 +4127,7 @@ spec:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /healthz
+              path: /health
               port: 8082
             periodSeconds: 10
             timeoutSeconds: 5
@@ -4219,7 +4147,7 @@ spec:
           startupProbe:
             failureThreshold: 60
             httpGet:
-              path: /healthz
+              path: /health
               port: 8082
             initialDelaySeconds: 5
             periodSeconds: 10
@@ -4227,10 +4155,6 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
-          - mountPath: /tmp
-            name: tokenizer-tmp
-          - mountPath: /.cache
-            name: tokenizer-cache
           - mountPath: /tmp/tokenizer
             name: tokenizer-uds
           workingDir: /mnt/models
@@ -4244,10 +4168,6 @@ spec:
               }}'
         - emptyDir: {}
           name: tokenizer-uds
-        - emptyDir: {}
-          name: tokenizer-tmp
-        - emptyDir: {}
-          name: tokenizer-cache
 ---
 apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
@@ -4261,10 +4181,6 @@ spec:
       - /bin/bash
       - -c
       - |-
-        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-          source /etc/profile.d/ibm-aiu-setup.sh
-        fi
-
         if [ "$KSERVE_INFER_ROCE" = "true" ]; then
           echo "Trying to infer RoCE configs ... "
           grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
@@ -4402,7 +4318,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -4429,8 +4345,8 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       startupProbe:
@@ -4445,8 +4361,6 @@ spec:
       volumeMounts:
       - mountPath: /home
         name: home
-      - mountPath: /tmp
-        name: tmp-dir
       - mountPath: /dev/shm
         name: dshm
       - mountPath: /models
@@ -4464,8 +4378,6 @@ spec:
       name: dshm
     - emptyDir: {}
       name: model-cache
-    - emptyDir: {}
-      name: tmp-dir
     - name: tls-certs
       secret:
         secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
@@ -4482,10 +4394,6 @@ spec:
       - /bin/bash
       - -c
       - |-
-        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-          source /etc/profile.d/ibm-aiu-setup.sh
-        fi
-
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -4653,7 +4561,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -4684,8 +4592,8 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       startupProbe:
@@ -4700,8 +4608,6 @@ spec:
       volumeMounts:
       - mountPath: /home
         name: home
-      - mountPath: /tmp
-        name: tmp-dir
       - mountPath: /dev/shm
         name: dshm
       - mountPath: /models
@@ -4713,8 +4619,6 @@ spec:
     volumes:
     - emptyDir: {}
       name: home
-    - emptyDir: {}
-      name: tmp-dir
     - emptyDir:
         medium: Memory
         sizeLimit: 8Gi
@@ -4730,10 +4634,6 @@ spec:
       - /bin/bash
       - -c
       - |-
-        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-          source /etc/profile.d/ibm-aiu-setup.sh
-        fi
-
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -4901,7 +4801,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
       imagePullPolicy: IfNotPresent
       name: main
       ports:
@@ -4916,8 +4816,8 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       terminationMessagePath: /dev/termination-log
@@ -4925,8 +4825,6 @@ spec:
       volumeMounts:
       - mountPath: /home
         name: home
-      - mountPath: /tmp
-        name: tmp-dir
       - mountPath: /dev/shm
         name: dshm
       - mountPath: /models
@@ -4938,8 +4836,6 @@ spec:
     volumes:
     - emptyDir: {}
       name: home
-    - emptyDir: {}
-      name: tmp-dir
     - emptyDir:
         medium: Memory
         sizeLimit: 8Gi
@@ -38127,630 +38023,342 @@ subjects:
 ---
 apiVersion: v1
 data:
-  _example: |-
-    ################################
-    #                              #
-    #    EXAMPLE CONFIGURATION     #
-    #                              #
-    ################################
-
-    # This block is not actually functional configuration,
-    # but serves to illustrate the available configuration
-    # options and document them in a way that is accessible
-    # to users that `kubectl edit` this config map.
-    #
-    # These sample configuration options may be copied out of
-    # this example block and unindented to be in the data block
-    # to actually change the configuration.
-
-    # ====================================== EXPLAINERS CONFIGURATION ======================================
-    # Example
-    explainers: |-
-      {
-          "art": {
-              "image" : "kserve/art-explainer",
-              "defaultImageVersion": "latest"
-          }
-      }
-    # Art Explainer runtime configuration
-     explainers: |-
-       {
-           # Art explainer runtime configuration
-           "art": {
-               # image contains the default Art explainer serving runtime image uri.
-               "image" : "kserve/art-explainer",
-
-               # defautltImageVersion contains the Art explainer serving runtime default image version.
-               "defaultImageVersion": "latest"
-           }
-       }
-    # ====================================== ISVC CONFIGURATION ======================================
-    # Example - setting custom annotation
-     inferenceService: |-
-       {
-         "serviceAnnotationDisallowedList": [
-            "my.custom.annotation/1"
-         ],
-         "serviceLabelDisallowedList": [
-            "my.custom.label.1"
-         ]
-       }
-    # Example - setting custom annotation
-    inferenceService: |-
-      {
-        # ServiceAnnotationDisallowedList is a list of annotations that are not allowed to be propagated to Knative
-        # revisions, which prevents the reconciliation loop to be triggered if the annotations is
-        # configured here are used.
-        # Default values are:
-        #  "autoscaling.knative.dev/min-scale",
-        #  "autoscaling.knative.dev/max-scale",
-        #  "internal.serving.kserve.io/storage-initializer-sourceuri",
-        #  "kubectl.kubernetes.io/last-applied-configuration",
-        #  "modelFormat"
-        # Any new value will be appended to the list.
-        "serviceAnnotationDisallowedList": [
-          "my.custom.annotation/1"
-        ],
-        # ServiceLabelDisallowedList is a list of labels that are not allowed to be propagated to Knative revisions
-        # which prevents the reconciliation loop to be triggered if the labels is configured here are used.
-        "serviceLabelDisallowedList": [
-          "my.custom.label.1"
-        ]
-      }
-    # Example - setting custom resource
-    inferenceService: |-
-      {
-        "resource": {
-          "cpuLimit": "1",
-          "memoryLimit": "2Gi",
-          "cpuRequest": "1",
-          "memoryRequest": "2Gi"
-        }
-      }
-    # Example - setting custom resource
-    inferenceService: |-
-      {
-        # resource contains the default resource configuration for the inference service.
-        # you can override this configuration by specifying the resources in the inference service yaml.
-        # If you want to unbound the resource (limits and requests), you can set the value to null or ""
-        # or just remove the specific field from the config.
-        "resource": {
-           # cpuLimit is the limits.cpu to set for the inference service.
-           "cpuLimit": "1",
-
-           # memoryLimit is the limits.memory to set for the inference service.
-           "memoryLimit": "2Gi",
-
-           # cpuRequest is the requests.cpu to set for the inference service.
-           "cpuRequest": "1",
-
-           # memoryRequest is the requests.memory to set for the inference service.
-           "memoryRequest": "2Gi"
-        }
-     }
-    # ====================================== MultiNode CONFIGURATION ======================================
-    # Example
-    multiNode: |-
-      {
-        "customGPUResourceTypeList": [
-          "custom.com/gpu"
-        ]
-      }
-    # Example of multinode configuration
-    multiNode: |-
-      {
-        # CustomGPUResourceTypeList is a list of custom GPU resource types intended to identify the GPU type of a resource,
-        # not to restrict the user from using a specific GPU type.
-        # The MultiNode runtime pod will dynamically add GPU resources based on the registered GPU types.
-        "customGPUResourceTypeList": [
-          "custom.com/gpu"
-        ]
-      }
-     # ====================================== OTelCollector CONFIGURATION ======================================
-     # Example
-     opentelemetryCollector: |-
-       {
-         # scrapeInterval is the interval at which the OpenTelemetry Collector will scrape the metrics.
-         "scrapeInterval": "5s",
-         # metricScalerEndpoint is the endpoint from which the KEDA's ScaledObject will scrape the metrics.
-         "metricScalerEndpoint": "keda-otel-scaler.keda.svc:4318",
-         # metricReceiverEndpoint is the endpoint from which the OpenTelemetry Collector will scrape the metrics.
-          "metricReceiverEndpoint": "keda-otel-scaler.keda.svc:4317"
-       }
-
-     # ====================================== AUTOSCALER CONFIGURATION ======================================
-     # Example
-     autoscaler: |-
-       {
-         # scaleUpStabilizationWindowSeconds is the stabilization window in seconds for scale up.
-         "scaleUpStabilizationWindowSeconds": "0",
-         # scaleDownStabilizationWindowSeconds is the stabilization window in seconds for scale down.
-         "scaleDownStabilizationWindowSeconds": "300"
-       }
-
-     # ====================================== STORAGE INITIALIZER CONFIGURATION ======================================
-     # Example
-     storageInitializer: |-
-       {
-           "image" : "kserve/storage-initializer:latest",
-           "memoryRequest": "100Mi",
-           "memoryLimit": "1Gi",
-           "cpuRequest": "100m",
-           "cpuLimit": "1",
-           "caBundleConfigMapName": "",
-           "caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-           "enableModelcar": false,
-           "cpuModelcar": "10m",
-           "memoryModelcar": "15Mi"
-       }
-     storageInitializer: |-
-       {
-           # image contains the default storage initializer image uri.
-           "image" : "kserve/storage-initializer:latest",
-
-           # memoryRequest is the requests.memory to set for the storage initializer init container.
-           "memoryRequest": "100Mi",
-
-            # memoryLimit is the limits.memory to set for the storage initializer init container.
-           "memoryLimit": "1Gi",
-
-           # cpuRequest is the requests.cpu to set for the storage initializer init container.
-           "cpuRequest": "100m",
-
-           # cpuLimit is the limits.cpu to set for the storage initializer init container.
-           "cpuLimit": "1",
-
-           # caBundleConfigMapName is the ConfigMap will be copied to a user namespace for the storage initializer init container.
-           "caBundleConfigMapName": "",
-
-           # caBundleVolumeMountPath is the mount point for the configmap set by caBundleConfigMapName for the storage initializer init container.
-           "caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-
-           # enableModelcar enabled allows you to directly access an OCI container image by
-           # using a source URL with an "oci://" schema.
-           "enableModelcar": false,
-
-           # cpuModelcar is the cpu request and limit that is used for the passive modelcar container. It can be
-           # set very low, but should be allowed by any Kubernetes LimitRange that might apply.
-           "cpuModelcar": "10m",
-
-           # cpuModelcar is the memory request and limit that is used for the passive modelcar container. It can be
-           # set very low, but should be allowed by any Kubernetes LimitRange that might apply.
-           "memoryModelcar": "15Mi",
-
-           # uidModelcar is the UID under with which the modelcar process and the main container is running.
-           # Some Kubernetes clusters might require this to be root (0). If not set the user id is left untouched (default)
-           "uidModelcar": 10
-       }
-
-     # ====================================== CREDENTIALS ======================================
-     # Example
-     credentials: |-
-       {
-          "storageSpecSecretName": "storage-config",
-          "storageSecretNameAnnotation": "serving.kserve.io/storageSecretName",
-          "gcs": {
-              "gcsCredentialFileName": "gcloud-application-credentials.json"
-          },
-          "s3": {
-              "s3AccessKeyIDName": "AWS_ACCESS_KEY_ID",
-              "s3SecretAccessKeyName": "AWS_SECRET_ACCESS_KEY",
-              "s3Endpoint": "",
-              "s3UseHttps": "",
-              "s3Region": "",
-              "s3VerifySSL": "",
-              "s3UseVirtualBucket": "",
-              "s3UseAccelerate": "",
-              "s3UseAnonymousCredential": "",
-              "s3CABundleConfigMap": "",
-              "s3CABundle": ""
-          }
-       }
-     # This is a global configuration used for downloading models from the cloud storage.
-     # You can override this configuration by specifying the annotations on service account or static secret.
-     # https://kserve.github.io/website/master/modelserving/storage/s3/s3/
-     # For a quick reference about AWS ENV variables:
-     # AWS Cli: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
-     # Boto: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables
-     #
-     # The `s3AccessKeyIDName` and `s3SecretAccessKeyName` fields are only used from this configmap when static credentials (IAM User Access Key Secret)
-     # are used as the authentication method for AWS S3.
-     # The rest of the fields are used in both authentication methods (IAM Role for Service Account & IAM User Access Key Secret) if a non-empty value is provided.
-     credentials: |-
-       {
-          # storageSpecSecretName contains the secret name which has the credentials for downloading the model.
-          # This option is used when specifying the storage spec on isvc yaml.
-          "storageSpecSecretName": "storage-config",
-
-          # The annotation can be specified on isvc yaml to allow overriding with the secret name reference from the annotation value.
-          # When using storageUri the order of the precedence is: secret name reference annotation > secret name references from service account
-          # When using storageSpec the order of the precedence is: secret name reference annotation > storageSpecSecretName in configmap
-
-          # Configuration for google cloud storage
-          "gcs": {
-              # gcsCredentialFileName specifies the filename of the gcs credential
-              "gcsCredentialFileName": "gcloud-application-credentials.json"
-          },
-
-          # Configuration for aws s3 storage. This add the corresponding environmental variables to the storage initializer init container.
-          # For more info on s3 storage see https://kserve.github.io/website/master/modelserving/storage/s3/s3/
-          "s3": {
-              # s3AccessKeyIDName specifies the s3 access key id name
-              "s3AccessKeyIDName": "AWS_ACCESS_KEY_ID",
-
-              # s3SecretAccessKeyName specifies the s3 secret access key name
-              "s3SecretAccessKeyName": "AWS_SECRET_ACCESS_KEY",
-
-              # s3Endpoint specifies the s3 endpoint
-              "s3Endpoint": "",
-
-              # s3UseHttps controls whether to use secure https or unsecure http to download models.
-              # Allowed values are 0 and 1.
-              "s3UseHttps": "",
-
-              # s3Region specifies the region of the bucket.
-              "s3Region": "",
-
-              # s3VerifySSL controls whether to verify the tls/ssl certificate.
-              "s3VerifySSL": "",
-
-              # s3UseVirtualBucket configures whether it is a virtual bucket or not.
-              "s3UseVirtualBucket": "",
-
-              # s3UseAccelerate configures whether to use transfer acceleration.
-              "s3UseAccelerate": "",
-
-              # s3UseAnonymousCredential configures whether to use anonymous credentials to download the model or not.
-              "s3UseAnonymousCredential": "",
-
-              # s3CABundleConfigMap specifies the mounted CA bundle config map name.
-              "s3CABundleConfigMap": "",
-
-              # s3CABundle specifies the full path (mount path + file name) for the mounted config map data when used with a configured CA bundle config map.
-              # s3CABundle specifies the path to a certificate bundle to use for HTTPS certificate validation when used absent of a configured CA bundle config map.
-              "s3CABundle": ""
-          }
-       }
-
-     # ====================================== INGRESS CONFIGURATION ======================================
-     # Example
-     ingress: |-
-       {
-           "enableGatewayApi": false,
-           "kserveIngressGateway": "kserve/kserve-ingress-gateway",
-           "ingressGateway" : "knative-serving/knative-ingress-gateway",
-           "localGateway" : "knative-serving/knative-local-gateway",
-           "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",
-           "ingressDomain"  : "example.com",
-           "additionalIngressDomains": ["additional-example.com", "additional-example-1.com"],
-           "ingressClassName" : "istio",
-           "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
-           "urlScheme": "http",
-           "disableIstioVirtualHost": false,
-           "disableIngressCreation": false,
-           "disableHTTPRouteTimeout": false
-       }
-     ingress: |-
-       {
-           # enableGatewayApi specifies whether to use Gateway API instead of Ingress to serve external traffic.
-           "enableGatewayApi": false,
-
-           # KServe implements [Gateway API](https://gateway-api.sigs.k8s.io/) to serve external traffic.
-           # By default, KServe configures a default gateway to serve external traffic.
-           # But, KServe can be configured to use a custom gateway by modifying this configuration.
-           # The gateway should be specified in format <gateway namespace>/<gateway name>
-           # NOTE: This configuration only applicable for raw deployment.
-           "kserveIngressGateway": "kserve/kserve-ingress-gateway",
-
-           # ingressGateway specifies the ingress gateway to serve external traffic.
-           # The gateway should be specified in format <gateway namespace>/<gateway name>
-           # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.
-           "ingressGateway" : "knative-serving/knative-ingress-gateway",
-
-           # knativeLocalGatewayService specifies the hostname of the Knative's local gateway service.
-           # The default KServe configurations are re-using the Istio local gateways for Knative. In this case, this
-           # knativeLocalGatewayService field can be left unset. When unset, the value of "localGatewayService" will be used.
-           # However, sometimes it may be better to have local gateways specifically for KServe (e.g. when enabling strict mTLS in Istio).
-           # Under such setups where KServe is needed to have its own local gateways, the values of the "localGateway" and
-           # "localGatewayService" should point to the KServe local gateways. Then, this knativeLocalGatewayService field
-           # should point to the Knative's local gateway service.
-           # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.
-           "knativeLocalGatewayService": "",
-
-           # localGateway specifies the gateway which handles the network traffic within the cluster.
-           # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.
-           "localGateway" : "knative-serving/knative-local-gateway",
-
-           # localGatewayService specifies the hostname of the local gateway service.
-           # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.
-           "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",
-
-           # ingressDomain specifies the domain name which is used for creating the url.
-           # If ingressDomain is empty then example.com is used as default domain.
-           # NOTE: This configuration only applicable for raw deployment.
-           "ingressDomain"  : "example.com",
-
-           # additionalIngressDomains specifies the additional domain names which are used for creating the url.
-           "additionalIngressDomains": ["additional-example.com", "additional-example-1.com"]
-
-           # ingressClassName specifies the ingress controller to use for ingress traffic.
-           # This is optional and if omitted the default ingress in the cluster is used.
-           # https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class
-           # NOTE: This configuration only applicable for raw deployment.
-           "ingressClassName" : "istio",
-
-           # domainTemplate specifies the template for generating domain/url for each inference service by combining variable from:
-           # Name of the inference service  ( {{ .Name}} )
-           # Namespace of the inference service ( {{ .Namespace }} )
-           # Annotation of the inference service ( {{ .Annotations.key }} )
-           # Label of the inference service ( {{ .Labels.key }} )
-           # IngressDomain ( {{ .IngressDomain }} )
-           # If domain template is empty the default template {{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }} is used.
-           # NOTE: This configuration only applicable for raw deployment.
-           "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
-
-           # urlScheme specifies the url scheme to use for inference service and inference graph.
-           # If urlScheme is empty then by default http is used.
-           "urlScheme": "http",
-
-           # disableIstioVirtualHost controls whether to use istio as network layer.
-           # By default istio is used as the network layer. When DisableIstioVirtualHost is true, KServe does not
-           # create the top level virtual service thus Istio is no longer required for serverless mode.
-           # By setting this field to true, user can use other networking layers supported by knative.
-           # For more info https://github.com/kserve/kserve/pull/2380, https://kserve.github.io/website/master/admin/serverless/kourier_networking/.
-           # NOTE: This configuration is only applicable to serverless deployment.
-           "disableIstioVirtualHost": false,
-
-           # disableIngressCreation controls whether to disable ingress creation for raw deployment mode.
-           "disableIngressCreation": false,
-
-           # disableHTTPRouteTimeout controls whether to omit the timeout field from HTTPRoute rules.
-           # Set to true for Gateway controllers (e.g. GKE Gateway) that do not support the optional timeouts field.
-           "disableHTTPRouteTimeout": false,
-
-           # pathTemplate specifies the template for generating path based url for each inference service.
-           # The following variables can be used in the template for generating url.
-           # Name of the inference service  ( {{ .Name}} )
-           # Namespace of the inference service ( {{ .Namespace }} )
-           # For more info https://github.com/kserve/kserve/issues/2257.
-           # NOTE: This configuration only applicable to serverless deployment.
-           "pathTemplate": "/serving/{{ .Namespace }}/{{ .Name }}"
-       }
-
-     # ====================================== LOGGER CONFIGURATION ======================================
-     # Example
-     logger: |-
-       {
-           "image" : "kserve/agent:latest",
-           "memoryRequest": "100Mi",
-           "memoryLimit": "1Gi",
-           "cpuRequest": "100m",
-           "cpuLimit": "1",
-           "defaultUrl": "http://default-broker"
-       }
-     logger: |-
-       {
-           # image contains the default logger image uri.
-           "image" : "kserve/agent:latest",
-
-           # memoryRequest is the requests.memory to set for the logger container.
-           "memoryRequest": "100Mi",
-
-           # memoryLimit is the limits.memory to set for the logger container.
-           "memoryLimit": "1Gi",
-
-           # cpuRequest is the requests.cpu to set for the logger container.
-           "cpuRequest": "100m",
-
-           # cpuLimit is the limits.cpu to set for the logger container.
-           "cpuLimit": "1",
-
-           # defaultUrl specifies the default logger url. If logger is not specified in the resource this url is used.
-           "defaultUrl": "http://default-broker"
-       }
-
-     # ====================================== BATCHER CONFIGURATION ======================================
-     # Example
-     batcher: |-
-       {
-           "image" : "kserve/agent:latest",
-           "memoryRequest": "1Gi",
-           "memoryLimit": "1Gi",
-           "cpuRequest": "1",
-           "cpuLimit": "1",
-           "maxBatchSize": "32",
-           "maxLatency": "5000"
-       }
-     batcher: |-
-       {
-           # image contains the default batcher image uri.
-           "image" : "kserve/agent:latest",
-
-           # memoryRequest is the requests.memory to set for the batcher container.
-           "memoryRequest": "1Gi",
-
-           # memoryLimit is the limits.memory to set for the batcher container.
-           "memoryLimit": "1Gi",
-
-           # cpuRequest is the requests.cpu to set for the batcher container.
-           "cpuRequest": "1",
-
-           # cpuLimit is the limits.cpu to set for the batcher container.
-           "cpuLimit": "1"
-
-           # maxBatchSize is the default maximum batch size for batcher.
-           "maxBatchSize": "32",
-
-           # maxLatency is the default maximum latency in milliseconds for batcher to wait and collect the batch.
-           "maxLatency": "5000"
-       }
-
-     # ====================================== AGENT CONFIGURATION ======================================
-     # Example
-     agent: |-
-       {
-           "image" : "kserve/agent:latest",
-           "memoryRequest": "100Mi",
-           "memoryLimit": "1Gi",
-           "cpuRequest": "100m",
-           "cpuLimit": "1"
-       }
-     agent: |-
-       {
-           # image contains the default agent image uri.
-           "image" : "kserve/agent:latest",
-
-           # memoryRequest is the requests.memory to set for the agent container.
-           "memoryRequest": "100Mi",
-
-           # memoryLimit is the limits.memory to set for the agent container.
-           "memoryLimit": "1Gi",
-
-           # cpuRequest is the requests.cpu to set for the agent container.
-           "cpuRequest": "100m",
-
-           # cpuLimit is the limits.cpu to set for the agent container.
-           "cpuLimit": "1"
-       }
-
-     # ====================================== ROUTER CONFIGURATION ======================================
-     # Example
-     router: |-
-       {
-           "image" : "kserve/router:latest",
-           "memoryRequest": "100Mi",
-           "memoryLimit": "1Gi",
-           "cpuRequest": "100m",
-           "cpuLimit": "1",
-           "headers": {
-             "propagate": []
-           },
-           "imagePullPolicy": "IfNotPresent",
-           "imagePullSecrets": ["docker-secret"]
-       }
-     # router is the implementation of inference graph.
-     router: |-
-       {
-           # image contains the default router image uri.
-           "image" : "kserve/router:latest",
-
-           # memoryRequest is the requests.memory to set for the router container.
-           "memoryRequest": "100Mi",
-
-           # memoryLimit is the limits.memory to set for the router container.
-           "memoryLimit": "1Gi",
-
-           # cpuRequest is the requests.cpu to set for the router container.
-           "cpuRequest": "100m",
-
-           # cpuLimit is the limits.cpu to set for the router container.
-           "cpuLimit": "1",
-
-           # Propagate the specified headers to all the steps specified in an InferenceGraph.
-           # You can either specify the exact header names or use [Golang supported regex patterns]
-           # (https://pkg.go.dev/regexp/syntax@go1.21.3#hdr-Syntax) to propagate multiple headers.
-           "headers": {
-             "propagate": [
-                "Authorization",
-                "Test-Header-*",
-                "*Trace-Id*"
-             ]
-           }
-
-           # imagePullPolicy specifies when the router image should be pulled from registry.
-           "imagePullPolicy": "IfNotPresent",
-
-           # # imagePullSecrets specifies the list of secrets to be used for pulling the router image from registry.
-           # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-           "imagePullSecrets": ["docker-secret"]
-       }
-
-    # ====================================== DEPLOYMENT CONFIGURATION ======================================
-    # Example
-    deploy: |-
-      {
-        "defaultDeploymentMode": "Serverless",
-        "deploymentRolloutStrategy": {
-          "defaultRollout": {
-            "maxSurge": "1",
-            "maxUnavailable": "1"
-          }
-        }
-      }
-
-    deploy: |-
-      {
-        # defaultDeploymentMode specifies the default deployment mode of the kserve. The supported values are
-        # Standard and Knative. Users can override the deployment mode at service level
-        # by adding the annotation serving.kserve.io/deploymentMode.
-        # "defaultDeploymentMode": "Standard",
-        # deploymentRolloutStrategy specifies the default rollout strategy for the Standard deployment mode
-        # "deploymentRolloutStrategy": {
-          # defaultRollout specifies the default rollout configuration using Kubernetes deployment strategy
-          # "defaultRollout": {
-            # maxSurge specifies the maximum number of pods that can be created above the desired replica count
-            # Can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%)
-            # "maxSurge": "1",
-            # maxUnavailable specifies the maximum number of pods that can be unavailable during the update
-            # Can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%)
-            # "maxUnavailable": "1"
-          # }
-        # }
-      }
-
-     # ====================================== SERVICE CONFIGURATION ======================================
-     # Example
-     service: |-
-       {
-         "serviceClusterIPNone":  false
-       }
-     service: |-
-       {
-          # ServiceClusterIPNone is a boolean flag to indicate if the service should have a clusterIP set to None.
-          # If the DeploymentMode is Raw, the default value for ServiceClusterIPNone if not set is false
-          # "serviceClusterIPNone":  false
-       }
-
-     # ====================================== METRICS CONFIGURATION ======================================
-     # Example
-     metricsAggregator: |-
-       {
-         "enableMetricAggregation": "false",
-         "enablePrometheusScraping" : "false"
-       }
-     # For more info see https://github.com/kserve/kserve/blob/master/qpext/README.md
-     metricsAggregator: |-
-       {
-         # enableMetricAggregation configures metric aggregation annotation. This adds the annotation serving.kserve.io/enable-metric-aggregation to every
-         # service with the specified boolean value. If true enables metric aggregation in queue-proxy by setting env vars in the queue proxy container
-         # to configure scraping ports.
-         "enableMetricAggregation": "false",
-
-         # enablePrometheusScraping configures metric aggregation annotation. This adds the annotation serving.kserve.io/enable-metric-aggregation to every
-         # service with the specified boolean value. If true, prometheus annotations are added to the pod. If serving.kserve.io/enable-metric-aggregation is false,
-         # the prometheus port is set with the default prometheus scraping port 9090, otherwise the prometheus port annotation is set with the metric aggregation port.
-         "enablePrometheusScraping" : "false"
-       }
-
-     # ====================================== LOCALMODEL CONFIGURATION ======================================
-     # Example
-     localModel: |-
-       {
-         "enabled": false,
-         # jobNamespace specifies the namespace where the download job will be created.
-         "jobNamespace": "kserve-localmodel-jobs",
-         # defaultJobImage specifies the default image used for the download job.
-         "defaultJobImage" : "kserve/storage-initializer:latest",
-         # Kubernetes modifies the filesystem group ID on the attached volume.
-         "fsGroup": 1000,
-         # TTL for the download job after it is finished.
-         "jobTTLSecondsAfterFinished": 3600,
-         # The frequency at which the local model agent reconciles the local models
-         # This is to detect if models are missing from local disk
-         "reconcilationFrequencyInSecs": 60,
-         # This is to disable localmodel pv and pvc management for namespaces without isvcs
-         "disableVolumeManagement": false
-       }
+  _example: "################################\n#                              #\n#
+    \   EXAMPLE CONFIGURATION     #\n#                              #\n################################\n\n#
+    This block is not actually functional configuration,\n# but serves to illustrate
+    the available configuration\n# options and document them in a way that is accessible\n#
+    to users that `kubectl edit` this config map.\n#\n# These sample configuration
+    options may be copied out of\n# this example block and unindented to be in the
+    data block\n# to actually change the configuration.\n\n# ======================================
+    EXPLAINERS CONFIGURATION ======================================\n# Example\nexplainers:
+    |-\n  {\n      \"art\": {\n          \"image\" : \"kserve/art-explainer\",\n          \"defaultImageVersion\":
+    \"latest\"\n      }\n  }\n# Art Explainer runtime configuration\n explainers:
+    |-\n   {\n       # Art explainer runtime configuration\n       \"art\": {\n           #
+    image contains the default Art explainer serving runtime image uri.\n           \"image\"
+    : \"kserve/art-explainer\",\n   \n           # defautltImageVersion contains the
+    Art explainer serving runtime default image version.\n           \"defaultImageVersion\":
+    \"latest\"\n       }\n   }\n# ====================================== ISVC CONFIGURATION
+    ======================================\n# Example - setting custom annotation
+    \ \n inferenceService: |-\n   {\n     \"serviceAnnotationDisallowedList\": [\n
+    \       \"my.custom.annotation/1\"  \n     ],\n     \"serviceLabelDisallowedList\":
+    [\n        \"my.custom.label.1\"  \n     ]\n   }\n# Example - setting custom annotation\ninferenceService:
+    |-\n  {\n    # ServiceAnnotationDisallowedList is a list of annotations that are
+    not allowed to be propagated to Knative \n    # revisions, which prevents the
+    reconciliation loop to be triggered if the annotations is \n    # configured here
+    are used.\n    # Default values are:\n    #  \"autoscaling.knative.dev/min-scale\",\n
+    \   #  \"autoscaling.knative.dev/max-scale\",\n    #  \"internal.serving.kserve.io/storage-initializer-sourceuri\",\n
+    \   #  \"kubectl.kubernetes.io/last-applied-configuration\",\n    #  \"modelFormat\"\n
+    \   # Any new value will be appended to the list.\n    \"serviceAnnotationDisallowedList\":
+    [\n      \"my.custom.annotation/1\"  \n    ],\n    # ServiceLabelDisallowedList
+    is a list of labels that are not allowed to be propagated to Knative revisions\n
+    \   # which prevents the reconciliation loop to be triggered if the labels is
+    configured here are used.\n    \"serviceLabelDisallowedList\": [\n      \"my.custom.label.1\"
+    \ \n    ]\n  } \n# Example - setting custom resource\ninferenceService: |-\n  {\n
+    \   \"resource\": {\n      \"cpuLimit\": \"1\",\n      \"memoryLimit\": \"2Gi\",\n
+    \     \"cpuRequest\": \"1\",\n      \"memoryRequest\": \"2Gi\"\n    }\n  }\n#
+    Example - setting custom resource\ninferenceService: |-\n  {\n    # resource contains
+    the default resource configuration for the inference service.\n    # you can override
+    this configuration by specifying the resources in the inference service yaml.\n
+    \   # If you want to unbound the resource (limits and requests), you can set the
+    value to null or \"\" \n    # or just remove the specific field from the config.\n
+    \   \"resource\": {\n       # cpuLimit is the limits.cpu to set for the inference
+    service.\n       \"cpuLimit\": \"1\",\n\n       # memoryLimit is the limits.memory
+    to set for the inference service.\n       \"memoryLimit\": \"2Gi\",\n\n       #
+    cpuRequest is the requests.cpu to set for the inference service.\n       \"cpuRequest\":
+    \"1\",\n\n       # memoryRequest is the requests.memory to set for the inference
+    service.\n       \"memoryRequest\": \"2Gi\"\n    }\n }\n# ======================================
+    MultiNode CONFIGURATION ======================================\n# Example   \nmultiNode:
+    |-\n  {\n    \"customGPUResourceTypeList\": [\n      \"custom.com/gpu\"\n    ]\n
+    \ }\n# Example of multinode configuration\nmultiNode: |-\n  {      \n    # CustomGPUResourceTypeList
+    is a list of custom GPU resource types intended to identify the GPU type of a
+    resource,\n    # not to restrict the user from using a specific GPU type.\n    #
+    The MultiNode runtime pod will dynamically add GPU resources based on the registered
+    GPU types.\n    \"customGPUResourceTypeList\": [\n      \"custom.com/gpu\"\n    ]\n
+    \ }  \n # ====================================== OTelCollector CONFIGURATION ======================================\n
+    # Example\n opentelemetryCollector: |-\n   {\n     # scrapeInterval is the interval
+    at which the OpenTelemetry Collector will scrape the metrics.\n     \"scrapeInterval\":
+    \"5s\",\n     # metricScalerEndpoint is the endpoint from which the KEDA's ScaledObject
+    will scrape the metrics.\n     \"metricScalerEndpoint\": \"keda-otel-scaler.keda.svc:4318\",\n
+    \    # metricReceiverEndpoint is the endpoint from which the OpenTelemetry Collector
+    will scrape the metrics.\n      \"metricReceiverEndpoint\": \"keda-otel-scaler.keda.svc:4317\"\n
+    \  }\n\n # ====================================== AUTOSCALER CONFIGURATION ======================================\n
+    # Example\n autoscaler: |-\n   {\n     # scaleUpStabilizationWindowSeconds is
+    the stabilization window in seconds for scale up.\n     \"scaleUpStabilizationWindowSeconds\":
+    \"0\",\n     # scaleDownStabilizationWindowSeconds is the stabilization window
+    in seconds for scale down.\n     \"scaleDownStabilizationWindowSeconds\": \"300\"\n
+    \  }\n  \n # ====================================== STORAGE INITIALIZER CONFIGURATION
+    ======================================\n # Example\n storageInitializer: |-\n
+    \  {\n       \"image\" : \"kserve/storage-initializer:latest\",\n       \"memoryRequest\":
+    \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"100m\",\n
+    \      \"cpuLimit\": \"1\",\n       \"caBundleConfigMapName\": \"\",\n       \"caBundleVolumeMountPath\":
+    \"/etc/ssl/custom-certs\",\n       \"enableModelcar\": false,\n       \"cpuModelcar\":
+    \"10m\",\n       \"memoryModelcar\": \"15Mi\"\n   }\n storageInitializer: |-\n
+    \  {\n       # image contains the default storage initializer image uri.\n       \"image\"
+    : \"kserve/storage-initializer:latest\",\n       \n       # memoryRequest is the
+    requests.memory to set for the storage initializer init container.\n       \"memoryRequest\":
+    \"100Mi\",\n   \n        # memoryLimit is the limits.memory to set for the storage
+    initializer init container.\n       \"memoryLimit\": \"1Gi\",\n       \n       #
+    cpuRequest is the requests.cpu to set for the storage initializer init container.\n
+    \      \"cpuRequest\": \"100m\",\n       \n       # cpuLimit is the limits.cpu
+    to set for the storage initializer init container.\n       \"cpuLimit\": \"1\",\n
+    \  \n       # caBundleConfigMapName is the ConfigMap will be copied to a user
+    namespace for the storage initializer init container.\n       \"caBundleConfigMapName\":
+    \"\",\n\n       # caBundleVolumeMountPath is the mount point for the configmap
+    set by caBundleConfigMapName for the storage initializer init container.\n       \"caBundleVolumeMountPath\":
+    \"/etc/ssl/custom-certs\",\n\n       # enableModelcar enabled allows you to directly
+    access an OCI container image by\n       # using a source URL with an \"oci://\"
+    schema.\n       \"enableModelcar\": false,\n\n       # cpuModelcar is the cpu
+    request and limit that is used for the passive modelcar container. It can be\n
+    \      # set very low, but should be allowed by any Kubernetes LimitRange that
+    might apply.\n       \"cpuModelcar\": \"10m\",\n\n       # cpuModelcar is the
+    memory request and limit that is used for the passive modelcar container. It can
+    be\n       # set very low, but should be allowed by any Kubernetes LimitRange
+    that might apply.\n       \"memoryModelcar\": \"15Mi\",\n\n       # uidModelcar
+    is the UID under with which the modelcar process and the main container is running.\n
+    \      # Some Kubernetes clusters might require this to be root (0). If not set
+    the user id is left untouched (default)\n       \"uidModelcar\": 10\n   }\n \n
+    # ====================================== CREDENTIALS ======================================\n
+    # Example\n credentials: |-\n   {\n      \"storageSpecSecretName\": \"storage-config\",\n
+    \     \"storageSecretNameAnnotation\": \"serving.kserve.io/storageSecretName\",\n
+    \     \"gcs\": {\n          \"gcsCredentialFileName\": \"gcloud-application-credentials.json\"\n
+    \     },\n      \"s3\": {\n          \"s3AccessKeyIDName\": \"AWS_ACCESS_KEY_ID\",\n
+    \         \"s3SecretAccessKeyName\": \"AWS_SECRET_ACCESS_KEY\",\n          \"s3Endpoint\":
+    \"\",\n          \"s3UseHttps\": \"\",\n          \"s3Region\": \"\",\n          \"s3VerifySSL\":
+    \"\",\n          \"s3UseVirtualBucket\": \"\",\n          \"s3UseAccelerate\":
+    \"\",\n          \"s3UseAnonymousCredential\": \"\",\n          \"s3CABundleConfigMap\":
+    \"\",\n          \"s3CABundle\": \"\"\n      }\n   }\n # This is a global configuration
+    used for downloading models from the cloud storage.\n # You can override this
+    configuration by specifying the annotations on service account or static secret.\n
+    # https://kserve.github.io/website/master/modelserving/storage/s3/s3/\n # For
+    a quick reference about AWS ENV variables:\n # AWS Cli: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html\n
+    # Boto: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables\n
+    #\n # The `s3AccessKeyIDName` and `s3SecretAccessKeyName` fields are only used
+    from this configmap when static credentials (IAM User Access Key Secret)\n # are
+    used as the authentication method for AWS S3.\n # The rest of the fields are used
+    in both authentication methods (IAM Role for Service Account & IAM User Access
+    Key Secret) if a non-empty value is provided.\n credentials: |-\n   {\n      #
+    storageSpecSecretName contains the secret name which has the credentials for downloading
+    the model.\n      # This option is used when specifying the storage spec on isvc
+    yaml.\n      \"storageSpecSecretName\": \"storage-config\",\n\n      # The annotation
+    can be specified on isvc yaml to allow overriding with the secret name reference
+    from the annotation value.\n      # When using storageUri the order of the precedence
+    is: secret name reference annotation > secret name references from service account\n
+    \     # When using storageSpec the order of the precedence is: secret name reference
+    annotation > storageSpecSecretName in configmap\n\n      # Configuration for google
+    cloud storage\n      \"gcs\": {\n          # gcsCredentialFileName specifies the
+    filename of the gcs credential\n          \"gcsCredentialFileName\": \"gcloud-application-credentials.json\"\n
+    \     },\n      \n      # Configuration for aws s3 storage. This add the corresponding
+    environmental variables to the storage initializer init container.\n      # For
+    more info on s3 storage see https://kserve.github.io/website/master/modelserving/storage/s3/s3/\n
+    \     \"s3\": {\n          # s3AccessKeyIDName specifies the s3 access key id
+    name\n          \"s3AccessKeyIDName\": \"AWS_ACCESS_KEY_ID\",\n   \n          #
+    s3SecretAccessKeyName specifies the s3 secret access key name\n          \"s3SecretAccessKeyName\":
+    \"AWS_SECRET_ACCESS_KEY\",\n          \n          # s3Endpoint specifies the s3
+    endpoint\n          \"s3Endpoint\": \"\",\n          \n          # s3UseHttps
+    controls whether to use secure https or unsecure http to download models.\n          #
+    Allowed values are 0 and 1.\n          \"s3UseHttps\": \"\",\n   \n          #
+    s3Region specifies the region of the bucket.\n          \"s3Region\": \"\",\n
+    \         \n          # s3VerifySSL controls whether to verify the tls/ssl certificate.\n
+    \         \"s3VerifySSL\": \"\",\n          \n          # s3UseVirtualBucket configures
+    whether it is a virtual bucket or not.\n          \"s3UseVirtualBucket\": \"\",\n\n
+    \         # s3UseAccelerate configures whether to use transfer acceleration.\n
+    \         \"s3UseAccelerate\": \"\",\n           \n          # s3UseAnonymousCredential
+    configures whether to use anonymous credentials to download the model or not.\n
+    \         \"s3UseAnonymousCredential\": \"\",\n\n          # s3CABundleConfigMap
+    specifies the mounted CA bundle config map name.\n          \"s3CABundleConfigMap\":
+    \"\",\n\n          # s3CABundle specifies the full path (mount path + file name)
+    for the mounted config map data when used with a configured CA bundle config map.\n
+    \         # s3CABundle specifies the path to a certificate bundle to use for HTTPS
+    certificate validation when used absent of a configured CA bundle config map.\n
+    \         \"s3CABundle\": \"\"\n      }\n   }\n \n # ======================================
+    INGRESS CONFIGURATION ======================================\n # Example\n ingress:
+    |-\n   {    \n       \"enableGatewayApi\": false,\n       \"kserveIngressGateway\":
+    \"kserve/kserve-ingress-gateway\",\n       \"ingressGateway\" : \"knative-serving/knative-ingress-gateway\",\n
+    \      \"localGateway\" : \"knative-serving/knative-local-gateway\",\n       \"localGatewayService\"
+    : \"knative-local-gateway.istio-system.svc.cluster.local\",\n       \"ingressDomain\"
+    \ : \"example.com\",\n       \"additionalIngressDomains\": [\"additional-example.com\",
+    \"additional-example-1.com\"],\n       \"ingressClassName\" : \"istio\",\n       \"domainTemplate\":
+    \"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}\",\n       \"urlScheme\":
+    \"http\",\n       \"disableIstioVirtualHost\": false,\n       \"disableIngressCreation\":
+    false\n   }\n ingress: |-\n   {   \n       # enableGatewayApi specifies whether
+    to use Gateway API instead of Ingress to serve external traffic.\n       \"enableGatewayApi\":
+    false,\n\n       # KServe implements [Gateway API](https://gateway-api.sigs.k8s.io/)
+    to serve external traffic. \n       # By default, KServe configures a default
+    gateway to serve external traffic.\n       # But, KServe can be configured to
+    use a custom gateway by modifying this configuration.\n       # The gateway should
+    be specified in format <gateway namespace>/<gateway name>\n       # NOTE: This
+    configuration only applicable for raw deployment.\n       \"kserveIngressGateway\":
+    \"kserve/kserve-ingress-gateway\",\n \n       # ingressGateway specifies the ingress
+    gateway to serve external traffic.\n       # The gateway should be specified in
+    format <gateway namespace>/<gateway name>\n       # NOTE: This configuration only
+    applicable for serverless deployment with Istio configured as network layer.\n
+    \      \"ingressGateway\" : \"knative-serving/knative-ingress-gateway\",\n \n
+    \      # knativeLocalGatewayService specifies the hostname of the Knative's local
+    gateway service.\n       # The default KServe configurations are re-using the
+    Istio local gateways for Knative. In this case, this\n       # knativeLocalGatewayService
+    field can be left unset. When unset, the value of \"localGatewayService\" will
+    be used.\n       # However, sometimes it may be better to have local gateways
+    specifically for KServe (e.g. when enabling strict mTLS in Istio).\n       # Under
+    such setups where KServe is needed to have its own local gateways, the values
+    of the \"localGateway\" and\n       # \"localGatewayService\" should point to
+    the KServe local gateways. Then, this knativeLocalGatewayService field\n       #
+    should point to the Knative's local gateway service.\n       # NOTE: This configuration
+    only applicable for serverless deployment with Istio configured as network layer.\n
+    \      \"knativeLocalGatewayService\": \"\",\n \n       # localGateway specifies
+    the gateway which handles the network traffic within the cluster.\n       # NOTE:
+    This configuration only applicable for serverless deployment with Istio configured
+    as network layer.\n       \"localGateway\" : \"knative-serving/knative-local-gateway\",\n
+    \n       # localGatewayService specifies the hostname of the local gateway service.\n
+    \      # NOTE: This configuration only applicable for serverless deployment with
+    Istio configured as network layer.\n       \"localGatewayService\" : \"knative-local-gateway.istio-system.svc.cluster.local\",\n
+    \n       # ingressDomain specifies the domain name which is used for creating
+    the url.\n       # If ingressDomain is empty then example.com is used as default
+    domain.\n       # NOTE: This configuration only applicable for raw deployment.\n
+    \      \"ingressDomain\"  : \"example.com\",\n\n       # additionalIngressDomains
+    specifies the additional domain names which are used for creating the url.\n       \"additionalIngressDomains\":
+    [\"additional-example.com\", \"additional-example-1.com\"]\n\n       # ingressClassName
+    specifies the ingress controller to use for ingress traffic.\n       # This is
+    optional and if omitted the default ingress in the cluster is used.\n       #
+    https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class\n
+    \      # NOTE: This configuration only applicable for raw deployment.\n       \"ingressClassName\"
+    : \"istio\",\n \n       # domainTemplate specifies the template for generating
+    domain/url for each inference service by combining variable from:\n       # Name
+    of the inference service  ( {{ .Name}} )\n       # Namespace of the inference
+    service ( {{ .Namespace }} )\n       # Annotation of the inference service ( {{
+    .Annotations.key }} )\n       # Label of the inference service ( {{ .Labels.key
+    }} )\n       # IngressDomain ( {{ .IngressDomain }} )\n       # If domain template
+    is empty the default template {{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}
+    is used.\n       # NOTE: This configuration only applicable for raw deployment.\n
+    \      \"domainTemplate\": \"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}\",\n
+    \n       # urlScheme specifies the url scheme to use for inference service and
+    inference graph.\n       # If urlScheme is empty then by default http is used.\n
+    \      \"urlScheme\": \"http\",\n \n       # disableIstioVirtualHost controls
+    whether to use istio as network layer.\n       # By default istio is used as the
+    network layer. When DisableIstioVirtualHost is true, KServe does not\n       #
+    create the top level virtual service thus Istio is no longer required for serverless
+    mode.\n       # By setting this field to true, user can use other networking layers
+    supported by knative.\n       # For more info https://github.com/kserve/kserve/pull/2380,
+    https://kserve.github.io/website/master/admin/serverless/kourier_networking/.\n
+    \      # NOTE: This configuration is only applicable to serverless deployment.\n
+    \      \"disableIstioVirtualHost\": false,\n\n       # disableIngressCreation
+    controls whether to disable ingress creation for raw deployment mode.\n       \"disableIngressCreation\":
+    false,\n \n       # pathTemplate specifies the template for generating path based
+    url for each inference service.\n       # The following variables can be used
+    in the template for generating url.\n       # Name of the inference service  (
+    {{ .Name}} )\n       # Namespace of the inference service ( {{ .Namespace }} )\n
+    \      # For more info https://github.com/kserve/kserve/issues/2257.\n       #
+    NOTE: This configuration only applicable to serverless deployment.\n       \"pathTemplate\":
+    \"/serving/{{ .Namespace }}/{{ .Name }}\"\n   }\n \n # ======================================
+    LOGGER CONFIGURATION ======================================\n # Example\n logger:
+    |-\n   {\n       \"image\" : \"kserve/agent:latest\",\n       \"memoryRequest\":
+    \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"100m\",\n
+    \      \"cpuLimit\": \"1\",\n       \"defaultUrl\": \"http://default-broker\"\n
+    \  }\n logger: |-\n   {\n       # image contains the default logger image uri.\n
+    \      \"image\" : \"kserve/agent:latest\",\n   \n       # memoryRequest is the
+    requests.memory to set for the logger container.\n       \"memoryRequest\": \"100Mi\",\n
+    \      \n       # memoryLimit is the limits.memory to set for the logger container.\n
+    \      \"memoryLimit\": \"1Gi\",\n       \n       # cpuRequest is the requests.cpu
+    to set for the logger container.\n       \"cpuRequest\": \"100m\",\n       \n
+    \      # cpuLimit is the limits.cpu to set for the logger container.\n       \"cpuLimit\":
+    \"1\",\n       \n       # defaultUrl specifies the default logger url. If logger
+    is not specified in the resource this url is used.\n       \"defaultUrl\": \"http://default-broker\"\n
+    \  }\n \n # ====================================== BATCHER CONFIGURATION ======================================\n
+    # Example\n batcher: |-\n   {\n       \"image\" : \"kserve/agent:latest\",\n       \"memoryRequest\":
+    \"1Gi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"1\",\n       \"cpuLimit\":
+    \"1\",\n       \"maxBatchSize\": \"32\",\n       \"maxLatency\": \"5000\"\n   }\n
+    batcher: |-\n   {\n       # image contains the default batcher image uri.\n       \"image\"
+    : \"kserve/agent:latest\",\n       \n       # memoryRequest is the requests.memory
+    to set for the batcher container.\n       \"memoryRequest\": \"1Gi\",\n   \n       #
+    memoryLimit is the limits.memory to set for the batcher container.\n       \"memoryLimit\":
+    \"1Gi\",\n       \n       # cpuRequest is the requests.cpu to set for the batcher
+    container.\n       \"cpuRequest\": \"1\",\n       \n       # cpuLimit is the limits.cpu
+    to set for the batcher container.\n       \"cpuLimit\": \"1\"\n\n       # maxBatchSize
+    is the default maximum batch size for batcher.\n       \"maxBatchSize\": \"32\",\n\n
+    \      # maxLatency is the default maximum latency in milliseconds for batcher
+    to wait and collect the batch.\n       \"maxLatency\": \"5000\"\n   }\n \n # ======================================
+    AGENT CONFIGURATION ======================================\n # Example\n agent:
+    |-\n   {\n       \"image\" : \"kserve/agent:latest\",\n       \"memoryRequest\":
+    \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"100m\",\n
+    \      \"cpuLimit\": \"1\"\n   }\n agent: |-\n   {\n       # image contains the
+    default agent image uri.\n       \"image\" : \"kserve/agent:latest\",\n   \n       #
+    memoryRequest is the requests.memory to set for the agent container.\n       \"memoryRequest\":
+    \"100Mi\",\n   \n       # memoryLimit is the limits.memory to set for the agent
+    container.\n       \"memoryLimit\": \"1Gi\",\n       \n       # cpuRequest is
+    the requests.cpu to set for the agent container.\n       \"cpuRequest\": \"100m\",\n
+    \      \n       # cpuLimit is the limits.cpu to set for the agent container.\n
+    \      \"cpuLimit\": \"1\"\n   }\n \n # ======================================
+    ROUTER CONFIGURATION ======================================\n # Example\n router:
+    |-\n   {\n       \"image\" : \"kserve/router:latest\",\n       \"memoryRequest\":
+    \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"100m\",\n
+    \      \"cpuLimit\": \"1\",\n       \"headers\": {\n         \"propagate\": []\n
+    \      },\n       \"imagePullPolicy\": \"IfNotPresent\",\n       \"imagePullSecrets\":
+    [\"docker-secret\"]\n   }\n # router is the implementation of inference graph.\n
+    router: |-\n   {\n       # image contains the default router image uri.\n       \"image\"
+    : \"kserve/router:latest\",\n       \n       # memoryRequest is the requests.memory
+    to set for the router container.\n       \"memoryRequest\": \"100Mi\",\n       \n
+    \      # memoryLimit is the limits.memory to set for the router container.\n       \"memoryLimit\":
+    \"1Gi\",\n       \n       # cpuRequest is the requests.cpu to set for the router
+    container.\n       \"cpuRequest\": \"100m\",\n       \n       # cpuLimit is the
+    limits.cpu to set for the router container.\n       \"cpuLimit\": \"1\",\n       \n
+    \      # Propagate the specified headers to all the steps specified in an InferenceGraph.
+    \n       # You can either specify the exact header names or use [Golang supported
+    regex patterns]\n       # (https://pkg.go.dev/regexp/syntax@go1.21.3#hdr-Syntax)
+    to propagate multiple headers.\n       \"headers\": {\n         \"propagate\":
+    [\n            \"Authorization\",\n            \"Test-Header-*\",\n            \"*Trace-Id*\"\n
+    \        ]\n       }\n\n       # imagePullPolicy specifies when the router image
+    should be pulled from registry.\n       \"imagePullPolicy\": \"IfNotPresent\",\n
+    \      \n       # # imagePullSecrets specifies the list of secrets to be used
+    for pulling the router image from registry.\n       # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/\n
+    \      \"imagePullSecrets\": [\"docker-secret\"]\n   }\n \n# ======================================
+    DEPLOYMENT CONFIGURATION ======================================\n# Example\ndeploy:
+    |-\n  {\n    \"defaultDeploymentMode\": \"Serverless\",\n    \"deploymentRolloutStrategy\":
+    {\n      \"defaultRollout\": {\n        \"maxSurge\": \"1\",\n        \"maxUnavailable\":
+    \"1\"\n      }\n    }\n  }\n\ndeploy: |-\n  {\n    # defaultDeploymentMode specifies
+    the default deployment mode of the kserve. The supported values are\n    # Standard
+    and Knative. Users can override the deployment mode at service level\n    # by
+    adding the annotation serving.kserve.io/deploymentMode.\n    # \"defaultDeploymentMode\":
+    \"Standard\",\n    # deploymentRolloutStrategy specifies the default rollout strategy
+    for the Standard deployment mode\n    # \"deploymentRolloutStrategy\": {\n      #
+    defaultRollout specifies the default rollout configuration using Kubernetes deployment
+    strategy\n      # \"defaultRollout\": {\n        # maxSurge specifies the maximum
+    number of pods that can be created above the desired replica count\n        #
+    Can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%)\n
+    \       # \"maxSurge\": \"1\",\n        # maxUnavailable specifies the maximum
+    number of pods that can be unavailable during the update\n        # Can be an
+    absolute number (ex: 5) or a percentage of desired pods (ex: 10%)\n        # \"maxUnavailable\":
+    \"1\"\n      # }\n    # }\n  }\n\n # ====================================== SERVICE
+    CONFIGURATION ======================================\n # Example\n service: |-\n
+    \  {\n     \"serviceClusterIPNone\":  false\n   }\n service: |-\n   {\n      #
+    ServiceClusterIPNone is a boolean flag to indicate if the service should have
+    a clusterIP set to None.\n      # If the DeploymentMode is Raw, the default value
+    for ServiceClusterIPNone if not set is false\n      # \"serviceClusterIPNone\":
+    \ false\n   }\n\n # ====================================== METRICS CONFIGURATION
+    ======================================\n # Example\n metricsAggregator: |-\n   {\n
+    \    \"enableMetricAggregation\": \"false\",\n     \"enablePrometheusScraping\"
+    : \"false\"\n   }\n # For more info see https://github.com/kserve/kserve/blob/master/qpext/README.md\n
+    metricsAggregator: |-\n   {\n     # enableMetricAggregation configures metric
+    aggregation annotation. This adds the annotation serving.kserve.io/enable-metric-aggregation
+    to every\n     # service with the specified boolean value. If true enables metric
+    aggregation in queue-proxy by setting env vars in the queue proxy container\n
+    \    # to configure scraping ports.\n     \"enableMetricAggregation\": \"false\",\n
+    \    \n     # enablePrometheusScraping configures metric aggregation annotation.
+    This adds the annotation serving.kserve.io/enable-metric-aggregation to every\n
+    \    # service with the specified boolean value. If true, prometheus annotations
+    are added to the pod. If serving.kserve.io/enable-metric-aggregation is false,\n
+    \    # the prometheus port is set with the default prometheus scraping port 9090,
+    otherwise the prometheus port annotation is set with the metric aggregation port.\n
+    \    \"enablePrometheusScraping\" : \"false\"\n   }\n  \n # ======================================
+    LOCALMODEL CONFIGURATION ======================================\n # Example\n
+    localModel: |-\n   {\n     \"enabled\": false,\n     # jobNamespace specifies
+    the namespace where the download job will be created.\n     \"jobNamespace\":
+    \"kserve-localmodel-jobs\",\n     # defaultJobImage specifies the default image
+    used for the download job.\n     \"defaultJobImage\" : \"kserve/storage-initializer:latest\",\n
+    \    # Kubernetes modifies the filesystem group ID on the attached volume.\n     \"fsGroup\":
+    1000,\n     # TTL for the download job after it is finished.\n     \"jobTTLSecondsAfterFinished\":
+    3600,\n     # The frequency at which the local model agent reconciles the local
+    models\n     # This is to detect if models are missing from local disk\n     \"reconcilationFrequencyInSecs\":
+    60,\n     # This is to disable localmodel pv and pvc management for namespaces
+    without isvcs\n     \"disableVolumeManagement\": false\n   }"
   agent: |-
     {
         "image" : "kserve/agent:latest",
@@ -38815,21 +38423,13 @@ data:
           "memoryRequest": "2Gi"
         }
     }
-  ingress: |-
-    {
-        "enableGatewayApi": false,
-        "kserveIngressGateway": "kserve/kserve-ingress-gateway",
-        "ingressGateway" : "knative-serving/knative-ingress-gateway",
-        "localGateway" : "knative-serving/knative-local-gateway",
-        "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",
-        "ingressDomain"  : "example.com",
-        "ingressClassName" : "istio",
-        "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
-        "urlScheme": "http",
-        "disableIstioVirtualHost": false,
-        "disableIngressCreation": false,
-        "disableHTTPRouteTimeout": false
-    }
+  ingress: "{   \n    \"enableGatewayApi\": false,\n    \"kserveIngressGateway\":
+    \"kserve/kserve-ingress-gateway\",\n    \"ingressGateway\" : \"knative-serving/knative-ingress-gateway\",\n
+    \   \"localGateway\" : \"knative-serving/knative-local-gateway\",\n    \"localGatewayService\"
+    : \"knative-local-gateway.istio-system.svc.cluster.local\",\n    \"ingressDomain\"
+    \ : \"example.com\",\n    \"ingressClassName\" : \"istio\",\n    \"domainTemplate\":
+    \"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}\",\n    \"urlScheme\": \"http\",\n
+    \   \"disableIstioVirtualHost\": false,\n    \"disableIngressCreation\": false\n}"
   localModel: |-
     {
       "enabled": false,
@@ -39124,7 +38724,6 @@ spec:
   - regex: https://(.+?).blob.core.windows.net/(.+)
   - regex: https://(.+?).file.core.windows.net/(.+)
   - regex: https?://(.+)/(.+)
-  supportsMultiModelDownload: true
   workloadType: initContainer
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -628,15 +628,15 @@ export RELEASE
 
 GOLANGCI_LINT_VERSION=v2.9.0
 CONTROLLER_TOOLS_VERSION=v0.19.0
-ENVTEST_VERSION=release-0.19
+ENVTEST_VERSION=latest
 YQ_VERSION=v4.52.1
 HELM_VERSION=v3.16.3
-KUSTOMIZE_VERSION=v5.8.1
+KUSTOMIZE_VERSION=v5.8.0
 HELM_DOCS_VERSION=v1.12.0
+BLACK_FMT_VERSION=24.3
 POETRY_VERSION=1.8.3
 UV_VERSION=0.7.8
 RUFF_VERSION=0.14.13
-PINACT_VERSION=v3.9.0
 KIND_VERSION=v0.30.0
 CERT_MANAGER_VERSION=v1.17.0
 ENVOY_GATEWAY_VERSION=v1.6.3
@@ -644,16 +644,14 @@ ENVOY_AI_GATEWAY_VERSION=v0.5.0
 KNATIVE_OPERATOR_VERSION=v1.21.1
 KNATIVE_SERVING_VERSION=1.21.1
 KEDA_OTEL_ADDON_VERSION=v0.0.6
-PROMETHEUS_VERSION=83.4.0
-PROMETHEUS_ADAPTER_VERSION=5.3.0
-KSERVE_VERSION=v0.18.0-rc1
+KSERVE_VERSION=v0.17.0
 ISTIO_VERSION=1.27.1
 KEDA_VERSION=2.17.3
 OPENTELEMETRY_OPERATOR_VERSION=0.74.3
-LWS_VERSION=v0.8.0
+LWS_VERSION=v0.7.0
 GATEWAY_API_VERSION=v1.4.1
-GIE_VERSION=v1.3.1
-WVA_VERSION=v0.6.0
+GIE_VERSION=v1.3.0
+WVA_VERSION=v0.5.1
 
 #================================================
 # Global Variables (from global-vars.env)
@@ -663,9 +661,6 @@ WVA_VERSION=v0.6.0
 
 KEDA_NAMESPACE="${KEDA_NAMESPACE:-keda}"
 KSERVE_NAMESPACE="${KSERVE_NAMESPACE:-kserve}"
-PROMETHEUS_NAMESPACE="${PROMETHEUS_NAMESPACE:-monitoring}"
-PROMETHEUS_ADAPTER_NAMESPACE="${PROMETHEUS_ADAPTER_NAMESPACE:-monitoring}"
-WVA_NAMESPACE="${WVA_NAMESPACE:-wva-system}"
 OTEL_NAMESPACE="${OTEL_NAMESPACE:-opentelemetry-operator}"
 OPERATOR_NAMESPACE="${OPERATOR_NAMESPACE:-knative-operator}"
 SERVING_NAMESPACE="${SERVING_NAMESPACE:-knative-serving}"
@@ -769,7 +764,7 @@ install_helm() {
     rm -rf "${temp_dir}"
 
     log_success "Successfully installed Helm ${HELM_VERSION} to ${BIN_DIR}/helm"
-    "${BIN_DIR}/helm" version
+    helm version
 }
 
 # ----------------------------------------
@@ -786,10 +781,10 @@ install_kustomize() {
 
     log_info "Installing Kustomize ${KUSTOMIZE_VERSION} for ${os}/${arch}..."
 
-    if [[ -x "${BIN_DIR}/kustomize" ]]; then
-        local current_version=$("${BIN_DIR}/kustomize" version 2>/dev/null | awk 'match($0, /v[0-9.]+/) {print substr($0, RSTART, RLENGTH)}')
+    if command -v kustomize &>/dev/null; then
+        local current_version=$(kustomize version --short 2>/dev/null | grep -oP 'v[0-9.]+')
         if [[ -n "$current_version" ]] && version_gte "$current_version" "$KUSTOMIZE_VERSION"; then
-            log_info "Kustomize ${current_version} is already installed in ${BIN_DIR} (>= ${KUSTOMIZE_VERSION})"
+            log_info "Kustomize ${current_version} is already installed (>= ${KUSTOMIZE_VERSION})"
             return 0
         fi
         [[ -n "$current_version" ]] && log_info "Upgrading Kustomize from ${current_version} to ${KUSTOMIZE_VERSION}..."
@@ -829,7 +824,7 @@ install_kustomize() {
     rm -rf "${temp_dir}"
 
     log_success "Successfully installed Kustomize ${KUSTOMIZE_VERSION} to ${BIN_DIR}/kustomize"
-    "${BIN_DIR}/kustomize" version
+    kustomize version
 }
 
 # ----------------------------------------
@@ -847,7 +842,7 @@ install_yq() {
     log_info "Installing yq ${YQ_VERSION} for ${os}/${arch}..."
 
     if [[ -x "${BIN_DIR}/yq" ]]; then
-        local current_version=$("${BIN_DIR}/yq" --version 2>&1 | awk 'match($0, /v[0-9.]+/) {print substr($0, RSTART, RLENGTH)}')
+        local current_version=$("${BIN_DIR}/yq" --version 2>&1 | grep -oP 'version \K[v0-9.]+')
         # Normalize version format (add 'v' prefix if missing)
         [[ -n "$current_version" && "$current_version" != v* ]] && current_version="v${current_version}"
         if [[ -n "$current_version" ]] && version_gte "$current_version" "$YQ_VERSION"; then
@@ -953,13 +948,13 @@ uninstall_kserve_kustomize() {
         # Uninstall overlay resources in reverse order
         for ((i=${#TARGET_OVERLAY_DIRS[@]}-1; i>=0; i--)); do
             log_info "Uninstalling resources from ${TARGET_OVERLAY_DIRS[$i]}..."
-            kustomize build "${TARGET_OVERLAY_DIRS[$i]}" | kubectl delete -f - --force --grace-period=0 2>/dev/null || true
+            kubectl kustomize "${TARGET_OVERLAY_DIRS[$i]}" | kubectl delete -f - --force --grace-period=0 2>/dev/null || true
         done
 
         # Uninstall CRDs in reverse order
         for ((i=${#TARGET_CRD_DIRS[@]}-1; i>=0; i--)); do
             log_info "Uninstalling CRDs from ${TARGET_CRD_DIRS[$i]}..."
-            kustomize build "${TARGET_CRD_DIRS[$i]}" | kubectl delete -f - --force --grace-period=0 2>/dev/null || true
+            kubectl kustomize "${TARGET_CRD_DIRS[$i]}" | kubectl delete -f - --force --grace-period=0 2>/dev/null || true
         done
     fi
 
@@ -1616,7 +1611,7 @@ spec:
       value: "8080"
     - name: MLSERVER_GRPC_PORT
       value: "9000"
-    image: docker.io/seldonio/mlserver:1.7.1
+    image: docker.io/seldonio/mlserver:1.5.0
     name: kserve-container
     resources:
       limits:
@@ -2057,10 +2052,6 @@ spec:
       - /bin/bash
       - -c
       - |-
-        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-          source /etc/profile.d/ibm-aiu-setup.sh
-        fi
-
         if [ "$KSERVE_INFER_ROCE" = "true" ]; then
           echo "Trying to infer RoCE configs ... "
           grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
@@ -2198,7 +2189,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -2225,8 +2216,8 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       startupProbe:
@@ -2241,8 +2232,6 @@ spec:
       volumeMounts:
       - mountPath: /home
         name: home
-      - mountPath: /tmp
-        name: tmp-dir
       - mountPath: /dev/shm
         name: dshm
       - mountPath: /models
@@ -2255,7 +2244,7 @@ spec:
       - /app/pd-sidecar
       - --port=8000
       - --vllm-port=8001
-      - --kv-connector=nixlv2
+      - --connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
@@ -2270,7 +2259,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.6.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -2301,8 +2290,8 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
       terminationMessagePath: /dev/termination-log
       terminationMessagePolicy: FallbackToLogsOnError
       volumeMounts:
@@ -2313,8 +2302,6 @@ spec:
     volumes:
     - emptyDir: {}
       name: home
-    - emptyDir: {}
-      name: tmp-dir
     - emptyDir:
         medium: Memory
         sizeLimit: 1Gi
@@ -2337,10 +2324,6 @@ spec:
       - /bin/bash
       - -c
       - |-
-        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-          source /etc/profile.d/ibm-aiu-setup.sh
-        fi
-
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -2508,7 +2491,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -2539,8 +2522,8 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       startupProbe:
@@ -2555,8 +2538,6 @@ spec:
       volumeMounts:
       - mountPath: /home
         name: home
-      - mountPath: /tmp
-        name: tmp-dir
       - mountPath: /dev/shm
         name: dshm
       - mountPath: /models
@@ -2569,7 +2550,7 @@ spec:
       - /app/pd-sidecar
       - --port=8000
       - --vllm-port=8001
-      - --kv-connector=nixlv2
+      - --connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
@@ -2584,7 +2565,7 @@ spec:
             fieldPath: metadata.namespace
       - name: SSL_CERT_DIR
         value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.7.1
+      image: ghcr.io/llm-d/llm-d-routing-sidecar:v0.6.0
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -2615,7 +2596,7 @@ spec:
           drop:
           - ALL
         readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       terminationMessagePath: /dev/termination-log
@@ -2628,8 +2609,6 @@ spec:
     volumes:
     - emptyDir: {}
       name: home
-    - emptyDir: {}
-      name: tmp-dir
     - emptyDir:
         medium: Memory
         sizeLimit: 8Gi
@@ -2645,10 +2624,6 @@ spec:
       - /bin/bash
       - -c
       - |-
-        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-          source /etc/profile.d/ibm-aiu-setup.sh
-        fi
-
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -2818,7 +2793,7 @@ spec:
         value: /models
       - name: VLLM_RANDOMIZE_DP_DUMMY_INPUTS
         value: "1"
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
       imagePullPolicy: IfNotPresent
       name: main
       ports:
@@ -2833,8 +2808,8 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       terminationMessagePath: /dev/termination-log
@@ -2842,8 +2817,6 @@ spec:
       volumeMounts:
       - mountPath: /home
         name: home
-      - mountPath: /tmp
-        name: tmp-dir
       - mountPath: /dev/shm
         name: dshm
       - mountPath: /models
@@ -2855,8 +2828,6 @@ spec:
     volumes:
     - emptyDir: {}
       name: home
-    - emptyDir: {}
-      name: tmp-dir
     - emptyDir:
         medium: Memory
         sizeLimit: 8Gi
@@ -2880,10 +2851,6 @@ spec:
         - /bin/bash
         - -c
         - |-
-          if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-            source /etc/profile.d/ibm-aiu-setup.sh
-          fi
-
           if [ "$KSERVE_INFER_ROCE" = "true" ]; then
             echo "Trying to infer RoCE configs ... "
             grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
@@ -3021,7 +2988,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -3048,8 +3015,8 @@ spec:
           capabilities:
             drop:
             - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
+          readOnlyRootFilesystem: false
+          runAsNonRoot: false
           seccompProfile:
             type: RuntimeDefault
         startupProbe:
@@ -3064,8 +3031,6 @@ spec:
         volumeMounts:
         - mountPath: /home
           name: home
-        - mountPath: /tmp
-          name: tmp-dir
         - mountPath: /dev/shm
           name: dshm
         - mountPath: /models
@@ -3077,8 +3042,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: home
-      - emptyDir: {}
-        name: tmp-dir
       - emptyDir:
           medium: Memory
           sizeLimit: 1Gi
@@ -3102,10 +3065,6 @@ spec:
         - /bin/bash
         - -c
         - |-
-          if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-            source /etc/profile.d/ibm-aiu-setup.sh
-          fi
-
           # In some versions, ZMQ bind doesn't resolve the address through DNS
           # Retry DP_ADDRESS resolution (configurable attempts, default 30)
           RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -3273,7 +3232,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -3304,8 +3263,8 @@ spec:
             - NET_RAW
             drop:
             - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
+          readOnlyRootFilesystem: false
+          runAsNonRoot: false
           seccompProfile:
             type: RuntimeDefault
         startupProbe:
@@ -3320,8 +3279,6 @@ spec:
         volumeMounts:
         - mountPath: /home
           name: home
-        - mountPath: /tmp
-          name: tmp-dir
         - mountPath: /dev/shm
           name: dshm
         - mountPath: /models
@@ -3333,8 +3290,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: home
-      - emptyDir: {}
-        name: tmp-dir
       - emptyDir:
           medium: Memory
           sizeLimit: 8Gi
@@ -3350,10 +3305,6 @@ spec:
         - /bin/bash
         - -c
         - |-
-          if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-            source /etc/profile.d/ibm-aiu-setup.sh
-          fi
-
           # In some versions, ZMQ bind doesn't resolve the address through DNS
           # Retry DP_ADDRESS resolution (configurable attempts, default 30)
           RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -3521,7 +3472,7 @@ spec:
           value: INFO
         - name: HF_HUB_CACHE
           value: /models
-        image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+        image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
         imagePullPolicy: IfNotPresent
         name: main
         ports:
@@ -3536,8 +3487,8 @@ spec:
             - NET_RAW
             drop:
             - ALL
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
+          readOnlyRootFilesystem: false
+          runAsNonRoot: false
           seccompProfile:
             type: RuntimeDefault
         terminationMessagePath: /dev/termination-log
@@ -3545,8 +3496,6 @@ spec:
         volumeMounts:
         - mountPath: /home
           name: home
-        - mountPath: /tmp
-          name: tmp-dir
         - mountPath: /dev/shm
           name: dshm
         - mountPath: /models
@@ -3558,8 +3507,6 @@ spec:
       volumes:
       - emptyDir: {}
         name: home
-      - emptyDir: {}
-        name: tmp-dir
       - emptyDir:
           medium: Memory
           sizeLimit: 8Gi
@@ -3625,25 +3572,6 @@ spec:
               backendRequest: 0s
               request: 0s
           - backendRefs:
-            - group: inference.networking.k8s.io
-              kind: InferencePool
-              name: '{{ ChildName .ObjectMeta.Name `-inference-pool` }}'
-              port: 8000
-              weight: 1
-            filters:
-            - type: URLRewrite
-              urlRewrite:
-                path:
-                  replacePrefixMatch: /v1/responses
-                  type: ReplacePrefixMatch
-            matches:
-            - path:
-                type: PathPrefix
-                value: /{{ .ObjectMeta.Namespace }}/{{ .ObjectMeta.Name }}/v1/responses
-            timeouts:
-              backendRequest: 0s
-              request: 0s
-          - backendRefs:
             - kind: Service
               name: '{{ ChildName .ObjectMeta.Name `-kserve-workload-svc` }}'
               port: 8000
@@ -3670,8 +3598,6 @@ metadata:
 spec:
   router:
     scheduler:
-      annotations:
-        app.kubernetes.io/version: 0.7.0
       pool:
         spec:
           endpointPickerRef:
@@ -3701,6 +3627,8 @@ spec:
           - "9002"
           - --grpc-health-port
           - "9003"
+          - --kv-cache-usage-percentage-metric
+          - vllm:kv_cache_usage_perc
           - '{{ if .GlobalConfig.EnableTLS }}--enable-cert-reload=true{{- end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--secure-serving=true{{- end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--model-server-metrics-scheme=https{{-
@@ -3710,7 +3638,7 @@ spec:
           env:
           - name: SSL_CERT_DIR
             value: /var/run/kserve/tls:/var/run/secrets/kubernetes.io/serviceaccount:/etc/pki/tls/certs
-          image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.1
+          image: ghcr.io/llm-d/llm-d-inference-scheduler:v0.6.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
@@ -3768,12 +3696,12 @@ spec:
         - env:
           - name: TOKENIZERS_DIR
             value: /mnt/models
-          image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.7.1
+          image: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.6.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 3
             httpGet:
-              path: /healthz
+              path: /health
               port: 8082
             periodSeconds: 15
             timeoutSeconds: 5
@@ -3785,7 +3713,7 @@ spec:
           readinessProbe:
             failureThreshold: 3
             httpGet:
-              path: /healthz
+              path: /health
               port: 8082
             periodSeconds: 10
             timeoutSeconds: 5
@@ -3805,7 +3733,7 @@ spec:
           startupProbe:
             failureThreshold: 60
             httpGet:
-              path: /healthz
+              path: /health
               port: 8082
             initialDelaySeconds: 5
             periodSeconds: 10
@@ -3813,10 +3741,6 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
-          - mountPath: /tmp
-            name: tokenizer-tmp
-          - mountPath: /.cache
-            name: tokenizer-cache
           - mountPath: /tmp/tokenizer
             name: tokenizer-uds
           workingDir: /mnt/models
@@ -3830,10 +3754,6 @@ spec:
               }}'
         - emptyDir: {}
           name: tokenizer-uds
-        - emptyDir: {}
-          name: tokenizer-tmp
-        - emptyDir: {}
-          name: tokenizer-cache
 ---
 apiVersion: serving.kserve.io/v1alpha2
 kind: LLMInferenceServiceConfig
@@ -3847,10 +3767,6 @@ spec:
       - /bin/bash
       - -c
       - |-
-        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-          source /etc/profile.d/ibm-aiu-setup.sh
-        fi
-
         if [ "$KSERVE_INFER_ROCE" = "true" ]; then
           echo "Trying to infer RoCE configs ... "
           grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
@@ -3988,7 +3904,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -4015,8 +3931,8 @@ spec:
         capabilities:
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       startupProbe:
@@ -4031,8 +3947,6 @@ spec:
       volumeMounts:
       - mountPath: /home
         name: home
-      - mountPath: /tmp
-        name: tmp-dir
       - mountPath: /dev/shm
         name: dshm
       - mountPath: /models
@@ -4050,8 +3964,6 @@ spec:
       name: dshm
     - emptyDir: {}
       name: model-cache
-    - emptyDir: {}
-      name: tmp-dir
     - name: tls-certs
       secret:
         secretName: '{{ ChildName .ObjectMeta.Name `-kserve-self-signed-certs` }}'
@@ -4068,10 +3980,6 @@ spec:
       - /bin/bash
       - -c
       - |-
-        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-          source /etc/profile.d/ibm-aiu-setup.sh
-        fi
-
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -4239,7 +4147,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 3
@@ -4270,8 +4178,8 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       startupProbe:
@@ -4286,8 +4194,6 @@ spec:
       volumeMounts:
       - mountPath: /home
         name: home
-      - mountPath: /tmp
-        name: tmp-dir
       - mountPath: /dev/shm
         name: dshm
       - mountPath: /models
@@ -4299,8 +4205,6 @@ spec:
     volumes:
     - emptyDir: {}
       name: home
-    - emptyDir: {}
-      name: tmp-dir
     - emptyDir:
         medium: Memory
         sizeLimit: 8Gi
@@ -4316,10 +4220,6 @@ spec:
       - /bin/bash
       - -c
       - |-
-        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
-          source /etc/profile.d/ibm-aiu-setup.sh
-        fi
-
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -4487,7 +4387,7 @@ spec:
         value: INFO
       - name: HF_HUB_CACHE
         value: /models
-      image: ghcr.io/llm-d/llm-d-cuda:v0.6.0
+      image: ghcr.io/llm-d/llm-d-cuda:v0.5.1
       imagePullPolicy: IfNotPresent
       name: main
       ports:
@@ -4502,8 +4402,8 @@ spec:
           - NET_RAW
           drop:
           - ALL
-        readOnlyRootFilesystem: true
-        runAsNonRoot: true
+        readOnlyRootFilesystem: false
+        runAsNonRoot: false
         seccompProfile:
           type: RuntimeDefault
       terminationMessagePath: /dev/termination-log
@@ -4511,8 +4411,6 @@ spec:
       volumeMounts:
       - mountPath: /home
         name: home
-      - mountPath: /tmp
-        name: tmp-dir
       - mountPath: /dev/shm
         name: dshm
       - mountPath: /models
@@ -4524,8 +4422,6 @@ spec:
     volumes:
     - emptyDir: {}
       name: home
-    - emptyDir: {}
-      name: tmp-dir
     - emptyDir:
         medium: Memory
         sizeLimit: 8Gi
@@ -37713,630 +37609,342 @@ subjects:
 ---
 apiVersion: v1
 data:
-  _example: |-
-    ################################
-    #                              #
-    #    EXAMPLE CONFIGURATION     #
-    #                              #
-    ################################
-
-    # This block is not actually functional configuration,
-    # but serves to illustrate the available configuration
-    # options and document them in a way that is accessible
-    # to users that `kubectl edit` this config map.
-    #
-    # These sample configuration options may be copied out of
-    # this example block and unindented to be in the data block
-    # to actually change the configuration.
-
-    # ====================================== EXPLAINERS CONFIGURATION ======================================
-    # Example
-    explainers: |-
-      {
-          "art": {
-              "image" : "kserve/art-explainer",
-              "defaultImageVersion": "latest"
-          }
-      }
-    # Art Explainer runtime configuration
-     explainers: |-
-       {
-           # Art explainer runtime configuration
-           "art": {
-               # image contains the default Art explainer serving runtime image uri.
-               "image" : "kserve/art-explainer",
-
-               # defautltImageVersion contains the Art explainer serving runtime default image version.
-               "defaultImageVersion": "latest"
-           }
-       }
-    # ====================================== ISVC CONFIGURATION ======================================
-    # Example - setting custom annotation
-     inferenceService: |-
-       {
-         "serviceAnnotationDisallowedList": [
-            "my.custom.annotation/1"
-         ],
-         "serviceLabelDisallowedList": [
-            "my.custom.label.1"
-         ]
-       }
-    # Example - setting custom annotation
-    inferenceService: |-
-      {
-        # ServiceAnnotationDisallowedList is a list of annotations that are not allowed to be propagated to Knative
-        # revisions, which prevents the reconciliation loop to be triggered if the annotations is
-        # configured here are used.
-        # Default values are:
-        #  "autoscaling.knative.dev/min-scale",
-        #  "autoscaling.knative.dev/max-scale",
-        #  "internal.serving.kserve.io/storage-initializer-sourceuri",
-        #  "kubectl.kubernetes.io/last-applied-configuration",
-        #  "modelFormat"
-        # Any new value will be appended to the list.
-        "serviceAnnotationDisallowedList": [
-          "my.custom.annotation/1"
-        ],
-        # ServiceLabelDisallowedList is a list of labels that are not allowed to be propagated to Knative revisions
-        # which prevents the reconciliation loop to be triggered if the labels is configured here are used.
-        "serviceLabelDisallowedList": [
-          "my.custom.label.1"
-        ]
-      }
-    # Example - setting custom resource
-    inferenceService: |-
-      {
-        "resource": {
-          "cpuLimit": "1",
-          "memoryLimit": "2Gi",
-          "cpuRequest": "1",
-          "memoryRequest": "2Gi"
-        }
-      }
-    # Example - setting custom resource
-    inferenceService: |-
-      {
-        # resource contains the default resource configuration for the inference service.
-        # you can override this configuration by specifying the resources in the inference service yaml.
-        # If you want to unbound the resource (limits and requests), you can set the value to null or ""
-        # or just remove the specific field from the config.
-        "resource": {
-           # cpuLimit is the limits.cpu to set for the inference service.
-           "cpuLimit": "1",
-
-           # memoryLimit is the limits.memory to set for the inference service.
-           "memoryLimit": "2Gi",
-
-           # cpuRequest is the requests.cpu to set for the inference service.
-           "cpuRequest": "1",
-
-           # memoryRequest is the requests.memory to set for the inference service.
-           "memoryRequest": "2Gi"
-        }
-     }
-    # ====================================== MultiNode CONFIGURATION ======================================
-    # Example
-    multiNode: |-
-      {
-        "customGPUResourceTypeList": [
-          "custom.com/gpu"
-        ]
-      }
-    # Example of multinode configuration
-    multiNode: |-
-      {
-        # CustomGPUResourceTypeList is a list of custom GPU resource types intended to identify the GPU type of a resource,
-        # not to restrict the user from using a specific GPU type.
-        # The MultiNode runtime pod will dynamically add GPU resources based on the registered GPU types.
-        "customGPUResourceTypeList": [
-          "custom.com/gpu"
-        ]
-      }
-     # ====================================== OTelCollector CONFIGURATION ======================================
-     # Example
-     opentelemetryCollector: |-
-       {
-         # scrapeInterval is the interval at which the OpenTelemetry Collector will scrape the metrics.
-         "scrapeInterval": "5s",
-         # metricScalerEndpoint is the endpoint from which the KEDA's ScaledObject will scrape the metrics.
-         "metricScalerEndpoint": "keda-otel-scaler.keda.svc:4318",
-         # metricReceiverEndpoint is the endpoint from which the OpenTelemetry Collector will scrape the metrics.
-          "metricReceiverEndpoint": "keda-otel-scaler.keda.svc:4317"
-       }
-
-     # ====================================== AUTOSCALER CONFIGURATION ======================================
-     # Example
-     autoscaler: |-
-       {
-         # scaleUpStabilizationWindowSeconds is the stabilization window in seconds for scale up.
-         "scaleUpStabilizationWindowSeconds": "0",
-         # scaleDownStabilizationWindowSeconds is the stabilization window in seconds for scale down.
-         "scaleDownStabilizationWindowSeconds": "300"
-       }
-
-     # ====================================== STORAGE INITIALIZER CONFIGURATION ======================================
-     # Example
-     storageInitializer: |-
-       {
-           "image" : "kserve/storage-initializer:latest",
-           "memoryRequest": "100Mi",
-           "memoryLimit": "1Gi",
-           "cpuRequest": "100m",
-           "cpuLimit": "1",
-           "caBundleConfigMapName": "",
-           "caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-           "enableModelcar": false,
-           "cpuModelcar": "10m",
-           "memoryModelcar": "15Mi"
-       }
-     storageInitializer: |-
-       {
-           # image contains the default storage initializer image uri.
-           "image" : "kserve/storage-initializer:latest",
-
-           # memoryRequest is the requests.memory to set for the storage initializer init container.
-           "memoryRequest": "100Mi",
-
-            # memoryLimit is the limits.memory to set for the storage initializer init container.
-           "memoryLimit": "1Gi",
-
-           # cpuRequest is the requests.cpu to set for the storage initializer init container.
-           "cpuRequest": "100m",
-
-           # cpuLimit is the limits.cpu to set for the storage initializer init container.
-           "cpuLimit": "1",
-
-           # caBundleConfigMapName is the ConfigMap will be copied to a user namespace for the storage initializer init container.
-           "caBundleConfigMapName": "",
-
-           # caBundleVolumeMountPath is the mount point for the configmap set by caBundleConfigMapName for the storage initializer init container.
-           "caBundleVolumeMountPath": "/etc/ssl/custom-certs",
-
-           # enableModelcar enabled allows you to directly access an OCI container image by
-           # using a source URL with an "oci://" schema.
-           "enableModelcar": false,
-
-           # cpuModelcar is the cpu request and limit that is used for the passive modelcar container. It can be
-           # set very low, but should be allowed by any Kubernetes LimitRange that might apply.
-           "cpuModelcar": "10m",
-
-           # cpuModelcar is the memory request and limit that is used for the passive modelcar container. It can be
-           # set very low, but should be allowed by any Kubernetes LimitRange that might apply.
-           "memoryModelcar": "15Mi",
-
-           # uidModelcar is the UID under with which the modelcar process and the main container is running.
-           # Some Kubernetes clusters might require this to be root (0). If not set the user id is left untouched (default)
-           "uidModelcar": 10
-       }
-
-     # ====================================== CREDENTIALS ======================================
-     # Example
-     credentials: |-
-       {
-          "storageSpecSecretName": "storage-config",
-          "storageSecretNameAnnotation": "serving.kserve.io/storageSecretName",
-          "gcs": {
-              "gcsCredentialFileName": "gcloud-application-credentials.json"
-          },
-          "s3": {
-              "s3AccessKeyIDName": "AWS_ACCESS_KEY_ID",
-              "s3SecretAccessKeyName": "AWS_SECRET_ACCESS_KEY",
-              "s3Endpoint": "",
-              "s3UseHttps": "",
-              "s3Region": "",
-              "s3VerifySSL": "",
-              "s3UseVirtualBucket": "",
-              "s3UseAccelerate": "",
-              "s3UseAnonymousCredential": "",
-              "s3CABundleConfigMap": "",
-              "s3CABundle": ""
-          }
-       }
-     # This is a global configuration used for downloading models from the cloud storage.
-     # You can override this configuration by specifying the annotations on service account or static secret.
-     # https://kserve.github.io/website/master/modelserving/storage/s3/s3/
-     # For a quick reference about AWS ENV variables:
-     # AWS Cli: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
-     # Boto: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables
-     #
-     # The `s3AccessKeyIDName` and `s3SecretAccessKeyName` fields are only used from this configmap when static credentials (IAM User Access Key Secret)
-     # are used as the authentication method for AWS S3.
-     # The rest of the fields are used in both authentication methods (IAM Role for Service Account & IAM User Access Key Secret) if a non-empty value is provided.
-     credentials: |-
-       {
-          # storageSpecSecretName contains the secret name which has the credentials for downloading the model.
-          # This option is used when specifying the storage spec on isvc yaml.
-          "storageSpecSecretName": "storage-config",
-
-          # The annotation can be specified on isvc yaml to allow overriding with the secret name reference from the annotation value.
-          # When using storageUri the order of the precedence is: secret name reference annotation > secret name references from service account
-          # When using storageSpec the order of the precedence is: secret name reference annotation > storageSpecSecretName in configmap
-
-          # Configuration for google cloud storage
-          "gcs": {
-              # gcsCredentialFileName specifies the filename of the gcs credential
-              "gcsCredentialFileName": "gcloud-application-credentials.json"
-          },
-
-          # Configuration for aws s3 storage. This add the corresponding environmental variables to the storage initializer init container.
-          # For more info on s3 storage see https://kserve.github.io/website/master/modelserving/storage/s3/s3/
-          "s3": {
-              # s3AccessKeyIDName specifies the s3 access key id name
-              "s3AccessKeyIDName": "AWS_ACCESS_KEY_ID",
-
-              # s3SecretAccessKeyName specifies the s3 secret access key name
-              "s3SecretAccessKeyName": "AWS_SECRET_ACCESS_KEY",
-
-              # s3Endpoint specifies the s3 endpoint
-              "s3Endpoint": "",
-
-              # s3UseHttps controls whether to use secure https or unsecure http to download models.
-              # Allowed values are 0 and 1.
-              "s3UseHttps": "",
-
-              # s3Region specifies the region of the bucket.
-              "s3Region": "",
-
-              # s3VerifySSL controls whether to verify the tls/ssl certificate.
-              "s3VerifySSL": "",
-
-              # s3UseVirtualBucket configures whether it is a virtual bucket or not.
-              "s3UseVirtualBucket": "",
-
-              # s3UseAccelerate configures whether to use transfer acceleration.
-              "s3UseAccelerate": "",
-
-              # s3UseAnonymousCredential configures whether to use anonymous credentials to download the model or not.
-              "s3UseAnonymousCredential": "",
-
-              # s3CABundleConfigMap specifies the mounted CA bundle config map name.
-              "s3CABundleConfigMap": "",
-
-              # s3CABundle specifies the full path (mount path + file name) for the mounted config map data when used with a configured CA bundle config map.
-              # s3CABundle specifies the path to a certificate bundle to use for HTTPS certificate validation when used absent of a configured CA bundle config map.
-              "s3CABundle": ""
-          }
-       }
-
-     # ====================================== INGRESS CONFIGURATION ======================================
-     # Example
-     ingress: |-
-       {
-           "enableGatewayApi": false,
-           "kserveIngressGateway": "kserve/kserve-ingress-gateway",
-           "ingressGateway" : "knative-serving/knative-ingress-gateway",
-           "localGateway" : "knative-serving/knative-local-gateway",
-           "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",
-           "ingressDomain"  : "example.com",
-           "additionalIngressDomains": ["additional-example.com", "additional-example-1.com"],
-           "ingressClassName" : "istio",
-           "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
-           "urlScheme": "http",
-           "disableIstioVirtualHost": false,
-           "disableIngressCreation": false,
-           "disableHTTPRouteTimeout": false
-       }
-     ingress: |-
-       {
-           # enableGatewayApi specifies whether to use Gateway API instead of Ingress to serve external traffic.
-           "enableGatewayApi": false,
-
-           # KServe implements [Gateway API](https://gateway-api.sigs.k8s.io/) to serve external traffic.
-           # By default, KServe configures a default gateway to serve external traffic.
-           # But, KServe can be configured to use a custom gateway by modifying this configuration.
-           # The gateway should be specified in format <gateway namespace>/<gateway name>
-           # NOTE: This configuration only applicable for raw deployment.
-           "kserveIngressGateway": "kserve/kserve-ingress-gateway",
-
-           # ingressGateway specifies the ingress gateway to serve external traffic.
-           # The gateway should be specified in format <gateway namespace>/<gateway name>
-           # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.
-           "ingressGateway" : "knative-serving/knative-ingress-gateway",
-
-           # knativeLocalGatewayService specifies the hostname of the Knative's local gateway service.
-           # The default KServe configurations are re-using the Istio local gateways for Knative. In this case, this
-           # knativeLocalGatewayService field can be left unset. When unset, the value of "localGatewayService" will be used.
-           # However, sometimes it may be better to have local gateways specifically for KServe (e.g. when enabling strict mTLS in Istio).
-           # Under such setups where KServe is needed to have its own local gateways, the values of the "localGateway" and
-           # "localGatewayService" should point to the KServe local gateways. Then, this knativeLocalGatewayService field
-           # should point to the Knative's local gateway service.
-           # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.
-           "knativeLocalGatewayService": "",
-
-           # localGateway specifies the gateway which handles the network traffic within the cluster.
-           # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.
-           "localGateway" : "knative-serving/knative-local-gateway",
-
-           # localGatewayService specifies the hostname of the local gateway service.
-           # NOTE: This configuration only applicable for serverless deployment with Istio configured as network layer.
-           "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",
-
-           # ingressDomain specifies the domain name which is used for creating the url.
-           # If ingressDomain is empty then example.com is used as default domain.
-           # NOTE: This configuration only applicable for raw deployment.
-           "ingressDomain"  : "example.com",
-
-           # additionalIngressDomains specifies the additional domain names which are used for creating the url.
-           "additionalIngressDomains": ["additional-example.com", "additional-example-1.com"]
-
-           # ingressClassName specifies the ingress controller to use for ingress traffic.
-           # This is optional and if omitted the default ingress in the cluster is used.
-           # https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class
-           # NOTE: This configuration only applicable for raw deployment.
-           "ingressClassName" : "istio",
-
-           # domainTemplate specifies the template for generating domain/url for each inference service by combining variable from:
-           # Name of the inference service  ( {{ .Name}} )
-           # Namespace of the inference service ( {{ .Namespace }} )
-           # Annotation of the inference service ( {{ .Annotations.key }} )
-           # Label of the inference service ( {{ .Labels.key }} )
-           # IngressDomain ( {{ .IngressDomain }} )
-           # If domain template is empty the default template {{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }} is used.
-           # NOTE: This configuration only applicable for raw deployment.
-           "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
-
-           # urlScheme specifies the url scheme to use for inference service and inference graph.
-           # If urlScheme is empty then by default http is used.
-           "urlScheme": "http",
-
-           # disableIstioVirtualHost controls whether to use istio as network layer.
-           # By default istio is used as the network layer. When DisableIstioVirtualHost is true, KServe does not
-           # create the top level virtual service thus Istio is no longer required for serverless mode.
-           # By setting this field to true, user can use other networking layers supported by knative.
-           # For more info https://github.com/kserve/kserve/pull/2380, https://kserve.github.io/website/master/admin/serverless/kourier_networking/.
-           # NOTE: This configuration is only applicable to serverless deployment.
-           "disableIstioVirtualHost": false,
-
-           # disableIngressCreation controls whether to disable ingress creation for raw deployment mode.
-           "disableIngressCreation": false,
-
-           # disableHTTPRouteTimeout controls whether to omit the timeout field from HTTPRoute rules.
-           # Set to true for Gateway controllers (e.g. GKE Gateway) that do not support the optional timeouts field.
-           "disableHTTPRouteTimeout": false,
-
-           # pathTemplate specifies the template for generating path based url for each inference service.
-           # The following variables can be used in the template for generating url.
-           # Name of the inference service  ( {{ .Name}} )
-           # Namespace of the inference service ( {{ .Namespace }} )
-           # For more info https://github.com/kserve/kserve/issues/2257.
-           # NOTE: This configuration only applicable to serverless deployment.
-           "pathTemplate": "/serving/{{ .Namespace }}/{{ .Name }}"
-       }
-
-     # ====================================== LOGGER CONFIGURATION ======================================
-     # Example
-     logger: |-
-       {
-           "image" : "kserve/agent:latest",
-           "memoryRequest": "100Mi",
-           "memoryLimit": "1Gi",
-           "cpuRequest": "100m",
-           "cpuLimit": "1",
-           "defaultUrl": "http://default-broker"
-       }
-     logger: |-
-       {
-           # image contains the default logger image uri.
-           "image" : "kserve/agent:latest",
-
-           # memoryRequest is the requests.memory to set for the logger container.
-           "memoryRequest": "100Mi",
-
-           # memoryLimit is the limits.memory to set for the logger container.
-           "memoryLimit": "1Gi",
-
-           # cpuRequest is the requests.cpu to set for the logger container.
-           "cpuRequest": "100m",
-
-           # cpuLimit is the limits.cpu to set for the logger container.
-           "cpuLimit": "1",
-
-           # defaultUrl specifies the default logger url. If logger is not specified in the resource this url is used.
-           "defaultUrl": "http://default-broker"
-       }
-
-     # ====================================== BATCHER CONFIGURATION ======================================
-     # Example
-     batcher: |-
-       {
-           "image" : "kserve/agent:latest",
-           "memoryRequest": "1Gi",
-           "memoryLimit": "1Gi",
-           "cpuRequest": "1",
-           "cpuLimit": "1",
-           "maxBatchSize": "32",
-           "maxLatency": "5000"
-       }
-     batcher: |-
-       {
-           # image contains the default batcher image uri.
-           "image" : "kserve/agent:latest",
-
-           # memoryRequest is the requests.memory to set for the batcher container.
-           "memoryRequest": "1Gi",
-
-           # memoryLimit is the limits.memory to set for the batcher container.
-           "memoryLimit": "1Gi",
-
-           # cpuRequest is the requests.cpu to set for the batcher container.
-           "cpuRequest": "1",
-
-           # cpuLimit is the limits.cpu to set for the batcher container.
-           "cpuLimit": "1"
-
-           # maxBatchSize is the default maximum batch size for batcher.
-           "maxBatchSize": "32",
-
-           # maxLatency is the default maximum latency in milliseconds for batcher to wait and collect the batch.
-           "maxLatency": "5000"
-       }
-
-     # ====================================== AGENT CONFIGURATION ======================================
-     # Example
-     agent: |-
-       {
-           "image" : "kserve/agent:latest",
-           "memoryRequest": "100Mi",
-           "memoryLimit": "1Gi",
-           "cpuRequest": "100m",
-           "cpuLimit": "1"
-       }
-     agent: |-
-       {
-           # image contains the default agent image uri.
-           "image" : "kserve/agent:latest",
-
-           # memoryRequest is the requests.memory to set for the agent container.
-           "memoryRequest": "100Mi",
-
-           # memoryLimit is the limits.memory to set for the agent container.
-           "memoryLimit": "1Gi",
-
-           # cpuRequest is the requests.cpu to set for the agent container.
-           "cpuRequest": "100m",
-
-           # cpuLimit is the limits.cpu to set for the agent container.
-           "cpuLimit": "1"
-       }
-
-     # ====================================== ROUTER CONFIGURATION ======================================
-     # Example
-     router: |-
-       {
-           "image" : "kserve/router:latest",
-           "memoryRequest": "100Mi",
-           "memoryLimit": "1Gi",
-           "cpuRequest": "100m",
-           "cpuLimit": "1",
-           "headers": {
-             "propagate": []
-           },
-           "imagePullPolicy": "IfNotPresent",
-           "imagePullSecrets": ["docker-secret"]
-       }
-     # router is the implementation of inference graph.
-     router: |-
-       {
-           # image contains the default router image uri.
-           "image" : "kserve/router:latest",
-
-           # memoryRequest is the requests.memory to set for the router container.
-           "memoryRequest": "100Mi",
-
-           # memoryLimit is the limits.memory to set for the router container.
-           "memoryLimit": "1Gi",
-
-           # cpuRequest is the requests.cpu to set for the router container.
-           "cpuRequest": "100m",
-
-           # cpuLimit is the limits.cpu to set for the router container.
-           "cpuLimit": "1",
-
-           # Propagate the specified headers to all the steps specified in an InferenceGraph.
-           # You can either specify the exact header names or use [Golang supported regex patterns]
-           # (https://pkg.go.dev/regexp/syntax@go1.21.3#hdr-Syntax) to propagate multiple headers.
-           "headers": {
-             "propagate": [
-                "Authorization",
-                "Test-Header-*",
-                "*Trace-Id*"
-             ]
-           }
-
-           # imagePullPolicy specifies when the router image should be pulled from registry.
-           "imagePullPolicy": "IfNotPresent",
-
-           # # imagePullSecrets specifies the list of secrets to be used for pulling the router image from registry.
-           # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-           "imagePullSecrets": ["docker-secret"]
-       }
-
-    # ====================================== DEPLOYMENT CONFIGURATION ======================================
-    # Example
-    deploy: |-
-      {
-        "defaultDeploymentMode": "Serverless",
-        "deploymentRolloutStrategy": {
-          "defaultRollout": {
-            "maxSurge": "1",
-            "maxUnavailable": "1"
-          }
-        }
-      }
-
-    deploy: |-
-      {
-        # defaultDeploymentMode specifies the default deployment mode of the kserve. The supported values are
-        # Standard and Knative. Users can override the deployment mode at service level
-        # by adding the annotation serving.kserve.io/deploymentMode.
-        # "defaultDeploymentMode": "Standard",
-        # deploymentRolloutStrategy specifies the default rollout strategy for the Standard deployment mode
-        # "deploymentRolloutStrategy": {
-          # defaultRollout specifies the default rollout configuration using Kubernetes deployment strategy
-          # "defaultRollout": {
-            # maxSurge specifies the maximum number of pods that can be created above the desired replica count
-            # Can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%)
-            # "maxSurge": "1",
-            # maxUnavailable specifies the maximum number of pods that can be unavailable during the update
-            # Can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%)
-            # "maxUnavailable": "1"
-          # }
-        # }
-      }
-
-     # ====================================== SERVICE CONFIGURATION ======================================
-     # Example
-     service: |-
-       {
-         "serviceClusterIPNone":  false
-       }
-     service: |-
-       {
-          # ServiceClusterIPNone is a boolean flag to indicate if the service should have a clusterIP set to None.
-          # If the DeploymentMode is Raw, the default value for ServiceClusterIPNone if not set is false
-          # "serviceClusterIPNone":  false
-       }
-
-     # ====================================== METRICS CONFIGURATION ======================================
-     # Example
-     metricsAggregator: |-
-       {
-         "enableMetricAggregation": "false",
-         "enablePrometheusScraping" : "false"
-       }
-     # For more info see https://github.com/kserve/kserve/blob/master/qpext/README.md
-     metricsAggregator: |-
-       {
-         # enableMetricAggregation configures metric aggregation annotation. This adds the annotation serving.kserve.io/enable-metric-aggregation to every
-         # service with the specified boolean value. If true enables metric aggregation in queue-proxy by setting env vars in the queue proxy container
-         # to configure scraping ports.
-         "enableMetricAggregation": "false",
-
-         # enablePrometheusScraping configures metric aggregation annotation. This adds the annotation serving.kserve.io/enable-metric-aggregation to every
-         # service with the specified boolean value. If true, prometheus annotations are added to the pod. If serving.kserve.io/enable-metric-aggregation is false,
-         # the prometheus port is set with the default prometheus scraping port 9090, otherwise the prometheus port annotation is set with the metric aggregation port.
-         "enablePrometheusScraping" : "false"
-       }
-
-     # ====================================== LOCALMODEL CONFIGURATION ======================================
-     # Example
-     localModel: |-
-       {
-         "enabled": false,
-         # jobNamespace specifies the namespace where the download job will be created.
-         "jobNamespace": "kserve-localmodel-jobs",
-         # defaultJobImage specifies the default image used for the download job.
-         "defaultJobImage" : "kserve/storage-initializer:latest",
-         # Kubernetes modifies the filesystem group ID on the attached volume.
-         "fsGroup": 1000,
-         # TTL for the download job after it is finished.
-         "jobTTLSecondsAfterFinished": 3600,
-         # The frequency at which the local model agent reconciles the local models
-         # This is to detect if models are missing from local disk
-         "reconcilationFrequencyInSecs": 60,
-         # This is to disable localmodel pv and pvc management for namespaces without isvcs
-         "disableVolumeManagement": false
-       }
+  _example: "################################\n#                              #\n#
+    \   EXAMPLE CONFIGURATION     #\n#                              #\n################################\n\n#
+    This block is not actually functional configuration,\n# but serves to illustrate
+    the available configuration\n# options and document them in a way that is accessible\n#
+    to users that `kubectl edit` this config map.\n#\n# These sample configuration
+    options may be copied out of\n# this example block and unindented to be in the
+    data block\n# to actually change the configuration.\n\n# ======================================
+    EXPLAINERS CONFIGURATION ======================================\n# Example\nexplainers:
+    |-\n  {\n      \"art\": {\n          \"image\" : \"kserve/art-explainer\",\n          \"defaultImageVersion\":
+    \"latest\"\n      }\n  }\n# Art Explainer runtime configuration\n explainers:
+    |-\n   {\n       # Art explainer runtime configuration\n       \"art\": {\n           #
+    image contains the default Art explainer serving runtime image uri.\n           \"image\"
+    : \"kserve/art-explainer\",\n   \n           # defautltImageVersion contains the
+    Art explainer serving runtime default image version.\n           \"defaultImageVersion\":
+    \"latest\"\n       }\n   }\n# ====================================== ISVC CONFIGURATION
+    ======================================\n# Example - setting custom annotation
+    \ \n inferenceService: |-\n   {\n     \"serviceAnnotationDisallowedList\": [\n
+    \       \"my.custom.annotation/1\"  \n     ],\n     \"serviceLabelDisallowedList\":
+    [\n        \"my.custom.label.1\"  \n     ]\n   }\n# Example - setting custom annotation\ninferenceService:
+    |-\n  {\n    # ServiceAnnotationDisallowedList is a list of annotations that are
+    not allowed to be propagated to Knative \n    # revisions, which prevents the
+    reconciliation loop to be triggered if the annotations is \n    # configured here
+    are used.\n    # Default values are:\n    #  \"autoscaling.knative.dev/min-scale\",\n
+    \   #  \"autoscaling.knative.dev/max-scale\",\n    #  \"internal.serving.kserve.io/storage-initializer-sourceuri\",\n
+    \   #  \"kubectl.kubernetes.io/last-applied-configuration\",\n    #  \"modelFormat\"\n
+    \   # Any new value will be appended to the list.\n    \"serviceAnnotationDisallowedList\":
+    [\n      \"my.custom.annotation/1\"  \n    ],\n    # ServiceLabelDisallowedList
+    is a list of labels that are not allowed to be propagated to Knative revisions\n
+    \   # which prevents the reconciliation loop to be triggered if the labels is
+    configured here are used.\n    \"serviceLabelDisallowedList\": [\n      \"my.custom.label.1\"
+    \ \n    ]\n  } \n# Example - setting custom resource\ninferenceService: |-\n  {\n
+    \   \"resource\": {\n      \"cpuLimit\": \"1\",\n      \"memoryLimit\": \"2Gi\",\n
+    \     \"cpuRequest\": \"1\",\n      \"memoryRequest\": \"2Gi\"\n    }\n  }\n#
+    Example - setting custom resource\ninferenceService: |-\n  {\n    # resource contains
+    the default resource configuration for the inference service.\n    # you can override
+    this configuration by specifying the resources in the inference service yaml.\n
+    \   # If you want to unbound the resource (limits and requests), you can set the
+    value to null or \"\" \n    # or just remove the specific field from the config.\n
+    \   \"resource\": {\n       # cpuLimit is the limits.cpu to set for the inference
+    service.\n       \"cpuLimit\": \"1\",\n\n       # memoryLimit is the limits.memory
+    to set for the inference service.\n       \"memoryLimit\": \"2Gi\",\n\n       #
+    cpuRequest is the requests.cpu to set for the inference service.\n       \"cpuRequest\":
+    \"1\",\n\n       # memoryRequest is the requests.memory to set for the inference
+    service.\n       \"memoryRequest\": \"2Gi\"\n    }\n }\n# ======================================
+    MultiNode CONFIGURATION ======================================\n# Example   \nmultiNode:
+    |-\n  {\n    \"customGPUResourceTypeList\": [\n      \"custom.com/gpu\"\n    ]\n
+    \ }\n# Example of multinode configuration\nmultiNode: |-\n  {      \n    # CustomGPUResourceTypeList
+    is a list of custom GPU resource types intended to identify the GPU type of a
+    resource,\n    # not to restrict the user from using a specific GPU type.\n    #
+    The MultiNode runtime pod will dynamically add GPU resources based on the registered
+    GPU types.\n    \"customGPUResourceTypeList\": [\n      \"custom.com/gpu\"\n    ]\n
+    \ }  \n # ====================================== OTelCollector CONFIGURATION ======================================\n
+    # Example\n opentelemetryCollector: |-\n   {\n     # scrapeInterval is the interval
+    at which the OpenTelemetry Collector will scrape the metrics.\n     \"scrapeInterval\":
+    \"5s\",\n     # metricScalerEndpoint is the endpoint from which the KEDA's ScaledObject
+    will scrape the metrics.\n     \"metricScalerEndpoint\": \"keda-otel-scaler.keda.svc:4318\",\n
+    \    # metricReceiverEndpoint is the endpoint from which the OpenTelemetry Collector
+    will scrape the metrics.\n      \"metricReceiverEndpoint\": \"keda-otel-scaler.keda.svc:4317\"\n
+    \  }\n\n # ====================================== AUTOSCALER CONFIGURATION ======================================\n
+    # Example\n autoscaler: |-\n   {\n     # scaleUpStabilizationWindowSeconds is
+    the stabilization window in seconds for scale up.\n     \"scaleUpStabilizationWindowSeconds\":
+    \"0\",\n     # scaleDownStabilizationWindowSeconds is the stabilization window
+    in seconds for scale down.\n     \"scaleDownStabilizationWindowSeconds\": \"300\"\n
+    \  }\n  \n # ====================================== STORAGE INITIALIZER CONFIGURATION
+    ======================================\n # Example\n storageInitializer: |-\n
+    \  {\n       \"image\" : \"kserve/storage-initializer:latest\",\n       \"memoryRequest\":
+    \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"100m\",\n
+    \      \"cpuLimit\": \"1\",\n       \"caBundleConfigMapName\": \"\",\n       \"caBundleVolumeMountPath\":
+    \"/etc/ssl/custom-certs\",\n       \"enableModelcar\": false,\n       \"cpuModelcar\":
+    \"10m\",\n       \"memoryModelcar\": \"15Mi\"\n   }\n storageInitializer: |-\n
+    \  {\n       # image contains the default storage initializer image uri.\n       \"image\"
+    : \"kserve/storage-initializer:latest\",\n       \n       # memoryRequest is the
+    requests.memory to set for the storage initializer init container.\n       \"memoryRequest\":
+    \"100Mi\",\n   \n        # memoryLimit is the limits.memory to set for the storage
+    initializer init container.\n       \"memoryLimit\": \"1Gi\",\n       \n       #
+    cpuRequest is the requests.cpu to set for the storage initializer init container.\n
+    \      \"cpuRequest\": \"100m\",\n       \n       # cpuLimit is the limits.cpu
+    to set for the storage initializer init container.\n       \"cpuLimit\": \"1\",\n
+    \  \n       # caBundleConfigMapName is the ConfigMap will be copied to a user
+    namespace for the storage initializer init container.\n       \"caBundleConfigMapName\":
+    \"\",\n\n       # caBundleVolumeMountPath is the mount point for the configmap
+    set by caBundleConfigMapName for the storage initializer init container.\n       \"caBundleVolumeMountPath\":
+    \"/etc/ssl/custom-certs\",\n\n       # enableModelcar enabled allows you to directly
+    access an OCI container image by\n       # using a source URL with an \"oci://\"
+    schema.\n       \"enableModelcar\": false,\n\n       # cpuModelcar is the cpu
+    request and limit that is used for the passive modelcar container. It can be\n
+    \      # set very low, but should be allowed by any Kubernetes LimitRange that
+    might apply.\n       \"cpuModelcar\": \"10m\",\n\n       # cpuModelcar is the
+    memory request and limit that is used for the passive modelcar container. It can
+    be\n       # set very low, but should be allowed by any Kubernetes LimitRange
+    that might apply.\n       \"memoryModelcar\": \"15Mi\",\n\n       # uidModelcar
+    is the UID under with which the modelcar process and the main container is running.\n
+    \      # Some Kubernetes clusters might require this to be root (0). If not set
+    the user id is left untouched (default)\n       \"uidModelcar\": 10\n   }\n \n
+    # ====================================== CREDENTIALS ======================================\n
+    # Example\n credentials: |-\n   {\n      \"storageSpecSecretName\": \"storage-config\",\n
+    \     \"storageSecretNameAnnotation\": \"serving.kserve.io/storageSecretName\",\n
+    \     \"gcs\": {\n          \"gcsCredentialFileName\": \"gcloud-application-credentials.json\"\n
+    \     },\n      \"s3\": {\n          \"s3AccessKeyIDName\": \"AWS_ACCESS_KEY_ID\",\n
+    \         \"s3SecretAccessKeyName\": \"AWS_SECRET_ACCESS_KEY\",\n          \"s3Endpoint\":
+    \"\",\n          \"s3UseHttps\": \"\",\n          \"s3Region\": \"\",\n          \"s3VerifySSL\":
+    \"\",\n          \"s3UseVirtualBucket\": \"\",\n          \"s3UseAccelerate\":
+    \"\",\n          \"s3UseAnonymousCredential\": \"\",\n          \"s3CABundleConfigMap\":
+    \"\",\n          \"s3CABundle\": \"\"\n      }\n   }\n # This is a global configuration
+    used for downloading models from the cloud storage.\n # You can override this
+    configuration by specifying the annotations on service account or static secret.\n
+    # https://kserve.github.io/website/master/modelserving/storage/s3/s3/\n # For
+    a quick reference about AWS ENV variables:\n # AWS Cli: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html\n
+    # Boto: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables\n
+    #\n # The `s3AccessKeyIDName` and `s3SecretAccessKeyName` fields are only used
+    from this configmap when static credentials (IAM User Access Key Secret)\n # are
+    used as the authentication method for AWS S3.\n # The rest of the fields are used
+    in both authentication methods (IAM Role for Service Account & IAM User Access
+    Key Secret) if a non-empty value is provided.\n credentials: |-\n   {\n      #
+    storageSpecSecretName contains the secret name which has the credentials for downloading
+    the model.\n      # This option is used when specifying the storage spec on isvc
+    yaml.\n      \"storageSpecSecretName\": \"storage-config\",\n\n      # The annotation
+    can be specified on isvc yaml to allow overriding with the secret name reference
+    from the annotation value.\n      # When using storageUri the order of the precedence
+    is: secret name reference annotation > secret name references from service account\n
+    \     # When using storageSpec the order of the precedence is: secret name reference
+    annotation > storageSpecSecretName in configmap\n\n      # Configuration for google
+    cloud storage\n      \"gcs\": {\n          # gcsCredentialFileName specifies the
+    filename of the gcs credential\n          \"gcsCredentialFileName\": \"gcloud-application-credentials.json\"\n
+    \     },\n      \n      # Configuration for aws s3 storage. This add the corresponding
+    environmental variables to the storage initializer init container.\n      # For
+    more info on s3 storage see https://kserve.github.io/website/master/modelserving/storage/s3/s3/\n
+    \     \"s3\": {\n          # s3AccessKeyIDName specifies the s3 access key id
+    name\n          \"s3AccessKeyIDName\": \"AWS_ACCESS_KEY_ID\",\n   \n          #
+    s3SecretAccessKeyName specifies the s3 secret access key name\n          \"s3SecretAccessKeyName\":
+    \"AWS_SECRET_ACCESS_KEY\",\n          \n          # s3Endpoint specifies the s3
+    endpoint\n          \"s3Endpoint\": \"\",\n          \n          # s3UseHttps
+    controls whether to use secure https or unsecure http to download models.\n          #
+    Allowed values are 0 and 1.\n          \"s3UseHttps\": \"\",\n   \n          #
+    s3Region specifies the region of the bucket.\n          \"s3Region\": \"\",\n
+    \         \n          # s3VerifySSL controls whether to verify the tls/ssl certificate.\n
+    \         \"s3VerifySSL\": \"\",\n          \n          # s3UseVirtualBucket configures
+    whether it is a virtual bucket or not.\n          \"s3UseVirtualBucket\": \"\",\n\n
+    \         # s3UseAccelerate configures whether to use transfer acceleration.\n
+    \         \"s3UseAccelerate\": \"\",\n           \n          # s3UseAnonymousCredential
+    configures whether to use anonymous credentials to download the model or not.\n
+    \         \"s3UseAnonymousCredential\": \"\",\n\n          # s3CABundleConfigMap
+    specifies the mounted CA bundle config map name.\n          \"s3CABundleConfigMap\":
+    \"\",\n\n          # s3CABundle specifies the full path (mount path + file name)
+    for the mounted config map data when used with a configured CA bundle config map.\n
+    \         # s3CABundle specifies the path to a certificate bundle to use for HTTPS
+    certificate validation when used absent of a configured CA bundle config map.\n
+    \         \"s3CABundle\": \"\"\n      }\n   }\n \n # ======================================
+    INGRESS CONFIGURATION ======================================\n # Example\n ingress:
+    |-\n   {    \n       \"enableGatewayApi\": false,\n       \"kserveIngressGateway\":
+    \"kserve/kserve-ingress-gateway\",\n       \"ingressGateway\" : \"knative-serving/knative-ingress-gateway\",\n
+    \      \"localGateway\" : \"knative-serving/knative-local-gateway\",\n       \"localGatewayService\"
+    : \"knative-local-gateway.istio-system.svc.cluster.local\",\n       \"ingressDomain\"
+    \ : \"example.com\",\n       \"additionalIngressDomains\": [\"additional-example.com\",
+    \"additional-example-1.com\"],\n       \"ingressClassName\" : \"istio\",\n       \"domainTemplate\":
+    \"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}\",\n       \"urlScheme\":
+    \"http\",\n       \"disableIstioVirtualHost\": false,\n       \"disableIngressCreation\":
+    false\n   }\n ingress: |-\n   {   \n       # enableGatewayApi specifies whether
+    to use Gateway API instead of Ingress to serve external traffic.\n       \"enableGatewayApi\":
+    false,\n\n       # KServe implements [Gateway API](https://gateway-api.sigs.k8s.io/)
+    to serve external traffic. \n       # By default, KServe configures a default
+    gateway to serve external traffic.\n       # But, KServe can be configured to
+    use a custom gateway by modifying this configuration.\n       # The gateway should
+    be specified in format <gateway namespace>/<gateway name>\n       # NOTE: This
+    configuration only applicable for raw deployment.\n       \"kserveIngressGateway\":
+    \"kserve/kserve-ingress-gateway\",\n \n       # ingressGateway specifies the ingress
+    gateway to serve external traffic.\n       # The gateway should be specified in
+    format <gateway namespace>/<gateway name>\n       # NOTE: This configuration only
+    applicable for serverless deployment with Istio configured as network layer.\n
+    \      \"ingressGateway\" : \"knative-serving/knative-ingress-gateway\",\n \n
+    \      # knativeLocalGatewayService specifies the hostname of the Knative's local
+    gateway service.\n       # The default KServe configurations are re-using the
+    Istio local gateways for Knative. In this case, this\n       # knativeLocalGatewayService
+    field can be left unset. When unset, the value of \"localGatewayService\" will
+    be used.\n       # However, sometimes it may be better to have local gateways
+    specifically for KServe (e.g. when enabling strict mTLS in Istio).\n       # Under
+    such setups where KServe is needed to have its own local gateways, the values
+    of the \"localGateway\" and\n       # \"localGatewayService\" should point to
+    the KServe local gateways. Then, this knativeLocalGatewayService field\n       #
+    should point to the Knative's local gateway service.\n       # NOTE: This configuration
+    only applicable for serverless deployment with Istio configured as network layer.\n
+    \      \"knativeLocalGatewayService\": \"\",\n \n       # localGateway specifies
+    the gateway which handles the network traffic within the cluster.\n       # NOTE:
+    This configuration only applicable for serverless deployment with Istio configured
+    as network layer.\n       \"localGateway\" : \"knative-serving/knative-local-gateway\",\n
+    \n       # localGatewayService specifies the hostname of the local gateway service.\n
+    \      # NOTE: This configuration only applicable for serverless deployment with
+    Istio configured as network layer.\n       \"localGatewayService\" : \"knative-local-gateway.istio-system.svc.cluster.local\",\n
+    \n       # ingressDomain specifies the domain name which is used for creating
+    the url.\n       # If ingressDomain is empty then example.com is used as default
+    domain.\n       # NOTE: This configuration only applicable for raw deployment.\n
+    \      \"ingressDomain\"  : \"example.com\",\n\n       # additionalIngressDomains
+    specifies the additional domain names which are used for creating the url.\n       \"additionalIngressDomains\":
+    [\"additional-example.com\", \"additional-example-1.com\"]\n\n       # ingressClassName
+    specifies the ingress controller to use for ingress traffic.\n       # This is
+    optional and if omitted the default ingress in the cluster is used.\n       #
+    https://kubernetes.io/docs/concepts/services-networking/ingress/#default-ingress-class\n
+    \      # NOTE: This configuration only applicable for raw deployment.\n       \"ingressClassName\"
+    : \"istio\",\n \n       # domainTemplate specifies the template for generating
+    domain/url for each inference service by combining variable from:\n       # Name
+    of the inference service  ( {{ .Name}} )\n       # Namespace of the inference
+    service ( {{ .Namespace }} )\n       # Annotation of the inference service ( {{
+    .Annotations.key }} )\n       # Label of the inference service ( {{ .Labels.key
+    }} )\n       # IngressDomain ( {{ .IngressDomain }} )\n       # If domain template
+    is empty the default template {{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}
+    is used.\n       # NOTE: This configuration only applicable for raw deployment.\n
+    \      \"domainTemplate\": \"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}\",\n
+    \n       # urlScheme specifies the url scheme to use for inference service and
+    inference graph.\n       # If urlScheme is empty then by default http is used.\n
+    \      \"urlScheme\": \"http\",\n \n       # disableIstioVirtualHost controls
+    whether to use istio as network layer.\n       # By default istio is used as the
+    network layer. When DisableIstioVirtualHost is true, KServe does not\n       #
+    create the top level virtual service thus Istio is no longer required for serverless
+    mode.\n       # By setting this field to true, user can use other networking layers
+    supported by knative.\n       # For more info https://github.com/kserve/kserve/pull/2380,
+    https://kserve.github.io/website/master/admin/serverless/kourier_networking/.\n
+    \      # NOTE: This configuration is only applicable to serverless deployment.\n
+    \      \"disableIstioVirtualHost\": false,\n\n       # disableIngressCreation
+    controls whether to disable ingress creation for raw deployment mode.\n       \"disableIngressCreation\":
+    false,\n \n       # pathTemplate specifies the template for generating path based
+    url for each inference service.\n       # The following variables can be used
+    in the template for generating url.\n       # Name of the inference service  (
+    {{ .Name}} )\n       # Namespace of the inference service ( {{ .Namespace }} )\n
+    \      # For more info https://github.com/kserve/kserve/issues/2257.\n       #
+    NOTE: This configuration only applicable to serverless deployment.\n       \"pathTemplate\":
+    \"/serving/{{ .Namespace }}/{{ .Name }}\"\n   }\n \n # ======================================
+    LOGGER CONFIGURATION ======================================\n # Example\n logger:
+    |-\n   {\n       \"image\" : \"kserve/agent:latest\",\n       \"memoryRequest\":
+    \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"100m\",\n
+    \      \"cpuLimit\": \"1\",\n       \"defaultUrl\": \"http://default-broker\"\n
+    \  }\n logger: |-\n   {\n       # image contains the default logger image uri.\n
+    \      \"image\" : \"kserve/agent:latest\",\n   \n       # memoryRequest is the
+    requests.memory to set for the logger container.\n       \"memoryRequest\": \"100Mi\",\n
+    \      \n       # memoryLimit is the limits.memory to set for the logger container.\n
+    \      \"memoryLimit\": \"1Gi\",\n       \n       # cpuRequest is the requests.cpu
+    to set for the logger container.\n       \"cpuRequest\": \"100m\",\n       \n
+    \      # cpuLimit is the limits.cpu to set for the logger container.\n       \"cpuLimit\":
+    \"1\",\n       \n       # defaultUrl specifies the default logger url. If logger
+    is not specified in the resource this url is used.\n       \"defaultUrl\": \"http://default-broker\"\n
+    \  }\n \n # ====================================== BATCHER CONFIGURATION ======================================\n
+    # Example\n batcher: |-\n   {\n       \"image\" : \"kserve/agent:latest\",\n       \"memoryRequest\":
+    \"1Gi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"1\",\n       \"cpuLimit\":
+    \"1\",\n       \"maxBatchSize\": \"32\",\n       \"maxLatency\": \"5000\"\n   }\n
+    batcher: |-\n   {\n       # image contains the default batcher image uri.\n       \"image\"
+    : \"kserve/agent:latest\",\n       \n       # memoryRequest is the requests.memory
+    to set for the batcher container.\n       \"memoryRequest\": \"1Gi\",\n   \n       #
+    memoryLimit is the limits.memory to set for the batcher container.\n       \"memoryLimit\":
+    \"1Gi\",\n       \n       # cpuRequest is the requests.cpu to set for the batcher
+    container.\n       \"cpuRequest\": \"1\",\n       \n       # cpuLimit is the limits.cpu
+    to set for the batcher container.\n       \"cpuLimit\": \"1\"\n\n       # maxBatchSize
+    is the default maximum batch size for batcher.\n       \"maxBatchSize\": \"32\",\n\n
+    \      # maxLatency is the default maximum latency in milliseconds for batcher
+    to wait and collect the batch.\n       \"maxLatency\": \"5000\"\n   }\n \n # ======================================
+    AGENT CONFIGURATION ======================================\n # Example\n agent:
+    |-\n   {\n       \"image\" : \"kserve/agent:latest\",\n       \"memoryRequest\":
+    \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"100m\",\n
+    \      \"cpuLimit\": \"1\"\n   }\n agent: |-\n   {\n       # image contains the
+    default agent image uri.\n       \"image\" : \"kserve/agent:latest\",\n   \n       #
+    memoryRequest is the requests.memory to set for the agent container.\n       \"memoryRequest\":
+    \"100Mi\",\n   \n       # memoryLimit is the limits.memory to set for the agent
+    container.\n       \"memoryLimit\": \"1Gi\",\n       \n       # cpuRequest is
+    the requests.cpu to set for the agent container.\n       \"cpuRequest\": \"100m\",\n
+    \      \n       # cpuLimit is the limits.cpu to set for the agent container.\n
+    \      \"cpuLimit\": \"1\"\n   }\n \n # ======================================
+    ROUTER CONFIGURATION ======================================\n # Example\n router:
+    |-\n   {\n       \"image\" : \"kserve/router:latest\",\n       \"memoryRequest\":
+    \"100Mi\",\n       \"memoryLimit\": \"1Gi\",\n       \"cpuRequest\": \"100m\",\n
+    \      \"cpuLimit\": \"1\",\n       \"headers\": {\n         \"propagate\": []\n
+    \      },\n       \"imagePullPolicy\": \"IfNotPresent\",\n       \"imagePullSecrets\":
+    [\"docker-secret\"]\n   }\n # router is the implementation of inference graph.\n
+    router: |-\n   {\n       # image contains the default router image uri.\n       \"image\"
+    : \"kserve/router:latest\",\n       \n       # memoryRequest is the requests.memory
+    to set for the router container.\n       \"memoryRequest\": \"100Mi\",\n       \n
+    \      # memoryLimit is the limits.memory to set for the router container.\n       \"memoryLimit\":
+    \"1Gi\",\n       \n       # cpuRequest is the requests.cpu to set for the router
+    container.\n       \"cpuRequest\": \"100m\",\n       \n       # cpuLimit is the
+    limits.cpu to set for the router container.\n       \"cpuLimit\": \"1\",\n       \n
+    \      # Propagate the specified headers to all the steps specified in an InferenceGraph.
+    \n       # You can either specify the exact header names or use [Golang supported
+    regex patterns]\n       # (https://pkg.go.dev/regexp/syntax@go1.21.3#hdr-Syntax)
+    to propagate multiple headers.\n       \"headers\": {\n         \"propagate\":
+    [\n            \"Authorization\",\n            \"Test-Header-*\",\n            \"*Trace-Id*\"\n
+    \        ]\n       }\n\n       # imagePullPolicy specifies when the router image
+    should be pulled from registry.\n       \"imagePullPolicy\": \"IfNotPresent\",\n
+    \      \n       # # imagePullSecrets specifies the list of secrets to be used
+    for pulling the router image from registry.\n       # https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/\n
+    \      \"imagePullSecrets\": [\"docker-secret\"]\n   }\n \n# ======================================
+    DEPLOYMENT CONFIGURATION ======================================\n# Example\ndeploy:
+    |-\n  {\n    \"defaultDeploymentMode\": \"Serverless\",\n    \"deploymentRolloutStrategy\":
+    {\n      \"defaultRollout\": {\n        \"maxSurge\": \"1\",\n        \"maxUnavailable\":
+    \"1\"\n      }\n    }\n  }\n\ndeploy: |-\n  {\n    # defaultDeploymentMode specifies
+    the default deployment mode of the kserve. The supported values are\n    # Standard
+    and Knative. Users can override the deployment mode at service level\n    # by
+    adding the annotation serving.kserve.io/deploymentMode.\n    # \"defaultDeploymentMode\":
+    \"Standard\",\n    # deploymentRolloutStrategy specifies the default rollout strategy
+    for the Standard deployment mode\n    # \"deploymentRolloutStrategy\": {\n      #
+    defaultRollout specifies the default rollout configuration using Kubernetes deployment
+    strategy\n      # \"defaultRollout\": {\n        # maxSurge specifies the maximum
+    number of pods that can be created above the desired replica count\n        #
+    Can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%)\n
+    \       # \"maxSurge\": \"1\",\n        # maxUnavailable specifies the maximum
+    number of pods that can be unavailable during the update\n        # Can be an
+    absolute number (ex: 5) or a percentage of desired pods (ex: 10%)\n        # \"maxUnavailable\":
+    \"1\"\n      # }\n    # }\n  }\n\n # ====================================== SERVICE
+    CONFIGURATION ======================================\n # Example\n service: |-\n
+    \  {\n     \"serviceClusterIPNone\":  false\n   }\n service: |-\n   {\n      #
+    ServiceClusterIPNone is a boolean flag to indicate if the service should have
+    a clusterIP set to None.\n      # If the DeploymentMode is Raw, the default value
+    for ServiceClusterIPNone if not set is false\n      # \"serviceClusterIPNone\":
+    \ false\n   }\n\n # ====================================== METRICS CONFIGURATION
+    ======================================\n # Example\n metricsAggregator: |-\n   {\n
+    \    \"enableMetricAggregation\": \"false\",\n     \"enablePrometheusScraping\"
+    : \"false\"\n   }\n # For more info see https://github.com/kserve/kserve/blob/master/qpext/README.md\n
+    metricsAggregator: |-\n   {\n     # enableMetricAggregation configures metric
+    aggregation annotation. This adds the annotation serving.kserve.io/enable-metric-aggregation
+    to every\n     # service with the specified boolean value. If true enables metric
+    aggregation in queue-proxy by setting env vars in the queue proxy container\n
+    \    # to configure scraping ports.\n     \"enableMetricAggregation\": \"false\",\n
+    \    \n     # enablePrometheusScraping configures metric aggregation annotation.
+    This adds the annotation serving.kserve.io/enable-metric-aggregation to every\n
+    \    # service with the specified boolean value. If true, prometheus annotations
+    are added to the pod. If serving.kserve.io/enable-metric-aggregation is false,\n
+    \    # the prometheus port is set with the default prometheus scraping port 9090,
+    otherwise the prometheus port annotation is set with the metric aggregation port.\n
+    \    \"enablePrometheusScraping\" : \"false\"\n   }\n  \n # ======================================
+    LOCALMODEL CONFIGURATION ======================================\n # Example\n
+    localModel: |-\n   {\n     \"enabled\": false,\n     # jobNamespace specifies
+    the namespace where the download job will be created.\n     \"jobNamespace\":
+    \"kserve-localmodel-jobs\",\n     # defaultJobImage specifies the default image
+    used for the download job.\n     \"defaultJobImage\" : \"kserve/storage-initializer:latest\",\n
+    \    # Kubernetes modifies the filesystem group ID on the attached volume.\n     \"fsGroup\":
+    1000,\n     # TTL for the download job after it is finished.\n     \"jobTTLSecondsAfterFinished\":
+    3600,\n     # The frequency at which the local model agent reconciles the local
+    models\n     # This is to detect if models are missing from local disk\n     \"reconcilationFrequencyInSecs\":
+    60,\n     # This is to disable localmodel pv and pvc management for namespaces
+    without isvcs\n     \"disableVolumeManagement\": false\n   }"
   agent: |-
     {
         "image" : "kserve/agent:latest",
@@ -38401,21 +38009,13 @@ data:
           "memoryRequest": "2Gi"
         }
     }
-  ingress: |-
-    {
-        "enableGatewayApi": false,
-        "kserveIngressGateway": "kserve/kserve-ingress-gateway",
-        "ingressGateway" : "knative-serving/knative-ingress-gateway",
-        "localGateway" : "knative-serving/knative-local-gateway",
-        "localGatewayService" : "knative-local-gateway.istio-system.svc.cluster.local",
-        "ingressDomain"  : "example.com",
-        "ingressClassName" : "istio",
-        "domainTemplate": "{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}",
-        "urlScheme": "http",
-        "disableIstioVirtualHost": false,
-        "disableIngressCreation": false,
-        "disableHTTPRouteTimeout": false
-    }
+  ingress: "{   \n    \"enableGatewayApi\": false,\n    \"kserveIngressGateway\":
+    \"kserve/kserve-ingress-gateway\",\n    \"ingressGateway\" : \"knative-serving/knative-ingress-gateway\",\n
+    \   \"localGateway\" : \"knative-serving/knative-local-gateway\",\n    \"localGatewayService\"
+    : \"knative-local-gateway.istio-system.svc.cluster.local\",\n    \"ingressDomain\"
+    \ : \"example.com\",\n    \"ingressClassName\" : \"istio\",\n    \"domainTemplate\":
+    \"{{ .Name }}-{{ .Namespace }}.{{ .IngressDomain }}\",\n    \"urlScheme\": \"http\",\n
+    \   \"disableIstioVirtualHost\": false,\n    \"disableIngressCreation\": false\n}"
   localModel: |-
     {
       "enabled": false,
@@ -38710,7 +38310,6 @@ spec:
   - regex: https://(.+?).blob.core.windows.net/(.+)
   - regex: https://(.+?).file.core.windows.net/(.+)
   - regex: https?://(.+)/(.+)
-  supportsMultiModelDownload: true
   workloadType: initContainer
 ---
 apiVersion: admissionregistration.k8s.io/v1

--- a/pkg/controller/v1alpha2/llmisvc/router_platform_networking_ocp.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_platform_networking_ocp.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -108,6 +109,26 @@ func (r *LLMISVCReconciler) reconcileRouterPlatformNetworking(ctx context.Contex
 	return r.reconcileIstioDestinationRules(ctx, llmSvc, isIstio)
 }
 
+// schedulerCertReloadEnabled reports whether the scheduler's main container has
+// the --enable-cert-reload flag set, meaning it can watch and reload TLS
+// certificates automatically without a pod restart.
+func schedulerCertReloadEnabled(llmSvc *v1alpha2.LLMInferenceService) bool {
+	if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Scheduler == nil || llmSvc.Spec.Router.Scheduler.Template == nil {
+		return false
+	}
+	hasCertReload := func(args []string) bool {
+		return slices.ContainsFunc(args, func(s string) bool {
+			return strings.HasPrefix(s, "--enable-cert-reload") || strings.HasPrefix(s, "-enable-cert-reload")
+		})
+	}
+	for _, c := range llmSvc.Spec.Router.Scheduler.Template.Containers {
+		if c.Name == "main" {
+			return hasCertReload(c.Command) || hasCertReload(c.Args)
+		}
+	}
+	return false
+}
+
 func (r *LLMISVCReconciler) reconcileIstioDestinationRules(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, isIstio bool) error {
 	shouldDelete := !isIstio || utils.GetForceStopRuntime(llmSvc)
 	if err := r.reconcileIstioDestinationRuleForScheduler(ctx, llmSvc, shouldDelete); err != nil {
@@ -176,11 +197,9 @@ func (r *LLMISVCReconciler) expectedIstioDestinationRuleForScheduler(ctx context
 		Spec: istionetworking.DestinationRule{
 			TrafficPolicy: &istionetworking.TrafficPolicy{
 				Tls: &istionetworking.ClientTLSSettings{
-					Mode: istionetworking.ClientTLSSettings_SIMPLE,
-					// The scheduler doesn't support watching and auto-reloading certificates yet.
-					// Fixed by https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/1765.
-					// Until that fix is available, skip verification to avoid SAN mismatch errors on upgrade.
-					InsecureSkipVerify: &wrapperspb.BoolValue{Value: true},
+					Mode:               istionetworking.ClientTLSSettings_SIMPLE,
+					CaCertificates:     IstioCACertificatePath,
+					InsecureSkipVerify: &wrapperspb.BoolValue{Value: false},
 				},
 			},
 			ExportTo: []string{"*"},
@@ -201,6 +220,14 @@ func (r *LLMISVCReconciler) expectedIstioDestinationRuleForScheduler(ctx context
 		hostname := network.GetServiceHostname(name, llmSvc.GetNamespace())
 		dr.Spec.Host = hostname
 		dr.Spec.TrafficPolicy.Tls.Sni = hostname
+	}
+
+	// Only enforce CA-based TLS verification when the scheduler supports automatic
+	// certificate reload. Without it, a renewed leaf certificate may not match
+	// verification before the pod restarts, causing connection failures.
+	if !schedulerCertReloadEnabled(llmSvc) {
+		dr.Spec.TrafficPolicy.Tls.CaCertificates = ""
+		dr.Spec.TrafficPolicy.Tls.InsecureSkipVerify = &wrapperspb.BoolValue{Value: true}
 	}
 
 	log.FromContext(ctx).V(2).Info("Expected destination rule for scheduler", "destinationrule", dr)
@@ -231,11 +258,9 @@ func (r *LLMISVCReconciler) expectedIstioDestinationRuleForShadowService(ctx con
 		Spec: istionetworking.DestinationRule{
 			TrafficPolicy: &istionetworking.TrafficPolicy{
 				Tls: &istionetworking.ClientTLSSettings{
-					Mode: istionetworking.ClientTLSSettings_SIMPLE,
-					// The shadow service forwards traffic to the workload service. Skip verification
-					// here for the same reason as the scheduler DR — the scheduler doesn't yet support
-					// watching and auto-reloading certificates.
-					InsecureSkipVerify: &wrapperspb.BoolValue{Value: true},
+					Mode:               istionetworking.ClientTLSSettings_SIMPLE,
+					CaCertificates:     IstioCACertificatePath,
+					InsecureSkipVerify: &wrapperspb.BoolValue{Value: false},
 				},
 			},
 			ExportTo: []string{"*"},
@@ -245,6 +270,13 @@ func (r *LLMISVCReconciler) expectedIstioDestinationRuleForShadowService(ctx con
 		hostname := network.GetServiceHostname(shadowSvc.GetName(), shadowSvc.GetNamespace())
 		dr.Spec.Host = hostname
 		dr.Spec.TrafficPolicy.Tls.Sni = network.GetServiceHostname(kmeta.ChildName(llmSvc.GetName(), "-kserve-workload-svc"), llmSvc.GetNamespace())
+	}
+
+	// The shadow service forwards traffic to the scheduler. Apply the same
+	// cert-reload guard as the scheduler DR.
+	if !schedulerCertReloadEnabled(llmSvc) {
+		dr.Spec.TrafficPolicy.Tls.CaCertificates = ""
+		dr.Spec.TrafficPolicy.Tls.InsecureSkipVerify = &wrapperspb.BoolValue{Value: true}
 	}
 
 	log.FromContext(ctx).V(2).Info("Expected destination rule for workload shadow service", "destinationrule", dr)
@@ -282,8 +314,9 @@ func (r *LLMISVCReconciler) expectedIstioDestinationRuleForWorkload(ctx context.
 		},
 	}
 
+	// The prefill sidecar reloads certificates implicitly without a flag.
+	// Keep InsecureSkipVerify for backward compatibility.
 	if llmSvc.Spec.Prefill != nil {
-		// The sidecar doesn't support watching and auto-reloading certificates yet.
 		dr.Spec.TrafficPolicy.Tls.CaCertificates = ""
 		dr.Spec.TrafficPolicy.Tls.InsecureSkipVerify = &wrapperspb.BoolValue{Value: true}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

All three Istio `DestinationRules` (scheduler, shadow service, workload) were using `InsecureSkipVerify: true`, bypassing TLS certificate validation entirely. This was originally a workaround for the scheduler not supporting certificate reload - when certs rotated, the scheduler held stale certs that would fail CA verification.

On OCP, all `LLMInferenceService` TLS certificates are signed by the OpenShift service-ca operator, and the CA certificate is already available in the gateway envoy pod at the standard service account path. `DestinationRules` now validate leaf certificates against this CA chain - a renewed cert signed by the same CA is accepted transparently.

TLS verification is guarded by whether the scheduler's main container has `--enable-cert-reload`: without it, `InsecureSkipVerify` is kept for backward compatibility. The prefill sidecar also retains `InsecureSkipVerify` - it handles cert reload implicitly without a flag.

The default scheduler config template is synced with upstream to include `--enable-cert-reload=true`, so new deployments get automatic certificate pickup out of the box.

**Feature/Issue validation/testing**:

- [x] Unit tests pass (distro and non-distro builds)
- [x] E2e coverage: `e2e-llm-inference-service` jobs run on OCP with TLS and Istio-backed gateway (`openshift-default` GatewayClass), implicitly validating DestinationRule TLS verification end-to-end

**Special notes for your reviewer**:

The "self-signed certs" naming in the codebase is misleading for the OCP build. On OCP, certificates are CA-signed by the service-ca operator - this is what makes DR-level CA verification work. On upstream (non-distro), certs are truly self-signed but DestinationRules don't exist there, so there's no conflict.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

## Release Notes
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds certificate reload support for the scheduler when TLS is enabled.

* **Bug Fixes**
  * Strengthens TLS verification by default for scheduler and routing services with a conditional fallback when reload isn't available.
  * Tokenizer health checks now use /health and tokenizer writable storage has been simplified.

* **Chores**
  * Adjusted container image versions and updated installer manifests/scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->