### PR TITLE
fix(deployment): always add OAuth proxy to new raw deployments

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -545,6 +545,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 									Env: []corev1.EnvVar{
 										{Name: constants.InferenceServiceNameEnvVarKey, Value: serviceName},
 									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "proxy-tls",
+											MountPath: "/etc/tls/private",
+										},
+									},
 									Resources: defaultResource,
 									ReadinessProbe: &corev1.Probe{
 										ProbeHandler: corev1.ProbeHandler{
@@ -564,13 +570,18 @@ var _ = Describe("v1beta1 inference service controller", func() {
 									TerminationMessagePolicy: "File",
 									ImagePullPolicy:          "IfNotPresent",
 								},
+								kubeRbacProxyContainer(nil, fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName)),
 							},
+							Volumes: proxyVolumes(
+								predictorDeploymentKey.Name+constants.ServingCertSecretSuffix,
+								fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName),
+							),
 							SchedulerName:                 "default-scheduler",
 							RestartPolicy:                 "Always",
 							TerminationGracePeriodSeconds: ptr.To(GRACE_PERIOD),
 							DNSPolicy:                     "ClusterFirst",
 							SecurityContext:               defaultSecurityContext,
-							AutomountServiceAccountToken:  ptr.To(false),
+							AutomountServiceAccountToken:  ptr.To(true),
 						},
 					},
 					// This is now customized and different from defaults set via `setDefaultDeploymentSpec`.
@@ -974,6 +985,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 									Env: []corev1.EnvVar{
 										{Name: constants.InferenceServiceNameEnvVarKey, Value: serviceName},
 									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "proxy-tls",
+											MountPath: "/etc/tls/private",
+										},
+									},
 									Resources: defaultResource,
 									ReadinessProbe: &corev1.Probe{
 										ProbeHandler: corev1.ProbeHandler{
@@ -993,13 +1010,18 @@ var _ = Describe("v1beta1 inference service controller", func() {
 									TerminationMessagePolicy: "File",
 									ImagePullPolicy:          "IfNotPresent",
 								},
+								kubeRbacProxyContainer(nil, fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName)),
 							},
+							Volumes: proxyVolumes(
+								predictorDeploymentKey.Name+constants.ServingCertSecretSuffix,
+								fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName),
+							),
 							SchedulerName:                 "default-scheduler",
 							RestartPolicy:                 "Always",
 							TerminationGracePeriodSeconds: ptr.To(GRACE_PERIOD),
 							DNSPolicy:                     "ClusterFirst",
 							SecurityContext:               defaultSecurityContext,
-							AutomountServiceAccountToken:  ptr.To(false),
+							AutomountServiceAccountToken:  ptr.To(true),
 						},
 					},
 					Strategy:                getDefaultRollingStrategy(),
@@ -4445,6 +4467,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 									Env: []corev1.EnvVar{
 										{Name: constants.InferenceServiceNameEnvVarKey, Value: serviceName},
 									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "proxy-tls",
+											MountPath: "/etc/tls/private",
+										},
+									},
 									Resources: defaultResource,
 									ReadinessProbe: &corev1.Probe{
 										ProbeHandler: corev1.ProbeHandler{
@@ -4464,13 +4492,18 @@ var _ = Describe("v1beta1 inference service controller", func() {
 									TerminationMessagePolicy: "File",
 									ImagePullPolicy:          "IfNotPresent",
 								},
+								kubeRbacProxyContainer(nil, fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName)),
 							},
+							Volumes: proxyVolumes(
+								predictorDeploymentKey.Name+constants.ServingCertSecretSuffix,
+								fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName),
+							),
 							SchedulerName:                 "default-scheduler",
 							RestartPolicy:                 "Always",
 							TerminationGracePeriodSeconds: ptr.To(GRACE_PERIOD),
 							DNSPolicy:                     "ClusterFirst",
 							SecurityContext:               defaultSecurityContext,
-							AutomountServiceAccountToken:  ptr.To(false),
+							AutomountServiceAccountToken:  ptr.To(true),
 						},
 					},
 					Strategy:                getDefaultRollingStrategy(),
@@ -4532,6 +4565,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 									Env: []corev1.EnvVar{
 										{Name: constants.InferenceServiceNameEnvVarKey, Value: serviceName},
 									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "proxy-tls",
+											MountPath: "/etc/tls/private",
+										},
+									},
 									Resources: defaultResource,
 									ReadinessProbe: &corev1.Probe{
 										ProbeHandler: corev1.ProbeHandler{
@@ -4551,13 +4590,18 @@ var _ = Describe("v1beta1 inference service controller", func() {
 									TerminationMessagePolicy: "File",
 									ImagePullPolicy:          "IfNotPresent",
 								},
+								kubeRbacProxyContainer(ptr.To(int64(30)), fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName)),
 							},
+							Volumes: proxyVolumes(
+								transformerDeploymentKey.Name+constants.ServingCertSecretSuffix,
+								fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName),
+							),
 							SchedulerName:                 "default-scheduler",
 							RestartPolicy:                 "Always",
 							TerminationGracePeriodSeconds: ptr.To(GRACE_PERIOD),
 							DNSPolicy:                     "ClusterFirst",
 							SecurityContext:               defaultSecurityContext,
-							AutomountServiceAccountToken:  ptr.To(false),
+							AutomountServiceAccountToken:  ptr.To(true),
 						},
 					},
 					Strategy:                getDefaultRollingStrategy(),
@@ -5215,6 +5259,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 									Env: []corev1.EnvVar{
 										{Name: constants.InferenceServiceNameEnvVarKey, Value: serviceName},
 									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "proxy-tls",
+											MountPath: "/etc/tls/private",
+										},
+									},
 									Resources: defaultResource,
 									ReadinessProbe: &corev1.Probe{
 										ProbeHandler: corev1.ProbeHandler{
@@ -5234,13 +5284,18 @@ var _ = Describe("v1beta1 inference service controller", func() {
 									TerminationMessagePolicy: "File",
 									ImagePullPolicy:          "IfNotPresent",
 								},
+								kubeRbacProxyContainer(nil, fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName)),
 							},
+							Volumes: proxyVolumes(
+								predictorDeploymentKey.Name+constants.ServingCertSecretSuffix,
+								fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName),
+							),
 							SchedulerName:                 "default-scheduler",
 							RestartPolicy:                 "Always",
 							TerminationGracePeriodSeconds: ptr.To(GRACE_PERIOD),
 							DNSPolicy:                     "ClusterFirst",
 							SecurityContext:               defaultSecurityContext,
-							AutomountServiceAccountToken:  ptr.To(false),
+							AutomountServiceAccountToken:  ptr.To(true),
 						},
 					},
 					Strategy:                getDefaultRollingStrategy(),
@@ -6371,6 +6426,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 									Env: []corev1.EnvVar{
 										{Name: constants.InferenceServiceNameEnvVarKey, Value: serviceName},
 									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "proxy-tls",
+											MountPath: "/etc/tls/private",
+										},
+									},
 									Resources: defaultResource,
 									ReadinessProbe: &corev1.Probe{
 										ProbeHandler: corev1.ProbeHandler{
@@ -6390,13 +6451,18 @@ var _ = Describe("v1beta1 inference service controller", func() {
 									TerminationMessagePolicy: "File",
 									ImagePullPolicy:          "IfNotPresent",
 								},
+								kubeRbacProxyContainer(nil, fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName)),
 							},
+							Volumes: proxyVolumes(
+								predictorDeploymentKey.Name+constants.ServingCertSecretSuffix,
+								fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName),
+							),
 							SchedulerName:                 "default-scheduler",
 							RestartPolicy:                 "Always",
 							TerminationGracePeriodSeconds: ptr.To(GRACE_PERIOD),
 							DNSPolicy:                     "ClusterFirst",
 							SecurityContext:               defaultSecurityContext,
-							AutomountServiceAccountToken:  ptr.To(false),
+							AutomountServiceAccountToken:  ptr.To(true),
 						},
 					},
 					Strategy:                getDefaultRollingStrategy(),
@@ -6458,6 +6524,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 									Env: []corev1.EnvVar{
 										{Name: constants.InferenceServiceNameEnvVarKey, Value: serviceName},
 									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "proxy-tls",
+											MountPath: "/etc/tls/private",
+										},
+									},
 									Resources: defaultResource,
 									ReadinessProbe: &corev1.Probe{
 										ProbeHandler: corev1.ProbeHandler{
@@ -6477,13 +6549,18 @@ var _ = Describe("v1beta1 inference service controller", func() {
 									TerminationMessagePolicy: "File",
 									ImagePullPolicy:          "IfNotPresent",
 								},
+								kubeRbacProxyContainer(ptr.To(int64(30)), fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName)),
 							},
+							Volumes: proxyVolumes(
+								transformerDeploymentKey.Name+constants.ServingCertSecretSuffix,
+								fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName),
+							),
 							SchedulerName:                 "default-scheduler",
 							RestartPolicy:                 "Always",
 							TerminationGracePeriodSeconds: ptr.To(GRACE_PERIOD),
 							DNSPolicy:                     "ClusterFirst",
 							SecurityContext:               defaultSecurityContext,
