### PR TITLE
ci: wire llmisvc-controller into Konflux group testing (release-v0.17)

### DIFF
--- a/.tekton/kserve-group-test.yaml
+++ b/.tekton/kserve-group-test.yaml
@@ -21,7 +21,7 @@ metadata:
 spec:
   params:
   - name: group-components
-    value: '{ "kserve-agent-ci": "opendatahub/kserve-agent", "kserve-controller-ci": "opendatahub/kserve-controller", "kserve-router-ci": "opendatahub/kserve-router", "kserve-storage-initializer-ci": "opendatahub/kserve-storage-initializer" }'
+    value: '{ "kserve-agent-ci": "opendatahub/kserve-agent", "kserve-controller-ci": "opendatahub/kserve-controller", "kserve-router-ci": "opendatahub/kserve-router", "kserve-storage-initializer-ci": "opendatahub/kserve-storage-initializer", "odh-kserve-llmisvc-controller-ci": "opendatahub/odh-kserve-llmisvc-controller" }'
   - name: git-url
     value: '{{source_url}}'
   - name: revision

--- a/.tekton/odh-kserve-llmisvc-controller-pull-request.yaml
+++ b/.tekton/odh-kserve-llmisvc-controller-pull-request.yaml
@@ -37,6 +37,8 @@ spec:
     - "GOTAGS=distro"
   - name: pipeline-type
     value: pull-request
+  - name: enable-group-testing
+    value: "true"
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary

[RHOAIENG-54574](https://redhat.atlassian.net/browse/RHOAIENG-54574)

Backport of the group-testing wiring from #1265 (master) to `release-v0.17`:

- Add `odh-kserve-llmisvc-controller-ci` to `group-components` so `generate-snapshot` includes the PR-built llmisvc controller image in the SNAPSHOT
- Add `enable-group-testing: "true"` to the llmisvc controller pull-request pipeline so it triggers group testing

Without this, merging [odh-konflux-central#219](https://github.com/opendatahub-io/odh-konflux-central/pull/219) would break `release-v0.17` group tests: the shared pipeline would try to extract `LLMISVC_CONTROLLER_IMAGE` from the SNAPSHOT, but the image would not be present (returning "null"), overwriting the valid `params.env` fallback.

## Test plan

- [ ] Verify Konflux group-test pipeline passes on a PR against `release-v0.17`
- [ ] Verify llmisvc controller image is present in the SNAPSHOT output

Made with [Cursor](https://cursor.com)