### PR TITLE
ci: guard against silent build breakage from build tag drift

### DIFF
--- a/.github/workflows/distro-build-check.yml
+++ b/.github/workflows/distro-build-check.yml
@@ -18,6 +18,8 @@ jobs:
     distro-build-check:
         name: distro-build-check / ${{ matrix.label }}
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         strategy:
             fail-fast: false
             matrix:

--- a/.github/workflows/distro-build-check.yml
+++ b/.github/workflows/distro-build-check.yml
@@ -1,0 +1,43 @@
+name: Build tag verification
+
+on:
+    pull_request:
+        paths:
+            - "**/*.go"
+            - "go.mod"
+            - "go.sum"
+            - ".github/workflows/distro-build-check.yml"
+    merge_group:
+        types: [checks_requested]
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    distro-build-check:
+        name: distro-build-check / ${{ matrix.label }}
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - label: no build tags
+                      tags: ""
+                    - label: distro
+                      tags: distro
+
+        steps:
+            - name: Check out code
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+            - name: Set up Go
+              uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+              with:
+                  go-version-file: go.mod
+                  cache: true
+
+            - name: vet + compile (incl. test files)
+              env:
+                  GOFLAGS: ${{ matrix.tags != '' && format('-tags={0}', matrix.tags) || '' }}
+              run: go test -vet=all -c -o /dev/null ./...

--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -30,7 +30,6 @@ import (
 	apixclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -178,16 +177,7 @@ func main() {
 		Cache: cache.Options{
 			ByObject: map[client.Object]cache.ByObject{
 				&corev1.Secret{}: {
-					Namespaces: map[string]cache.Config{
-						llmisvc.ServiceCASigningSecretNamespace: {
-							FieldSelector: fields.SelectorFromSet(map[string]string{
-								"metadata.name": llmisvc.ServiceCASigningSecretName,
-							}),
-						},
-						cache.AllNamespaces: {
-							LabelSelector: llmSvcCacheSelector,
-						},
-					},
+					Label: llmSvcCacheSelector,
 				},
 				&corev1.ConfigMap{}: {
 					Label: llmSvcCacheSelector,


### PR DESCRIPTION
**What this PR does / why we need it**:

Build tag drift - where a symbol is defined under one tag constraint but referenced from another - can silently break compilation for an entire build variant while CI stays green. 

Adds a workflow that validates both the `distro` and non-distro build variants on every Go-touching PRs and dependency update, catching compilation failures and vet issues (including test files) early.

Also fixes a compilation failure in non-distro builds caused by the Secret cache setup in the manager referencing a `distro`-only symbol. The distro-specific narrowing already had a dedicated hook for this - the duplicate in `main` was both redundant and a portability hazard.

Fixes [RHOAIENG-57502](https://redhat.atlassian.net/browse/RHOAIENG-57502)

**Feature/Issue validation/testing**:

- [ ] CI passes for both `distro` and non-distro build tag variants

**Special notes for your reviewer**:

The `go test -vet=all -c -o /dev/null ./...` approach compiles test binaries (so vet covers `*_test.go` files) without executing them - `TestMain` never fires, so no envtest/etcd setup is attempted in CI.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated build verification workflow to validate builds across different build configurations.
  * Simplified service cache behavior to streamline how service-related data is filtered and retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->