-							AutomountServiceAccountToken:  ptr.To(false),
+							AutomountServiceAccountToken:  ptr.To(true),
 						},
 					},
 					Strategy:                getDefaultRollingStrategy(),
@@ -7190,6 +7267,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 									Env: []corev1.EnvVar{
 										{Name: constants.InferenceServiceNameEnvVarKey, Value: serviceName},
 									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "proxy-tls",
+											MountPath: "/etc/tls/private",
+										},
+									},
 									Resources: defaultResource,
 									ReadinessProbe: &corev1.Probe{
 										ProbeHandler: corev1.ProbeHandler{
@@ -7209,13 +7292,18 @@ var _ = Describe("v1beta1 inference service controller", func() {
 									TerminationMessagePolicy: "File",
 									ImagePullPolicy:          "IfNotPresent",
 								},
+								kubeRbacProxyContainer(nil, fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName)),
 							},
+							Volumes: proxyVolumes(
+								predictorDeploymentKey.Name+constants.ServingCertSecretSuffix,
+								fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName),
+							),
 							SchedulerName:                 "default-scheduler",
 							RestartPolicy:                 "Always",
 							TerminationGracePeriodSeconds: ptr.To(GRACE_PERIOD),
 							DNSPolicy:                     "ClusterFirst",
 							SecurityContext:               defaultSecurityContext,
-							AutomountServiceAccountToken:  ptr.To(false),
+							AutomountServiceAccountToken:  ptr.To(true),
 						},
 					},
 					Strategy:                getDefaultRollingStrategy(),
@@ -8161,7 +8249,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			_ = k8sClient.Create(context.TODO(), &servingRuntime)
 			defer k8sClient.Delete(context.TODO(), &servingRuntime)
 
-			serviceName := "raw-foo"
+			serviceName := "raw-foo-no-gw"
 			expectedRequest := reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: "default"}}
 			serviceKey := expectedRequest.NamespacedName
 
@@ -8310,8 +8398,10 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			}
 			Expect(actualIngress.Spec).To(Equal(expectedIngress.Spec))
 			// verify if InferenceService status is updated
-			expectedIsvcStatus := getExpectedIsvcStatus(serviceKey, "http", "raw-foo-predictor.default.svc.cluster.local",
-				"raw-foo-predictor-default.example.com", "8080")
+			expectedIsvcStatus := getExpectedIsvcStatus(serviceKey, "http",
+				fmt.Sprintf("%s-predictor.%s.svc.cluster.local", serviceName, serviceKey.Namespace),
+				fmt.Sprintf("%s-predictor-%s.%s", serviceName, serviceKey.Namespace, domain),
+				"8080")
 			Eventually(func() string {
 				isvc := &v1beta1.InferenceService{}
 				if err := k8sClient.Get(context.TODO(), serviceKey, isvc); err != nil {
@@ -8578,107 +8668,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 									TerminationMessagePolicy: "File",
 									ImagePullPolicy:          "IfNotPresent",
 								},
-								{
-									Name:  constants.KubeRbacContainerName,
-									Image: constants.OauthProxyImage,
-									Args: []string{
-										`--secure-listen-address=:8443`,
-										`--proxy-endpoints-port=8643`,
-										`--upstream=http://localhost:8080`,
-										`--auth-header-fields-enabled=true`,
-										`--tls-cert-file=/etc/tls/private/tls.crt`,
-										`--tls-private-key-file=/etc/tls/private/tls.key`,
-										`--config-file=/etc/kube-rbac-proxy/config-file.yaml`,
-										`--v=4`,
-									},
-									Ports: []corev1.ContainerPort{
-										{
-											ContainerPort: constants.OauthProxyPort,
-											Name:          "https",
-											Protocol:      corev1.ProtocolTCP,
-										},
-										{
-											ContainerPort: constants.OauthProxyProbePort,
-											Name:          "proxy",
-											Protocol:      corev1.ProtocolTCP,
-										},
-									},
-									LivenessProbe: &corev1.Probe{
-										ProbeHandler: corev1.ProbeHandler{
-											HTTPGet: &corev1.HTTPGetAction{
-												Path:   "/healthz",
-												Port:   intstr.FromInt32(constants.OauthProxyProbePort),
-												Scheme: corev1.URISchemeHTTPS,
-											},
-										},
-										InitialDelaySeconds: 30,
-										TimeoutSeconds:      1,
-										PeriodSeconds:       5,
-										SuccessThreshold:    1,
-										FailureThreshold:    3,
-									},
-									ReadinessProbe: &corev1.Probe{
-										ProbeHandler: corev1.ProbeHandler{
-											HTTPGet: &corev1.HTTPGetAction{
-												Path:   "/healthz",
-												Port:   intstr.FromInt32(constants.OauthProxyProbePort),
-												Scheme: corev1.URISchemeHTTPS,
-											},
-										},
-										InitialDelaySeconds: 5,
-										TimeoutSeconds:      1,
-										PeriodSeconds:       5,
-										SuccessThreshold:    1,
-										FailureThreshold:    3,
-									},
-									Resources: corev1.ResourceRequirements{
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse(constants.OauthProxyResourceCPULimit),
-											corev1.ResourceMemory: resource.MustParse(constants.OauthProxyResourceMemoryLimit),
-										},
-										Requests: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse(constants.OauthProxyResourceCPURequest),
-											corev1.ResourceMemory: resource.MustParse(constants.OauthProxyResourceMemoryRequest),
-										},
-									},
-									VolumeMounts: []corev1.VolumeMount{
-										{
-											Name:      "proxy-tls",
-											MountPath: "/etc/tls/private",
-										},
-										{
-											Name:      fmt.Sprintf("%s-%s", serviceKey.Name, constants.OauthProxySARCMName),
-											MountPath: "/etc/kube-rbac-proxy",
-											ReadOnly:  true,
-										},
-									},
-									TerminationMessagePath:   "/dev/termination-log",
-									TerminationMessagePolicy: "File",
-									ImagePullPolicy:          "IfNotPresent",
-								},
+								kubeRbacProxyContainer(nil, fmt.Sprintf("%s-%s", serviceKey.Name, constants.OauthProxySARCMName)),
 							},
-							Volumes: []corev1.Volume{
-								{
-									Name: "proxy-tls",
-									VolumeSource: corev1.VolumeSource{
-										Secret: &corev1.SecretVolumeSource{
-											SecretName:  predictorDeploymentKey.Name + constants.ServingCertSecretSuffix,
-											DefaultMode: func(i int32) *int32 { return &i }(420),
-										},
-									},
-								},
-								{
-									Name: fmt.Sprintf("%s-%s", serviceKey.Name, constants.OauthProxySARCMName),
-									VolumeSource: corev1.VolumeSource{
-										ConfigMap: &corev1.ConfigMapVolumeSource{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: fmt.Sprintf("%s-%s", serviceKey.Name, constants.OauthProxySARCMName),
-											},
-											DefaultMode: func(i int32) *int32 { return &i }(420),
-										},
-									},
-								},
-							},
+							Volumes: proxyVolumes(
+								predictorDeploymentKey.Name+constants.ServingCertSecretSuffix,
+								fmt.Sprintf("%s-%s", serviceKey.Name, constants.OauthProxySARCMName),
+							),
 							SchedulerName:                 "default-scheduler",
 							RestartPolicy:                 "Always",
 							TerminationGracePeriodSeconds: &gracePeriod,
