### PR TITLE
fix: add back the patch to remove clusterServingRuntime

### DIFF
--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -20,6 +20,7 @@ namespace: opendatahub
 patches:
 - path: patches/remove-namespace.yaml
 - path: patches/remove-cert-manager.yaml
+- path: patches/remove-clusterservingruntime.yaml
 - path: patches/inferenceservice-config-patch.yaml
 - path: patches/set-resources-manager-patch.yaml
 - path: patches/remove-auth-proxy-patch.yaml


### PR DESCRIPTION
# Description 
 - include back the patch to remove the `ClusterSeringRuntime` resource.