### PR TITLE
feat(rules): add CodeRabbit rules for clean merges

### DIFF
--- a/.rules/build-tags.md
+++ b/.rules/build-tags.md
@@ -1,0 +1,45 @@
+# Midstream Build Tags and Companion File Rules
+
+These rules apply to **Go source files** (`*.go`, `*_test.go`). Skip this rule for non-Go file diffs.
+
+This repository is a midstream fork of kserve/kserve running on OpenShift (OCP). Platform-specific
+code must be isolated using Go build tags so upstream syncs stay conflict-free. OCP-specific logic
+lives in `*_ocp.go` files compiled only with `//go:build distro`; the upstream fallback lives in
+`*_default.go` files compiled with `//go:build !distro`.
+
+## Violations - flag as blocking
+
+1. **Missing build tag on OCP imports** - If a file imports packages whose import path contains
+   `openshift/`, `opendatahub/`, or `istio.io/`, it must have `//go:build distro` before the `package`
+   declaration. Flag if the header is absent.
+
+2. **`*_ocp.go` without build tag** - Any file named `*_ocp.go` or `*_ocp_test.go` must have
+   `//go:build distro` before the `package` declaration. Flag if missing.
+
+3. **`*_default.go` without build tag** - Any file named `*_default.go` must have
+   `//go:build !distro` before the `package` declaration. Flag if missing.
+
+4. **Commented-out code blocks** - Commented-out function bodies, struct fields, type definitions,
+   or conditional branches are a violation. They rot, cause merge conflicts, and are never
+   re-enabled. Use `//go:build` compile-time exclusion instead. Flag any `//` comment that wraps
+   meaningful code (not documentation or inline explanation). Suggest the author remove the commented
+   block or move it behind a `//go:build` constraint instead.
+
+5. **OCP logic in non-companion file** - If a file contains OCP-specific imports or logic (signals:
+   `openshift/`, `opendatahub/`, `istio.io/` import paths) and is not named `*_ocp.go` or
+   `*_ocp_test.go`, flag it. Suggest extracting the OCP-specific parts to a `<basename>_ocp.go`
+   companion with a `<basename>_default.go` with `//go:build !distro` and stub implementations of the same function signatures.
+
+6. **Missing default companion** - If a `*_ocp.go` file is added in this PR but no corresponding
+   `*_default.go` exists in the same package (check both the PR diff and the existing repo tree),
+   flag it. Upstream builds without `GOTAGS=distro` will fail to link. If the reviewer cannot inspect the
+   full repository tree (diff-only mode), flag tentatively and ask the author to confirm whether a
+   `*_default.go` companion exists in the same package.
+
+## Exemptions - do not flag
+
+- Files under a `distro/` sub-package (e.g. `pkg/controller/.../distro/controller_rbac_ocp.go`)
+  that contain no executable code - package declaration, license/copyright header, explanatory
+  comments, and `//+kubebuilder:rbac:` markers are all fine. These intentionally have no build tag
+  and are not named `*_ocp.go` - `controller-gen` must scan them in all build configurations.
+  Exempt from violations #2, #3, and #5.

--- a/.rules/kustomize-hygiene.md
+++ b/.rules/kustomize-hygiene.md
@@ -1,0 +1,35 @@
+# Midstream Kustomize Hygiene Rules
+
+These rules apply to **YAML files under `config/`**. Skip for non-YAML or non-`config/` file diffs.
+
+This repository uses kustomize overlays to separate upstream manifests from midstream
+(OpenShift/ODH) customizations. Upstream manifests under `config/` must stay clean. All OCP/ODH
+additions go into `config/overlays/odh/` as kustomize strategic merge or JSON patches - never as
+direct edits to upstream manifests.
+
+## Violations - flag as blocking
+
+1. **OCP/ODH content outside the ODH overlay** - If a YAML file outside `config/overlays/odh/`
+   contains `openshift.io` or `opendatahub.io` in annotations, labels, resource API groups, or any
+   other field, flag it. This content belongs in a patch under `config/overlays/odh/patches/`.
+   Direct edits to upstream manifests cause merge conflicts on every sync.
+
+2. **Commented-out YAML blocks** - Commented-out sections in any `config/**/*.yaml` file are a
+   violation. Use kustomize patches or transformers to remove or replace content instead. Flag any
+   consecutive `#`-prefixed lines that, if the `#` were removed, would parse as valid YAML key-value
+   pairs, sequences, or mapping nodes. Do not flag single-line descriptive comments (e.g. `# This file
+   configures X`). Suggest the appropriate kustomize patch type (strategic merge or JSON patch).
+   Place the patch under `config/overlays/odh/patches/` and reference it in the overlay's
+   `kustomization.yaml`.
+
+## Exemptions - do not flag
+
+- `config/crd/external/` - vendored third-party CRDs; `opendatahub.io` group references here are
+  expected and correct
+- `config/overlays/odh/` - the ODH overlay itself; OCP content here is the point
+- `config/overlays/odh-test/` - ODH-specific test overlay; OCP content is intentional here
+- `config/overlays/odh-xks/` - ODH on external Kubernetes; midstream overlay, OCP content is intentional here
+- `config/overlays/test/configmap/inferenceservice-openshift-ci-raw.yaml` - known pre-existing drift, tracked for migration to `config/overlays/odh-test/`
+- `config/overlays/test/configmap/inferenceservice-openshift-ci-serverless.yaml` - known pre-existing drift, tracked for migration to `config/overlays/odh-test/`
+- `config/overlays/test/configmap/inferenceservice-openshift-ci-serverless-predictor.yaml` - known pre-existing drift, tracked for migration to `config/overlays/odh-test/`
+- `config/rbac/role.yaml` - known pre-existing drift (`route.openshift.io` at lines 188 and 200), tracked for migration to the ODH overlay

