### PR TITLE
chore: extract OpenShift Route and CA bundle injection to companion files

### DIFF
--- a/pkg/controller/v1alpha1/inferencegraph/controller.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller.go
@@ -32,9 +32,6 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-
-	osv1 "github.com/openshift/api/route/v1"
-
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -269,14 +266,7 @@ func (r *InferenceGraphReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			}
 		}
 
-		routeReconciler := OpenShiftRouteReconciler{
-			Scheme: r.Scheme,
-			Client: r.Client,
-		}
-		hostname, err := routeReconciler.Reconcile(ctx, graph)
-		url.Host = hostname
-		url.Scheme = "https"
-		if err != nil {
+		if err := reconcilePlatformRoute(ctx, r, graph, url); err != nil {
 			return ctrl.Result{}, errors.Wrapf(err, "fails to reconcile Route for InferenceGraph")
 		}
 
@@ -444,8 +434,9 @@ func (r *InferenceGraphReconciler) SetupWithManager(mgr ctrl.Manager, deployConf
 
 	ctrlBuilder := ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.InferenceGraph{}).
-		Owns(&appsv1.Deployment{}).
-		Owns(&osv1.Route{})
+		Owns(&appsv1.Deployment{})
+
+	ctrlBuilder = setupPlatformOwns(ctrlBuilder)
 
 	if ksvcFound {
 		ctrlBuilder = ctrlBuilder.Owns(&knservingv1.Service{})

--- a/pkg/controller/v1alpha1/inferencegraph/controller_route_default.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller_route_default.go
@@ -1,0 +1,38 @@
+//go:build !distro
+
+/*
+Copyright 2023 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inferencegraph
+
+import (
+	"context"
+
+	"knative.dev/pkg/apis"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+)
+
+// reconcilePlatformRoute is a no-op for non-OpenShift builds.
+func reconcilePlatformRoute(_ context.Context, _ *InferenceGraphReconciler, _ *v1alpha1.InferenceGraph, _ *apis.URL) error {
+	return nil
+}
+
+// setupPlatformOwns returns the builder unchanged for non-OpenShift builds.
+func setupPlatformOwns(ctrlBuilder *ctrl.Builder) *ctrl.Builder {
+	return ctrlBuilder
+}

--- a/pkg/controller/v1alpha1/inferencegraph/controller_route_ocp.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller_route_ocp.go
@@ -1,0 +1,49 @@
+//go:build distro
+
+/*
+Copyright 2023 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inferencegraph
+
+import (
+	"context"
+
+	osv1 "github.com/openshift/api/route/v1"
+	"knative.dev/pkg/apis"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
+)
+
+// reconcilePlatformRoute reconciles the OpenShift Route for the InferenceGraph.
+func reconcilePlatformRoute(ctx context.Context, r *InferenceGraphReconciler, graph *v1alpha1.InferenceGraph, url *apis.URL) error {
+	routeReconciler := OpenShiftRouteReconciler{
+		Scheme: r.Scheme,
+		Client: r.Client,
+	}
+	hostname, err := routeReconciler.Reconcile(ctx, graph)
+	if err != nil {
+		return err
+	}
+	url.Host = hostname
+	url.Scheme = "https"
+	return nil
+}
+
+// setupPlatformOwns adds OpenShift Route to the controller's owned resources.
+func setupPlatformOwns(ctrlBuilder *ctrl.Builder) *ctrl.Builder {
+	return ctrlBuilder.Owns(&osv1.Route{})
+}

--- a/pkg/controller/v1alpha1/inferencegraph/knative_reconciler.go
+++ b/pkg/controller/v1alpha1/inferencegraph/knative_reconciler.go
@@ -227,31 +227,7 @@ func createKnativeService(
 											Drop: []corev1.Capability{corev1.Capability("ALL")},
 										},
 									},
-									VolumeMounts: []corev1.VolumeMount{
-										{
-											Name:      "openshift-service-ca-bundle",
-											MountPath: "/etc/odh/openshift-service-ca-bundle",
-										},
-									},
-									Env: []corev1.EnvVar{
-										{
-											Name:  "SSL_CERT_FILE",
-											Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
-										},
-									},
 									ReadinessProbe: constants.GetRouterReadinessProbe(),
-								},
-							},
-							Volumes: []corev1.Volume{
-								{
-									Name: "openshift-service-ca-bundle",
-									VolumeSource: corev1.VolumeSource{
-										ConfigMap: &corev1.ConfigMapVolumeSource{
-											LocalObjectReference: corev1.LocalObjectReference{
-												Name: constants.OpenShiftServiceCaConfigMapName,
-											},
-										},
-									},
 								},
 							},
 							Affinity:                     graph.Spec.Affinity,
@@ -267,6 +243,9 @@ func createKnativeService(
 			},
 		},
 	}
+
+	// Apply platform-specific defaults (e.g. CA bundle injection on OpenShift)
+	applyKnativePlatformDefaults(service)
 
 	// Only adding this env variable "PROPAGATE_HEADERS" if router's headers config has the key "propagate"
 	value, exists := config.Headers["propagate"]

--- a/pkg/controller/v1alpha1/inferencegraph/knative_reconciler_default.go
+++ b/pkg/controller/v1alpha1/inferencegraph/knative_reconciler_default.go
@@ -1,0 +1,26 @@
+//go:build !distro
+
+/*
+Copyright 2022 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inferencegraph
+
+import (
+	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
+)
+
+// applyKnativePlatformDefaults is a no-op for non-OpenShift builds.
+func applyKnativePlatformDefaults(_ *knservingv1.Service) {}

--- a/pkg/controller/v1alpha1/inferencegraph/knative_reconciler_ocp.go
+++ b/pkg/controller/v1alpha1/inferencegraph/knative_reconciler_ocp.go
@@ -1,0 +1,59 @@
+//go:build distro
+
+/*
+Copyright 2022 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inferencegraph
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
+
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+// applyKnativePlatformDefaults injects the OpenShift service CA bundle volume, mount,
+// and SSL_CERT_FILE environment variable into the Knative service pod spec.
+func applyKnativePlatformDefaults(service *knservingv1.Service) {
+	podSpec := &service.Spec.ConfigurationSpec.Template.Spec.PodSpec
+
+	podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts,
+		corev1.VolumeMount{
+			Name:      "openshift-service-ca-bundle",
+			MountPath: "/etc/odh/openshift-service-ca-bundle",
+		},
+	)
+
+	podSpec.Containers[0].Env = append(podSpec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "SSL_CERT_FILE",
+			Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
+		},
+	)
+
+	podSpec.Volumes = append(podSpec.Volumes,
+		corev1.Volume{
+			Name: "openshift-service-ca-bundle",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: constants.OpenShiftServiceCaConfigMapName,
+					},
+				},
+			},
+		},
+	)
+}

--- a/pkg/controller/v1alpha1/inferencegraph/openshift_route_reconciler_ocp.go
+++ b/pkg/controller/v1alpha1/inferencegraph/openshift_route_reconciler_ocp.go
@@ -1,3 +1,5 @@
+//go:build distro
+
 /*
 Copyright 2023 The KServe Authors.
 

--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig.go
@@ -84,30 +84,6 @@ func createInferenceGraphPodSpec(graph *v1alpha1.InferenceGraph, config *RouterC
 						Drop: []corev1.Capability{corev1.Capability("ALL")},
 					},
 				},
-				VolumeMounts: []corev1.VolumeMount{
-					{
-						Name:      "openshift-service-ca-bundle",
-						MountPath: "/etc/odh/openshift-service-ca-bundle",
-					},
-				},
-				Env: []corev1.EnvVar{
-					{
-						Name:  "SSL_CERT_FILE",
-						Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
-					},
-				},
-			},
-		},
-		Volumes: []corev1.Volume{
-			{
-				Name: "openshift-service-ca-bundle",
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: constants.OpenShiftServiceCaConfigMapName,
-						},
-					},
-				},
 			},
 		},
 		Affinity:                     graph.Spec.Affinity,
@@ -119,6 +95,9 @@ func createInferenceGraphPodSpec(graph *v1alpha1.InferenceGraph, config *RouterC
 		NodeName:                     graph.Spec.NodeName,
 		// ServiceAccountName:           graph.Spec.ServiceAccountName,
 	}
+
+	// Apply platform-specific pod spec defaults (e.g. CA bundle injection on OpenShift)
+	applyPlatformPodSpecDefaults(podSpec)
 
 	// Only adding this env variable "PROPAGATE_HEADERS" if router's headers config has the key "propagate"
 	value, exists := config.Headers["propagate"]
@@ -152,9 +131,6 @@ func createInferenceGraphPodSpec(graph *v1alpha1.InferenceGraph, config *RouterC
 		// and bind needed privileges for the auth verification.
 		podSpec.ServiceAccountName = graph.GetName() + "-auth-verifier"
 	}
-
-	// In ODH, the readiness probe is using HTTPS
-	podSpec.Containers[0].ReadinessProbe.HTTPGet.Scheme = corev1.URISchemeHTTPS
 
 	return podSpec
 }

--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig_default.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig_default.go
@@ -1,0 +1,26 @@
+//go:build !distro
+
+/*
+Copyright 2023 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inferencegraph
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// applyPlatformPodSpecDefaults is a no-op for non-OpenShift builds.
+func applyPlatformPodSpecDefaults(_ *corev1.PodSpec) {}

--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig_ocp.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig_ocp.go
@@ -1,0 +1,60 @@
+//go:build distro
+
+/*
+Copyright 2023 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inferencegraph
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+// applyPlatformPodSpecDefaults injects the OpenShift service CA bundle volume, mount,
+// and SSL_CERT_FILE environment variable into the pod spec. It also sets the readiness
+// probe scheme to HTTPS.
+func applyPlatformPodSpecDefaults(podSpec *corev1.PodSpec) {
+	podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts,
+		corev1.VolumeMount{
+			Name:      "openshift-service-ca-bundle",
+			MountPath: "/etc/odh/openshift-service-ca-bundle",
+		},
+	)
+
+	podSpec.Containers[0].Env = append(podSpec.Containers[0].Env,
+		corev1.EnvVar{
+			Name:  "SSL_CERT_FILE",
+			Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
+		},
+	)
+
+	podSpec.Volumes = append(podSpec.Volumes,
+		corev1.Volume{
+			Name: "openshift-service-ca-bundle",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: constants.OpenShiftServiceCaConfigMapName,
+					},
+				},
+			},
+		},
+	)
+
+	// In ODH, the readiness probe is using HTTPS
+	podSpec.Containers[0].ReadinessProbe.HTTPGet.Scheme = corev1.URISchemeHTTPS
+}

--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig_test.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig_test.go
@@ -63,7 +63,7 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 	}
 
 	expectedReadinessProbe := constants.GetRouterReadinessProbe()
-	expectedReadinessProbe.HTTPGet.Scheme = corev1.URISchemeHTTPS
+	expectedReadinessProbe.HTTPGet.Scheme = expectedReadinessProbeScheme()
 
 	testIGSpecs := map[string]*InferenceGraph{
 		"basic": {
@@ -221,32 +221,11 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 							Drop: []corev1.Capability{corev1.Capability("ALL")},
 						},
 					},
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      "openshift-service-ca-bundle",
-							MountPath: "/etc/odh/openshift-service-ca-bundle",
-						},
-					},
-					Env: []corev1.EnvVar{
-						{
-							Name:  "SSL_CERT_FILE",
-							Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
-						},
-					},
+					VolumeMounts: expectedPlatformVolumeMounts(),
+					Env:          expectedPlatformEnvVars(),
 				},
 			},
-			Volumes: []corev1.Volume{
-				{
-					Name: "openshift-service-ca-bundle",
-					VolumeSource: corev1.VolumeSource{
-						ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: constants.OpenShiftServiceCaConfigMapName,
-							},
-						},
-					},
-				},
-			},
+			Volumes:                      expectedPlatformVolumes(),
 			AutomountServiceAccountToken: proto.Bool(false),
 			ServiceAccountName:           "default",
 			ImagePullSecrets:             []corev1.LocalObjectReference{},
@@ -261,16 +240,12 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 						"--graph-json",
 						"{\"nodes\":{\"root\":{\"routerType\":\"Sequence\",\"steps\":[{\"serviceUrl\":\"http://someservice.example.com\"}]}},\"resources\":{}}",
 					},
-					Env: []corev1.EnvVar{
-						{
-							Name:  "SSL_CERT_FILE",
-							Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
-						},
-						{
+					Env: append(expectedPlatformEnvVars(),
+						corev1.EnvVar{
 							Name:  "PROPAGATE_HEADERS",
 							Value: "Authorization,Intuit_tid",
 						},
-					},
+					),
 					Resources: corev1.ResourceRequirements{
 						Limits: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -291,26 +266,10 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 							Drop: []corev1.Capability{corev1.Capability("ALL")},
 						},
 					},
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      "openshift-service-ca-bundle",
-							MountPath: "/etc/odh/openshift-service-ca-bundle",
-						},
-					},
+					VolumeMounts: expectedPlatformVolumeMounts(),
 				},
 			},
-			Volumes: []corev1.Volume{
-				{
-					Name: "openshift-service-ca-bundle",
-					VolumeSource: corev1.VolumeSource{
-						ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: constants.OpenShiftServiceCaConfigMapName,
-							},
-						},
-					},
-				},
-			},
+			Volumes:                      expectedPlatformVolumes(),
 			AutomountServiceAccountToken: proto.Bool(false),
 			ServiceAccountName:           "default",
 			ImagePullSecrets:             []corev1.LocalObjectReference{},
@@ -345,32 +304,11 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 							Drop: []corev1.Capability{corev1.Capability("ALL")},
 						},
 					},
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      "openshift-service-ca-bundle",
-							MountPath: "/etc/odh/openshift-service-ca-bundle",
-						},
-					},
-					Env: []corev1.EnvVar{
-						{
-							Name:  "SSL_CERT_FILE",
-							Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
-						},
-					},
+					VolumeMounts: expectedPlatformVolumeMounts(),
+					Env:          expectedPlatformEnvVars(),
 				},
 			},
-			Volumes: []corev1.Volume{
-				{
-					Name: "openshift-service-ca-bundle",
-					VolumeSource: corev1.VolumeSource{
-						ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: constants.OpenShiftServiceCaConfigMapName,
-							},
-						},
-					},
-				},
-			},
+			Volumes:                      expectedPlatformVolumes(),
 			AutomountServiceAccountToken: proto.Bool(false),
 			ServiceAccountName:           "default",
 			ImagePullSecrets:             []corev1.LocalObjectReference{},
@@ -405,32 +343,11 @@ func TestCreateInferenceGraphPodSpec(t *testing.T) {
 							Drop: []corev1.Capability{corev1.Capability("ALL")},
 						},
 					},
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      "openshift-service-ca-bundle",
-							MountPath: "/etc/odh/openshift-service-ca-bundle",
-						},
-					},
-					Env: []corev1.EnvVar{
-						{
-							Name:  "SSL_CERT_FILE",
-							Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
-						},
-					},
+					VolumeMounts: expectedPlatformVolumeMounts(),
+					Env:          expectedPlatformEnvVars(),
 				},
 			},
-			Volumes: []corev1.Volume{
-				{
-					Name: "openshift-service-ca-bundle",
-					VolumeSource: corev1.VolumeSource{
-						ConfigMap: &corev1.ConfigMapVolumeSource{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: constants.OpenShiftServiceCaConfigMapName,
-							},
-						},
-					},
-				},
-			},
+			Volumes:                      expectedPlatformVolumes(),
 			AutomountServiceAccountToken: proto.Bool(false),
 			ServiceAccountName:           "default",
 			ImagePullSecrets:             []corev1.LocalObjectReference{},

--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig_test_default.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig_test_default.go
@@ -1,0 +1,43 @@
+//go:build !distro
+
+/*
+Copyright 2023 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inferencegraph
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// expectedReadinessProbeScheme returns the expected readiness probe scheme for non-OCP builds.
+func expectedReadinessProbeScheme() corev1.URIScheme {
+	return corev1.URISchemeHTTP
+}
+
+// expectedPlatformVolumeMounts returns no volume mounts for non-OCP builds.
+func expectedPlatformVolumeMounts() []corev1.VolumeMount {
+	return nil
+}
+
+// expectedPlatformEnvVars returns no env vars for non-OCP builds.
+func expectedPlatformEnvVars() []corev1.EnvVar {
+	return nil
+}
+
+// expectedPlatformVolumes returns no volumes for non-OCP builds.
+func expectedPlatformVolumes() []corev1.Volume {
+	return nil
+}

--- a/pkg/controller/v1alpha1/inferencegraph/raw_ig_test_ocp.go
+++ b/pkg/controller/v1alpha1/inferencegraph/raw_ig_test_ocp.go
@@ -1,0 +1,66 @@
+//go:build distro
+
+/*
+Copyright 2023 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inferencegraph
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+// expectedReadinessProbeScheme returns the expected readiness probe scheme for OCP builds.
+func expectedReadinessProbeScheme() corev1.URIScheme {
+	return corev1.URISchemeHTTPS
+}
+
+// expectedPlatformVolumeMounts returns the CA bundle volume mount expected on OCP.
+func expectedPlatformVolumeMounts() []corev1.VolumeMount {
+	return []corev1.VolumeMount{
+		{
+			Name:      "openshift-service-ca-bundle",
+			MountPath: "/etc/odh/openshift-service-ca-bundle",
+		},
+	}
+}
+
+// expectedPlatformEnvVars returns the SSL_CERT_FILE env var expected on OCP.
+func expectedPlatformEnvVars() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{
+			Name:  "SSL_CERT_FILE",
+			Value: "/etc/odh/openshift-service-ca-bundle/service-ca.crt",
+		},
+	}
+}
+
+// expectedPlatformVolumes returns the CA bundle volume expected on OCP.
+func expectedPlatformVolumes() []corev1.Volume {
+	return []corev1.Volume{
+		{
+			Name: "openshift-service-ca-bundle",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: constants.OpenShiftServiceCaConfigMapName,
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -26,10 +26,6 @@ import (
 	"sort"
 	"strings"
 
-	routev1 "github.com/openshift/api/route/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/pkg/apis"
-
 	"github.com/pkg/errors"
 	goerrors "github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -520,52 +516,6 @@ func MergeServingRuntimeAndInferenceServiceSpecs(srContainers []corev1.Container
 		return 0, nil, nil, errors.New(errMsg)
 	}
 	return containerIndexInSR, mergedContainer, mergedPodSpec, nil
-}
-
-// GetRouteURLIfExists Check for route created by odh-model-controller. If the route is found, use it as the isvc URL
-func GetRouteURLIfExists(ctx context.Context, cli client.Client, metadata metav1.ObjectMeta, isvcName string) (*apis.URL, error) {
-	foundRoute := false
-	routeReady := false
-	route := &routev1.Route{}
-	err := cli.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: metadata.Namespace}, route)
-	if err != nil {
-		return nil, err
-	}
-
-	// Check if the route is owned by the InferenceService
-	for _, ownerRef := range route.OwnerReferences {
-		if ownerRef.UID == metadata.UID {
-			foundRoute = true
-		}
-	}
-
-	// Check if the route is admitted
-	for _, ingress := range route.Status.Ingress {
-		for _, condition := range ingress.Conditions {
-			if condition.Type == "Admitted" && condition.Status == "True" {
-				routeReady = true
-			}
-		}
-	}
-
-	if !foundRoute || !routeReady {
-		return nil, fmt.Errorf("route %s/%s not found or not ready", metadata.Namespace, metadata.Name)
-	}
-
-	// Construct the URL
-	host := route.Spec.Host
-	scheme := "http"
-	if route.Spec.TLS != nil && route.Spec.TLS.Termination != "" {
-		scheme = "https"
-	}
-
-	// Create the URL as an apis.URL object
-	routeURL := &apis.URL{
-		Scheme: scheme,
-		Host:   host,
-	}
-
-	return routeURL, nil
 }
 
 func FilterList(slice []string, element string) []string {

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils_default.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils_default.go
@@ -1,0 +1,34 @@
+//go:build !distro
+
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetRouteURLIfExists is a no-op stub for non-OpenShift builds.
+// OpenShift Route support is only available in the distro build.
+func GetRouteURLIfExists(_ context.Context, _ client.Client, _ metav1.ObjectMeta, _ string) (*apis.URL, error) {
+	return nil, fmt.Errorf("OpenShift Route support is not available in this build")
+}

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils_ocp.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils_ocp.go
@@ -1,0 +1,77 @@
+//go:build distro
+
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	routev1 "github.com/openshift/api/route/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetRouteURLIfExists checks for an OpenShift Route created by odh-model-controller.
+// If the route is found and admitted, it returns the route URL.
+func GetRouteURLIfExists(ctx context.Context, cli client.Client, metadata metav1.ObjectMeta, isvcName string) (*apis.URL, error) {
+	foundRoute := false
+	routeReady := false
+	route := &routev1.Route{}
+	err := cli.Get(ctx, types.NamespacedName{Name: isvcName, Namespace: metadata.Namespace}, route)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if the route is owned by the InferenceService
+	for _, ownerRef := range route.OwnerReferences {
+		if ownerRef.UID == metadata.UID {
+			foundRoute = true
+		}
+	}
+
+	// Check if the route is admitted
+	for _, ingress := range route.Status.Ingress {
+		for _, condition := range ingress.Conditions {
+			if condition.Type == "Admitted" && condition.Status == "True" {
+				routeReady = true
+			}
+		}
+	}
+
+	if !foundRoute || !routeReady {
+		return nil, fmt.Errorf("route %s/%s not found or not ready", metadata.Namespace, metadata.Name)
+	}
+
+	// Construct the URL
+	host := route.Spec.Host
+	scheme := "http"
+	if route.Spec.TLS != nil && route.Spec.TLS.Termination != "" {
+		scheme = "https"
+	}
+
+	// Create the URL as an apis.URL object
+	routeURL := &apis.URL{
+		Scheme: scheme,
+		Host:   host,
+	}
+
+	return routeURL, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Extracts OpenShift-specific code (Route URL handling, CA bundle volume/mount injection, HTTPS readiness probe override, Route reconciliation) from upstream files into `//go:build distro` / `!distro` companion files.

This follows the same hook pattern established in the LLMInferenceService controller (`router_platform_networking_ocp.go` / `_default.go`). Upstream files now call thin platform hooks that are no-ops in the default build and carry the OCP behavior in the distro build.

**Changes:**

- `utils/utils.go` - moves `GetRouteURLIfExists` (which imports `routev1`) to `utils_ocp.go` / `utils_default.go`
- `inferencegraph/raw_ig.go` - extracts CA bundle volume/mount/env and HTTPS probe scheme to `applyPlatformPodSpecDefaults` hook (`raw_ig_ocp.go` / `raw_ig_default.go`)
- `inferencegraph/knative_reconciler.go` - extracts CA bundle injection to `applyKnativePlatformDefaults` hook (`knative_reconciler_ocp.go` / `knative_reconciler_default.go`)
- `inferencegraph/controller.go` - extracts Route reconciliation and `Owns(&Route{})` to `reconcilePlatformRoute` / `setupPlatformOwns` hooks (`controller_route_ocp.go` / `controller_route_default.go`)
- `inferencegraph/openshift_route_reconciler.go` - renamed to `_ocp.go` with `//go:build distro` tag
- Test expectations updated with build-tagged helpers so tests pass in both modes

**Which issue(s) this PR fixes**:
Part of the clean-cut effort to reduce midstream/upstream divergence.

**Feature/Issue validation/testing**:

- [x] `go build ./pkg/... ./cmd/...` passes (default build)
- [x] `go build -tags distro ./pkg/... ./cmd/...` passes (distro build)
- [x] `go vet ./pkg/...` and `go vet -tags distro ./pkg/...` clean
- [x] Unit tests pass in both modes (`go test` and `go test -tags distro`)

**Special notes for your reviewer**:

`FilterList` remains in `utils.go` (not extracted) because it's a generic utility used by 7+ call sites in non-build-tagged files (`ingress_reconciler.go`, `predictor.go`, `transformer.go`, `explainer.go`). Moving it behind `//go:build distro` would break upstream builds.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* Refactored OpenShift-specific configuration (Routes, TLS certificates) into separate build-tag-gated modules for improved code organization.
* Simplified core controller logic by delegating platform-specific Route reconciliation and pod specification defaults to centralized helper functions.
* Enabled conditional compilation to support both OpenShift and non-OpenShift deployments from the same codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->