@@ -10431,7 +10426,8 @@ var _ = Describe("v1beta1 inference service controller", func() {
 					"cpuModelcar": "10m",
 					"memoryModelcar": "15Mi"
 				}`,
-				"service": `{"serviceClusterIPNone": true}`,
+				"service":    `{"serviceClusterIPNone": true}`,
+				"oauthProxy": `{"image": "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m"}`,
 			}
 			configMap := createInferenceServiceConfigMap(configs)
 			Expect(k8sClient.Create(ctx, configMap)).NotTo(HaveOccurred())
@@ -10586,6 +10582,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				"localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local",
 				"additionalIngressDomains": ["additional.example.com"]
 			}`,
+			"oauthProxy": `{"image": "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m"}`,
 			"storageInitializer": `{
 				"image" : "kserve/storage-initializer:latest",
 				"memoryRequest": "100Mi",

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -3552,9 +3552,9 @@ var _ = Describe("v1beta1 inference service controller", func() {
 				return k8sClient.Get(context.TODO(), types.NamespacedName{Name: constants.InferenceServiceConfigMapName, Namespace: isvcNamespace}, cm)
 			}, timeout, interval).Should(Succeed())
 
-			isvcNamePytorch := "isvc-enable-auto-update-multiple-pytorch"
+			isvcNamePytorch := "isvc-multi-pytorch"
 			serviceKeyPytorch := types.NamespacedName{Name: isvcNamePytorch, Namespace: isvcNamespace}
-			isvcNameTensorflow := "isvc-enable-auto-update-multiple-tensorflow"
+			isvcNameTensorflow := "isvc-multi-tensorflow"
 			serviceKeyTensorflow := types.NamespacedName{Name: isvcNameTensorflow, Namespace: isvcNamespace}
 
 			servingRuntimePytorchName := "pytorch-serving-auto-update-true-multiple"
@@ -3752,7 +3752,9 @@ var _ = Describe("v1beta1 inference service controller", func() {
 
 			tensorFlowDeploymentAfterUpdate := &appsv1.Deployment{}
 			tensorflowDeploymentName := constants.PredictorServiceName(serviceKeyTensorflow.Name)
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: tensorflowDeploymentName, Namespace: serviceKeyTensorflow.Namespace}, tensorFlowDeploymentAfterUpdate)).Should(Succeed())
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: tensorflowDeploymentName, Namespace: serviceKeyTensorflow.Namespace}, tensorFlowDeploymentAfterUpdate)
+			}, timeout, interval).Should(Succeed())
 			Expect(tensorFlowDeploymentAfterUpdate.Spec.Template.ObjectMeta.Labels["key1"]).Should(Equal("val1FromSR"))
 		})
 	})

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -127,34 +127,37 @@ func createRawDeploymentODH(ctx context.Context,
 	}
 
 	// Check if this is a new deployment
-	// Note: If client is nil (e.g., in some tests), treat as new deployment
 	isNewDeployment := false
-	if client != nil {
-		existingDeployment := &appsv1.Deployment{}
-		err = client.Get(ctx, types.NamespacedName{
-			Namespace: componentMeta.Namespace,
-			Name:      componentMeta.Name,
-		}, existingDeployment)
-		if err != nil {
-			if apierr.IsNotFound(err) {
-				isNewDeployment = true
-			}
-			// For other errors, treat as existing to be safe (preserves current behavior)
+	existingDeployment := &appsv1.Deployment{}
+	existingDeploymentFound := false
+	err = client.Get(ctx, types.NamespacedName{
+		Namespace: componentMeta.Namespace,
+		Name:      componentMeta.Name,
+	}, existingDeployment)
+	if err != nil {
+		if apierr.IsNotFound(err) {
+			isNewDeployment = true
 		}
+		// For other errors, treat as existing to be safe (preserves current behavior)
 	} else {
-		// If client is nil, assume new deployment (for backward compatibility with tests)
-		isNewDeployment = true
+		existingDeploymentFound = true
 	}
 
 	enableAuth := false
 	addNewAuthProxy := false
 	authProxyPreserved := false
-	alwaysAddProxy := false
 
 	// For new InferenceService deployments, always add OAuth proxy
-	// Only if client and clientset are available (needed for SAR ConfigMap creation)
-	if isNewDeployment && resourceType == constants.InferenceServiceResource && client != nil && clientset != nil {
-		alwaysAddProxy = true
+	alwaysAddProxy := isNewDeployment && resourceType == constants.InferenceServiceResource
+
+	// If the deployment already exists and has the kube-rbac-proxy container, preserve it.
+	if !alwaysAddProxy && existingDeploymentFound && resourceType == constants.InferenceServiceResource {
+		for _, c := range existingDeployment.Spec.Template.Spec.Containers {
+			if c.Name == constants.KubeRbacContainerName {
+				alwaysAddProxy = true
+				break
+			}
+		}
 	}
 
 	// Deployment list is for multi-node, we only need to add oauth proxy and serving secret certs to the head deployment

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -127,22 +127,12 @@ func createRawDeploymentODH(ctx context.Context,
 	}
 
 	// Check if an existing deployment is already deployed.
-	existingDeployment := &appsv1.Deployment{}
-	existingDeploymentFound := false
-	err = client.Get(ctx, types.NamespacedName{
-		Namespace: componentMeta.Namespace,
-		Name:      componentMeta.Name,
-	}, existingDeployment)
+	existingProxyType, existingProxyImage, existingDeployment, err := getExistingAuthProxyType(ctx, client,
+		componentMeta.Namespace, componentMeta.Name)
 	if err != nil {
-		if !apierr.IsNotFound(err) {
-			return nil, false, fmt.Errorf("failed to check deployment %s/%s: %w", componentMeta.Namespace, componentMeta.Name, err)
-		}
-	} else {
-		existingDeploymentFound = true
+		return nil, false, fmt.Errorf("failed to fetch deployment %s/%s: %w", componentMeta.Namespace, componentMeta.Name, err)
 	}
-
-	addNewAuthProxy := false
-	authProxyPreserved := false
+	existingDeploymentFound := existingDeployment != nil
 
 	// shouldAddAuthProxy controls whether the OAuth proxy sidecar is injected or preserved.
 	// For InferenceService: always inject for new deployments (to avoid pod-template rollouts
@@ -157,7 +147,7 @@ func createRawDeploymentODH(ctx context.Context,
 				shouldAddAuthProxy = true
 			}
 			for _, c := range existingDeployment.Spec.Template.Spec.Containers {
-				if c.Name == constants.KubeRbacContainerName {
+				if c.Name == constants.KubeRbacContainerName || c.Name == constants.OauthProxyContainerName {
 					shouldAddAuthProxy = true
 					break
 				}
@@ -168,16 +158,11 @@ func createRawDeploymentODH(ctx context.Context,
 	// Deployment list is for multi-node, we only need to add oauth proxy and serving secret certs to the head deployment
 	headDeployment := deploymentList[0]
 
+	authProxyPreserved := false
 	if shouldAddAuthProxy {
 		wantsMigration := false
 		if val, ok := componentMeta.Annotations[constants.ODHAuthProxyTypeAnnotation]; ok {
-			wantsMigration = (val == constants.KubeRbacProxyType)
-		}
-
-		existingProxyType, existingProxyImage, existingDeployment, err := getExistingAuthProxyType(ctx, client,
-			componentMeta.Namespace, componentMeta.Name)
-		if err != nil {
-			return nil, false, err
+			wantsMigration = val == constants.KubeRbacProxyType
 		}
 
 		oauthConfig, cfgErr := getOauthProxyConfig(ctx, clientset)
@@ -185,53 +170,46 @@ func createRawDeploymentODH(ctx context.Context,
 			oauthConfig = nil
 		}
 
-		if resourceType != constants.InferenceGraphResource { // InferenceGraphs don't use rbac-proxy
-			if existingProxyType != "" {
-				switch existingProxyType {
-				case constants.OauthProxyContainerName:
-					if wantsMigration {
-						addNewAuthProxy = true
-						err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname)
-						if err != nil {
-							return nil, false, err
-						}
-					} else {
-						log.Info("Preserving existing auth proxy container", "isvc", isvcname, "type", existingProxyType)
-						authProxyPreserved = true
-						copyAuthProxyFromExisting(existingDeployment, headDeployment, existingProxyType)
+		if existingProxyType != "" {
+			switch existingProxyType {
+			case constants.OauthProxyContainerName:
+				if wantsMigration {
+					err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname)
+					if err != nil {
+						return nil, false, err
 					}
-				case constants.KubeRbacContainerName:
-					configuredKubeRbacImage := ""
-					if oauthConfig != nil {
-						configuredKubeRbacImage = oauthConfig.Image
-					}
-					if configuredKubeRbacImage != "" && existingProxyImage == configuredKubeRbacImage {
-						addNewAuthProxy = true
-						err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname)
-						if err != nil {
-							return nil, false, err
-						}
-					} else {
-						log.Info("Preserving existing auth proxy container (image differs from config)",
-							"isvc", isvcname, "type", existingProxyType,
-							"existingImage", existingProxyImage, "configImage", configuredKubeRbacImage)
-						authProxyPreserved = true
-						copyAuthProxyFromExisting(existingDeployment, headDeployment, existingProxyType)
-					}
+				} else {
+					log.Info("Preserving existing auth proxy container", "isvc", isvcname, "type", existingProxyType)
+					authProxyPreserved = true
+					copyAuthProxyFromExisting(existingDeployment, headDeployment, existingProxyType)
 				}
-			} else {
-				addNewAuthProxy = true
-				err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname)
-				if err != nil {
-					return nil, false, err
+			case constants.KubeRbacContainerName:
+				configuredKubeRbacImage := ""
+				if oauthConfig != nil {
+					configuredKubeRbacImage = oauthConfig.Image
 				}
+				if configuredKubeRbacImage != "" && existingProxyImage == configuredKubeRbacImage {
+					err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname)
+					if err != nil {
+						return nil, false, err
+					}
+				} else {
+					log.Info("Preserving existing auth proxy container (image differs from config)",
+						"isvc", isvcname, "type", existingProxyType,
+						"existingImage", existingProxyImage, "configImage", configuredKubeRbacImage)
+					authProxyPreserved = true
+					copyAuthProxyFromExisting(existingDeployment, headDeployment, existingProxyType)
+				}
+			}
+		} else {
+			err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname)
+			if err != nil {
+				return nil, false, err
 			}
 		}
 	}
-	if shouldAddAuthProxy || resourceType == constants.InferenceGraphResource {
-		if addNewAuthProxy || resourceType == constants.InferenceGraphResource {
-			mountServingSecretCMVolumeToDeployment(headDeployment, componentMeta, resourceType, isvcname)
-		}
+	if (shouldAddAuthProxy && !authProxyPreserved) || resourceType == constants.InferenceGraphResource {
+		mountServingSecretCMVolumeToDeployment(headDeployment, componentMeta, resourceType, isvcname)
 	}
 	return deploymentList, authProxyPreserved, nil
 }

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -126,14 +126,46 @@ func createRawDeploymentODH(ctx context.Context,
 		isvcname = componentMeta.Name
 	}
 
+	// Check if this is a new deployment
+	// Note: If client is nil (e.g., in some tests), treat as new deployment
+	isNewDeployment := false
+	if client != nil {
+		existingDeployment := &appsv1.Deployment{}
+		err = client.Get(ctx, types.NamespacedName{
+			Namespace: componentMeta.Namespace,
+			Name:      componentMeta.Name,
+		}, existingDeployment)
+		if err != nil {
+			if apierr.IsNotFound(err) {
+				isNewDeployment = true
+			}
+			// For other errors, treat as existing to be safe (preserves current behavior)
+		}
+	} else {
+		// If client is nil, assume new deployment (for backward compatibility with tests)
+		isNewDeployment = true
+	}
+
 	enableAuth := false
 	addNewAuthProxy := false
 	authProxyPreserved := false
+	alwaysAddProxy := false
+
+	// For new InferenceService deployments, always add OAuth proxy
+	// Only if client and clientset are available (needed for SAR ConfigMap creation)
+	if isNewDeployment && resourceType == constants.InferenceServiceResource && client != nil && clientset != nil {
+		alwaysAddProxy = true
+	}
+
 	// Deployment list is for multi-node, we only need to add oauth proxy and serving secret certs to the head deployment
 	headDeployment := deploymentList[0]
+
+	// Determine if auth is enabled
 	if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && strings.EqualFold(val, "true") {
 		enableAuth = true
+	}
 
+	if enableAuth || alwaysAddProxy {
 		wantsMigration := false
 		if val, ok := componentMeta.Annotations[constants.ODHAuthProxyTypeAnnotation]; ok {
 			wantsMigration = (val == constants.KubeRbacProxyType)
@@ -156,7 +188,7 @@ func createRawDeploymentODH(ctx context.Context,
 				case constants.OauthProxyContainerName:
 					if wantsMigration {
 						addNewAuthProxy = true
-						err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname)
+						err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname, true)
 						if err != nil {
 							return nil, false, err
 						}
@@ -172,7 +204,7 @@ func createRawDeploymentODH(ctx context.Context,
 					}
 					if configuredKubeRbacImage != "" && existingProxyImage == configuredKubeRbacImage {
 						addNewAuthProxy = true
-						err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname)
+						err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname, true)
 						if err != nil {
 							return nil, false, err
 						}
@@ -186,14 +218,14 @@ func createRawDeploymentODH(ctx context.Context,
 				}
 			} else {
 				addNewAuthProxy = true
-				err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname)
+				err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname, alwaysAddProxy)
 				if err != nil {
 					return nil, false, err
 				}
 			}
 		}
 	}
-	if (resourceType == constants.InferenceServiceResource && enableAuth) || resourceType == constants.InferenceGraphResource {
+	if alwaysAddProxy || (resourceType == constants.InferenceServiceResource && enableAuth) || resourceType == constants.InferenceGraphResource {
 		if addNewAuthProxy || resourceType == constants.InferenceGraphResource {
 			mountServingSecretCMVolumeToDeployment(headDeployment, componentMeta, resourceType, isvcname)
 		}
@@ -360,10 +392,18 @@ func addOauthContainerToDeployment(ctx context.Context,
 	componentMeta metav1.ObjectMeta,
 	componentExt *v1beta1.ComponentExtensionSpec,
 	podSpec *corev1.PodSpec, isvcName string,
+	forceAdd bool,
 ) error {
 	var upstreamPort, upstreamTimeout string
 
+	// Check if we should add the proxy
+	// Either forced (new deployment) or auth is enabled (existing deployment)
+	shouldAdd := forceAdd
 	if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && strings.EqualFold(val, "true") {
+		shouldAdd = true
+	}
+
+	if shouldAdd {
 		switch {
 		case componentExt != nil && componentExt.Batcher != nil:
 			upstreamPort = constants.InferenceServiceDefaultAgentPortStr

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -137,8 +137,9 @@ func createRawDeploymentODH(ctx context.Context,
 	if err != nil {
 		if apierr.IsNotFound(err) {
 			isNewDeployment = true
+		} else {
+			return nil, false, fmt.Errorf("failed to check deployment %s/%s: %w", componentMeta.Namespace, componentMeta.Name, err)
 		}
-		// For other errors, treat as existing to be safe (preserves current behavior)
 	} else {
 		existingDeploymentFound = true
 	}
@@ -647,8 +648,8 @@ func createSarCm(ctx context.Context, client kclient.Client, clientset kubernete
 			Namespace: namespace,
 			OwnerReferences: []metav1.OwnerReference{
 				{
-					APIVersion:         inferenceService.APIVersion,
-					Kind:               inferenceService.Kind,
+					APIVersion:         v1beta1.SchemeGroupVersion.String(),
+					Kind:               "InferenceService",
 					Name:               inferenceService.Name,
 					UID:                inferenceService.UID,
 					Controller:         ptr.To(true),

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -126,8 +126,7 @@ func createRawDeploymentODH(ctx context.Context,
 		isvcname = componentMeta.Name
 	}
 
-	// Check if this is a new deployment
-	isNewDeployment := false
+	// Check if an existing deployment is already deployed.
 	existingDeployment := &appsv1.Deployment{}
 	existingDeploymentFound := false
 	err = client.Get(ctx, types.NamespacedName{
@@ -135,28 +134,33 @@ func createRawDeploymentODH(ctx context.Context,
 		Name:      componentMeta.Name,
 	}, existingDeployment)
 	if err != nil {
-		if apierr.IsNotFound(err) {
-			isNewDeployment = true
-		} else {
+		if !apierr.IsNotFound(err) {
 			return nil, false, fmt.Errorf("failed to check deployment %s/%s: %w", componentMeta.Namespace, componentMeta.Name, err)
 		}
 	} else {
 		existingDeploymentFound = true
 	}
 
-	enableAuth := false
 	addNewAuthProxy := false
 	authProxyPreserved := false
 
-	// For new InferenceService deployments, always add OAuth proxy
-	alwaysAddProxy := isNewDeployment && resourceType == constants.InferenceServiceResource
-
-	// If the deployment already exists and has the kube-rbac-proxy container, preserve it.
-	if !alwaysAddProxy && existingDeploymentFound && resourceType == constants.InferenceServiceResource {
-		for _, c := range existingDeployment.Spec.Template.Spec.Containers {
-			if c.Name == constants.KubeRbacContainerName {
-				alwaysAddProxy = true
-				break
+	// shouldAddAuthProxy controls whether the OAuth proxy sidecar is injected or preserved.
+	// For InferenceService: always inject for new deployments (to avoid pod-template rollouts
+	// when auth is later toggled), preserve for existing deployments that already carry the
+	// proxy, and also inject when auth is explicitly enabled via annotation.
+	shouldAddAuthProxy := false
+	if resourceType == constants.InferenceServiceResource {
+		if !existingDeploymentFound {
+			shouldAddAuthProxy = true
+		} else {
+			if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && strings.EqualFold(val, "true") {
+				shouldAddAuthProxy = true
+			}
+			for _, c := range existingDeployment.Spec.Template.Spec.Containers {
+				if c.Name == constants.KubeRbacContainerName {
+					shouldAddAuthProxy = true
+					break
+				}
 			}
 		}
 	}
@@ -164,12 +168,7 @@ func createRawDeploymentODH(ctx context.Context,
 	// Deployment list is for multi-node, we only need to add oauth proxy and serving secret certs to the head deployment
 	headDeployment := deploymentList[0]
 
-	// Determine if auth is enabled
-	if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && strings.EqualFold(val, "true") {
-		enableAuth = true
-	}
-
-	if enableAuth || alwaysAddProxy {
+	if shouldAddAuthProxy {
 		wantsMigration := false
 		if val, ok := componentMeta.Annotations[constants.ODHAuthProxyTypeAnnotation]; ok {
 			wantsMigration = (val == constants.KubeRbacProxyType)
@@ -192,7 +191,7 @@ func createRawDeploymentODH(ctx context.Context,
 				case constants.OauthProxyContainerName:
 					if wantsMigration {
 						addNewAuthProxy = true
-						err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname, true)
+						err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname)
 						if err != nil {
 							return nil, false, err
 						}
@@ -208,7 +207,7 @@ func createRawDeploymentODH(ctx context.Context,
 					}
 					if configuredKubeRbacImage != "" && existingProxyImage == configuredKubeRbacImage {
 						addNewAuthProxy = true
-						err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname, true)
+						err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname)
 						if err != nil {
 							return nil, false, err
 						}
@@ -222,14 +221,14 @@ func createRawDeploymentODH(ctx context.Context,
 				}
 			} else {
 				addNewAuthProxy = true
-				err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname, alwaysAddProxy)
+				err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname)
 				if err != nil {
 					return nil, false, err
 				}
 			}
 		}
 	}
-	if alwaysAddProxy || (resourceType == constants.InferenceServiceResource && enableAuth) || resourceType == constants.InferenceGraphResource {
+	if shouldAddAuthProxy || resourceType == constants.InferenceGraphResource {
 		if addNewAuthProxy || resourceType == constants.InferenceGraphResource {
 			mountServingSecretCMVolumeToDeployment(headDeployment, componentMeta, resourceType, isvcname)
 		}
@@ -396,44 +395,34 @@ func addOauthContainerToDeployment(ctx context.Context,
 	componentMeta metav1.ObjectMeta,
 	componentExt *v1beta1.ComponentExtensionSpec,
 	podSpec *corev1.PodSpec, isvcName string,
-	forceAdd bool,
 ) error {
 	var upstreamPort, upstreamTimeout string
 
-	// Check if we should add the proxy
-	// Either forced (new deployment) or auth is enabled (existing deployment)
-	shouldAdd := forceAdd
-	if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && strings.EqualFold(val, "true") {
-		shouldAdd = true
+	switch {
+	case componentExt != nil && componentExt.Batcher != nil:
+		upstreamPort = constants.InferenceServiceDefaultAgentPortStr
+	case componentExt != nil && componentExt.Logger != nil:
+		upstreamPort = constants.InferenceServiceDefaultAgentPortStr
+	default:
+		upstreamPort = GetKServeContainerPort(podSpec)
+		if upstreamPort == "" {
+			upstreamPort = constants.InferenceServiceDefaultHttpPort
+		}
 	}
 
-	if shouldAdd {
-		switch {
-		case componentExt != nil && componentExt.Batcher != nil:
-			upstreamPort = constants.InferenceServiceDefaultAgentPortStr
-		case componentExt != nil && componentExt.Logger != nil:
-			upstreamPort = constants.InferenceServiceDefaultAgentPortStr
-		default:
-			upstreamPort = GetKServeContainerPort(podSpec)
-			if upstreamPort == "" {
-				upstreamPort = constants.InferenceServiceDefaultHttpPort
-			}
-		}
-
-		if componentExt != nil && componentExt.TimeoutSeconds != nil {
-			upstreamTimeout = strconv.FormatInt(*componentExt.TimeoutSeconds, 10)
-		}
-
-		oauthProxyContainer, err := generateOauthProxyContainer(ctx, client, clientset, oauthConfig, isvcName, componentMeta.Namespace, upstreamPort, upstreamTimeout)
-		if err != nil {
-			return err
-		}
-		updatedPodSpec := deployment.Spec.Template.Spec.DeepCopy()
-		// ODH override. See : https://issues.redhat.com/browse/RHOAIENG-19904
-		updatedPodSpec.AutomountServiceAccountToken = proto.Bool(true)
-		updatedPodSpec.Containers = append(updatedPodSpec.Containers, *oauthProxyContainer)
-		deployment.Spec.Template.Spec = *updatedPodSpec
+	if componentExt != nil && componentExt.TimeoutSeconds != nil {
+		upstreamTimeout = strconv.FormatInt(*componentExt.TimeoutSeconds, 10)
 	}
+
+	oauthProxyContainer, err := generateOauthProxyContainer(ctx, client, clientset, oauthConfig, isvcName, componentMeta.Namespace, upstreamPort, upstreamTimeout)
+	if err != nil {
+		return err
+	}
+	updatedPodSpec := deployment.Spec.Template.Spec.DeepCopy()
+	// ODH override. See: https://issues.redhat.com/browse/RHOAIENG-19904
+	updatedPodSpec.AutomountServiceAccountToken = proto.Bool(true)
+	updatedPodSpec.Containers = append(updatedPodSpec.Containers, *oauthProxyContainer)
+	deployment.Spec.Template.Spec = *updatedPodSpec
 	return nil
 }
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
@@ -1563,18 +1563,19 @@ type mockClientForCheckDeploymentExist struct {
 }
 
 func (m *mockClientForCheckDeploymentExist) Get(ctx context.Context, key kclient.ObjectKey, obj kclient.Object, opts ...kclient.GetOption) error {
-	if m.getErr != nil {
-		return m.getErr
-	}
-
 	// Handle different object types
 	switch o := obj.(type) {
 	case *appsv1.Deployment:
+		// Return error only for Deployment Get() calls
+		if m.getErr != nil {
+			return m.getErr
+		}
 		if m.getDeployment != nil {
 			*o = *m.getDeployment.DeepCopy()
 		}
 	case *v1beta1.InferenceService:
-		// For InferenceService, create a minimal mock object with required fields
+		// For InferenceService, always create a minimal mock object with required fields
+		// This is needed for SAR ConfigMap creation
 		o.ObjectMeta = metav1.ObjectMeta{
 			Name:      key.Name,
 			Namespace: key.Namespace,
@@ -2451,4 +2452,326 @@ func TestGetAuthProxyConditionNoCondition(t *testing.T) {
 	cond, condType := reconciler.GetAuthProxyCondition()
 	assert.Nil(t, cond)
 	assert.Empty(t, condType)
+}
+
+// Tests for RHOAIENG-52129: OAuth proxy always added to new deployments
+
+func TestNewRawDeploymentWithAuthDisabled_IncludesOAuthProxy(t *testing.T) {
+	client := &mockClientForCheckDeploymentExist{
+		getErr: errors.NewNotFound(appsv1.Resource("deployment"), "default-predictor"),
+	}
+	clientset := fake.NewSimpleClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace},
+		Data: map[string]string{
+			oauthProxyISVCConfigKey: `{"image": "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m"}`,
+		},
+	})
+
+	objectMeta := metav1.ObjectMeta{
+		Name:      "default-predictor",
+		Namespace: "default-predictor-namespace",
+		Annotations: map[string]string{
+			constants.ODHKserveRawAuth: "false", // Auth disabled
+		},
+		Labels: map[string]string{
+			constants.DeploymentMode:  string(constants.Standard),
+			constants.AutoscalerClass: string(constants.DefaultAutoscalerClass),
+		},
+	}
+
+	deployments, _, err := createRawDeploymentODH(
+		context.TODO(),
+		client,
+		clientset,
+		constants.InferenceServiceResource,
+		objectMeta,
+		metav1.ObjectMeta{},
+		&v1beta1.ComponentExtensionSpec{},
+		&corev1.PodSpec{},
+		nil,
+		nil,
+	)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, deployments)
+
+	// Verify OAuth proxy container is present even though auth is disabled
+	containers := deployments[0].Spec.Template.Spec.Containers
+	oauthProxyFound := false
+	for _, container := range containers {
+		if container.Name == constants.KubeRbacContainerName {
+			oauthProxyFound = true
+			break
+		}
+	}
+	assert.True(t, oauthProxyFound, "OAuth proxy should be present in new deployment even with auth disabled")
+
+	// Verify AutomountServiceAccountToken is set
+	assert.NotNil(t, deployments[0].Spec.Template.Spec.AutomountServiceAccountToken)
+	assert.True(t, *deployments[0].Spec.Template.Spec.AutomountServiceAccountToken)
+
+	// Verify volumes are mounted
+	volumes := deployments[0].Spec.Template.Spec.Volumes
+	tlsVolumeFound := false
+	sarVolumeFound := false
+	for _, vol := range volumes {
+		if vol.Name == "proxy-tls" {
+			tlsVolumeFound = true
+		}
+		if vol.Name == "default-predictor-kube-rbac-proxy-sar-config" {
+			sarVolumeFound = true
+		}
+	}
+	assert.True(t, tlsVolumeFound, "TLS volume should be mounted")
+	assert.True(t, sarVolumeFound, "SAR ConfigMap volume should be mounted")
+}
+
+func TestNewRawDeploymentWithAuthEnabled_IncludesOAuthProxy(t *testing.T) {
+	client := &mockClientForCheckDeploymentExist{
+		getErr: errors.NewNotFound(appsv1.Resource("deployment"), "auth-enabled-predictor"),
+	}
+	clientset := fake.NewSimpleClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace},
+		Data: map[string]string{
+			oauthProxyISVCConfigKey: `{"image": "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m"}`,
+		},
+	})
+
+	objectMeta := metav1.ObjectMeta{
+		Name:      "auth-enabled-predictor",
+		Namespace: "default-predictor-namespace",
+		Annotations: map[string]string{
+			constants.ODHKserveRawAuth: "true", // Auth enabled
+		},
+		Labels: map[string]string{
+			constants.DeploymentMode:  string(constants.Standard),
+			constants.AutoscalerClass: string(constants.DefaultAutoscalerClass),
+		},
+	}
+
+	deployments, _, err := createRawDeploymentODH(
+		context.TODO(),
+		client,
+		clientset,
+		constants.InferenceServiceResource,
+		objectMeta,
+		metav1.ObjectMeta{},
+		&v1beta1.ComponentExtensionSpec{},
+		&corev1.PodSpec{},
+		nil,
+		nil,
+	)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, deployments)
+
+	// Verify OAuth proxy container is present
+	containers := deployments[0].Spec.Template.Spec.Containers
+	oauthProxyFound := false
+	for _, container := range containers {
+		if container.Name == constants.KubeRbacContainerName {
+			oauthProxyFound = true
+			break
+		}
+	}
+	assert.True(t, oauthProxyFound, "OAuth proxy should be present in new deployment with auth enabled")
+}
+
+func TestExistingRawDeploymentWithAuthDisabled_NoOAuthProxyAdded(t *testing.T) {
+	existingDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-predictor",
+			Namespace: "default-predictor-namespace",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: constants.InferenceServiceContainerName},
+					},
+				},
+			},
+		},
+	}
+
+	client := &mockClientForCheckDeploymentExist{
+		getDeployment: existingDeployment,
+		getErr:        nil,
+	}
+	clientset := fake.NewSimpleClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace},
+		Data: map[string]string{
+			oauthProxyISVCConfigKey: `{"image": "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m"}`,
+		},
+	})
+
+	objectMeta := metav1.ObjectMeta{
+		Name:      "existing-predictor",
+		Namespace: "default-predictor-namespace",
+		Annotations: map[string]string{
+			constants.ODHKserveRawAuth: "false",
+		},
+		Labels: map[string]string{
+			constants.DeploymentMode:  string(constants.Standard),
+			constants.AutoscalerClass: string(constants.DefaultAutoscalerClass),
+		},
+	}
+
+	deployments, _, err := createRawDeploymentODH(
+		context.TODO(),
+		client,
+		clientset,
+		constants.InferenceServiceResource,
+		objectMeta,
+		metav1.ObjectMeta{},
+		&v1beta1.ComponentExtensionSpec{},
+		&corev1.PodSpec{},
+		nil,
+		nil,
+	)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, deployments)
+
+	// Verify OAuth proxy is NOT added to existing deployment with auth disabled
+	containers := deployments[0].Spec.Template.Spec.Containers
+	oauthProxyFound := false
+	for _, container := range containers {
+		if container.Name == constants.KubeRbacContainerName {
+			oauthProxyFound = true
+			break
+		}
+	}
+	assert.False(t, oauthProxyFound, "OAuth proxy should NOT be added to existing deployment with auth disabled")
+}
+
+func TestExistingRawDeploymentWithAuthEnabled_PreservesOAuthProxy(t *testing.T) {
+	existingDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "existing-auth-predictor",
+			Namespace: "default-predictor-namespace",
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: constants.InferenceServiceContainerName},
+						{Name: constants.KubeRbacContainerName},
+					},
+				},
+			},
+		},
+	}
+
+	client := &mockClientForCheckDeploymentExist{
+		getDeployment: existingDeployment,
+		getErr:        nil,
+	}
+	clientset := fake.NewSimpleClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace},
+		Data: map[string]string{
+			oauthProxyISVCConfigKey: `{"image": "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m"}`,
+		},
+	})
+
+	objectMeta := metav1.ObjectMeta{
+		Name:      "existing-auth-predictor",
+		Namespace: "default-predictor-namespace",
+		Annotations: map[string]string{
+			constants.ODHKserveRawAuth: "true",
+		},
+		Labels: map[string]string{
+			constants.DeploymentMode:  string(constants.Standard),
+			constants.AutoscalerClass: string(constants.DefaultAutoscalerClass),
+		},
+	}
+
+	deployments, _, err := createRawDeploymentODH(
+		context.TODO(),
+		client,
+		clientset,
+		constants.InferenceServiceResource,
+		objectMeta,
+		metav1.ObjectMeta{},
+		&v1beta1.ComponentExtensionSpec{},
+		&corev1.PodSpec{},
+		nil,
+		nil,
+	)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, deployments)
+
+	// Verify OAuth proxy is still present in existing deployment with auth enabled
+	containers := deployments[0].Spec.Template.Spec.Containers
+	oauthProxyFound := false
+	for _, container := range containers {
+		if container.Name == constants.KubeRbacContainerName {
+			oauthProxyFound = true
+			break
+		}
+	}
+	assert.True(t, oauthProxyFound, "OAuth proxy should be preserved in existing deployment with auth enabled")
+}
+
+func TestNewInferenceGraph_NoOAuthProxy(t *testing.T) {
+	client := &mockClientForCheckDeploymentExist{
+		getErr: errors.NewNotFound(appsv1.Resource("deployment"), "ig-predictor"),
+	}
+	clientset := fake.NewSimpleClientset(&corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace},
+		Data: map[string]string{
+			oauthProxyISVCConfigKey: `{"image": "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m"}`,
+		},
+	})
+
+	objectMeta := metav1.ObjectMeta{
+		Name:      "ig-predictor",
+		Namespace: "default-predictor-namespace",
+		Annotations: map[string]string{
+			constants.ODHKserveRawAuth: "false",
+		},
+		Labels: map[string]string{
+			constants.DeploymentMode:  string(constants.Standard),
+			constants.AutoscalerClass: string(constants.DefaultAutoscalerClass),
+		},
+	}
+
+	deployments, _, err := createRawDeploymentODH(
+		context.TODO(),
+		client,
+		clientset,
+		constants.InferenceGraphResource,
+		objectMeta,
+		metav1.ObjectMeta{},
+		&v1beta1.ComponentExtensionSpec{},
+		&corev1.PodSpec{},
+		nil,
+		nil,
+	)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, deployments)
+
+	// Verify OAuth proxy is NOT added to InferenceGraph
+	containers := deployments[0].Spec.Template.Spec.Containers
+	oauthProxyFound := false
+	for _, container := range containers {
+		if container.Name == constants.KubeRbacContainerName {
+			oauthProxyFound = true
+			break
+		}
+	}
+	assert.False(t, oauthProxyFound, "OAuth proxy should NOT be added to InferenceGraph resources")
+
+	// Verify TLS volumes ARE still mounted (for serving cert)
+	volumes := deployments[0].Spec.Template.Spec.Volumes
+	tlsVolumeFound := false
+	for _, vol := range volumes {
+		if vol.Name == "proxy-tls" {
+			tlsVolumeFound = true
+			break
+		}
+	}
+	assert.True(t, tlsVolumeFound, "TLS volume should be mounted for InferenceGraph")
 }

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
@@ -1592,20 +1592,18 @@ func (m *mockClientForCheckDeploymentExist) Get(ctx context.Context, key kclient
 		if m.getErr != nil {
 			return m.getErr
 		}
-		if m.getDeployment != nil {
-			*o = *m.getDeployment.DeepCopy()
+		if m.getDeployment == nil {
+			return errors.NewNotFound(appsv1.Resource("deployment"), key.Name)
 		}
+		*o = *m.getDeployment.DeepCopy()
 	case *v1beta1.InferenceService:
-		// For InferenceService, always create a minimal mock object with required fields
-		// This is needed for SAR ConfigMap creation
+		// For InferenceService, always create a minimal mock object with required fields.
+		// TypeMeta is intentionally left zero-valued to match real controller-runtime client behavior.
+		// This is needed for SAR ConfigMap creation.
 		o.ObjectMeta = metav1.ObjectMeta{
 			Name:      key.Name,
 			Namespace: key.Namespace,
 			UID:       "test-uid-12345",
-		}
-		o.TypeMeta = metav1.TypeMeta{
-			APIVersion: "serving.kserve.io/v1beta1",
-			Kind:       "InferenceService",
 		}
 	}
 	return nil

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
@@ -44,7 +44,13 @@ import (
 	"github.com/kserve/kserve/pkg/utils"
 )
 
-const oauthProxyISVCConfigKey = "oauthProxy"
+const (
+	oauthProxyISVCConfigKey = "oauthProxy"
+
+	oauthProxyConfig = `{"image": "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m"}`
+
+	oauthProxyConfigWithTimeout = `{"image": "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m", "upstreamTimeoutSeconds": "20"}`
+)
 
 func TestCreateDefaultDeployment(t *testing.T) {
 	type args struct {
@@ -898,7 +904,7 @@ func TestOauthProxyUpstreamTimeout(t *testing.T) {
 				clientset: fake.NewSimpleClientset(&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace},
 					Data: map[string]string{
-						oauthProxyISVCConfigKey: `{"image": "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m"}`,
+						oauthProxyISVCConfigKey: oauthProxyConfig,
 					},
 				}),
 				objectMeta: metav1.ObjectMeta{
@@ -926,7 +932,7 @@ func TestOauthProxyUpstreamTimeout(t *testing.T) {
 				clientset: fake.NewSimpleClientset(&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace},
 					Data: map[string]string{
-						oauthProxyISVCConfigKey: `{"image": "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m", "upstreamTimeoutSeconds": "20"}`,
+						oauthProxyISVCConfigKey: oauthProxyConfigWithTimeout,
 					},
 				}),
 				objectMeta: metav1.ObjectMeta{
@@ -954,7 +960,7 @@ func TestOauthProxyUpstreamTimeout(t *testing.T) {
 				clientset: fake.NewSimpleClientset(&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace},
 					Data: map[string]string{
-						oauthProxyISVCConfigKey: `{"image": "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m", "upstreamTimeoutSeconds": "20"}`,
+						oauthProxyISVCConfigKey: oauthProxyConfigWithTimeout,
 					},
 				}),
 				objectMeta: metav1.ObjectMeta{
@@ -1382,7 +1388,15 @@ func TestNewDeploymentReconciler(t *testing.T) {
 		{
 			name: "default deployment",
 			fields: fields{
-				client:       nil,
+				client: &mockClientForCheckDeploymentExist{
+					getErr: errors.NewNotFound(appsv1.Resource("deployment"), "test-predictor"),
+				},
+				clientset: fake.NewSimpleClientset(&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace},
+					Data: map[string]string{
+						oauthProxyISVCConfigKey: oauthProxyConfig,
+					},
+				}),
 				resourceType: constants.InferenceServiceResource,
 				scheme:       nil,
 				objectMeta: metav1.ObjectMeta{
@@ -1412,7 +1426,15 @@ func TestNewDeploymentReconciler(t *testing.T) {
 		{
 			name: "multi-node deployment",
 			fields: fields{
-				client:       nil,
+				client: &mockClientForCheckDeploymentExist{
+					getErr: errors.NewNotFound(appsv1.Resource("deployment"), "test-predictor"),
+				},
+				clientset: fake.NewSimpleClientset(&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace},
+					Data: map[string]string{
+						oauthProxyISVCConfigKey: oauthProxyConfig,
+					},
+				}),
 				resourceType: constants.InferenceServiceResource,
 				scheme:       nil,
 				objectMeta: metav1.ObjectMeta{
@@ -2463,7 +2485,7 @@ func TestNewRawDeploymentWithAuthDisabled_IncludesOAuthProxy(t *testing.T) {
 	clientset := fake.NewSimpleClientset(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace},
 		Data: map[string]string{
-			oauthProxyISVCConfigKey: `{"image": "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m"}`,
+			oauthProxyISVCConfigKey: oauthProxyConfig,
 		},
 	})
 
@@ -2518,7 +2540,7 @@ func TestNewRawDeploymentWithAuthDisabled_IncludesOAuthProxy(t *testing.T) {
 		if vol.Name == "proxy-tls" {
 			tlsVolumeFound = true
 		}
-		if vol.Name == "default-predictor-kube-rbac-proxy-sar-config" {
+		if vol.Name == fmt.Sprintf("%s-%s", objectMeta.Name, constants.OauthProxySARCMName) {
 			sarVolumeFound = true
 		}
 	}
@@ -2533,7 +2555,7 @@ func TestNewRawDeploymentWithAuthEnabled_IncludesOAuthProxy(t *testing.T) {
 	clientset := fake.NewSimpleClientset(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace},
 		Data: map[string]string{
-			oauthProxyISVCConfigKey: `{"image": "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m"}`,
+			oauthProxyISVCConfigKey: oauthProxyConfig,
 		},
 	})
 
@@ -2601,7 +2623,7 @@ func TestExistingRawDeploymentWithAuthDisabled_NoOAuthProxyAdded(t *testing.T) {
 	clientset := fake.NewSimpleClientset(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace},
 		Data: map[string]string{
-			oauthProxyISVCConfigKey: `{"image": "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m"}`,
+			oauthProxyISVCConfigKey: oauthProxyConfig,
 		},
 	})
 
@@ -2670,7 +2692,7 @@ func TestExistingRawDeploymentWithAuthEnabled_PreservesOAuthProxy(t *testing.T) 
 	clientset := fake.NewSimpleClientset(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace},
 		Data: map[string]string{
-			oauthProxyISVCConfigKey: `{"image": "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m"}`,
+			oauthProxyISVCConfigKey: oauthProxyConfig,
 		},
 	})
 
@@ -2721,7 +2743,7 @@ func TestNewInferenceGraph_NoOAuthProxy(t *testing.T) {
 	clientset := fake.NewSimpleClientset(&corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace},
 		Data: map[string]string{
-			oauthProxyISVCConfigKey: `{"image": "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m"}`,
+			oauthProxyISVCConfigKey: oauthProxyConfig,
 		},
 	})
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
@@ -2474,8 +2474,7 @@ func TestGetAuthProxyConditionNoCondition(t *testing.T) {
 	assert.Empty(t, condType)
 }
 
-// Tests for RHOAIENG-52129: OAuth proxy always added to new deployments
-
+// Tests for OAuth proxy always added to new deployments
 func TestNewRawDeploymentWithAuthDisabled_IncludesOAuthProxy(t *testing.T) {
 	client := &mockClientForCheckDeploymentExist{
 		getErr: errors.NewNotFound(appsv1.Resource("deployment"), "default-predictor"),

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/factory_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/factory_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -33,6 +34,7 @@ import (
 
 func TestCreateWorkloadReconciler(t *testing.T) {
 	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
 	_ = v1beta1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
 

--- a/pkg/controller/v1beta1/inferenceservice/suite_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/suite_test.go
@@ -147,6 +147,7 @@ func getBaseTestConfigs() map[string]string {
 				"defaultDeploymentMode": "Knative"
 			}`,
 		"inferenceService": `{}`,
+		"oauthProxy":       `{"image": "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m"}`,
 	}
 }
 

