### PR TITLE
fix(llmisvc): update Spyre configs for continuous batching

### DIFF
--- a/config/overlays/odh/accelerators/ibm-spyre-ppc64le-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/ibm-spyre-ppc64le-config-llm-template.yaml
@@ -24,11 +24,5 @@ spec:
             value: error
           - name: TORCH_SENDNN_LOG
             value: CRITICAL
-          - name: VLLM_SPYRE_WARMUP_BATCH_SIZES
-            value: "4"
-          - name: VLLM_SPYRE_WARMUP_PROMPT_LENS
-            value: "1024"
-          - name: VLLM_SPYRE_WARMUP_NEW_TOKENS
-            value: "256"
-          - name: VLLM_SPYRE_REQUIRE_PRECOMPILED_DECODERS
-            value: "0"
+          - name: VLLM_SPYRE_USE_CB
+            value: "1"

--- a/config/overlays/odh/accelerators/ibm-spyre-s390x-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/ibm-spyre-s390x-config-llm-template.yaml
@@ -29,3 +29,5 @@ spec:
             value: "1"
           - name: TORCH_SENDNN_CACHE_ENABLE
             value: "1"
+          - name: VLLM_DT_CHUNK_LEN
+            value: "512"

--- a/config/overlays/odh/accelerators/ibm-spyre-x86-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/ibm-spyre-x86-config-llm-template.yaml
@@ -24,11 +24,5 @@ spec:
             value: error
           - name: TORCH_SENDNN_LOG
             value: CRITICAL
-          - name: VLLM_SPYRE_WARMUP_BATCH_SIZES
-            value: "4"
-          - name: VLLM_SPYRE_WARMUP_PROMPT_LENS
-            value: "1024"
-          - name: VLLM_SPYRE_WARMUP_NEW_TOKENS
-            value: "256"
-          - name: VLLM_SPYRE_REQUIRE_PRECOMPILED_DECODERS
-            value: "0"
+          - name: VLLM_SPYRE_USE_CB
+            value: "1"


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the IBM Spyre accelerator config env vars to target continuous batching as the default, since these are `LLMInferenceServiceConfig` templates for LLM serving.

The ppc64le and x86 configs were shipping static batching warmup env vars (`VLLM_SPYRE_WARMUP_BATCH_SIZES`, `VLLM_SPYRE_WARMUP_PROMPT_LENS`, `VLLM_SPYRE_WARMUP_NEW_TOKENS`) which are not applicable to continuous batching - the primary use case for `LLMInferenceService`. These caused liveness probe failures during ppc64le testing (warmup too aggressive for the default probe timeouts).

Changes:
- **ppc64le + x86**: Remove static batching warmup vars and `VLLM_SPYRE_REQUIRE_PRECOMPILED_DECODERS`, add `VLLM_SPYRE_USE_CB=1`
- **s390x**: Add `VLLM_DT_CHUNK_LEN=512` (image defaults to 1024, Z requires 512)

Env var values confirmed by IBM Spyre team: Shafi Hussain (ppc64le) and Dilip Bhagavan (s390x).

Follow-up to #1130.

**Which issue(s) this PR fixes**:
Fixes https://redhat.atlassian.net/browse/RHOAIENG-55774

**Feature/Issue validation/testing**:

This is a config-only change (3 YAML files). End-to-end validation requires IBM Spyre hardware which is not available in CI. Testing will be coordinated with the IBM P and Z teams:

- [ ] ppc64le: Verify vLLM starts with `VLLM_SPYRE_USE_CB=1` and no warmup vars
- [ ] s390x: Verify `VLLM_DT_CHUNK_LEN=512` is picked up correctly
- [ ] Confirm no `VLLM_SPYRE_WARMUP_*` vars remain in ppc64le or x86 configs
- [ ] Confirm `VLLM_SPYRE_USE_CB=1` present in all 3 Spyre configs

**Special notes for your reviewer**:

The `kustomize build config/overlays/odh/` has a pre-existing error related to `storageInitializer` replacement target format - this is unrelated to this PR. The accelerator config YAML files themselves are valid.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
  - No - requires IBM Spyre hardware not available in CI. Will be validated by IBM P/Z teams.
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note
Update IBM Spyre accelerator configs (ppc64le, x86, s390x) to use continuous batching defaults instead of static batching warmup parameters.
```
