### PR TITLE
chore: compile out ClusterServingRuntime via build tags

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -231,10 +231,7 @@ func main() {
 		Handler: &pod.Mutator{Client: mgr.GetClient(), Clientset: clientSet, Decoder: admission.NewDecoder(mgr.GetScheme())},
 	})
 
-	// log.Info("registering cluster serving runtime validator webhook to the webhook server")
-	// hookServer.Register("/validate-serving-kserve-io-v1alpha1-clusterservingruntime", &webhook.Admission{
-	// 	Handler: &servingruntime.ClusterServingRuntimeValidator{Client: mgr.GetClient(), Decoder: admission.NewDecoder(mgr.GetScheme())},
-	// })
+	registerCSRWebhook(hookServer, mgr)
 
 	setupLog.Info("registering serving runtime validator webhook to the webhook server")
 	hookServer.Register("/validate-serving-kserve-io-v1alpha1-servingruntime", &webhook.Admission{

--- a/cmd/manager/main_csr_default.go
+++ b/cmd/manager/main_csr_default.go
@@ -1,0 +1,34 @@
+//go:build !distro
+
+/*
+Copyright 2023 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/kserve/kserve/pkg/webhook/admission/servingruntime"
+)
+
+func registerCSRWebhook(hookServer webhook.Server, mgr manager.Manager) {
+	setupLog.Info("registering cluster serving runtime validator webhook to the webhook server")
+	hookServer.Register("/validate-serving-kserve-io-v1alpha1-clusterservingruntime", &webhook.Admission{
+		Handler: &servingruntime.ClusterServingRuntimeValidator{Client: mgr.GetClient(), Decoder: admission.NewDecoder(mgr.GetScheme())},
+	})
+}

--- a/cmd/manager/main_csr_ocp.go
+++ b/cmd/manager/main_csr_ocp.go
@@ -1,0 +1,27 @@
+//go:build distro
+
+/*
+Copyright 2023 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// registerCSRWebhook is a no-op on OCP/ODH where ClusterServingRuntime is not supported.
+func registerCSRWebhook(_ webhook.Server, _ manager.Manager) {}

--- a/pkg/apis/serving/v1alpha1/servingruntime_types.go
+++ b/pkg/apis/serving/v1alpha1/servingruntime_types.go
@@ -286,8 +286,7 @@ type WorkerSpec struct {
 
 func init() {
 	SchemeBuilder.Register(&ServingRuntime{}, &ServingRuntimeList{})
-	// ODH does not have ClusterServingRuntime
-	// SchemeBuilder.Register(&ClusterServingRuntime{}, &ClusterServingRuntimeList{})
+	registerClusterServingRuntime()
 }
 
 func (srSpec *ServingRuntimeSpec) IsDisabled() bool {

--- a/pkg/apis/serving/v1alpha1/servingruntime_types_default.go
+++ b/pkg/apis/serving/v1alpha1/servingruntime_types_default.go
@@ -1,0 +1,23 @@
+//go:build !distro
+
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+func registerClusterServingRuntime() {
+	SchemeBuilder.Register(&ClusterServingRuntime{}, &ClusterServingRuntimeList{})
+}

--- a/pkg/apis/serving/v1alpha1/servingruntime_types_ocp.go
+++ b/pkg/apis/serving/v1alpha1/servingruntime_types_ocp.go
@@ -1,0 +1,22 @@
+//go:build distro
+
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+// registerClusterServingRuntime is a no-op on OCP/ODH where ClusterServingRuntime is not supported.
+func registerClusterServingRuntime() {}

--- a/pkg/apis/serving/v1beta1/predictor_model.go
+++ b/pkg/apis/serving/v1beta1/predictor_model.go
@@ -95,17 +95,7 @@ func (m *ModelSpec) GetSupportingRuntimes(ctx context.Context, cl client.Client,
 	// Sort namespace-scoped runtimes by created timestamp desc and name asc.
 	sortServingRuntimeList(runtimes)
 
-	// ODH does not support ClusterServingRuntimes
-	// // List all cluster-scoped runtimes.
-	// clusterRuntimes := &v1alpha1.ClusterServingRuntimeList{}
-	// if err := cl.List(context.TODO(), clusterRuntimes); err != nil {
-	//	return nil, err
-	// }
-	// // Sort cluster-scoped runtimes by created timestamp desc and name asc.
-	// sortClusterServingRuntimeList(clusterRuntimes)
-
 	srSpecs := []v1alpha1.SupportedRuntime{}
-	// var clusterSrSpecs []v1alpha1.SupportedRuntime
 	for i := range runtimes.Items {
 		rt := &runtimes.Items[i]
 		if !rt.Spec.IsDisabled() && rt.Spec.IsMultiModelRuntime() == isMMS &&
@@ -114,15 +104,12 @@ func (m *ModelSpec) GetSupportingRuntimes(ctx context.Context, cl client.Client,
 		}
 	}
 	sortSupportedRuntimeByPriority(srSpecs, m.ModelFormat)
-	// for i := range clusterRuntimes.Items {
-	// 	crt := &clusterRuntimes.Items[i]
-	// 	if !crt.Spec.IsDisabled() && crt.Spec.IsMultiModelRuntime() == isMMS &&
-	// 		m.RuntimeSupportsModel(&crt.Spec) && crt.Spec.IsProtocolVersionSupported(modelProtocolVersion) && crt.Spec.IsMultiNodeRuntime() == isMultinode {
-	// 		clusterSrSpecs = append(clusterSrSpecs, v1alpha1.SupportedRuntime{Name: crt.GetName(), Spec: crt.Spec})
-	// 	}
-	// }
-	// sortSupportedRuntimeByPriority(clusterSrSpecs, m.ModelFormat)
-	// srSpecs = append(srSpecs, clusterSrSpecs...)
+
+	clusterSrSpecs, err := m.getClusterServingRuntimes(ctx, cl, isMMS, isMultinode, modelProtocolVersion)
+	if err != nil {
+		return nil, err
+	}
+	srSpecs = append(srSpecs, clusterSrSpecs...)
 	return srSpecs, nil
 }
 
@@ -178,26 +165,6 @@ func sortServingRuntimeList(runtimes *v1alpha1.ServingRuntimeList) {
 		return runtimes.Items[i].Name < runtimes.Items[j].Name
 	})
 }
-
-// func sortClusterServingRuntimeList(runtimes *v1alpha1.ClusterServingRuntimeList) {
-//	sort.Slice(runtimes.Items, func(i, j int) bool {
-//		if GetProtocolVersionPriority(runtimes.Items[i].Spec.ProtocolVersions) <
-//			GetProtocolVersionPriority(runtimes.Items[j].Spec.ProtocolVersions) {
-//			return true
-//		}
-//		if GetProtocolVersionPriority(runtimes.Items[i].Spec.ProtocolVersions) >
-//			GetProtocolVersionPriority(runtimes.Items[j].Spec.ProtocolVersions) {
-//			return false
-//		}
-//		if runtimes.Items[i].CreationTimestamp.Before(&runtimes.Items[j].CreationTimestamp) {
-//			return false
-//		}
-//		if runtimes.Items[j].CreationTimestamp.Before(&runtimes.Items[i].CreationTimestamp) {
-//			return true
-//		}
-//		return runtimes.Items[i].Name < runtimes.Items[j].Name
-//	})
-// }
 
 func sortSupportedRuntimeByPriority(runtimes []v1alpha1.SupportedRuntime, modelFormat ModelFormat) {
 	sort.Slice(runtimes, func(i, j int) bool {

--- a/pkg/apis/serving/v1beta1/predictor_model_default.go
+++ b/pkg/apis/serving/v1beta1/predictor_model_default.go
@@ -1,0 +1,69 @@
+//go:build !distro
+
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+	"sort"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+// getClusterServingRuntimes lists and filters ClusterServingRuntimes that support the given model.
+func (m *ModelSpec) getClusterServingRuntimes(ctx context.Context, cl client.Client, isMMS bool, isMultinode bool, modelProtocolVersion constants.InferenceServiceProtocol) ([]v1alpha1.SupportedRuntime, error) {
+	clusterRuntimes := &v1alpha1.ClusterServingRuntimeList{}
+	if err := cl.List(ctx, clusterRuntimes); err != nil {
+		return nil, err
+	}
+	sortClusterServingRuntimeList(clusterRuntimes)
+
+	var clusterSrSpecs []v1alpha1.SupportedRuntime
+	for i := range clusterRuntimes.Items {
+		crt := &clusterRuntimes.Items[i]
+		if !crt.Spec.IsDisabled() && crt.Spec.IsMultiModelRuntime() == isMMS &&
+			m.RuntimeSupportsModel(&crt.Spec) && crt.Spec.IsProtocolVersionSupported(modelProtocolVersion) && crt.Spec.IsMultiNodeRuntime() == isMultinode {
+			clusterSrSpecs = append(clusterSrSpecs, v1alpha1.SupportedRuntime{Name: crt.GetName(), Spec: crt.Spec})
+		}
+	}
+	sortSupportedRuntimeByPriority(clusterSrSpecs, m.ModelFormat)
+	return clusterSrSpecs, nil
+}
+
+func sortClusterServingRuntimeList(runtimes *v1alpha1.ClusterServingRuntimeList) {
+	sort.Slice(runtimes.Items, func(i, j int) bool {
+		if GetProtocolVersionPriority(runtimes.Items[i].Spec.ProtocolVersions) <
+			GetProtocolVersionPriority(runtimes.Items[j].Spec.ProtocolVersions) {
+			return true
+		}
+		if GetProtocolVersionPriority(runtimes.Items[i].Spec.ProtocolVersions) >
+			GetProtocolVersionPriority(runtimes.Items[j].Spec.ProtocolVersions) {
+			return false
+		}
+		if runtimes.Items[i].CreationTimestamp.Before(&runtimes.Items[j].CreationTimestamp) {
+			return false
+		}
+		if runtimes.Items[j].CreationTimestamp.Before(&runtimes.Items[i].CreationTimestamp) {
+			return true
+		}
+		return runtimes.Items[i].Name < runtimes.Items[j].Name
+	})
+}

--- a/pkg/apis/serving/v1beta1/predictor_model_ocp.go
+++ b/pkg/apis/serving/v1beta1/predictor_model_ocp.go
@@ -1,0 +1,33 @@
+//go:build distro
+
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"context"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+// getClusterServingRuntimes is a no-op on OCP/ODH where ClusterServingRuntime is not supported.
+func (m *ModelSpec) getClusterServingRuntimes(_ context.Context, _ client.Client, _ bool, _ bool, _ constants.InferenceServiceProtocol) ([]v1alpha1.SupportedRuntime, error) {
+	return nil, nil
+}

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -503,40 +503,6 @@ func (r *InferenceServiceReconciler) servingRuntimeFunc(ctx context.Context, obj
 	return requests
 }
 
-// func (r *InferenceServiceReconciler) clusterServingRuntimeFunc(ctx context.Context, obj client.Object) []reconcile.Request {
-//	clusterServingRuntimeObj, ok := obj.(*v1alpha1.ClusterServingRuntime)
-//
-//	if !ok || clusterServingRuntimeObj == nil {
-//		return nil
-//	}
-//
-//	var isvcList v1beta1.InferenceServiceList
-//	if err := r.List(ctx, &isvcList, client.InNamespace(clusterServingRuntimeObj.Namespace)); err != nil {
-//		r.Log.Error(err, "unable to list InferenceServices", "clusterServingRuntime", clusterServingRuntimeObj.Name)
-//		return nil
-//	}
-//
-//	requests := make([]reconcile.Request, 0, len(isvcList.Items))
-//	for _, isvc := range isvcList.Items {
-//		annotations := isvc.GetAnnotations()
-//		if annotations != nil {
-//			if disableAutoUpdate, found := annotations[constants.DisableAutoUpdateAnnotationKey]; found && disableAutoUpdate == "true" && isvc.Status.IsReady() {
-//				r.Log.Info("Auto-update is disabled for InferenceService", "InferenceService", isvc.Name)
-//				continue
-//			}
-//		}
-//		if isvc.Status.ClusterServingRuntimeName == clusterServingRuntimeObj.Name {
-//			requests = append(requests, reconcile.Request{
-//				NamespacedName: types.NamespacedName{
-//					Namespace: isvc.Namespace,
-//					Name:      isvc.Name,
-//				},
-//			})
-//		}
-//	}
-//	return requests
-//}
-
 func (r *InferenceServiceReconciler) podInitContainersFunc(ctx context.Context, obj client.Object) []reconcile.Request {
 	pod, ok := obj.(*corev1.Pod)
 	if !ok || pod == nil {
@@ -565,21 +531,6 @@ func servingRuntimesPredicate() predicate.Funcs {
 			oldServingRuntime := e.ObjectOld.(*v1alpha1.ServingRuntime)
 			newServingRuntime := e.ObjectNew.(*v1alpha1.ServingRuntime)
 			return !reflect.DeepEqual(oldServingRuntime.Spec, newServingRuntime.Spec)
-		},
-		CreateFunc:  func(e event.CreateEvent) bool { return false },
-		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
-		GenericFunc: func(e event.GenericEvent) bool { return false },
-	}
-}
-
-// clusterServingRuntimesPredicate returns a predicate that filters ClusterServingRuntime updates
-// to only include those where the Spec has changed.
-func clusterServingRuntimesPredicate() predicate.Funcs {
-	return predicate.Funcs{
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			oldClusterServingRuntime := e.ObjectOld.(*v1alpha1.ClusterServingRuntime)
-			newClusterServingRuntime := e.ObjectNew.(*v1alpha1.ClusterServingRuntime)
-			return !reflect.DeepEqual(oldClusterServingRuntime.Spec, newClusterServingRuntime.Spec)
 		},
 		CreateFunc:  func(e event.CreateEvent) bool { return false },
 		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
@@ -647,10 +598,7 @@ func (r *InferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager, deployCo
 		if isvc.Status.ServingRuntimeName != "" {
 			return []string{isvc.Status.ServingRuntimeName}
 		}
-		// if isvc.Status.ClusterServingRuntimeName != "" {
-		//	return []string{isvc.Status.ClusterServingRuntimeName}
-		// }
-		return nil
+		return csrFieldIndexValues(isvc)
 	}); err != nil {
 		return err
 	}
@@ -665,18 +613,6 @@ func (r *InferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager, deployCo
 		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
 		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
-
-	// TODO: Find a way to distinguish if the ServingRuntime is a ClusterServingRuntime or not
-	// clusterServingRuntimesPredicate := predicate.Funcs{
-	//	UpdateFunc: func(e event.UpdateEvent) bool {
-	//		oldClusterServingRuntime := e.ObjectOld.(*v1alpha1.ClusterServingRuntime)
-	//		newClusterServingRuntime := e.ObjectNew.(*v1alpha1.ClusterServingRuntime)
-	//		return !reflect.DeepEqual(oldClusterServingRuntime.Spec, newClusterServingRuntime.Spec)
-	//	},
-	//	CreateFunc:  func(e event.CreateEvent) bool { return false },
-	//	DeleteFunc:  func(e event.DeleteEvent) bool { return false },
-	//	GenericFunc: func(e event.GenericEvent) bool { return false },
-	// }
 
 	ctrlBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.InferenceService{}).
@@ -734,10 +670,12 @@ func (r *InferenceServiceReconciler) SetupWithManager(mgr ctrl.Manager, deployCo
 		ctrlBuilder = ctrlBuilder.Owns(&netv1.Ingress{})
 	}
 
-	return ctrlBuilder.Watches(&v1alpha1.ServingRuntime{}, handler.EnqueueRequestsFromMapFunc(r.servingRuntimeFunc), builder.WithPredicates(servingRuntimesPredicate)).
-		// Watches(&v1alpha1.ClusterServingRuntime{}, handler.EnqueueRequestsFromMapFunc(r.clusterServingRuntimeFunc), builder.WithPredicates(clusterServingRuntimesPredicate())).
-		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(r.podInitContainersFunc), builder.WithPredicates(podInitContainersPredicate())).
-		Complete(r)
+	ctrlBuilder = ctrlBuilder.Watches(&v1alpha1.ServingRuntime{}, handler.EnqueueRequestsFromMapFunc(r.servingRuntimeFunc), builder.WithPredicates(servingRuntimesPredicate)).
+		Watches(&corev1.Pod{}, handler.EnqueueRequestsFromMapFunc(r.podInitContainersFunc), builder.WithPredicates(podInitContainersPredicate()))
+
+	ctrlBuilder = setupCSRWatch(ctrlBuilder, r)
+
+	return ctrlBuilder.Complete(r)
 }
 
 func (r *InferenceServiceReconciler) deleteExternalResources(ctx context.Context, isvc *v1beta1.InferenceService) error {

--- a/pkg/controller/v1beta1/inferenceservice/controller_csr_default.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_csr_default.go
@@ -1,0 +1,93 @@
+//go:build !distro
+
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inferenceservice
+
+import (
+	"context"
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+func (r *InferenceServiceReconciler) clusterServingRuntimeFunc(ctx context.Context, obj client.Object) []reconcile.Request {
+	clusterServingRuntimeObj, ok := obj.(*v1alpha1.ClusterServingRuntime)
+
+	if !ok || clusterServingRuntimeObj == nil {
+		return nil
+	}
+
+	var isvcList v1beta1.InferenceServiceList
+	if err := r.List(ctx, &isvcList, client.InNamespace(clusterServingRuntimeObj.Namespace)); err != nil {
+		r.Log.Error(err, "unable to list InferenceServices", "clusterServingRuntime", clusterServingRuntimeObj.Name)
+		return nil
+	}
+
+	requests := make([]reconcile.Request, 0, len(isvcList.Items))
+	for _, isvc := range isvcList.Items {
+		annotations := isvc.GetAnnotations()
+		if annotations != nil {
+			if disableAutoUpdate, found := annotations[constants.DisableAutoUpdateAnnotationKey]; found && disableAutoUpdate == "true" && isvc.Status.IsReady() {
+				r.Log.Info("Auto-update is disabled for InferenceService", "InferenceService", isvc.Name)
+				continue
+			}
+		}
+		if isvc.Status.ClusterServingRuntimeName == clusterServingRuntimeObj.Name {
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Namespace: isvc.Namespace,
+					Name:      isvc.Name,
+				},
+			})
+		}
+	}
+	return requests
+}
+
+// csrFieldIndexValues returns field index values for ClusterServingRuntime name.
+func csrFieldIndexValues(isvc *v1beta1.InferenceService) []string {
+	if isvc.Status.ClusterServingRuntimeName != "" {
+		return []string{isvc.Status.ClusterServingRuntimeName}
+	}
+	return nil
+}
+
+// setupCSRWatch adds a watch for ClusterServingRuntime changes.
+func setupCSRWatch(ctrlBuilder *builder.Builder, r *InferenceServiceReconciler) *builder.Builder {
+	return ctrlBuilder.Watches(&v1alpha1.ClusterServingRuntime{}, handler.EnqueueRequestsFromMapFunc(r.clusterServingRuntimeFunc),
+		builder.WithPredicates(predicate.Funcs{
+			UpdateFunc: func(e event.UpdateEvent) bool {
+				oldClusterServingRuntime := e.ObjectOld.(*v1alpha1.ClusterServingRuntime)
+				newClusterServingRuntime := e.ObjectNew.(*v1alpha1.ClusterServingRuntime)
+				return !reflect.DeepEqual(oldClusterServingRuntime.Spec, newClusterServingRuntime.Spec)
+			},
+			CreateFunc:  func(e event.CreateEvent) bool { return false },
+			DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+			GenericFunc: func(e event.GenericEvent) bool { return false },
+		}))
+}

--- a/pkg/controller/v1beta1/inferenceservice/controller_csr_ocp.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_csr_ocp.go
@@ -1,0 +1,35 @@
+//go:build distro
+
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inferenceservice
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+)
+
+// csrFieldIndexValues is a no-op on OCP/ODH where ClusterServingRuntime is not supported.
+func csrFieldIndexValues(_ *v1beta1.InferenceService) []string {
+	return nil
+}
+
+// setupCSRWatch is a no-op on OCP/ODH where ClusterServingRuntime is not supported.
+func setupCSRWatch(ctrlBuilder *builder.Builder, _ *InferenceServiceReconciler) *builder.Builder {
+	return ctrlBuilder
+}

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -336,15 +336,7 @@ func GetServingRuntime(ctx context.Context, cl client.Client, name string, names
 		return nil, nil, err, false
 	}
 
-	// ODH does not support ClusterServingRuntimes
-	// clusterRuntime := &v1alpha1.ClusterServingRuntime{}
-	// err = cl.Get(ctx, client.ObjectKey{Name: name}, clusterRuntime)
-	// if err == nil {
-	//	return &clusterRuntime.Spec, clusterRuntime.Annotations, nil, true
-	// } else if !apierrors.IsNotFound(err) {
-	//	return nil, err, false
-	//}
-	return nil, nil, goerrors.New("No ServingRuntimes with the name: " + name), false
+	return getClusterServingRuntime(ctx, cl, name)
 }
 
 // ReplacePlaceholders Replace placeholders in runtime container by values from inferenceservice metadata

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils_csr_default.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils_csr_default.go
@@ -1,0 +1,42 @@
+//go:build !distro
+
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+
+	goerrors "github.com/pkg/errors"
+)
+
+// getClusterServingRuntime looks up a ClusterServingRuntime by name.
+func getClusterServingRuntime(ctx context.Context, cl client.Client, name string) (*v1alpha1.ServingRuntimeSpec, map[string]string, error, bool) {
+	clusterRuntime := &v1alpha1.ClusterServingRuntime{}
+	err := cl.Get(ctx, client.ObjectKey{Name: name}, clusterRuntime)
+	if err == nil {
+		return &clusterRuntime.Spec, clusterRuntime.Annotations, nil, true
+	} else if !apierrors.IsNotFound(err) {
+		return nil, nil, err, false
+	}
+	return nil, nil, goerrors.New("No ServingRuntimes with the name: " + name), false
+}

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils_csr_ocp.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils_csr_ocp.go
@@ -1,0 +1,33 @@
+//go:build distro
+
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+
+	goerrors "github.com/pkg/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+)
+
+// getClusterServingRuntime is a no-op on OCP/ODH where ClusterServingRuntime is not supported.
+func getClusterServingRuntime(_ context.Context, _ client.Client, name string) (*v1alpha1.ServingRuntimeSpec, map[string]string, error, bool) {
+	return nil, nil, goerrors.New("No ServingRuntimes with the name: " + name), false
+}

--- a/pkg/webhook/admission/servingruntime/servingruntime_webhook.go
+++ b/pkg/webhook/admission/servingruntime/servingruntime_webhook.go
@@ -37,12 +37,12 @@ import (
 var log = logf.Log.WithName(constants.ServingRuntimeValidatorWebhookName)
 
 const (
-	InvalidPriorityError                      = "same priority assigned for the model format %s"
-	InvalidPriorityServingRuntimeError        = "%s in the servingruntimes %s and %s in namespace %s"
-	InvalidPriorityClusterServingRuntimeError = "%s in the clusterservingruntimes %s and %s"
-	ProrityIsNotSameError                     = "different priorities assigned for the model format %s"
-	ProrityIsNotSameServingRuntimeError       = "%s under the servingruntime %s"
-	// ProrityIsNotSameClusterServingRuntimeError          = "%s under the clusterservingruntime %s"
+	InvalidPriorityError                                = "same priority assigned for the model format %s"
+	InvalidPriorityServingRuntimeError                  = "%s in the servingruntimes %s and %s in namespace %s"
+	InvalidPriorityClusterServingRuntimeError           = "%s in the clusterservingruntimes %s and %s"
+	ProrityIsNotSameError                               = "different priorities assigned for the model format %s"
+	ProrityIsNotSameServingRuntimeError                 = "%s under the servingruntime %s"
+	ProrityIsNotSameClusterServingRuntimeError          = "%s under the clusterservingruntime %s"
 	InvalidUnknownGPUTypeError                          = "unknown GPU resource type in a container(%s)"
 	InvalidWorkerSpecPipelineParallelSizeValueError     = "the WorkerSpec.PipelineParallelSize cannot be less than 1(%s)"
 	InvalidWorkerSpecTensorParallelSizeValueError       = "the WorkerSpec.TensorParallelSize cannot be less than 1(%s)"
@@ -52,13 +52,6 @@ const (
 	DisallowedWorkerSpecPipelineParallelSizeEnvError    = "setting PIPELINE_PARALLEL_SIZE in environment variables is not allowed"
 	DisallowedWorkerSpecTensorParallelSizeEnvError      = "setting TENSOR_PARALLEL_SIZE in environment variables is not allowed"
 )
-
-// // kubebuilder:webhook:verbs=create;update,path=/validate-serving-kserve-io-v1alpha1-clusterservingruntime,mutating=false,failurePolicy=fail,groups=serving.kserve.io,resources=clusterservingruntimes,versions=v1alpha1,name=clusterservingruntime.kserve-webhook-server.validator
-//
-// type ClusterServingRuntimeValidator struct {
-//	 Client  client.Client
-//	 Decoder admission.Decoder
-// }
 
 // +kubebuilder:webhook:verbs=create;update,path=/validate-serving-kserve-io-v1alpha1-servingruntime,mutating=false,failurePolicy=fail,groups=serving.kserve.io,resources=servingruntimes,versions=v1alpha1,name=servingruntime.kserve-webhook-server.validator
 
@@ -104,43 +97,6 @@ func (sr *ServingRuntimeValidator) Handle(ctx context.Context, req admission.Req
 
 	return admission.Allowed("")
 }
-
-// // Handle validates the incoming request
-// func (csr *ClusterServingRuntimeValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
-// 	clusterServingRuntime := &v1alpha1.ClusterServingRuntime{}
-// 	if err := csr.Decoder.Decode(req, clusterServingRuntime); err != nil {
-// 		log.Error(err, "Failed to decode cluster serving runtime", "name", clusterServingRuntime.Name)
-// 		return admission.Errored(http.StatusBadRequest, err)
-// 	}
-
-// ExistingRuntimes := &v1alpha1.ClusterServingRuntimeList{}
-// if err := csr.Client.List(ctx, ExistingRuntimes); err != nil {
-//	log.Error(err, "Failed to get cluster serving runtime list")
-//	return admission.Errored(http.StatusInternalServerError, err)
-//}
-
-// 	// Only validate for priority if the new cluster serving runtime is not disabled
-// 	if clusterServingRuntime.Spec.IsDisabled() {
-// 		return admission.Allowed("")
-// 	}
-// 	existingRuntimeSpec := v1alpha1.ServingRuntimeSpec{}
-// 	for i := range ExistingRuntimes.Items {
-// 		if err := validateModelFormatPrioritySame(&clusterServingRuntime.Spec); err != nil {
-// 			return admission.Denied(fmt.Sprintf(ProrityIsNotSameClusterServingRuntimeError, err.Error(), clusterServingRuntime.Name))
-// 		}
-// 		if err := validateServingRuntimePriority(&clusterServingRuntime.Spec, &ExistingRuntimes.Items[i].Spec, clusterServingRuntime.Name, ExistingRuntimes.Items[i].Name); err != nil {
-// 			return admission.Denied(fmt.Sprintf(InvalidPriorityClusterServingRuntimeError, err.Error(), ExistingRuntimes.Items[i].Name, clusterServingRuntime.Name))
-// 		}
-// 		if clusterServingRuntime.Name == ExistingRuntimes.Items[i].Name {
-// 			existingRuntimeSpec = ExistingRuntimes.Items[i].Spec
-// 		}
-// 	}
-
-// 	if err := validateMultiNodeSpec(&clusterServingRuntime.Spec, &existingRuntimeSpec); err != nil {
-// 		return admission.Denied(fmt.Sprintf(InvalidMultiNodeSpecError, clusterServingRuntime.Kind, clusterServingRuntime.Name, err.Error()))
-// 	}
-// 	return admission.Allowed("")
-// }
 
 func areSupportedModelFormatsEqual(m1 v1alpha1.SupportedModelFormat, m2 v1alpha1.SupportedModelFormat) bool {
 	if strings.EqualFold(m1.Name, m2.Name) && ((m1.Version == nil && m2.Version == nil) ||

--- a/pkg/webhook/admission/servingruntime/servingruntime_webhook_default.go
+++ b/pkg/webhook/admission/servingruntime/servingruntime_webhook_default.go
@@ -1,0 +1,74 @@
+//go:build !distro
+
+/*
+Copyright 2023 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servingruntime
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+)
+
+// +kubebuilder:webhook:verbs=create;update,path=/validate-serving-kserve-io-v1alpha1-clusterservingruntime,mutating=false,failurePolicy=fail,groups=serving.kserve.io,resources=clusterservingruntimes,versions=v1alpha1,name=clusterservingruntime.kserve-webhook-server.validator
+
+type ClusterServingRuntimeValidator struct {
+	Client  client.Client
+	Decoder admission.Decoder
+}
+
+// Handle validates the incoming request
+func (csr *ClusterServingRuntimeValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	clusterServingRuntime := &v1alpha1.ClusterServingRuntime{}
+	if err := csr.Decoder.Decode(req, clusterServingRuntime); err != nil {
+		log.Error(err, "Failed to decode cluster serving runtime", "name", clusterServingRuntime.Name)
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	ExistingRuntimes := &v1alpha1.ClusterServingRuntimeList{}
+	if err := csr.Client.List(ctx, ExistingRuntimes); err != nil {
+		log.Error(err, "Failed to get cluster serving runtime list")
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	// Only validate for priority if the new cluster serving runtime is not disabled
+	if clusterServingRuntime.Spec.IsDisabled() {
+		return admission.Allowed("")
+	}
+	existingRuntimeSpec := v1alpha1.ServingRuntimeSpec{}
+	for i := range ExistingRuntimes.Items {
+		if err := validateModelFormatPrioritySame(&clusterServingRuntime.Spec); err != nil {
+			return admission.Denied(fmt.Sprintf(ProrityIsNotSameClusterServingRuntimeError, err.Error(), clusterServingRuntime.Name))
+		}
+		if err := validateServingRuntimePriority(&clusterServingRuntime.Spec, &ExistingRuntimes.Items[i].Spec, clusterServingRuntime.Name, ExistingRuntimes.Items[i].Name); err != nil {
+			return admission.Denied(fmt.Sprintf(InvalidPriorityClusterServingRuntimeError, err.Error(), ExistingRuntimes.Items[i].Name, clusterServingRuntime.Name))
+		}
+		if clusterServingRuntime.Name == ExistingRuntimes.Items[i].Name {
+			existingRuntimeSpec = ExistingRuntimes.Items[i].Spec
+		}
+	}
+
+	if err := validateMultiNodeSpec(&clusterServingRuntime.Spec, &existingRuntimeSpec); err != nil {
+		return admission.Denied(fmt.Sprintf(InvalidMultiNodeSpecError, clusterServingRuntime.Kind, clusterServingRuntime.Name, err.Error()))
+	}
+	return admission.Allowed("")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces all commented-out ClusterServingRuntime (CSR) code with proper `distro`/`!distro` build-tag companion files. ODH doesn't support CSR, and this has been expressed as commented-out blocks scattered across 6 packages. This PR converts each to a clean hook + build-tag pair so:

- `go build ./...` (upstream, `!distro`) compiles with full CSR support
- `go build -tags distro ./...` (ODH) compiles with CSR excluded - no commented code, no dead branches

**Files changed (6 hook points, 11 new companion files):**

| Package | Hook | `_default.go` | `_ocp.go` |
|---|---|---|---|
| `v1alpha1/servingruntime_types` | `registerClusterServingRuntime()` | registers CSR types with scheme | no-op |
| `v1beta1/predictor_model` | `getClusterServingRuntimes()` | lists + filters + sorts CSRs | returns nil |
| `cmd/manager` | `registerCSRWebhook()` | registers CSR validator webhook | no-op |
| `inferenceservice/utils` | `getClusterServingRuntime()` | CSR lookup fallback | returns "not found" |
| `inferenceservice/controller` | `setupCSRWatch()` + `csrFieldIndexValues()` | CSR watch, predicate, field index | no-op |
| `webhook/servingruntime` | `ClusterServingRuntimeValidator` | struct + Handle method | (nothing needed) |

**Which issue(s) this PR fixes**:

Part of the clean-cut effort to replace commented-out midstream code with build-tag-guarded companion files.

**Feature/Issue validation/testing**:

- [x] `go build ./...` passes (upstream mode, CSR compiled in)
- [x] `go build -tags distro ./...` passes (ODH mode, CSR compiled out)
- [x] `go vet ./...` clean for both modes
- [x] No behavior change - the distro build excludes exactly the same CSR code paths that were previously commented out

**Special notes for your reviewer**:

This follows the same pattern already established in `pkg/controller/v1alpha2/llmisvc/` (see `controller_setup_default.go` / `controller_setup_ocp.go`).

The pre-existing build failure in `cmd/llmisvc/main.go` is unrelated to this PR.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for cluster-scoped serving runtime resources with automatic validation.
  * Cluster-scoped runtimes are now considered when matching to inference services.
  * Added admission validation for cluster-scoped runtime configurations.

* **Refactor**
  * Reorganized controller and webhook setup with build-tagged implementations for environment-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->