--- a/pkg/controller/v1beta1/inferenceservice/tests_common.go
+++ b/pkg/controller/v1beta1/inferenceservice/tests_common.go
@@ -280,8 +280,8 @@ func kubeRbacProxyContainer(upstreamTimeoutSeconds *int64, sarVolumeName string)
 		Image: constants.OauthProxyImage,
 		Args:  args,
 		Ports: []corev1.ContainerPort{
-			{ContainerPort: constants.OauthProxyPort, Name: "https", Protocol: corev1.ProtocolTCP},
-			{ContainerPort: constants.OauthProxyProbePort, Name: "proxy", Protocol: corev1.ProtocolTCP},
+			{ContainerPort: constants.OauthProxyPort, Name: "https"},
+			{ContainerPort: constants.OauthProxyProbePort, Name: "proxy"},
 		},
 		LivenessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
@@ -325,9 +325,6 @@ func kubeRbacProxyContainer(upstreamTimeoutSeconds *int64, sarVolumeName string)
 			{Name: "proxy-tls", MountPath: "/etc/tls/private"},
 			{Name: sarVolumeName, MountPath: "/etc/kube-rbac-proxy", ReadOnly: true},
 		},
-		TerminationMessagePath:   "/dev/termination-log",
-		TerminationMessagePolicy: "File",
-		ImagePullPolicy:          "IfNotPresent",
 	}
 }
 
