### PR TITLE
chore: sync master to release-v0.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # KServe
 [![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white)](https://pkg.go.dev/github.com/kserve/kserve)
-[![Coverage Status](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/andyi2it/5174bd748ac63a6e4803afea902e9810/raw/coverage.json)](https://github.com/kserve/kserve/actions/workflows/go.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kserve/kserve)](https://goreportcard.com/report/github.com/kserve/kserve)
 [![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/6643/badge)](https://bestpractices.coreinfrastructure.org/projects/6643)
 [![Releases](https://img.shields.io/github/release-pre/kserve/kserve.svg?sort=semver)](https://github.com/kserve/kserve/releases)

--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -10,6 +10,10 @@ spec:
       - /bin/bash
       - -c
       - |-
+        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+          source /etc/profile.d/ibm-aiu-setup.sh
+        fi
+
         if [ "$KSERVE_INFER_ROCE" = "true" ]; then
           echo "Trying to infer RoCE configs ... "
           grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
@@ -282,6 +286,10 @@ spec:
       - /bin/bash
       - -c
       - |-
+        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+          source /etc/profile.d/ibm-aiu-setup.sh
+        fi
+
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -582,6 +590,10 @@ spec:
       - /bin/bash
       - -c
       - |-
+        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+          source /etc/profile.d/ibm-aiu-setup.sh
+        fi
+
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -809,6 +821,10 @@ spec:
         - /bin/bash
         - -c
         - |-
+          if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+            source /etc/profile.d/ibm-aiu-setup.sh
+          fi
+
           if [ "$KSERVE_INFER_ROCE" = "true" ]; then
             echo "Trying to infer RoCE configs ... "
             grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
@@ -1023,6 +1039,10 @@ spec:
         - /bin/bash
         - -c
         - |-
+          if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+            source /etc/profile.d/ibm-aiu-setup.sh
+          fi
+
           # In some versions, ZMQ bind doesn't resolve the address through DNS
           # Retry DP_ADDRESS resolution (configurable attempts, default 30)
           RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -1263,6 +1283,10 @@ spec:
         - /bin/bash
         - -c
         - |-
+          if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+            source /etc/profile.d/ibm-aiu-setup.sh
+          fi
+
           # In some versions, ZMQ bind doesn't resolve the address through DNS
           # Retry DP_ADDRESS resolution (configurable attempts, default 30)
           RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -1750,6 +1774,10 @@ spec:
       - /bin/bash
       - -c
       - |-
+        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+          source /etc/profile.d/ibm-aiu-setup.sh
+        fi
+
         if [ "$KSERVE_INFER_ROCE" = "true" ]; then
           echo "Trying to infer RoCE configs ... "
           grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
@@ -1963,6 +1991,10 @@ spec:
       - /bin/bash
       - -c
       - |-
+        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+          source /etc/profile.d/ibm-aiu-setup.sh
+        fi
+
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -2203,6 +2235,10 @@ spec:
       - /bin/bash
       - -c
       - |-
+        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+          source /etc/profile.d/ibm-aiu-setup.sh
+        fi
+
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}

--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -15,6 +15,10 @@ spec:
           - "/bin/bash"
           - "-c"
           - |-
+            if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+              source /etc/profile.d/ibm-aiu-setup.sh
+            fi
+
             if [ "$KSERVE_INFER_ROCE" = "true" ]; then
               echo "Trying to infer RoCE configs ... "
               grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -74,6 +74,10 @@ spec:
           - "/bin/bash"
           - "-c"
           - |-
+            if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+              source /etc/profile.d/ibm-aiu-setup.sh
+            fi
+
             # In some versions, ZMQ bind doesn't resolve the address through DNS
             # Retry DP_ADDRESS resolution (configurable attempts, default 30)
             RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -316,6 +320,10 @@ spec:
           - "/bin/bash"
           - "-c"
           - |-
+            if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+              source /etc/profile.d/ibm-aiu-setup.sh
+            fi
+
             # In some versions, ZMQ bind doesn't resolve the address through DNS
             # Retry DP_ADDRESS resolution (configurable attempts, default 30)
             RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}

--- a/config/llmisvcconfig/config-llm-prefill-template.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-template.yaml
@@ -16,6 +16,10 @@ spec:
             - "/bin/bash"
             - "-c"
             - |-
+              if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+                source /etc/profile.d/ibm-aiu-setup.sh
+              fi
+
               if [ "$KSERVE_INFER_ROCE" = "true" ]; then
                 echo "Trying to infer RoCE configs ... "
                 grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null

--- a/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
@@ -16,6 +16,10 @@ spec:
             - "/bin/bash"
             - "-c"
             - |-
+              if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+                source /etc/profile.d/ibm-aiu-setup.sh
+              fi
+
               # In some versions, ZMQ bind doesn't resolve the address through DNS
               # Retry DP_ADDRESS resolution (configurable attempts, default 30)
               RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -258,6 +262,10 @@ spec:
             - "/bin/bash"
             - "-c"
             - |-
+              if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+                source /etc/profile.d/ibm-aiu-setup.sh
+              fi
+
               # In some versions, ZMQ bind doesn't resolve the address through DNS
               # Retry DP_ADDRESS resolution (configurable attempts, default 30)
               RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}

--- a/config/llmisvcconfig/config-llm-template.yaml
+++ b/config/llmisvcconfig/config-llm-template.yaml
@@ -15,6 +15,10 @@ spec:
           - "/bin/bash"
           - "-c"
           - |-
+            if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+              source /etc/profile.d/ibm-aiu-setup.sh
+            fi
+
             if [ "$KSERVE_INFER_ROCE" = "true" ]; then
               echo "Trying to infer RoCE configs ... "
               grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null

--- a/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
@@ -15,6 +15,10 @@ spec:
           - "/bin/bash"
           - "-c"
           - |-
+            if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+              source /etc/profile.d/ibm-aiu-setup.sh
+            fi
+
             # In some versions, ZMQ bind doesn't resolve the address through DNS
             # Retry DP_ADDRESS resolution (configurable attempts, default 30)
             RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -257,6 +261,10 @@ spec:
           - "/bin/bash"
           - "-c"
           - |-
+            if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+              source /etc/profile.d/ibm-aiu-setup.sh
+            fi
+
             # In some versions, ZMQ bind doesn't resolve the address through DNS
             # Retry DP_ADDRESS resolution (configurable attempts, default 30)
             RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -2466,6 +2466,10 @@ spec:
       - /bin/bash
       - -c
       - |-
+        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+          source /etc/profile.d/ibm-aiu-setup.sh
+        fi
+
         if [ "$KSERVE_INFER_ROCE" = "true" ]; then
           echo "Trying to infer RoCE configs ... "
           grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
@@ -2738,6 +2742,10 @@ spec:
       - /bin/bash
       - -c
       - |-
+        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+          source /etc/profile.d/ibm-aiu-setup.sh
+        fi
+
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -3038,6 +3046,10 @@ spec:
       - /bin/bash
       - -c
       - |-
+        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+          source /etc/profile.d/ibm-aiu-setup.sh
+        fi
+
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -3265,6 +3277,10 @@ spec:
         - /bin/bash
         - -c
         - |-
+          if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+            source /etc/profile.d/ibm-aiu-setup.sh
+          fi
+
           if [ "$KSERVE_INFER_ROCE" = "true" ]; then
             echo "Trying to infer RoCE configs ... "
             grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
@@ -3479,6 +3495,10 @@ spec:
         - /bin/bash
         - -c
         - |-
+          if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+            source /etc/profile.d/ibm-aiu-setup.sh
+          fi
+
           # In some versions, ZMQ bind doesn't resolve the address through DNS
           # Retry DP_ADDRESS resolution (configurable attempts, default 30)
           RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -3719,6 +3739,10 @@ spec:
         - /bin/bash
         - -c
         - |-
+          if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+            source /etc/profile.d/ibm-aiu-setup.sh
+          fi
+
           # In some versions, ZMQ bind doesn't resolve the address through DNS
           # Retry DP_ADDRESS resolution (configurable attempts, default 30)
           RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -4206,6 +4230,10 @@ spec:
       - /bin/bash
       - -c
       - |-
+        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+          source /etc/profile.d/ibm-aiu-setup.sh
+        fi
+
         if [ "$KSERVE_INFER_ROCE" = "true" ]; then
           echo "Trying to infer RoCE configs ... "
           grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
@@ -4419,6 +4447,10 @@ spec:
       - /bin/bash
       - -c
       - |-
+        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+          source /etc/profile.d/ibm-aiu-setup.sh
+        fi
+
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -4659,6 +4691,10 @@ spec:
       - /bin/bash
       - -c
       - |-
+        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+          source /etc/profile.d/ibm-aiu-setup.sh
+        fi
+
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -2052,6 +2052,10 @@ spec:
       - /bin/bash
       - -c
       - |-
+        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+          source /etc/profile.d/ibm-aiu-setup.sh
+        fi
+
         if [ "$KSERVE_INFER_ROCE" = "true" ]; then
           echo "Trying to infer RoCE configs ... "
           grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
@@ -2324,6 +2328,10 @@ spec:
       - /bin/bash
       - -c
       - |-
+        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+          source /etc/profile.d/ibm-aiu-setup.sh
+        fi
+
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -2624,6 +2632,10 @@ spec:
       - /bin/bash
       - -c
       - |-
+        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+          source /etc/profile.d/ibm-aiu-setup.sh
+        fi
+
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -2851,6 +2863,10 @@ spec:
         - /bin/bash
         - -c
         - |-
+          if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+            source /etc/profile.d/ibm-aiu-setup.sh
+          fi
+
           if [ "$KSERVE_INFER_ROCE" = "true" ]; then
             echo "Trying to infer RoCE configs ... "
             grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
@@ -3065,6 +3081,10 @@ spec:
         - /bin/bash
         - -c
         - |-
+          if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+            source /etc/profile.d/ibm-aiu-setup.sh
+          fi
+
           # In some versions, ZMQ bind doesn't resolve the address through DNS
           # Retry DP_ADDRESS resolution (configurable attempts, default 30)
           RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -3305,6 +3325,10 @@ spec:
         - /bin/bash
         - -c
         - |-
+          if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+            source /etc/profile.d/ibm-aiu-setup.sh
+          fi
+
           # In some versions, ZMQ bind doesn't resolve the address through DNS
           # Retry DP_ADDRESS resolution (configurable attempts, default 30)
           RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -3792,6 +3816,10 @@ spec:
       - /bin/bash
       - -c
       - |-
+        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+          source /etc/profile.d/ibm-aiu-setup.sh
+        fi
+
         if [ "$KSERVE_INFER_ROCE" = "true" ]; then
           echo "Trying to infer RoCE configs ... "
           grep -H . /sys/class/infiniband/*/ports/*/gids/* 2>/dev/null
@@ -4005,6 +4033,10 @@ spec:
       - /bin/bash
       - -c
       - |-
+        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+          source /etc/profile.d/ibm-aiu-setup.sh
+        fi
+
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}
@@ -4245,6 +4277,10 @@ spec:
       - /bin/bash
       - -c
       - |-
+        if [ -f /etc/profile.d/ibm-aiu-setup.sh ]; then
+          source /etc/profile.d/ibm-aiu-setup.sh
+        fi
+
         # In some versions, ZMQ bind doesn't resolve the address through DNS
         # Retry DP_ADDRESS resolution (configurable attempts, default 30)
         RESOLVE_ATTEMPTS=${DP_ADDRESS_RESOLVE_ATTEMPTS:-30}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -343,7 +343,10 @@ var (
 	IstioMeshGateway = "mesh"
 )
 
-const WorkerNodeSuffix = "worker"
+const (
+	WorkerNodeSuffix       = "worker"
+	WorkerNodeSuffixPlural = "workers"
+)
 
 // InferenceService Component enums
 const (
@@ -683,10 +686,18 @@ const (
 	DefaultPipelineParallelSize = 1
 )
 
+// MultiNode executor backend annotation
+// If not set, defaults to ray
+const (
+	MultiNodeExecutorBackendAnnotationKey = "multinode/executor-backend"
+	MultiNodeExecutorBackendMp            = "mp"
+)
+
 // Multi Node Labels
 var (
 	MultiNodeRoleLabelKey = "multinode/role"
 	MultiNodeHead         = "head"
+	MultiNodeWorker       = "worker"
 )
 
 // GetRawServiceLabel generate native service label
@@ -703,6 +714,12 @@ func GetRawWorkerServiceLabel(service string) string {
 func GetHeadServiceName(service string, isvcGeneration string) string {
 	isvcName := strings.TrimSuffix(service, "-predictor")
 	return isvcName + "-" + MultiNodeHead + "-" + isvcGeneration
+}
+
+// GetWorkerServiceName generate worker headless service name
+func GetWorkerServiceName(service string, isvcGeneration string) string {
+	isvcName := strings.TrimSuffix(service, "-predictor")
+	return isvcName + "-" + WorkerNodeSuffixPlural + "-" + isvcGeneration
 }
 
 func (e InferenceServiceComponent) String() string {

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -555,15 +555,22 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 		*workerContainer,
 	}
 
-	// Calculate the total number of GPUs required for the request based on the tensor parallel size and pipeline parallel size specified in the worker spec.
-	// totalRequestGPUCount is the product of TensorParallelSize and PipelineParallelSize,
-	// which represents the total number of GPUs needed for distributed computation.
+	// Calculate node count and GPU allocation based on executor backend mode.
+	var nodeCount, workerNodeGPUCount, headNodeGPUCount int
+	executorBackend := sRuntime.Annotations[constants.MultiNodeExecutorBackendAnnotationKey]
 
-	totalRequestGPUCount := *sRuntime.WorkerSpec.TensorParallelSize * *sRuntime.WorkerSpec.PipelineParallelSize
-
-	rayNodeCount, workerNodeGPUCount, headNodeGPUCount, err := computeRayNodeAndGPUs(mergedWorkerPodSpec, totalRequestGPUCount, podSpec)
-	if err != nil {
-		return nil, err
+	if executorBackend == constants.MultiNodeExecutorBackendMp {
+		// mp mode: PP determines node count, TP determines GPUs per node
+		nodeCount, workerNodeGPUCount, headNodeGPUCount = computeMpNodeAndGPUs(
+			*sRuntime.WorkerSpec.PipelineParallelSize, *sRuntime.WorkerSpec.TensorParallelSize)
+	} else {
+		// ray mode (default): compute based on total GPU count and worker GPU resources
+		totalRequestGPUCount := *sRuntime.WorkerSpec.TensorParallelSize * *sRuntime.WorkerSpec.PipelineParallelSize
+		var err error
+		nodeCount, workerNodeGPUCount, headNodeGPUCount, err = computeRayNodeAndGPUs(mergedWorkerPodSpec, totalRequestGPUCount, podSpec)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Add required environment variables: PipelineParallelSize, TensorParallelSize
@@ -574,7 +581,7 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 	if err := isvcutils.AddEnvVarToPodSpec(podSpec, constants.InferenceServiceContainerName, constants.TensorParallelSizeEnvName, strconv.Itoa(*sRuntime.WorkerSpec.TensorParallelSize)); err != nil {
 		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.TensorParallelSizeEnvName, constants.InferenceServiceContainerName)
 	}
-	if err := isvcutils.AddEnvVarToPodSpec(podSpec, constants.InferenceServiceContainerName, constants.RayNodeCountEnvName, strconv.Itoa(rayNodeCount)); err != nil {
+	if err := isvcutils.AddEnvVarToPodSpec(podSpec, constants.InferenceServiceContainerName, constants.RayNodeCountEnvName, strconv.Itoa(nodeCount)); err != nil {
 		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.RayNodeCountEnvName, constants.InferenceServiceContainerName)
 	}
 	if err := isvcutils.AddEnvVarToPodSpec(podSpec, constants.InferenceServiceContainerName, constants.RequestGPUCountEnvName, strconv.Itoa(headNodeGPUCount)); err != nil {
@@ -595,11 +602,17 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 		}
 	}
 	// Worker node deployement
-	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, constants.RayNodeCountEnvName, strconv.Itoa(rayNodeCount)); err != nil {
+	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, constants.RayNodeCountEnvName, strconv.Itoa(nodeCount)); err != nil {
 		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.RayNodeCountEnvName, constants.WorkerContainerName)
 	}
 	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, constants.RequestGPUCountEnvName, strconv.Itoa(workerNodeGPUCount)); err != nil {
 		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.RequestGPUCountEnvName, constants.WorkerContainerName)
+	}
+	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, constants.PipelineParallelSizeEnvName, strconv.Itoa(*sRuntime.WorkerSpec.PipelineParallelSize)); err != nil {
+		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.PipelineParallelSizeEnvName, constants.WorkerContainerName)
+	}
+	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, constants.TensorParallelSizeEnvName, strconv.Itoa(*sRuntime.WorkerSpec.TensorParallelSize)); err != nil {
+		return nil, errors.Wrapf(err, "failed to add %s environment to the container(%s)", constants.TensorParallelSizeEnvName, constants.WorkerContainerName)
 	}
 	// Set the environment variable for "isvc name" to the ISVC_NAME when multiNodeEnabled is true.
 	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, "ISVC_NAME", isvc.Name); err != nil {
@@ -608,6 +621,10 @@ func multiNodeProcess(sRuntime v1alpha1.ServingRuntimeSpec, isvc *v1beta1.Infere
 	// Set the environment variable for "isvc name" to the HEAD_SVC when multiNodeEnabled is true.
 	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, "HEAD_SVC", constants.GetHeadServiceName(isvc.Name, isvcGeneration)); err != nil {
 		return nil, errors.Wrapf(err, "failed to add HEAD_SVC environment to the container(%s)", constants.WorkerContainerName)
+	}
+	// Set the environment variable for worker headless service name to the WORKER_SVC when multiNodeEnabled is true.
+	if err := isvcutils.AddEnvVarToPodSpec(mergedWorkerPodSpec, constants.WorkerContainerName, "WORKER_SVC", constants.GetWorkerServiceName(constants.PredictorServiceName(isvc.Name), isvcGeneration)); err != nil {
+		return nil, errors.Wrapf(err, "failed to add WORKER_SVC environment to the container(%s)", constants.WorkerContainerName)
 	}
 	return mergedWorkerPodSpec, nil
 }
@@ -688,6 +705,15 @@ func computeRayNodeAndGPUs(mergedWorkerPodSpec *corev1.PodSpec, totalRequestGPUC
 
 	// Case 4: No GPUs found → Default values
 	return totalRequestGPUCount, 1, 1, nil
+}
+
+// computeMpNodeAndGPUs computes node count and GPU allocation for mp (multiprocessing) executor backend.
+// In mp mode, PipelineParallelSize directly determines the number of nodes,
+// and TensorParallelSize determines the number of GPUs per node.
+func computeMpNodeAndGPUs(pipelineParallelSize, tensorParallelSize int) (int, int, int) {
+	nodeCount := pipelineParallelSize
+	gpuPerNode := tensorParallelSize
+	return nodeCount, gpuPerNode, gpuPerNode
 }
 
 func (p *Predictor) reconcileRawDeployment(ctx context.Context, isvc *v1beta1.InferenceService, objectMeta, workerObjectMeta metav1.ObjectMeta, podSpec, workerPodSpec *corev1.PodSpec) error {

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2024 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package components
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComputeMpNodeAndGPUs(t *testing.T) {
+	tests := []struct {
+		name                 string
+		pipelineParallelSize int
+		tensorParallelSize   int
+		expectedNodeCount    int
+		expectedWorkerGPU    int
+		expectedHeadGPU      int
+	}{
+		{
+			name:                 "PP=2, TP=2: 2 nodes, 2 GPUs per node",
+			pipelineParallelSize: 2,
+			tensorParallelSize:   2,
+			expectedNodeCount:    2,
+			expectedWorkerGPU:    2,
+			expectedHeadGPU:      2,
+		},
+		{
+			name:                 "PP=4, TP=8: 4 nodes, 8 GPUs per node",
+			pipelineParallelSize: 4,
+			tensorParallelSize:   8,
+			expectedNodeCount:    4,
+			expectedWorkerGPU:    8,
+			expectedHeadGPU:      8,
+		},
+		{
+			name:                 "PP=1, TP=4: 1 node, 4 GPUs",
+			pipelineParallelSize: 1,
+			tensorParallelSize:   4,
+			expectedNodeCount:    1,
+			expectedWorkerGPU:    4,
+			expectedHeadGPU:      4,
+		},
+		{
+			name:                 "PP=2, TP=1: 2 nodes, 1 GPU per node",
+			pipelineParallelSize: 2,
+			tensorParallelSize:   1,
+			expectedNodeCount:    2,
+			expectedWorkerGPU:    1,
+			expectedHeadGPU:      1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodeCount, workerGPU, headGPU := computeMpNodeAndGPUs(tt.pipelineParallelSize, tt.tensorParallelSize)
+			assert.Equal(t, tt.expectedNodeCount, nodeCount)
+			assert.Equal(t, tt.expectedWorkerGPU, workerGPU)
+			assert.Equal(t, tt.expectedHeadGPU, headGPU)
+		})
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
@@ -897,7 +897,7 @@ func (r *RawHTTPRouteReconciler) Reconcile(ctx context.Context, isvc *v1beta1.In
 	if isvc.Status.URL, err = createRawURL(isvc, r.ingressConfig); err != nil {
 		return ctrl.Result{}, err
 	}
-	isvc.Status.Address, err = createAddress(ctx, r.client, isvc, r.ingressConfig)
+	isvc.Status.Address, err = createAddress(ctx, r.client, isvc)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
@@ -131,7 +131,7 @@ func (r *RawIngressReconciler) Reconcile(ctx context.Context, isvc *v1beta1.Infe
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	isvc.Status.Address, err = createAddress(ctx, r.client, isvc, r.ingressConfig)
+	isvc.Status.Address, err = createAddress(ctx, r.client, isvc)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -143,7 +143,7 @@ func (r *RawIngressReconciler) Reconcile(ctx context.Context, isvc *v1beta1.Infe
 	return ctrl.Result{}, nil
 }
 
-func createAddress(ctx context.Context, cl client.Client, isvc *v1beta1.InferenceService, ingressConfig *v1beta1.IngressConfig) (*duckv1.Addressable, error) {
+func createAddress(ctx context.Context, cl client.Client, isvc *v1beta1.InferenceService) (*duckv1.Addressable, error) {
 	host := getRawServiceHost(isvc)
 	// Determine the entry point service name.
 	// If a transformer exists, it becomes the entry point; otherwise, the predictor is.
@@ -165,7 +165,7 @@ func createAddress(ctx context.Context, cl client.Client, isvc *v1beta1.Inferenc
 	return &duckv1.Addressable{
 		URL: &apis.URL{
 			Host:   host,
-			Scheme: ingressConfig.UrlScheme,
+			Scheme: "http",
 			Path:   "",
 		},
 	}, nil

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler_test.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	netv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+const (
+	testIsvcName  = "test-isvc"
+	testNamespace = "default"
+)
+
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = v1beta1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+	_ = netv1.AddToScheme(s)
+	return s
+}
+
+func makeService(name string, headless bool) *corev1.Service {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+		Spec:       corev1.ServiceSpec{ClusterIP: "10.0.0.1"},
+	}
+	if headless {
+		svc.Spec.ClusterIP = corev1.ClusterIPNone
+	}
+	return svc
+}
+
+func predictorHost() string {
+	return fmt.Sprintf("%s-predictor.%s.svc.cluster.local", testIsvcName, testNamespace)
+}
+
+func transformerHost() string {
+	return fmt.Sprintf("%s-transformer.%s.svc.cluster.local", testIsvcName, testNamespace)
+}
+
+// ---------------------------------------------------------------------------
+// TestCreateAddress -- unit tests for createAddress
+//
+// The internal address must always use "http" regardless of urlScheme config.
+// ---------------------------------------------------------------------------
+
+func TestCreateAddress(t *testing.T) {
+	tests := []struct {
+		name       string
+		headless   bool
+		wantScheme string
+		wantHost   string
+	}{
+		{
+			name:       "ClusterIP service",
+			headless:   false,
+			wantScheme: "http",
+			wantHost:   predictorHost(),
+		},
+		{
+			name:       "headless service appends port 8080",
+			headless:   true,
+			wantScheme: "http",
+			wantHost:   predictorHost() + ":" + constants.InferenceServiceDefaultHttpPort,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			s := testScheme()
+
+			svcName := constants.PredictorServiceName(testIsvcName)
+			svc := makeService(svcName, tc.headless)
+			cl := fake.NewClientBuilder().WithScheme(s).WithObjects(svc).Build()
+
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: testIsvcName, Namespace: testNamespace},
+				Spec:       v1beta1.InferenceServiceSpec{Predictor: v1beta1.PredictorSpec{}},
+			}
+
+			addr, err := createAddress(t.Context(), cl, isvc)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(addr).ToNot(BeNil())
+			g.Expect(addr.URL.Scheme).To(Equal(tc.wantScheme), "address scheme must be http for in-cluster endpoint")
+			g.Expect(addr.URL.Host).To(Equal(tc.wantHost))
+		})
+	}
+}
+
+func TestCreateAddress_Transformer(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := testScheme()
+
+	svcName := constants.TransformerServiceName(testIsvcName)
+	svc := makeService(svcName, false)
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(svc).Build()
+
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: testIsvcName, Namespace: testNamespace},
+		Spec: v1beta1.InferenceServiceSpec{
+			Predictor:   v1beta1.PredictorSpec{},
+			Transformer: &v1beta1.TransformerSpec{},
+		},
+	}
+
+	addr, err := createAddress(t.Context(), cl, isvc)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(addr.URL.Host).To(Equal(transformerHost()))
+	g.Expect(addr.URL.Scheme).To(Equal("http"))
+}
+
+// ---------------------------------------------------------------------------
+// TestRawIngressReconciler_URLAndAddress
+//
+// Integration test exercising the full Reconcile path.
+// Uses DisableIngressCreation: true to skip ingress object management and
+// focus on Status.URL / Status.Address logic.
+//
+// The urlScheme=https rows must produce http addresses, proving the internal
+// address is decoupled from the ingress URL scheme.
+// ---------------------------------------------------------------------------
+
+func TestRawIngressReconciler_URLAndAddress(t *testing.T) {
+	pHost := predictorHost()
+
+	tests := []struct {
+		name           string
+		headless       bool
+		urlScheme      string
+		wantAddrScheme string
+		wantAddrHost   string
+	}{
+		{
+			name:           "ClusterIP, urlScheme=http",
+			headless:       false,
+			urlScheme:      "http",
+			wantAddrScheme: "http",
+			wantAddrHost:   pHost,
+		},
+		{
+			name:           "ClusterIP, urlScheme=https -- address must still be http",
+			headless:       false,
+			urlScheme:      "https",
+			wantAddrScheme: "http",
+			wantAddrHost:   pHost,
+		},
+		{
+			name:           "headless, urlScheme=http",
+			headless:       true,
+			urlScheme:      "http",
+			wantAddrScheme: "http",
+			wantAddrHost:   pHost + ":" + constants.InferenceServiceDefaultHttpPort,
+		},
+		{
+			name:           "headless, urlScheme=https -- address must still be http",
+			headless:       true,
+			urlScheme:      "https",
+			wantAddrScheme: "http",
+			wantAddrHost:   pHost + ":" + constants.InferenceServiceDefaultHttpPort,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			s := testScheme()
+
+			svcName := constants.PredictorServiceName(testIsvcName)
+			svc := makeService(svcName, tc.headless)
+			cl := fake.NewClientBuilder().WithScheme(s).WithObjects(svc).Build()
+
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{Name: testIsvcName, Namespace: testNamespace},
+				Spec:       v1beta1.InferenceServiceSpec{Predictor: v1beta1.PredictorSpec{}},
+				Status:     v1beta1.InferenceServiceStatus{},
+			}
+
+			ingressConfig := &v1beta1.IngressConfig{
+				DisableIngressCreation: true,
+				UrlScheme:              tc.urlScheme,
+				IngressDomain:          "example.com",
+				DomainTemplate:         "{{.Name}}-{{.Namespace}}.{{.IngressDomain}}",
+			}
+			isvcConfig := &v1beta1.InferenceServicesConfig{}
+
+			reconciler, err := NewRawIngressReconciler(cl, s, ingressConfig, isvcConfig)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			result, err := reconciler.Reconcile(t.Context(), isvc)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(result).To(Equal(ctrl.Result{}))
+
+			g.Expect(isvc.Status.URL).ToNot(BeNil(), "Status.URL should be set")
+
+			g.Expect(isvc.Status.Address).ToNot(BeNil(), "Status.Address should be set")
+			g.Expect(isvc.Status.Address.URL.Scheme).To(Equal(tc.wantAddrScheme), "address scheme must be http for in-cluster endpoint")
+			g.Expect(isvc.Status.Address.URL.Host).To(Equal(tc.wantAddrHost))
+
+			cond := isvc.Status.GetCondition(v1beta1.IngressReady)
+			g.Expect(cond).ToNot(BeNil())
+			g.Expect(cond.Status).To(Equal(corev1.ConditionTrue))
+		})
+	}
+}
+
+func TestRawIngressReconciler_URLAndAddress_Transformer(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := testScheme()
+
+	tHost := transformerHost()
+	svcName := constants.TransformerServiceName(testIsvcName)
+	svc := makeService(svcName, false)
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(svc).Build()
+
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{Name: testIsvcName, Namespace: testNamespace},
+		Spec: v1beta1.InferenceServiceSpec{
+			Predictor:   v1beta1.PredictorSpec{},
+			Transformer: &v1beta1.TransformerSpec{},
+		},
+		Status: v1beta1.InferenceServiceStatus{},
+	}
+
+	ingressConfig := &v1beta1.IngressConfig{
+		DisableIngressCreation: true,
+		UrlScheme:              "http",
+		IngressDomain:          "example.com",
+		DomainTemplate:         "{{.Name}}-{{.Namespace}}.{{.IngressDomain}}",
+	}
+	isvcConfig := &v1beta1.InferenceServicesConfig{}
+
+	reconciler, err := NewRawIngressReconciler(cl, s, ingressConfig, isvcConfig)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	result, err := reconciler.Reconcile(t.Context(), isvc)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	g.Expect(isvc.Status.URL).ToNot(BeNil())
+	g.Expect(isvc.Status.Address.URL.Host).To(Equal(tHost), "address should use transformer service host")
+	g.Expect(isvc.Status.Address.URL.Scheme).To(Equal("http"))
+}
+
+func TestRawIngressReconciler_ClusterLocal(t *testing.T) {
+	g := NewGomegaWithT(t)
+	s := testScheme()
+
+	pHost := predictorHost()
+	svcName := constants.PredictorServiceName(testIsvcName)
+	svc := makeService(svcName, false)
+	cl := fake.NewClientBuilder().WithScheme(s).WithObjects(svc).Build()
+
+	isvc := &v1beta1.InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testIsvcName,
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				constants.NetworkVisibility: constants.ClusterLocalVisibility,
+			},
+		},
+		Spec:   v1beta1.InferenceServiceSpec{Predictor: v1beta1.PredictorSpec{}},
+		Status: v1beta1.InferenceServiceStatus{},
+	}
+
+	ingressConfig := &v1beta1.IngressConfig{
+		UrlScheme:      "http",
+		IngressDomain:  "example.com",
+		DomainTemplate: "{{.Name}}-{{.Namespace}}.{{.IngressDomain}}",
+	}
+	isvcConfig := &v1beta1.InferenceServicesConfig{}
+
+	reconciler, err := NewRawIngressReconciler(cl, s, ingressConfig, isvcConfig)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	result, err := reconciler.Reconcile(t.Context(), isvc)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(result).To(Equal(ctrl.Result{}))
+
+	g.Expect(isvc.Status.URL).ToNot(BeNil(), "URL should still be set for cluster-local")
+	g.Expect(isvc.Status.Address).ToNot(BeNil(), "Address should still be set for cluster-local")
+	g.Expect(isvc.Status.Address.URL.Host).To(Equal(pHost))
+	g.Expect(isvc.Status.Address.URL.Scheme).To(Equal("http"))
+
+	cond := isvc.Status.GetCondition(v1beta1.IngressReady)
+	g.Expect(cond).ToNot(BeNil())
+	g.Expect(cond.Status).To(Equal(corev1.ConditionTrue))
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
@@ -81,27 +81,21 @@ func createService(componentMeta metav1.ObjectMeta, componentExt *v1beta1.Compon
 	podSpec *corev1.PodSpec, multiNodeEnabled bool, serviceConfig *v1beta1.ServiceConfig,
 ) []*corev1.Service {
 	var svcList []*corev1.Service
-	var isWorkerContainer bool
-
-	if multiNodeEnabled {
-		for _, container := range podSpec.Containers {
-			if container.Name == constants.WorkerContainerName {
-				isWorkerContainer = true
-			}
-		}
-	}
 
 	if !multiNodeEnabled {
 		// If multiNodeEnabled is false, only defaultSvc will be created.
 		defaultSvc := createDefaultSvc(componentMeta, componentExt, podSpec, serviceConfig)
 		svcList = append(svcList, defaultSvc)
-	} else if multiNodeEnabled && !isWorkerContainer {
-		// If multiNodeEnabled is true, both defaultSvc and headSvc will be created.
+	} else {
+		// If multiNodeEnabled is true, create defaultSvc, headSvc and workerSvc.
 		defaultSvc := createDefaultSvc(componentMeta, componentExt, podSpec, serviceConfig)
 		svcList = append(svcList, defaultSvc)
 
 		headSvc := createHeadlessSvc(componentMeta)
 		svcList = append(svcList, headSvc)
+
+		workerSvc := createWorkerHeadlessSvc(componentMeta)
+		svcList = append(svcList, workerSvc)
 	}
 
 	return svcList
@@ -191,6 +185,27 @@ func createDefaultSvc(componentMeta metav1.ObjectMeta, componentExt *v1beta1.Com
 		service.Spec.ClusterIP = corev1.ClusterIPNone
 	}
 
+	return service
+}
+
+func createWorkerHeadlessSvc(componentMeta metav1.ObjectMeta) *corev1.Service {
+	workerComponentMeta := componentMeta.DeepCopy()
+	predictorSvcName := workerComponentMeta.Name
+	isvcGeneration := componentMeta.GetLabels()[constants.InferenceServiceGenerationPodLabelKey]
+	workerComponentMeta.Name = constants.GetWorkerServiceName(predictorSvcName, isvcGeneration)
+	workerComponentMeta.Labels[constants.MultiNodeRoleLabelKey] = constants.MultiNodeWorker
+
+	service := &corev1.Service{
+		ObjectMeta: *workerComponentMeta,
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"app": constants.GetRawWorkerServiceLabel(predictorSvcName),
+				constants.InferenceServiceGenerationPodLabelKey: isvcGeneration,
+			},
+			ClusterIP:                "None",
+			PublishNotReadyAddresses: true,
+		},
+	}
 	return service
 }
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_test.go
@@ -192,6 +192,30 @@ func TestCreateDefaultDeployment(t *testing.T) {
 					PublishNotReadyAddresses: true,
 				},
 			},
+			&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default-workers-1",
+					Namespace: "default-predictor-namespace",
+					Labels: map[string]string{
+						constants.RawDeploymentAppLabel:                 "isvc.default-predictor",
+						constants.KServiceComponentLabel:                "predictor",
+						constants.InferenceServicePodLabelKey:           "default-predictor",
+						constants.InferenceServiceGenerationPodLabelKey: "1",
+						constants.MultiNodeRoleLabelKey:                 constants.MultiNodeWorker,
+					},
+					Annotations: map[string]string{
+						"annotation": "annotation-value",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						"app": "isvc.default-predictor-worker",
+						constants.InferenceServiceGenerationPodLabelKey: "1",
+					},
+					ClusterIP:                "None",
+					PublishNotReadyAddresses: true,
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
Sync odh/master into release-v0.17.

Commits included:
- fix(llmisvc): re-add ibm-aiu-setup.sh sourcing (#1391)
- feat(multinode): add groundwork for multinode support without ray (#5366)
- chore: remove coverage badge (#5298)
- fix: hardcode Status.Address scheme to http in raw deployment (#5363)

No merge conflicts.

Made with [Cursor](https://cursor.com)