### PR TITLE
feat(llmisvc): add WVA autoscaling config to ODH overlay

### DIFF
--- a/config/overlays/odh/patches/inferenceservice-config-patch.yaml
+++ b/config/overlays/odh/patches/inferenceservice-config-patch.yaml
@@ -140,7 +140,7 @@ data:
       "prometheus": {
         "url": "https://thanos-querier.openshift-monitoring.svc.cluster.local:9091",
         "authModes": "bearer",
-        "triggerAuthName": "keda-thanos-token",
+        "triggerAuthName": "ai-inference-keda-thanos",
         "triggerAuthKind": "ClusterTriggerAuthentication"
       }
     }


### PR DESCRIPTION
## Summary

- Adds the `autoscaling-wva-controller-config` key to the ODH `inferenceservice-config` ConfigMap patch, configuring KEDA to query Prometheus metrics from the OpenShift Thanos Querier using bearer token authentication via the `keda-thanos-token` ClusterTriggerAuthentication.
- This eliminates the need for a manual `kubectl patch` post-install step when enabling WVA autoscaling on OpenShift.

## Details

The llmisvc controller reads the `autoscaling-wva-controller-config` key from the `inferenceservice-config` ConfigMap to configure KEDA ScaledObject Prometheus triggers. Previously this key had to be set imperatively after install. Now it is set declaratively via the ODH kustomize overlay, consistent with how other OpenShift-specific settings (ingress, credentials, deploy mode) are already managed.

Prerequisites: the KEDA auth resources (ServiceAccount, ClusterRoleBinding, Secret, ClusterTriggerAuthentication) in the `openshift-keda` namespace must be deployed separately (it is part of openshift overlay in WVA).