@@ -513,7 +510,7 @@ func getDeploymentWithKServiceLabel(predictorDeploymentKey types.NamespacedName,
 							TerminationMessagePolicy: "File",
 							ImagePullPolicy:          "IfNotPresent",
 						},
-						kubeRbacProxyContainer(isvc.Spec.Predictor.ComponentExtensionSpec.TimeoutSeconds, fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName)),
+						kubeRbacProxyContainer(isvc.Spec.Predictor.TimeoutSeconds, fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName)),
 					},
 					Volumes: proxyVolumes(
 						predictorDeploymentKey.Name+constants.ServingCertSecretSuffix,

--- a/pkg/controller/v1beta1/inferenceservice/tests_common.go
+++ b/pkg/controller/v1beta1/inferenceservice/tests_common.go
@@ -280,8 +280,8 @@ func kubeRbacProxyContainer(upstreamTimeoutSeconds *int64, sarVolumeName string)
 		Image: constants.OauthProxyImage,
 		Args:  args,
 		Ports: []corev1.ContainerPort{
-			{ContainerPort: constants.OauthProxyPort, Name: "https"},
-			{ContainerPort: constants.OauthProxyProbePort, Name: "proxy"},
+			{ContainerPort: constants.OauthProxyPort, Name: "https", Protocol: corev1.ProtocolTCP},
+			{ContainerPort: constants.OauthProxyProbePort, Name: "proxy", Protocol: corev1.ProtocolTCP},
 		},
 		LivenessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
@@ -325,6 +325,9 @@ func kubeRbacProxyContainer(upstreamTimeoutSeconds *int64, sarVolumeName string)
 			{Name: "proxy-tls", MountPath: "/etc/tls/private"},
 			{Name: sarVolumeName, MountPath: "/etc/kube-rbac-proxy", ReadOnly: true},
 		},
