### PR TITLE
feat(llmisvc): add Intel Gaudi accelerator LLMInferenceServiceConfig

### DIFF
--- a/config/overlays/odh/accelerators/intel-gaudi-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/intel-gaudi-config-llm-template.yaml
@@ -1,0 +1,13 @@
+apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: kserve-config-llm-template-intel-gaudi
+  annotations:
+    openshift.io/display-name: vLLM Intel Gaudi LLMInferenceServiceConfig
+    openshift.io/description: vLLM Intel Gaudi LLMInferenceServiceConfig for LLMInferenceService.
+    opendatahub.io/recommended-accelerators: '["habana.ai/gaudi"]'
+spec:
+  template:
+    containers:
+      - name: main
+        image: placeholder

--- a/config/overlays/odh/accelerators/kustomization.yaml
+++ b/config/overlays/odh/accelerators/kustomization.yaml
@@ -7,6 +7,7 @@ commonLabels:
 resources:
 - nvidia-cuda-config-llm-template.yaml
 - amd-rocm-config-llm-template.yaml
+- intel-gaudi-config-llm-template.yaml
 - ibm-spyre-s390x-config-llm-template.yaml
 - ibm-spyre-x86-config-llm-template.yaml
 - ibm-spyre-ppc64le-config-llm-template.yaml

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -189,6 +189,16 @@ replacements:
 - source:
     kind: ConfigMap
     name: kserve-parameters
+    fieldPath: data.kserve-llm-d-intel-gaudi
+  targets:
+  - select:
+      kind: LLMInferenceServiceConfig
+      name: kserve-config-llm-template-intel-gaudi
+    fieldPaths:
+    - spec.template.containers.[name=main].image
+- source:
+    kind: ConfigMap
+    name: kserve-parameters
     fieldPath: data.kserve-llm-d-ibm-spyre
   targets:
   - select:

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -9,6 +9,7 @@ kserve-llm-d-routing-sidecar=quay.io/opendatahub/llm-d-routing-sidecar:odh-stabl
 kserve-llm-d-uds-tokenizer=quay.io/opendatahub/llm-d-kv-cache:v0.6.0
 kserve-llm-d-nvidia-cuda=registry.redhat.io/rhaiis/vllm-cuda-rhel9@sha256:fc68d623d1bfc36c8cb2fe4a71f19c8578cfb420ce8ce07b20a02c1ee0be0cf3
 kserve-llm-d-amd-rocm=registry.redhat.io/rhaiis/vllm-rocm-rhel9@sha256:d9a48add238cc095fa43eeee17c8c4d104de60c4dc623e0bc7f8c4b53b2b2e97
+kserve-llm-d-intel-gaudi=registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9:3.4.0-ea.2
 kserve-llm-d-ibm-spyre=registry.redhat.io/rhaiis/vllm-spyre-rhel9@sha256:80ae3e435a5be2c1f117f36599103ab05357917dd6e37f0df6613cb3ac2c13ea
 # TODO update when our changes are introduced in the official image
 kube-rbac-proxy=quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds an Intel Gaudi (`habana.ai/gaudi`) accelerator-specific `LLMInferenceServiceConfig` template, following the same pattern as the existing NVIDIA CUDA and AMD ROCm configs. This enables the RHOAI dashboard to present Intel Gaudi as an accelerator option for vLLM-backed LLMInferenceService deployments.

RHAIIS 3.4-EA2 now includes a Gaudi vLLM image (`registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9`), currently in Tech Preview. The config is image-override only for now, no Gaudi-specific env vars needed. Currently reaching out to the RHAIIS team to verify.

Changes:
- New accelerator config: `config/overlays/odh/accelerators/intel-gaudi-config-llm-template.yaml`
- `params.env` entry: `kserve-llm-d-intel-gaudi` with EA2 image reference
- Kustomize replacement wiring for image injection
- Added to `accelerators/kustomization.yaml` resources

Companion operator PR needed to add `RELATED_IMAGE_RHAIIS_VLLM_GAUDI_IMAGE` mapping in opendatahub-operator ([RHOAIENG-56360](https://redhat.atlassian.net/browse/RHOAIENG-56360)).

Intel Gaudi accelerator config work is up across four repos:

kserve (accelerator config + params.env + kustomize wiring): https://github.com/opendatahub-io/kserve/pull/1331
operator (RELATED_IMAGE mapping): https://github.com/opendatahub-io/opendatahub-operator/pull/3370
ODH-Build-Config (image entry): https://github.com/opendatahub-io/ODH-Build-Config/pull/1039
RHOAI-Build-Config (sync from ea.2 to rhoai-3.4): https://github.com/red-hat-data-services/RHOAI-Build-Config/pull/18915

**Which issue(s) this PR fixes**:
Fixes https://redhat.atlassian.net/browse/RHOAIENG-56358

**Feature/Issue validation/testing**:

- [x] `kustomize build config/overlays/odh/accelerators/` renders 6 accelerator configs (5 existing + 1 new Gaudi)
- [x] `habana.ai/gaudi` annotation present in built output
- [x] `opendatahub.io/config-type: accelerator` label applied via commonLabels
- [x] No existing accelerator configs modified
- [ ] End-to-end validation on Intel Gaudi hardware (requires Gaudi node, not available in CI)

**Special notes for your reviewer**:

The full `kustomize build config/overlays/odh/` has a pre-existing error related to `storageInitializer` replacement target format. This is unrelated to this PR. The accelerator configs build cleanly via `kustomize build config/overlays/odh/accelerators/`.

The `params.env` image uses the EA path (`rhaii-early-access/vllm-gaudi-rhel9:3.4.0-ea.2`) as the default. The operator overrides this at deploy time via `RELATED_IMAGE_*`.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
  - No, requires Intel Gaudi hardware not available in CI. Config follows the validated CUDA/ROCm pattern.
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note
Add Intel Gaudi accelerator LLMInferenceServiceConfig template for vLLM deployments on Intel Habana Gaudi HPUs.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Intel Gaudi accelerators for LLM inference services, expanding hardware acceleration options and enabling efficient large language model serving on Gaudi-based systems with ready-to-use configuration templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->