### PR TITLE
ci: use build SA for export-pipeline-logs

### DIFF
--- a/.tekton/kserve-group-test.yaml
+++ b/.tekton/kserve-group-test.yaml
@@ -62,6 +62,8 @@ spec:
       serviceAccountName: build-pipeline-kserve-group
     - pipelineTaskName: build-error-404-isvc
       serviceAccountName: build-pipeline-kserve-group
+    - pipelineTaskName: export-pipeline-logs
+      serviceAccountName: build-pipeline-kserve-group
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/kserve-group-test.yaml
+++ b/.tekton/kserve-group-test.yaml
@@ -62,11 +62,7 @@ spec:
       serviceAccountName: build-pipeline-kserve-group
     - pipelineTaskName: build-error-404-isvc
       serviceAccountName: build-pipeline-kserve-group
-    - pipelineTaskName: export-pipeline-logs
-      serviceAccountName: build-pipeline-kserve-group
   workspaces:
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'
-  - name: pipeline-logs
-    emptyDir: {}


### PR DESCRIPTION
## Summary
- Adds `taskRunSpecs` entry for `export-pipeline-logs` to use `build-pipeline-kserve-group` SA
- Fixes "unauthorized" error when the task pushes log artifacts to Quay

## Context
PR #1397 added the `pipeline-logs` workspace binding, but the `export-pipeline-logs` finally task was falling back to the default `konflux-integration-runner` SA which doesn't have access to `odh-registry-secret`. The other tasks that need registry access already use `build-pipeline-kserve-group`.

## Test plan
- [ ] Trigger `/group-test` and verify log artifacts are pushed to `quay.io/opendatahub/odh-ci-artifacts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined pipeline configuration by removing an unused workspace declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->