+		TerminationMessagePath:   "/dev/termination-log",
+		TerminationMessagePolicy: "File",
+		ImagePullPolicy:          "IfNotPresent",
 	}
 }
 

--- a/pkg/controller/v1beta1/inferenceservice/tests_common.go
+++ b/pkg/controller/v1beta1/inferenceservice/tests_common.go
@@ -258,6 +258,105 @@ func getDefaultRollingStrategy() appsv1.DeploymentStrategy {
 	}
 }
 
+// kubeRbacProxyContainer returns the kube-rbac-proxy sidecar container for an InferenceService deployment.
+// sarVolumeName is the pod volume label for the SAR ConfigMap volume (matches the volume defined by proxyVolumes).
+// If upstreamTimeoutSeconds is non-nil, --upstream-timeout=<N>s is appended to the args.
+func kubeRbacProxyContainer(upstreamTimeoutSeconds *int64, sarVolumeName string) corev1.Container {
+	args := []string{
+		`--secure-listen-address=:8443`,
+		`--proxy-endpoints-port=8643`,
+		`--upstream=http://localhost:8080`,
+		`--auth-header-fields-enabled=true`,
+		`--tls-cert-file=/etc/tls/private/tls.crt`,
+		`--tls-private-key-file=/etc/tls/private/tls.key`,
+		`--config-file=/etc/kube-rbac-proxy/config-file.yaml`,
+		`--v=4`,
+	}
+	if upstreamTimeoutSeconds != nil {
+		args = append(args, fmt.Sprintf("--upstream-timeout=%ds", *upstreamTimeoutSeconds))
+	}
+	return corev1.Container{
+		Name:  constants.KubeRbacContainerName,
+		Image: constants.OauthProxyImage,
+		Args:  args,
+		Ports: []corev1.ContainerPort{
+			{ContainerPort: constants.OauthProxyPort, Name: "https", Protocol: corev1.ProtocolTCP},
+			{ContainerPort: constants.OauthProxyProbePort, Name: "proxy", Protocol: corev1.ProtocolTCP},
+		},
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/healthz",
+					Port:   intstr.FromInt32(constants.OauthProxyProbePort),
+					Scheme: corev1.URISchemeHTTPS,
+				},
+			},
+			InitialDelaySeconds: 30,
+			TimeoutSeconds:      1,
+			PeriodSeconds:       5,
+			SuccessThreshold:    1,
+			FailureThreshold:    3,
+		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path:   "/healthz",
+					Port:   intstr.FromInt32(constants.OauthProxyProbePort),
+					Scheme: corev1.URISchemeHTTPS,
+				},
+			},
+			InitialDelaySeconds: 5,
+			TimeoutSeconds:      1,
+			PeriodSeconds:       5,
+			SuccessThreshold:    1,
+			FailureThreshold:    3,
+		},
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(constants.OauthProxyResourceCPULimit),
+				corev1.ResourceMemory: resource.MustParse(constants.OauthProxyResourceMemoryLimit),
+			},
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse(constants.OauthProxyResourceCPURequest),
+				corev1.ResourceMemory: resource.MustParse(constants.OauthProxyResourceMemoryRequest),
+			},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "proxy-tls", MountPath: "/etc/tls/private"},
+			{Name: sarVolumeName, MountPath: "/etc/kube-rbac-proxy", ReadOnly: true},
+		},
+		TerminationMessagePath:   "/dev/termination-log",
+		TerminationMessagePolicy: "File",
+		ImagePullPolicy:          "IfNotPresent",
+	}
+}
+
+// proxyVolumes returns the proxy-tls and SAR ConfigMap volumes for an InferenceService deployment.
+// tlsSecretName is the serving certificate Secret name; sarConfigMapName is the full SAR ConfigMap name.
+func proxyVolumes(tlsSecretName, sarConfigMapName string) []corev1.Volume {
+	defaultMode := int32(420)
+	return []corev1.Volume{
+		{
+			Name: "proxy-tls",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  tlsSecretName,
+					DefaultMode: &defaultMode,
+				},
+			},
+		},
+		{
+			Name: sarConfigMapName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: sarConfigMapName},
+					DefaultMode:          &defaultMode,
+				},
+			},
+		},
+	}
+}
+
 func getExpectedDeployment(explainerDeploymentKey types.NamespacedName, serviceName string, serviceKey types.NamespacedName, predictorServiceKey types.NamespacedName) appsv1.Deployment {
 	return appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -317,14 +416,25 @@ func getExpectedDeployment(explainerDeploymentKey types.NamespacedName, serviceN
 							TerminationMessagePath:   "/dev/termination-log",
 							TerminationMessagePolicy: "File",
 							ImagePullPolicy:          "IfNotPresent",
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "proxy-tls",
+									MountPath: "/etc/tls/private",
+								},
+							},
 						},
