### PR TITLE
ci: bind pipeline-logs workspace for group test

### DIFF
--- a/.tekton/kserve-group-test.yaml
+++ b/.tekton/kserve-group-test.yaml
@@ -66,3 +66,5 @@ spec:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
+  - name: pipeline-logs
+    emptyDir: {}


### PR DESCRIPTION
## Summary
- Adds `pipeline-logs` workspace binding (`emptyDir: {}`) to the kserve group test PipelineRun
- Required by the `export-pipeline-logs` task added in [odh-konflux-central#240](https://github.com/opendatahub-io/odh-konflux-central/pull/240)

## Context
The group test pipeline now includes an `export-pipeline-logs` finally task that archives Tekton task logs and pushes them to Quay as OCI artifacts. The task needs a `pipeline-logs` workspace for scratch storage. Currently the workspace is marked optional in the pipeline ([odh-konflux-central#259](https://github.com/opendatahub-io/odh-konflux-central/pull/259)), but once this PR merges the optional marker can be removed.

## Test plan
- [ ] Trigger `/group-test` and verify pipeline logs are exported to `quay.io/opendatahub/odh-ci-artifacts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)