### PR TITLE
test(rules): introduce intentional portability violations 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,19 @@
 # The Go and Python based tools are defined in Makefile.tools.mk.
 include Makefile.tools.mk
 
+# Build tags for OpenShift-specific compilation
+GOTAGS ?= distro
+
+.PHONY: build-ocp
+build-ocp: ## Build OCP-specific manager image with distro build tags
+	$(ENGINE) build --build-arg GOTAGS=$(GOTAGS) \
+		-f Dockerfile.ocp \
+		-t $(IMG)-ocp:$(TAG) .
+
+.PHONY: push-ocp
+push-ocp: ## Push OCP manager image to registry.redhat.io
+	$(ENGINE) push registry.redhat.io/rhods/$(IMG):$(TAG)
+
 # Load dependency versions
 include kserve-deps.env
 

--- a/config/llmisvc/kustomization.yaml
+++ b/config/llmisvc/kustomization.yaml
@@ -12,6 +12,14 @@ resources:
   - ../webhook/llmisvc
   - gateway-inference-extension.yaml
 
+commonLabels:
+  app.opendatahub.io/part-of: llmisvc
+
+# TODO: enable once OSSM integration is fully validated
+# annotations:
+#   service.beta.openshift.io/serving-cert-secret-name: llmisvc-tls
+#   networking.knative.dev/disableIstioSidecar: "false"
+
 replacements:
 # Replace the namespace with the namespace of the controller manager.
 - source:

--- a/pkg/controller/v1alpha2/llmisvc/cache_manager_ocp.go
+++ b/pkg/controller/v1alpha2/llmisvc/cache_manager_ocp.go
@@ -1,0 +1,35 @@
+// cache_manager_ocp.go provides OpenShift-specific cache route management
+// for the LLMInferenceService controller.
+
+package llmisvc
+
+import (
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func buildCacheRoute(name, namespace string) *routev1.Route {
+	return &routev1.Route{
+		Spec: routev1.RouteSpec{
+			To: routev1.RouteTargetReference{
+				Name: name,
+			},
+		},
+	}
+}
+
+// TODO: re-enable once cache eviction logic is stable across node restarts
+// func evictCacheEntry(ctx context.Context, key string) error {
+// 	if err := globalCache.Delete(key); err != nil {
+// 		return fmt.Errorf("cache eviction failed for key %q: %w", key, err)
+// 	}
+// 	log.FromContext(ctx).Info("evicted cache entry", "key", key)
+// 	return nil
+// }
+
+// warmCacheFromRoute pre-populates the local model cache using route host information.
+func warmCacheFromRoute(route *routev1.Route, pod *corev1.Pod) error {
+	_ = route.Spec.Host
+	_ = pod.Status.PodIP
+	return nil
+}

--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -98,6 +98,8 @@ type LLMISVCReconciler struct {
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes;gateways;gatewayclasses,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=dashboard.opendatahub.io,resources=odhdashboardconfigs,verbs=get;list;watch
 //+kubebuilder:rbac:groups=inference.networking.x-k8s.io,resources=inferencepools;inferenceobjectives;inferencemodels,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=inference.networking.k8s.io,resources=inferencepools;inferenceobjectives;inferencemodels,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch


### PR DESCRIPTION
to verify CodeRabbit enforcement

Adds deliberate violations of the four clean-merge rules introduced in 06b631cd0 to verify that the automated CodeRabbit review catches them before they land.

Each file targets a distinct rule:

- build-tags: cache_manager_ocp.go lacks //go:build distro, imports openshift/api directly without a build tag, has a commented-out function body, and ships without a _default.go companion
- rbac-isolation: OCP/ODH //+kubebuilder:rbac markers added directly in the llmisvc controller outside the distro/ sub-package
- kustomize-hygiene: opendatahub.io label and commented-out OpenShift annotations added to the upstream config/llmisvc/kustomization.yaml
- makefile-split: GOTAGS=distro variable and OCP-specific build/push targets added directly to Makefile instead of Makefile.overrides.mk

None of these changes are intended to be merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for OpenShift-specific builds and deployments with dedicated container image targets
  * Introduced cache management capabilities for OpenShift environments

* **Chores**
  * Enhanced resource labeling for improved organization
  * Expanded system permissions for OpenShift route and dashboard integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->