+						kubeRbacProxyContainer(ptr.To(int64(30)), fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName)),
 					},
+					Volumes: proxyVolumes(
+						explainerDeploymentKey.Name+constants.ServingCertSecretSuffix,
+						fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName),
+					),
 					SchedulerName:                 "default-scheduler",
 					RestartPolicy:                 "Always",
 					TerminationGracePeriodSeconds: ptr.To(GRACE_PERIOD),
 					DNSPolicy:                     "ClusterFirst",
 					SecurityContext:               defaultSecurityContext,
-					AutomountServiceAccountToken:  ptr.To(false),
+					AutomountServiceAccountToken:  ptr.To(true),
 				},
 			},
 			Strategy:                getDefaultRollingStrategy(),
@@ -378,6 +488,12 @@ func getDeploymentWithKServiceLabel(predictorDeploymentKey types.NamespacedName,
 							Env: []corev1.EnvVar{
 								{Name: constants.InferenceServiceNameEnvVarKey, Value: serviceName},
 							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "proxy-tls",
+									MountPath: "/etc/tls/private",
+								},
+							},
 							Resources: defaultResource,
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
@@ -397,13 +513,18 @@ func getDeploymentWithKServiceLabel(predictorDeploymentKey types.NamespacedName,
 							TerminationMessagePolicy: "File",
 							ImagePullPolicy:          "IfNotPresent",
 						},
