### PR TITLE
fix: clusterStorageContainer image and resources in ODH overlay

### DIFF
--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -51,6 +51,10 @@ patches:
     kind: Deployment
     name: llmisvc-controller-manager
   path: patches/remove-kserve-controller-runas.yaml
+- target:
+    kind: ClusterStorageContainer
+    name: default
+  path: patches/set-resources-storagecontainer-patch.yaml
 
 replacements:
 - source:
@@ -149,6 +153,19 @@ replacements:
       name: llmisvc-controller-manager
     fieldPaths:
     - spec.template.spec.containers.[name=manager].image
+
+# Replace ClusterStorageContainer image with ODH image
+- source:
+    kind: ConfigMap
+    name: kserve-parameters
+    fieldPath: data.kserve-storage-initializer
+  targets:
+  - select:
+      kind: ClusterStorageContainer
+      name: default
+    fieldPaths:
+    - spec.container.image
+
 - source:
     kind: ConfigMap
     name: kserve-parameters

--- a/config/overlays/odh/patches/set-resources-storagecontainer-patch.yaml
+++ b/config/overlays/odh/patches/set-resources-storagecontainer-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: "serving.kserve.io/v1alpha1"
+kind: ClusterStorageContainer
+metadata:
+  name: default
+spec:
+  container:
+    resources:
+      limits:
+        memory: 24Gi
+        cpu: "1"


### PR DESCRIPTION
   Add a kustomize replacement to set the ClusterStorageContainer default
   image from the kserve-parameters ConfigMap, and a strategic merge patch
   to align its resource limits with the inferenceservice-config
   storageInitializer settings, preventing resource mismatches at runtime.


**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:


- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note

```
