### PR TITLE
feat: add ONNX model class support for MLServer

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_defaults.go
+++ b/pkg/apis/serving/v1beta1/inference_service_defaults.go
@@ -443,6 +443,8 @@ func (isvc *InferenceService) SetMlServerDefaults() {
 		modelClass = constants.MLServerModelClassLightGBM
 	case constants.SupportedModelMLFlow:
 		modelClass = constants.MLServerModelClassMLFlow
+	case constants.SupportedModelONNX:
+		modelClass = constants.MLServerModelClassONNX
 	}
 	if isvc.Labels == nil {
 		isvc.Labels = map[string]string{constants.ModelClassLabel: modelClass}

--- a/pkg/apis/serving/v1beta1/inference_service_defaults_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_defaults_test.go
@@ -779,6 +779,36 @@ func TestMlServerDefaults(t *testing.T) {
 				"labels":          gomega.HaveKeyWithValue(constants.ModelClassLabel, constants.MLServerModelClassLightGBM),
 			},
 		},
+		"ONNX model": {
+			config: &InferenceServicesConfig{},
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						Model: &ModelSpec{
+							ModelFormat: ModelFormat{
+								Name: constants.SupportedModelONNX,
+							},
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI: proto.String("gs://testbucket/testmodel"),
+							},
+						},
+					},
+				},
+			},
+			matcher: map[string]types.GomegaMatcher{
+				"env": gomega.ContainElement(
+					corev1.EnvVar{
+						Name:  constants.MLServerModelURIEnv,
+						Value: constants.DefaultModelLocalMountPath,
+					}),
+				"protocolVersion": gomega.Equal(constants.ProtocolV2),
+				"labels":          gomega.HaveKeyWithValue(constants.ModelClassLabel, constants.MLServerModelClassONNX),
+			},
+		},
 		"LightGBM model with labels": {
 			config: &InferenceServicesConfig{},
 			isvc: InferenceService{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -610,6 +610,7 @@ const (
 	MLServerModelClassXGBoost  = "mlserver_xgboost.XGBoostModel"
 	MLServerModelClassLightGBM = "mlserver_lightgbm.LightGBMModel"
 	MLServerModelClassMLFlow   = "mlserver_mlflow.MLflowRuntime"
+	MLServerModelClassONNX     = "mlserver_onnx.OnnxModel"
 )
 
 // torchserve service envelope label allowed values


### PR DESCRIPTION
## Summary
- Add `MLServerModelClassONNX` constant (`mlserver_onnx.OnnxModel`) to support ONNX model serving via MLServer
- Add ONNX case to `SetMlServerDefaults()` so that `MLSERVER_MODEL_IMPLEMENTATION` label is correctly set for ONNX models
- Add unit test for ONNX model class in `TestMlServerDefaults`

## Changes
- `pkg/constants/constants.go`: Add `MLServerModelClassONNX = "mlserver_onnx.OnnxModel"` constant
- `pkg/apis/serving/v1beta1/inference_service_defaults.go`: Add ONNX model format case in the switch statement
- `pkg/apis/serving/v1beta1/inference_service_defaults_test.go`: Add ONNX test case to `TestMlServerDefaults`

## Test plan
- [x] Unit test `TestMlServerDefaults` passes with ONNX case
- [ ] Verify no regression for existing model classes (SKLearn, XGBoost, LightGBM, MLFlow)