+						kubeRbacProxyContainer(isvc.Spec.Predictor.ComponentExtensionSpec.TimeoutSeconds, fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName)),
 					},
+					Volumes: proxyVolumes(
+						predictorDeploymentKey.Name+constants.ServingCertSecretSuffix,
+						fmt.Sprintf("%s-%s", serviceName, constants.OauthProxySARCMName),
+					),
 					SchedulerName:                 "default-scheduler",
 					RestartPolicy:                 "Always",
 					TerminationGracePeriodSeconds: ptr.To(GRACE_PERIOD),
 					DNSPolicy:                     "ClusterFirst",
 					SecurityContext:               defaultSecurityContext,
-					AutomountServiceAccountToken:  ptr.To(false),
+					AutomountServiceAccountToken:  ptr.To(true),
 				},
 			},
 			Strategy:                getDefaultRollingStrategy(),


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, toggling the `security.opendatahub.io/enable-auth` annotation on a raw deployment InferenceService caused the OAuth proxy container to be added or removed from the pod template. Because Kubernetes rolls pods on any pod template change, this produced an unwanted rollout — particularly disruptive for large models or resource-constrained clusters.

The fix introduces a distinction between new and existing deployments:
- New InferenceService deployments always receive the kube-rbac-proxy container and its associated TLS/SAR volumes, regardless of the auth annotation. This means future auth toggles only update the Service (which already switches its target port based on the annotation), leaving the pod template — and therefore the pod — untouched.
- Existing deployments (those already present in the cluster) are left unchanged to avoid forced rollouts during version upgrades, achieving a seamless migration path.

Also updates the mock client used in tests so that Deployment-specific errors do not propagate to InferenceService lookups performed during SAR ConfigMap creation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes https://redhat.atlassian.net/browse/RHOAIENG-52129



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More consistent OAuth proxy handling: new deployments reliably get the proxy plus TLS/SAR mounts; existing deployments preserve prior proxy state and respect auth settings.
  * Main containers now mount TLS volume and ServiceAccountToken automount is enabled when proxy is present.
  * Upstream timeout/port for the proxy is derived from component/pod spec for consistent behavior.

* **Tests**
  * Added comprehensive unit tests, shared proxy fixtures/helpers, and a base test config with pinned oauth-proxy image and resource settings validating proxy, volumes, automount, and auth scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->