### PR TITLE
refactor: restore upstream ValidateInitialScaleAnnotation

### DIFF
--- a/pkg/controller/v1alpha1/inferencegraph/controller.go
+++ b/pkg/controller/v1alpha1/inferencegraph/controller.go
@@ -301,7 +301,7 @@ func (r *InferenceGraphReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			return ctrl.Result{}, errors.Wrapf(err, "failed to retrieve the knative autoscaler configuration")
 		}
 
-		knutils.ValidateInitialScaleAnnotation(graph.Annotations, allowZeroInitialScale, graph.Spec.MinReplicas, r.Log)
+		knutils.ValidateInitialScaleAnnotationWithReplicas(graph.Annotations, allowZeroInitialScale, graph.Spec.MinReplicas, r.Log)
 
 		desired := createKnativeService(graph.ObjectMeta, graph, routerConfig)
 

--- a/pkg/controller/v1alpha1/utils/utils.go
+++ b/pkg/controller/v1alpha1/utils/utils.go
@@ -111,21 +111,10 @@ func CheckZeroInitialScaleAllowed(ctx context.Context, clientset kubernetes.Inte
 // ValidateInitialScaleAnnotation checks the annotations of a resource for the knative initial scale annotation.
 // When the annotation is set validation is performed. If any of this validation fails, the annotation will
 // be removed and the default initial scale behavior will be used.
-func ValidateInitialScaleAnnotation(annotations map[string]string, allowZeroInitialScale bool, minReplicas *int32, log logr.Logger) {
+func ValidateInitialScaleAnnotation(annotations map[string]string, allowZeroInitialScale bool, log logr.Logger) {
 	// Check that the annoation is set.
 	_, set := annotations[autoscaling.InitialScaleAnnotationKey]
 	if !set {
-		// ODH Only
-		// For scenarios where zero min replicas are requested, set the initial scale annotation to 0
-		// unless explicitly set by an end user.
-		if allowZeroInitialScale {
-			if minReplicas == nil && constants.DefaultMinReplicas == 0 {
-				annotations[autoscaling.InitialScaleAnnotationKey] = "0"
-			}
-			if minReplicas != nil && *minReplicas == 0 {
-				annotations[autoscaling.InitialScaleAnnotationKey] = "0"
-			}
-		}
 		return
 	}
 

--- a/pkg/controller/v1alpha1/utils/utils_zeroscale_default.go
+++ b/pkg/controller/v1alpha1/utils/utils_zeroscale_default.go
@@ -1,0 +1,29 @@
+//go:build !distro
+
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"github.com/go-logr/logr"
+)
+
+// ValidateInitialScaleAnnotationWithReplicas delegates to ValidateInitialScaleAnnotation in upstream builds.
+// The minReplicas parameter is accepted for API compatibility but is unused.
+func ValidateInitialScaleAnnotationWithReplicas(annotations map[string]string, allowZeroInitialScale bool, _ *int32, log logr.Logger) {
+	ValidateInitialScaleAnnotation(annotations, allowZeroInitialScale, log)
+}

--- a/pkg/controller/v1alpha1/utils/utils_zeroscale_ocp.go
+++ b/pkg/controller/v1alpha1/utils/utils_zeroscale_ocp.go
@@ -1,0 +1,43 @@
+//go:build distro
+
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"github.com/go-logr/logr"
+	"knative.dev/serving/pkg/apis/autoscaling"
+
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+// ValidateInitialScaleAnnotationWithReplicas wraps ValidateInitialScaleAnnotation and additionally
+// sets the initial scale annotation to 0 when zero min replicas are requested but the annotation
+// is not explicitly set by the user.
+func ValidateInitialScaleAnnotationWithReplicas(annotations map[string]string, allowZeroInitialScale bool, minReplicas *int32, log logr.Logger) {
+	_, set := annotations[autoscaling.InitialScaleAnnotationKey]
+	if !set && allowZeroInitialScale {
+		if minReplicas == nil && constants.DefaultMinReplicas == 0 {
+			annotations[autoscaling.InitialScaleAnnotationKey] = "0"
+		}
+		if minReplicas != nil && *minReplicas == 0 {
+			annotations[autoscaling.InitialScaleAnnotationKey] = "0"
+		}
+	}
+
+	ValidateInitialScaleAnnotation(annotations, allowZeroInitialScale, log)
+}

--- a/pkg/controller/v1beta1/inferenceservice/components/annotation_filter_default.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/annotation_filter_default.go
@@ -1,0 +1,33 @@
+//go:build !distro
+
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package components
+
+import (
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/utils"
+)
+
+// filterServiceAnnotations filters annotations against the disallowed list.
+// In upstream builds the deploymentMode parameter is unused - annotations are
+// always filtered using the full disallowed list.
+func filterServiceAnnotations(annotations map[string]string, disallowedList []string, _ constants.DeploymentModeType) map[string]string {
+	return utils.Filter(annotations, func(key string) bool {
+		return !utils.Includes(disallowedList, key)
+	})
+}

--- a/pkg/controller/v1beta1/inferenceservice/components/annotation_filter_ocp.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/annotation_filter_ocp.go
@@ -1,0 +1,40 @@
+//go:build distro
+
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package components
+
+import (
+	"github.com/kserve/kserve/pkg/constants"
+	isvcutils "github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/utils"
+	"github.com/kserve/kserve/pkg/utils"
+)
+
+// filterServiceAnnotations filters annotations against the disallowed list.
+// In Standard (Knative) mode the ODHKserveRawAuth annotation is also disallowed;
+// in RawDeployment mode it is allowed through so the auth proxy can be configured.
+// https://issues.redhat.com/browse/RHOAIENG-20326
+func filterServiceAnnotations(annotations map[string]string, disallowedList []string, deploymentMode constants.DeploymentModeType) map[string]string {
+	if deploymentMode == constants.Standard {
+		return utils.Filter(annotations, func(key string) bool {
+			return !utils.Includes(isvcutils.FilterList(disallowedList, constants.ODHKserveRawAuth), key)
+		})
+	}
+	return utils.Filter(annotations, func(key string) bool {
+		return !utils.Includes(disallowedList, key)
+	})
+}

--- a/pkg/controller/v1beta1/inferenceservice/components/explainer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/explainer.go
@@ -74,18 +74,7 @@ func NewExplainer(client client.Client, clientset kubernetes.Interface, scheme *
 func (e *Explainer) Reconcile(ctx context.Context, isvc *v1beta1.InferenceService) (ctrl.Result, error) {
 	e.Log.Info("Reconciling Explainer", "ExplainerSpec", isvc.Spec.Explainer)
 	explainer := isvc.Spec.Explainer.GetImplementation()
-	var annotations map[string]string
-	if e.deploymentMode == constants.Standard {
-		annotations = utils.Filter(isvc.Annotations, func(key string) bool {
-			// https://issues.redhat.com/browse/RHOAIENG-20326
-			// For RawDeployment, we allow the security.opendatahub.io/enable-auth annotation
-			return !utils.Includes(isvcutils.FilterList(e.inferenceServiceConfig.ServiceAnnotationDisallowedList, constants.ODHKserveRawAuth), key)
-		})
-	} else {
-		annotations = utils.Filter(isvc.Annotations, func(key string) bool {
-			return !utils.Includes(e.inferenceServiceConfig.ServiceAnnotationDisallowedList, key)
-		})
-	}
+	annotations := filterServiceAnnotations(isvc.Annotations, e.inferenceServiceConfig.ServiceAnnotationDisallowedList, e.deploymentMode)
 
 	sourceURI := explainer.GetStorageUri()
 
@@ -107,18 +96,7 @@ func (e *Explainer) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 	// Labels and annotations from explainer component
 	// Label filter will be handled in ksvc_reconciler and raw reconciler
 	explainerLabels := isvc.Spec.Explainer.Labels
-	var explainerAnnotations map[string]string
-	if e.deploymentMode == constants.Standard {
-		explainerAnnotations = utils.Filter(isvc.Spec.Explainer.Annotations, func(key string) bool {
-			// https://issues.redhat.com/browse/RHOAIENG-20326
-			// For RawDeployment, we allow the security.opendatahub.io/enable-auth annotation
-			return !utils.Includes(isvcutils.FilterList(e.inferenceServiceConfig.ServiceAnnotationDisallowedList, constants.ODHKserveRawAuth), key)
-		})
-	} else {
-		explainerAnnotations = utils.Filter(isvc.Spec.Explainer.Annotations, func(key string) bool {
-			return !utils.Includes(e.inferenceServiceConfig.ServiceAnnotationDisallowedList, key)
-		})
-	}
+	explainerAnnotations := filterServiceAnnotations(isvc.Spec.Explainer.Annotations, e.inferenceServiceConfig.ServiceAnnotationDisallowedList, e.deploymentMode)
 
 	// Labels and annotations priority: explainer component > isvc
 	// Labels and annotations from high priority will overwrite that from low priority
@@ -237,7 +215,7 @@ func (e *Explainer) reconcileExplainerRawDeployment(ctx context.Context, isvc *v
 }
 
 func (e *Explainer) reconcileExplainerKnativeDeployment(ctx context.Context, isvc *v1beta1.InferenceService, objectMeta *metav1.ObjectMeta, podSpec *corev1.PodSpec) error {
-	knutils.ValidateInitialScaleAnnotation(objectMeta.Annotations, e.allowZeroInitialScale, isvc.Spec.Explainer.MinReplicas, e.Log)
+	knutils.ValidateInitialScaleAnnotationWithReplicas(objectMeta.Annotations, e.allowZeroInitialScale, isvc.Spec.Explainer.MinReplicas, e.Log)
 
 	isvcConfigMap, err := v1beta1.GetInferenceServiceConfigMap(ctx, e.clientset)
 	if err != nil {

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -99,18 +99,7 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 	if isvc.Spec.Predictor.WorkerSpec != nil {
 		multiNodeEnabled = true
 	}
-	var annotations map[string]string
-	if p.deploymentMode == constants.Standard {
-		annotations = utils.Filter(isvc.Annotations, func(key string) bool {
-			// https://issues.redhat.com/browse/RHOAIENG-20326
-			// For RawDeployment, we allow the security.opendatahub.io/enable-auth annotation
-			return !utils.Includes(isvcutils.FilterList(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, constants.ODHKserveRawAuth), key)
-		})
-	} else {
-		annotations = utils.Filter(isvc.Annotations, func(key string) bool {
-			return !utils.Includes(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, key)
-		})
-	}
+	annotations := filterServiceAnnotations(isvc.Annotations, p.inferenceServiceConfig.ServiceAnnotationDisallowedList, p.deploymentMode)
 
 	p.Log.V(1).Info("Predictor custom annotations", "annotations", p.inferenceServiceConfig.ServiceAnnotationDisallowedList)
 	p.Log.V(1).Info("Predictor custom labels", "labels", p.inferenceServiceConfig.ServiceLabelDisallowedList)
@@ -178,18 +167,7 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 	// Labels and annotations from predictor component
 	// Label filter will be handled in ksvc_reconciler and raw reconciler
 	predictorLabels := isvc.Spec.Predictor.Labels
-	var predictorAnnotations map[string]string
-	if p.deploymentMode == constants.Standard {
-		predictorAnnotations = utils.Filter(isvc.Spec.Predictor.Annotations, func(key string) bool {
-			// https://issues.redhat.com/browse/RHOAIENG-20326
-			// For RawDeployment, we allow the security.opendatahub.io/enable-auth annotation
-			return !utils.Includes(isvcutils.FilterList(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, constants.ODHKserveRawAuth), key)
-		})
-	} else {
-		predictorAnnotations = utils.Filter(isvc.Spec.Predictor.Annotations, func(key string) bool {
-			return !utils.Includes(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, key)
-		})
-	}
+	predictorAnnotations := filterServiceAnnotations(isvc.Spec.Predictor.Annotations, p.inferenceServiceConfig.ServiceAnnotationDisallowedList, p.deploymentMode)
 
 	// Label filter will be handled in ksvc_reconciler
 	sRuntimeLabels = sRuntime.Labels
@@ -776,7 +754,7 @@ func (p *Predictor) reconcileRawDeployment(ctx context.Context, isvc *v1beta1.In
 }
 
 func (p *Predictor) reconcileKnativeDeployment(ctx context.Context, isvc *v1beta1.InferenceService, objectMeta *metav1.ObjectMeta, podSpec *corev1.PodSpec) (*knservingv1.ServiceStatus, error) {
-	knutils.ValidateInitialScaleAnnotation(objectMeta.Annotations, p.allowZeroInitialScale, isvc.Spec.Predictor.MinReplicas, p.Log)
+	knutils.ValidateInitialScaleAnnotationWithReplicas(objectMeta.Annotations, p.allowZeroInitialScale, isvc.Spec.Predictor.MinReplicas, p.Log)
 
 	isvcConfigMap, err := v1beta1.GetInferenceServiceConfigMap(ctx, p.clientset)
 	if err != nil {

--- a/pkg/controller/v1beta1/inferenceservice/components/transformer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/transformer.go
@@ -76,18 +76,7 @@ func NewTransformer(client client.Client, clientset kubernetes.Interface, scheme
 func (p *Transformer) Reconcile(ctx context.Context, isvc *v1beta1.InferenceService) (ctrl.Result, error) {
 	p.Log.Info("Reconciling Transformer", "TransformerSpec", isvc.Spec.Transformer)
 	transformer := isvc.Spec.Transformer.GetImplementation()
-	var annotations map[string]string
-	if p.deploymentMode == constants.Standard {
-		annotations = utils.Filter(isvc.Annotations, func(key string) bool {
-			// https://issues.redhat.com/browse/RHOAIENG-20326
-			// For RawDeployment, we allow the security.opendatahub.io/enable-auth annotation
-			return !utils.Includes(isvcutils.FilterList(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, constants.ODHKserveRawAuth), key)
-		})
-	} else {
-		annotations = utils.Filter(isvc.Annotations, func(key string) bool {
-			return !utils.Includes(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, key)
-		})
-	}
+	annotations := filterServiceAnnotations(isvc.Annotations, p.inferenceServiceConfig.ServiceAnnotationDisallowedList, p.deploymentMode)
 
 	sourceURI := transformer.GetStorageUri()
 
@@ -110,18 +99,7 @@ func (p *Transformer) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServ
 	// Labels and annotations from transformer component
 	// Label filter will be handled in ksvc_reconciler and raw reconciler
 	transformerLabels := isvc.Spec.Transformer.Labels
-	var transformerAnnotations map[string]string
-	if p.deploymentMode == constants.Standard {
-		transformerAnnotations = utils.Filter(isvc.Spec.Transformer.Annotations, func(key string) bool {
-			// https://issues.redhat.com/browse/RHOAIENG-20326
-			// For RawDeployment, we allow the security.opendatahub.io/enable-auth annotation
-			return !utils.Includes(isvcutils.FilterList(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, constants.ODHKserveRawAuth), key)
-		})
-	} else {
-		transformerAnnotations = utils.Filter(isvc.Spec.Transformer.Annotations, func(key string) bool {
-			return !utils.Includes(p.inferenceServiceConfig.ServiceAnnotationDisallowedList, key)
-		})
-	}
+	transformerAnnotations := filterServiceAnnotations(isvc.Spec.Transformer.Annotations, p.inferenceServiceConfig.ServiceAnnotationDisallowedList, p.deploymentMode)
 
 	// Labels and annotations priority: transformer component > isvc
 	// Labels and annotations from high priority will overwrite that from low priority
@@ -273,7 +251,7 @@ func (p *Transformer) reconcileTransformerRawDeployment(ctx context.Context, isv
 }
 
 func (p *Transformer) reconcileTransformerKnativeDeployment(ctx context.Context, isvc *v1beta1.InferenceService, objectMeta *metav1.ObjectMeta, podSpec *corev1.PodSpec) error {
-	knutils.ValidateInitialScaleAnnotation(objectMeta.Annotations, p.allowZeroInitialScale, isvc.Spec.Transformer.MinReplicas, p.Log)
+	knutils.ValidateInitialScaleAnnotationWithReplicas(objectMeta.Annotations, p.allowZeroInitialScale, isvc.Spec.Transformer.MinReplicas, p.Log)
 
 	isvcConfigMap, err := v1beta1.GetInferenceServiceConfigMap(ctx, p.clientset)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

The midstream fork modified the upstream public function `ValidateInitialScaleAnnotation` by adding a minReplicas parameter, making every upstream rebase a potential conflict source.

This restores the upstream signature and moves the OCP-specific zero-scale-on-minReplicas logic into build-tag-gated companion files (ValidateInitialScaleAnnotationWithReplicas). The same companion file pattern isolates the ODHKserveRawAuth annotation filtering that was duplicated identically across predictor, transformer, and explainer components.

