### PR TITLE
[RHOAIENG-56198] fix: rebase group-test Dockerfiles to ubi9

### DIFF
--- a/python/custom_model_grpc.Dockerfile
+++ b/python/custom_model_grpc.Dockerfile
@@ -1,17 +1,11 @@
-ARG PYTHON_VERSION=3.11
-ARG BASE_IMAGE=docker.io/library/python:${PYTHON_VERSION}-slim-bookworm
+ARG BASE_IMAGE=registry.access.redhat.com/ubi9/python-311:9.7
 ARG VENV_PATH=/prod_venv
 
 FROM ${BASE_IMAGE} AS builder
+WORKDIR /
+USER 0
 
-# Install system dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    curl \
-    build-essential \
-    python3-dev && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN dnf install -y gcc gcc-c++ make python3.11-devel && dnf clean all
 
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
@@ -49,6 +43,7 @@ RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 # ------------------ Final stage ------------------
 FROM ${BASE_IMAGE} AS prod
+WORKDIR /
 
 # Activate virtual env
 ARG VENV_PATH
@@ -59,6 +54,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY third_party third_party
 
 # Create and switch to a non-root user
+USER 0
 RUN useradd kserve -m -u 1000 -d /home/kserve
 
 COPY --from=builder --chown=kserve:kserve third_party third_party

--- a/python/custom_transformer.Dockerfile
+++ b/python/custom_transformer.Dockerfile
@@ -1,17 +1,11 @@
-ARG PYTHON_VERSION=3.11
-ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim-bookworm
+ARG BASE_IMAGE=registry.access.redhat.com/ubi9/python-311:9.7
 ARG VENV_PATH=/prod_venv
 
 FROM ${BASE_IMAGE} AS builder
+WORKDIR /
+USER 0
 
-# Install system dependencies
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    curl \
-    build-essential \
-    python3-dev && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN dnf install -y gcc gcc-c++ make python3.11-devel && dnf clean all
 
 # Install uv and ensure it's in PATH
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
@@ -49,6 +43,7 @@ RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 # ---------- Production image ----------
 FROM ${BASE_IMAGE} AS prod
+WORKDIR /
 
 # Activate virtual env
 ARG VENV_PATH
@@ -59,6 +54,7 @@ ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
 COPY third_party third_party
 
 # Create non-root user
+USER 0
 RUN useradd kserve -m -u 1000 -d /home/kserve
 
 COPY --from=builder --chown=kserve:kserve third_party third_party

--- a/python/error_404_isvc.Dockerfile
+++ b/python/error_404_isvc.Dockerfile
@@ -1,11 +1,11 @@
-ARG PYTHON_VERSION=3.11
-ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim-bookworm
+ARG BASE_IMAGE=registry.access.redhat.com/ubi9/python-311:9.7
 ARG VENV_PATH=/prod_venv
 
 FROM ${BASE_IMAGE} AS builder
+WORKDIR /
+USER 0
 
-RUN apt-get update && apt-get install -y gcc python3-dev curl && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN dnf install -y gcc python3.11-devel && dnf clean all
 
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
@@ -41,12 +41,14 @@ RUN pip install --no-cache-dir tomli
 RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 FROM ${BASE_IMAGE} AS prod
+WORKDIR /
 
 # Activate virtual env
 ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
+USER 0
 RUN useradd kserve -m -u 1000 -d /home/kserve
 
 COPY --from=builder --chown=kserve:kserve third_party third_party

--- a/python/sklearn.Dockerfile
+++ b/python/sklearn.Dockerfile
@@ -1,12 +1,11 @@
-ARG PYTHON_VERSION=3.11
-ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim-bookworm
+ARG BASE_IMAGE=registry.access.redhat.com/ubi9/python-311:9.7
 ARG VENV_PATH=/prod_venv
 
 FROM ${BASE_IMAGE} AS builder
+WORKDIR /
+USER 0
 
-# Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends python3-dev curl build-essential && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN dnf install -y gcc gcc-c++ make python3.11-devel && dnf clean all
 
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
@@ -52,6 +51,7 @@ RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 # =================== Final stage ===================
 FROM ${BASE_IMAGE} AS prod
+WORKDIR /
 
 COPY third_party third_party
 
@@ -60,6 +60,7 @@ ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
+USER 0
 RUN useradd kserve -m -u 1000 -d /home/kserve
 
 COPY --from=builder --chown=kserve:kserve third_party third_party

--- a/python/success_200_isvc.Dockerfile
+++ b/python/success_200_isvc.Dockerfile
@@ -1,11 +1,11 @@
-ARG PYTHON_VERSION=3.11
-ARG BASE_IMAGE=python:${PYTHON_VERSION}-slim-bookworm
+ARG BASE_IMAGE=registry.access.redhat.com/ubi9/python-311:9.7
 ARG VENV_PATH=/prod_venv
 
 FROM ${BASE_IMAGE} AS builder
+WORKDIR /
+USER 0
 
-RUN apt-get update && apt-get install -y gcc python3-dev curl && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN dnf install -y gcc python3.11-devel && dnf clean all
 
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
@@ -41,12 +41,14 @@ RUN pip install --no-cache-dir tomli
 RUN mkdir -p third_party/library && python3 pip-licenses.py
 
 FROM ${BASE_IMAGE} AS prod
+WORKDIR /
 
 # Activate virtual env
 ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
+USER 0
 RUN useradd kserve -m -u 1000 -d /home/kserve
 
 COPY --from=builder --chown=kserve:kserve third_party third_party


### PR DESCRIPTION
## Summary

- Replace `docker.io/library/python:3.11-slim-bookworm` with `registry.access.redhat.com/ubi9/python-311:9.7` in the 5 test Dockerfiles built by the Konflux group-test pipeline (`success_200_isvc`, `error_404_isvc`, `sklearn`, `custom_transformer`, `custom_model_grpc`)
- Fixes Docker Hub unauthenticated pull rate limit errors (`toomanyrequests`) that were causing group-test build failures
- Adapts package management from Debian (`apt-get`) to RHEL (`dnf`), adds `WORKDIR /` and `USER 0` directives needed by the UBI S2I base image

## Changes per Dockerfile

| Change | Reason |
|---|---|
| `BASE_IMAGE=registry.access.redhat.com/ubi9/python-311:9.7` | Official Red Hat UBI image, public (no auth), no rate limits |
| `apt-get` -> `dnf` | UBI python image ships `dnf`, not `apt-get` |
| Added `WORKDIR /` | UBI defaults to `/opt/app-root/src`; original python:slim used `/` |
| Added `USER 0` before `dnf install` and `useradd` | UBI defaults to UID 1001 |
| Removed `PYTHON_VERSION` ARG | No longer needed (version baked into image name) |

## Test plan

- [x] `podman build` all 5 Dockerfiles locally -- all pass
- [ ] Verify Konflux group-test pipeline builds succeed with these changes