### PR TITLE
fix(llmisvc): add missing inference.networking RBAC permissions

### DIFF
--- a/config/rbac/llmisvc/role.yaml
+++ b/config/rbac/llmisvc/role.yaml
@@ -133,10 +133,25 @@ rules:
   - watch
 - apiGroups:
   - inference.networking.k8s.io
-  - inference.networking.x-k8s.io
   resources:
   - inferencemodels
   - inferenceobjectives
+  - inferencepools
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - inference.networking.x-k8s.io
+  resources:
+  - inferencemodelrewrites
+  - inferencemodels
+  - inferenceobjectives
+  - inferencepoolimports
   - inferencepools
   verbs:
   - create

--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -98,7 +98,7 @@ type LLMISVCReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes;gateways;gatewayclasses,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=inference.networking.x-k8s.io,resources=inferencepools;inferenceobjectives;inferencemodels,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=inference.networking.x-k8s.io,resources=inferencepools;inferenceobjectives;inferencemodels;inferencemodelrewrites;inferencepoolimports,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=inference.networking.k8s.io,resources=inferencepools;inferenceobjectives;inferencemodels,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -697,7 +697,7 @@ func (r *LLMISVCReconciler) expectedSchedulerRole(llmSvc *v1alpha2.LLMInferenceS
 		},
 		Rules: []rbacv1.PolicyRule{
 			{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: []string{"get", "list", "watch"}},
-			{APIGroups: []string{"inference.networking.k8s.io", "inference.networking.x-k8s.io"}, Resources: []string{"inferencepools", "inferenceobjectives", "inferencemodels"}, Verbs: []string{"get", "list", "watch"}},
+			{APIGroups: []string{"inference.networking.k8s.io", "inference.networking.x-k8s.io"}, Resources: []string{"inferencepools", "inferenceobjectives", "inferencemodels", "inferencemodelrewrites", "inferencepoolimports"}, Verbs: []string{"get", "list", "watch"}},
 			{APIGroups: []string{"discovery.k8s.io"}, Resources: []string{"endpointslices"}, Verbs: []string{"get", "list", "watch"}},
 			{APIGroups: []string{"coordination.k8s.io"}, Resources: []string{"leases"}, Verbs: []string{"get", "list", "watch", "create", "update", "patch", "delete"}},
 		},


### PR DESCRIPTION
EPP service accounts need permissions to watch inferencemodelrewrites and inferencepoolimports resources. Without these permissions, EPP fails at startup with RBAC errors when attempting to register watchers for these CRDs.

Changes:
- Added kubebuilder RBAC annotation for inferencemodelrewrites and inferencepoolimports to inference.networking.x-k8s.io resources
- Regenerated manager ClusterRole from annotations via make manifests (llmisvc-controller-manager service account gets this role)
- Updated dynamically-created EPP namespace Role in scheduler.go (per-LLMInferenceService <name>-epp-sa service accounts get this role)

Note: The distro ClusterRole is auto-generated by controller-gen and should not be manually edited. Since llmisvc-controller-manager gets both the manager and distro ClusterRoles, updating the manager role is sufficient.

Fixes: [RHOAIENG-56779](https://redhat.atlassian.net/browse/RHOAIENG-56779)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated system role permissions to support inference model rewrite and pool import operations, extending management capabilities for inference resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->