--- a/.rules/makefile-split.md
+++ b/.rules/makefile-split.md
@@ -1,0 +1,32 @@
+# Midstream Makefile Split Rules
+
+These rules apply to **`Makefile` only** (exact filename match). Do not apply to
+`Makefile.overrides.mk`, `Makefile.tools.mk`, or any other `Makefile.*` variant - those are either
+upstream-owned tooling or the intended home for midstream content.
+
+This repository uses `Makefile.overrides.mk` (included by the upstream `Makefile` via `-include`)
+to isolate all midstream build logic. The upstream `Makefile` must stay clean.
+
+## Violations - flag as blocking
+
+1. **Distro-specific targets or variables in `Makefile`** - If a new make target, variable
+   assignment, or conditional block is OCP/OpenShift/distro-specific (signals: references to
+   `distro`, `openshift`, `OCP`, `odh`, or OpenShift-specific tooling (`oc`, `opm`, `rosa`), or distro-specific image registries (`registry.redhat.io`, `registry.access.redhat.com`, `quay.io/rhoai`, `quay.io/rhods`)), flag it and suggest moving
+   it to `Makefile.overrides.mk`.
+
+2. **`GOTAGS=distro` or build tag references** - Any addition of `GOTAGS=distro` or references to
+   `//go:build distro` directly in `Makefile` belongs in `Makefile.overrides.mk`, where it is
+   already set.
+
+3. **Modifying existing upstream targets or variables** - If a change appends distro-specific flags
+   to an existing upstream make target (e.g. adding `-tags distro` to a build target, appending to
+   `$(MAKE) test`, overriding a variable already defined upstream), flag it and suggest using
+   `Makefile.overrides.mk` override syntax instead.
+
+4. **New `-include` directives** - A new `-include` line may introduce a useful extension point.
+   Ask the author (in the review thread): is this generally useful and worth proposing to upstream
+   kserve/kserve? A change is generally useful if it is not OCP/ODH-specific, does not reference
+   distro registries or credentials, and adds an extension point any downstream project could benefit
+   from. If yes, ask the author to confirm an upstream proposal is planned or filed. If
+   midstream-only, suggest moving it to `Makefile.overrides.mk` instead. Block merge until the
+   author confirms intent in the PR description or review thread.

