### PR TITLE
[RHOAIENG-54222] CVE-2026-30922: pin pyasn1>=0.6.3

### DIFF
--- a/docs/samples/explanation/alibi/alibiexplainer/poetry.lock
+++ b/docs/samples/explanation/alibi/alibiexplainer/poetry.lock
@@ -2237,7 +2237,9 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
+pyasn1 = ">=0.6.3"
 pydantic = "^2.5.0"
+PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
 pyyaml = "^6.0.0"
 requests = {version = "^2.32.2", optional = true}
@@ -3711,13 +3713,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
 
 [[package]]
@@ -3893,23 +3895,24 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pyjwt"
-version = "2.10.1"
+version = "2.12.1"
 description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb"},
-    {file = "pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953"},
+    {file = "pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"},
+    {file = "pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"},
 ]
 
 [package.dependencies]
 cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"crypto\""}
+typing_extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]
-dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
+dev = ["coverage[toml] (==7.10.7)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=8.4.2,<9.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
 docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
-tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
+tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
 
 [[package]]
 name = "pyparsing"

--- a/python/aiffairness/poetry.lock
+++ b/python/aiffairness/poetry.lock
@@ -1317,6 +1317,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
+pyasn1 = ">=0.6.3"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2242,13 +2243,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
 
 [[package]]

--- a/python/artexplainer/poetry.lock
+++ b/python/artexplainer/poetry.lock
@@ -1103,6 +1103,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
+pyasn1 = ">=0.6.3"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2144,13 +2145,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
 
 [[package]]

--- a/python/custom_model/poetry.lock
+++ b/python/custom_model/poetry.lock
@@ -1060,6 +1060,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
+pyasn1 = ">=0.6.3"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2017,13 +2018,13 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
 
 [[package]]

--- a/python/custom_tokenizer/poetry.lock
+++ b/python/custom_tokenizer/poetry.lock
@@ -902,6 +902,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
+pyasn1 = ">=0.6.3"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -1653,13 +1654,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
 
 [[package]]

--- a/python/custom_transformer/poetry.lock
+++ b/python/custom_transformer/poetry.lock
@@ -974,6 +974,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
+pyasn1 = ">=0.6.3"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -1927,13 +1928,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
 
 [[package]]

--- a/python/huggingfaceserver/poetry.lock
+++ b/python/huggingfaceserver/poetry.lock
@@ -2235,6 +2235,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
+pyasn1 = ">=0.6.3"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -4055,13 +4056,13 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
 
 [[package]]

--- a/python/kserve/poetry.lock
+++ b/python/kserve/poetry.lock
@@ -4047,13 +4047,13 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
 
 [[package]]
@@ -6385,4 +6385,4 @@ storage = ["azure-identity", "azure-storage-blob", "azure-storage-file-share", "
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "952e85f97de0bb933aea5978369830ffff23d349eae36d4b9b1aadb96340766e"
+content-hash = "7e6f9b1ee36681da00753de1c40126ea4a438e85aa72ab1962dccfed5cafabc9"

--- a/python/kserve/pyproject.toml
+++ b/python/kserve/pyproject.toml
@@ -58,6 +58,9 @@ aiohttp = ">=3.13.3"
 # CVE-2026-32597 PyJWT accepts unknown `crit` header extensions (RFC 7515 §4.1.11 MUST violation)
 # Pinning because it is a transitive dependency.
 PyJWT = ">=2.12.0"
+# CVE-2026-30922 pyasn1 Vulnerable to Denial of Service via Unbounded Recursion.
+# Pinning because it is a transitive dependency.
+pyasn1 = ">=0.6.3"
 
 # Storage dependencies. They can be opted into by apps.
 requests = { version = "^2.32.2", optional = true }

--- a/python/lgbserver/poetry.lock
+++ b/python/lgbserver/poetry.lock
@@ -1561,6 +1561,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
+pyasn1 = ">=0.6.3"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2392,13 +2393,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
 
 [[package]]

--- a/python/paddleserver/poetry.lock
+++ b/python/paddleserver/poetry.lock
@@ -1572,6 +1572,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
+pyasn1 = ">=0.6.3"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2561,13 +2562,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
 
 [[package]]

--- a/python/pmmlserver/poetry.lock
+++ b/python/pmmlserver/poetry.lock
@@ -1616,6 +1616,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
+pyasn1 = ">=0.6.3"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2432,13 +2433,13 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
 
 [[package]]

--- a/python/sklearnserver/poetry.lock
+++ b/python/sklearnserver/poetry.lock
@@ -1561,6 +1561,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
+pyasn1 = ">=0.6.3"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2366,13 +2367,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
 
 [[package]]

--- a/python/storage/poetry.lock
+++ b/python/storage/poetry.lock
@@ -833,13 +833,13 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
 
 [[package]]
@@ -1079,4 +1079,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "bd34474235c2f51936d24e1cb62f18feaef8406975da697efdbaa71983f152d5"
+content-hash = "1db0519c75c10e682b54e6ee431935ac9862244516df3cca69d2dffacbe42c5c"

--- a/python/storage/pyproject.toml
+++ b/python/storage/pyproject.toml
@@ -34,6 +34,9 @@ PyJWT = {version = ">=2.12.0"}
 # CVE-2026-26007 cryptography fails to validate EC public key subgroup membership (SECT curves)
 # Pinning because it is a transitive dependency.
 cryptography = {version = ">=46.0.5"}
+# CVE-2026-30922 pyasn1 Vulnerable to Denial of Service via Unbounded Recursion.
+# Pinning because it is a transitive dependency.
+pyasn1 = {version = ">=0.6.3"}
 
 
 #[tool.poetry-version-plugin]

--- a/python/test_resources/graph/error_404_isvc/poetry.lock
+++ b/python/test_resources/graph/error_404_isvc/poetry.lock
@@ -891,6 +891,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
+pyasn1 = ">=0.6.3"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -1577,13 +1578,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
 
 [[package]]

--- a/python/test_resources/graph/success_200_isvc/poetry.lock
+++ b/python/test_resources/graph/success_200_isvc/poetry.lock
@@ -891,6 +891,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
+pyasn1 = ">=0.6.3"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -1577,13 +1578,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
 
 [[package]]

--- a/python/xgbserver/poetry.lock
+++ b/python/xgbserver/poetry.lock
@@ -1561,6 +1561,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
+pyasn1 = ">=0.6.3"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2377,13 +2378,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Pin `pyasn1>=0.6.3` in both `python/kserve/pyproject.toml` and `python/storage/pyproject.toml` to fix CVE-2026-30922 (Denial of Service via Unbounded Recursion)
- Regenerated all poetry.lock files

JIRA: https://issues.redhat.com/browse/RHOAIENG-54222