### PR TITLE
fix(llmisvc): autoscaling config logging

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/scaling.go
+++ b/pkg/controller/v1alpha2/llmisvc/scaling.go
@@ -18,7 +18,6 @@ package llmisvc
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strconv"
 
@@ -216,10 +215,10 @@ func (r *LLMISVCReconciler) reconcileActuator(ctx context.Context, llmSvc *v1alp
 // must be set together or both left empty).
 func validateAutoscalingConfig(cfg *WVAAutoscalingConfig) error {
 	if cfg == nil || cfg.Prometheus.URL == "" {
-		return errors.New("autoscaling.prometheus.url is required in inferenceservice-config when using KEDA")
+		return fmt.Errorf("%s.prometheus.url is required in inferenceservice-config when using KEDA", autoscalingConfigName)
 	}
 	if (cfg.Prometheus.TriggerAuthName == "") != (cfg.Prometheus.AuthModes == "") {
-		return errors.New("autoscaling.prometheus.authModes and autoscaling.prometheus.triggerAuthName must both be set or both be empty")
+		return fmt.Errorf("%s.prometheus.authModes and %s.prometheus.triggerAuthName must both be set or both be empty", autoscalingConfigName, autoscalingConfigName)
 	}
 	return nil
 }

--- a/pkg/controller/v1alpha2/llmisvc/scaling_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scaling_test.go
@@ -553,12 +553,12 @@ func TestValidateAutoscalingConfig(t *testing.T) {
 		{
 			name:    "nil config returns error",
 			cfg:     nil,
-			wantErr: "autoscaling.prometheus.url is required",
+			wantErr: "autoscaling-wva-controller-config.prometheus.url is required",
 		},
 		{
 			name:    "missing prometheus.url returns error",
 			cfg:     &WVAAutoscalingConfig{},
-			wantErr: "autoscaling.prometheus.url is required",
+			wantErr: "autoscaling-wva-controller-config.prometheus.url is required",
 		},
 		{
 			name: "no auth fields is valid",
@@ -582,7 +582,7 @@ func TestValidateAutoscalingConfig(t *testing.T) {
 					AuthModes: "bearer",
 				},
 			},
-			wantErr: "autoscaling.prometheus.authModes and autoscaling.prometheus.triggerAuthName must both be set or both be empty",
+			wantErr: "autoscaling-wva-controller-config.prometheus.authModes and autoscaling-wva-controller-config.prometheus.triggerAuthName must both be set or both be empty",
 		},
 		{
 			name: "triggerAuthName set without authModes returns error",
@@ -592,7 +592,7 @@ func TestValidateAutoscalingConfig(t *testing.T) {
 					TriggerAuthName: "prom-auth",
 				},
 			},
-			wantErr: "autoscaling.prometheus.authModes and autoscaling.prometheus.triggerAuthName must both be set or both be empty",
+			wantErr: "autoscaling-wva-controller-config.prometheus.authModes and autoscaling-wva-controller-config.prometheus.triggerAuthName must both be set or both be empty",
 		},
 		{
 			name: "ClusterTriggerAuthentication kind with both auth fields is valid",


### PR DESCRIPTION
Backport of: https://github.com/kserve/kserve/pull/5304

cc @zdtsw @vivekk16 @pierDipi 

**What this PR does / why we need it**:

Bug fix: the llmisvc status points to the following:
```yaml
- lastTransitionTime: "2026-03-25T18:39:43Z"
  message: 'failed to reconcile main workload scaling: failed to reconcile main actuator: autoscaling.prometheus.url is required in inferenceservice-config when using KEDA'
  reason: ReconcileScalingError
  status: "False"
  type: WorkloadsReady
```

After this I apply the patch as directed:
```
kubectl patch configmap inferenceservice-config -n opendatahub --type merge \
    -p '{"data":{"autoscaling":"{\"prometheus\":{\"url\":\"https://thanos-querier.openshift-monitoring.svc.cluster.local:9092/\"}}"}}'
```
But I still see: `...autoscaling.prometheus.url is required`.
However once submitting the following patch:
```
kubectl patch configmap inferenceservice-config -n opendatahub --type merge \
    -p '{"data":{"autoscaling-wva-controller-config":"{\"prometheus\":{\"url\":\"https://thanos-querier.openshift-monitoring.svc.cluster.local:9092/\"}}"}}'
```

This issue resolves itself. 

cc @vivekk16 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated autoscaling configuration validation error messages to include config name prefixes for improved error identification.
  * Refactored internal error handling mechanisms in autoscaling validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->