--- a/.rules/rbac-isolation.md
+++ b/.rules/rbac-isolation.md
@@ -1,0 +1,63 @@
+# Midstream RBAC Isolation Rules
+
+These rules apply to **Go source files** (`*.go`, `*_test.go`). Skip for non-Go file diffs.
+
+This repository uses kubebuilder RBAC markers (`//+kubebuilder:rbac:...`) to generate ClusterRole
+manifests. Markers for OCP/ODH-specific API groups must live in a dedicated `distro/` sub-package
+so they generate a separate ClusterRole and do not contaminate the upstream-generated `role.yaml`.
+
+Correct pattern:
+- `pkg/<controller>/distro/controller_rbac_ocp.go` - file containing only `//+kubebuilder:rbac:`
+  markers, **no build tag** (controller-gen must scan it in all configurations), processed by a
+  separate `controller-gen` invocation in `Makefile.overrides.mk`
+
+## Violations - flag as blocking
+
+1. **OCP/ODH RBAC markers outside `distro/`** - If a file that is NOT under a `distro/`
+   package path contains `//+kubebuilder:rbac:` markers referencing `*.opendatahub.io` or
+   `*.openshift.io` groups, flag it. These markers pollute the upstream
+   `role.yaml` with OCP-specific permissions. Move them to
+   `pkg/<controller>/distro/controller_rbac_ocp.go`.
+
+2. **OCP/ODH RBAC markers without build tag outside `distro/`** - A stricter form of
+   violation #1: same markers as above, additionally in a file without a `//go:build distro` header
+   and not in a `distro/` path. If this applies, flag #1 as well. The absence of a build tag means
+   the OCP-specific code is compiled unconditionally into the upstream build, making this more
+   urgent than #1 alone. The fix is the same: move markers to `distro/` and add the build tag to
+   any remaining OCP logic.
+
+## Advisory - flag as non-blocking comment
+
+3. **Istio RBAC markers outside `distro/`** - If a file outside a `distro/` path contains
+   `//+kubebuilder:rbac:` markers referencing `*.istio.io` groups, leave a non-blocking comment
+   asking whether this permission is OCP/midstream-specific. If it is, it should move to `distro/`.
+   If it is genuinely needed by upstream kserve (istio is used upstream too), no action is needed.
+
+   Note: this advisory treatment is intentionally more lenient than the import rule in
+   `build-tags.md`, which requires `//go:build distro` for any `istio.io/` import. The reason:
+   an import is a compilation artifact (isolate it to avoid upstream build failures), but an RBAC
+   permission for `networking.istio.io` may be legitimately needed by upstream kserve regardless of
+   where the import lives. If the RBAC marker is midstream-only, move it to `distro/`; if it is
+   upstream-needed, leave it and the import rule still applies to the import itself.
+
+## Exemptions - do not flag
+
+- Files under a `distro/` sub-package that contain **only** a `package` declaration and
+  `//+kubebuilder:rbac:` marker comments - no function definitions, no type definitions, no imports.
+  No build tag is intentional - `controller-gen` must parse them regardless of build configuration,
+  and since the file contains no executable code, there is nothing for a build constraint to exclude.
+  The Go compiler parses and compiles this file in all configurations (it is just nearly empty);
+  `controller-gen` scans it unconditionally to extract the RBAC markers - that is why no build tag
+  is needed or wanted.
+  This is the canonical correct pattern; see `pkg/controller/v1alpha2/llmisvc/distro/controller_rbac_ocp.go`
+  as a reference.
+
+## Pre-existing technical debt - do not flag on unmodified files
+
+The following files carry OCP-group RBAC markers predating this policy. Flag only if new markers
+are **added** in this PR:
+
+- `pkg/controller/v1beta1/inferenceservice/controller.go` (`route.openshift.io`,
+  `networking.istio.io` (treated as OCP-specific for exemption purposes))
+- `pkg/controller/v1alpha1/inferencegraph/controller.go` (`route.openshift.io`,
+  `networking.istio.io` (treated as OCP-specific for exemption purposes))


### PR DESCRIPTION
**What this PR does / why we need it**:

Every upstream sync into this midstream fork risks merge conflicts when OCP/ODH-specific code lives inline in upstream files. We have clean-cut principles that define how to avoid this - build tags, companion files, kustomize overlays, Makefile separation, RBAC isolation - but nothing enforced them automatically in PR review.

Adds four CodeRabbit review rules under `.rules/` so violations get caught before they land rather than discovered at the next sync. Each rule targets a specific layer of the clean-cut separation:

- Build tag/companion file hygiene in Go code
- OCP/ODH content outside the ODH kustomize overlay
- Distro-specific additions directly to `Makefile` instead of `Makefile.overrides.mk`
- kubebuilder RBAC markers for OCP groups outside `distro/` sub-packages

Rules document known pre-existing violations explicitly so reviewers can distinguish new drift from inherited tech debt.

**Which issue(s) this PR fixes**:
Fixes [RHOAIENG-56273](https://redhat.atlassian.net/browse/RHOAIENG-56273)

**Special notes for your reviewer**:

CodeRabbit reads `.rules/*.md` natively - no `.coderabbit.yaml` changes needed. Rules are intentionally targeted to hopefully keep noise low and reviewer trust high.

**Release note**:
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Go build-tag conventions and companion-file naming standards to enforce midstream separation
  * Introduced Kustomize YAML hygiene rules and overlay/patch guidance for config cleanliness
  * Defined Makefile split policy to keep upstream build logic separate from midstream additions
  * Added Kubernetes RBAC marker isolation guidance to ensure API-group–specific permissions are isolated
<!-- end of auto-generated comment: release notes by coderabbit.ai -->