### PR TITLE
fix(llmisvc): remove cert-hash restart annotation from scheduler

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -38,9 +38,6 @@ import (
 	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
 )
 
-// Must match scheduler.schedulerSelfSignedTLSRestartAnnotation in production code.
-const schedulerSelfSignedTLSRestartAnnotation = "serving.kserve.io/scheduler-self-signed-tls-sha256"
-
 var _ = Describe("LLMInferenceService Scheduler Config", func() {
 	Context("Inline scheduler config", func() {
 		It("should use inline scheduler config in the scheduler deployment", func(ctx SpecContext) {
@@ -911,123 +908,6 @@ schedulingProfiles:
 			Expect(countLeaderElectionFlags(expectedDeployment)).To(Equal(1),
 				"Expected exactly one --ha-enable-leader-election flag (not duplicated)")
 		})
-	})
-
-	Context("Certificate hash annotation", func() {
-		It("should set cert-hash annotation on the scheduler pod template", func(ctx SpecContext) {
-			// given
-			svcName := "test-llm-scheduler-cert-hash"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
-
-			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
-				WithModelURI("hf://facebook/opt-125m"),
-				WithManagedRoute(),
-				WithManagedGateway(),
-				WithManagedScheduler(),
-			)
-
-			// when
-			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
-			defer func() {
-				testNs.DeleteAndWait(ctx, llmSvc)
-			}()
-
-			// then - verify the scheduler deployment has the cert-hash annotation
-			Eventually(func(g Gomega, ctx context.Context) error {
-				schedulerDeployment := &appsv1.Deployment{}
-				g.Expect(envTest.Get(ctx, types.NamespacedName{
-					Name:      kmeta.ChildName(svcName, "-kserve-router-scheduler"),
-					Namespace: testNs.Name,
-				}, schedulerDeployment)).To(Succeed())
-
-				g.Expect(schedulerDeployment.Spec.Template.Annotations).To(
-					HaveKey(schedulerSelfSignedTLSRestartAnnotation),
-					"Scheduler pod template should have cert-hash annotation to trigger restart on cert renewal",
-				)
-				g.Expect(schedulerDeployment.Spec.Template.Annotations[schedulerSelfSignedTLSRestartAnnotation]).To(
-					MatchRegexp("^[0-9a-f]{64}$"), "cert-hash should be a SHA-256 hex string",
-				)
-
-				return nil
-			}).WithContext(ctx).Should(Succeed())
-		})
-
-		DescribeTable("should skip cert-hash annotation when scheduler supports cert reload",
-			func(ctx SpecContext, certReloadArg string) {
-				// given
-				svcName := "test-llm-cert-reload-skip"
-				testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
-
-				modelConfig := LLMInferenceServiceConfig("model-cert-reload",
-					InNamespace[*v1alpha2.LLMInferenceServiceConfig](testNs.Name),
-					WithConfigModelName("facebook/opt-125m"),
-					WithConfigModelURI("hf://facebook/opt-125m"),
-				)
-
-				routerConfig := LLMInferenceServiceConfig("router-cert-reload",
-					InNamespace[*v1alpha2.LLMInferenceServiceConfig](testNs.Name),
-				)
-				routerConfig.Spec.Router = &v1alpha2.RouterSpec{
-					Gateway: &v1alpha2.GatewaySpec{},
-					Route:   &v1alpha2.GatewayRoutesSpec{},
-					Scheduler: &v1alpha2.SchedulerSpec{
-						Template: &corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name:  "main",
-									Image: "ghcr.io/llm-d/llm-d-inference-scheduler:v0.6.0",
-									Args: []string{
-										certReloadArg,
-										"--poolName",
-										"test-pool",
-									},
-									Ports: []corev1.ContainerPort{
-										{Name: "grpc", ContainerPort: 9002, Protocol: corev1.ProtocolTCP},
-										{Name: "grpc-health", ContainerPort: 9003, Protocol: corev1.ProtocolTCP},
-										{Name: "metrics", ContainerPort: 9090, Protocol: corev1.ProtocolTCP},
-									},
-								},
-							},
-						},
-						Pool: &v1alpha2.InferencePoolSpec{},
-					},
-				}
-
-				Expect(envTest.Client.Create(ctx, modelConfig)).To(Succeed())
-				Expect(envTest.Client.Create(ctx, routerConfig)).To(Succeed())
-
-				llmSvc := LLMInferenceService(svcName,
-					InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
-					WithBaseRefs(
-						corev1.LocalObjectReference{Name: "model-cert-reload"},
-						corev1.LocalObjectReference{Name: "router-cert-reload"},
-					),
-				)
-
-				// when
-				Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
-				defer func() {
-					testNs.DeleteAndWait(ctx, llmSvc)
-				}()
-
-				// then - the scheduler deployment must NOT have cert-hash annotation
-				schedulerDeployment := &appsv1.Deployment{}
-				Eventually(func(g Gomega, ctx context.Context) error {
-					return envTest.Get(ctx, types.NamespacedName{
-						Name:      svcName + "-kserve-router-scheduler",
-						Namespace: testNs.Name,
-					}, schedulerDeployment)
-				}).WithContext(ctx).Should(Succeed())
-
-				Expect(schedulerDeployment.Spec.Template.Annotations).NotTo(
-					HaveKey(schedulerSelfSignedTLSRestartAnnotation),
-					"Scheduler with cert reload enabled should not have cert-hash annotation",
-				)
-			},
-			Entry("bare flag", "--enable-cert-reload"),
-			Entry("flag with =true", "--enable-cert-reload=true"),
-		)
 	})
 
 	Context("Scheduler RBAC", func() {

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -18,14 +18,11 @@ package llmisvc
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"maps"
 	"path"
 	"slices"
 	"sort"
-	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -57,10 +54,6 @@ const (
 	prefixCacheScorerPlugin        = "prefix-cache-scorer"
 	udsTokenizerBaseModelName      = "base"
 	udsTokenizerSocketFile         = "/tmp/tokenizer/tokenizer-uds.socket" //nolint:gosec // G101: not a credential, UDS socket path
-
-	// schedulerSelfSignedTLSRestartAnnotation triggers a scheduler roll when the
-	// self-signed TLS secret changes (value is a SHA-256 hex digest of tls.crt+tls.key).
-	schedulerSelfSignedTLSRestartAnnotation = "serving.kserve.io/scheduler-self-signed-tls-sha256"
 )
 
 // reconcileScheduler manages the scheduler component and its related resources
@@ -455,33 +448,6 @@ func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llm
 	}
 
 	r.propagateSchedulerMetadata(llmSvc, d)
-
-	// Set a hash of the current certificate data on the pod template so that
-	// when certificates are renewed the pod template changes and the scheduler
-	// is restarted to pick up the new certificate.
-	// Skip if the main container supports automatic cert reload.
-	mainIdxForCert := -1
-	if llmSvc.Spec.Router != nil && llmSvc.Spec.Router.Scheduler != nil && llmSvc.Spec.Router.Scheduler.Template != nil {
-		mainIdxForCert = slices.IndexFunc(d.Spec.Template.Spec.Containers, func(c corev1.Container) bool {
-			return c.Name == "main"
-		})
-	}
-	certReloadEnabled := func(args []string) bool {
-		return slices.ContainsFunc(args, func(s string) bool {
-			return strings.HasPrefix(s, "--enable-cert-reload") ||
-				strings.HasPrefix(s, "-enable-cert-reload")
-		})
-	}
-	if mainIdxForCert >= 0 &&
-		!certReloadEnabled(d.Spec.Template.Spec.Containers[mainIdxForCert].Command) &&
-		!certReloadEnabled(d.Spec.Template.Spec.Containers[mainIdxForCert].Args) {
-		if h := r.getSelfSignedCertHash(ctx, llmSvc); h != "" {
-			if d.Spec.Template.Annotations == nil {
-				d.Spec.Template.Annotations = map[string]string{}
-			}
-			d.Spec.Template.Annotations[schedulerSelfSignedTLSRestartAnnotation] = h
-		}
-	}
 
 	log.FromContext(ctx).V(2).Info("Expected router scheduler deployment", "deployment", d)
 
@@ -991,22 +957,4 @@ func SchedulerLabels(llmSvc *v1alpha2.LLMInferenceService) map[string]string {
 		constants.KubernetesAppNameLabelKey:   llmSvc.GetName(),
 		constants.KubernetesPartOfLabelKey:    constants.LLMInferenceServicePartOfValue,
 	}
-}
-
-func (r *LLMISVCReconciler) getSelfSignedCertHash(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) string {
-	secret := &corev1.Secret{}
-	key := client.ObjectKey{
-		Namespace: llmSvc.GetNamespace(),
-		Name:      kmeta.ChildName(llmSvc.GetName(), "-kserve-self-signed-certs"),
-	}
-	if err := r.Get(ctx, key, secret); err != nil {
-		return ""
-	}
-	crt, okCrt := secret.Data["tls.crt"]
-	keyPEM, okKey := secret.Data["tls.key"]
-	if !okCrt || !okKey || len(crt) == 0 || len(keyPEM) == 0 {
-		return ""
-	}
-	sum := sha256.Sum256(append(append([]byte{}, crt...), keyPEM...))
-	return hex.EncodeToString(sum[:])
 }


### PR DESCRIPTION
Cherry-pick of upstream PR https://github.com/kserve/kserve/pull/5308

It got lost in the latest sync.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed TLS certificate hash-based scheduler pod restart trigger logic and related imports.

* **Tests**
  * Removed test coverage for certificate hash annotation verification in scheduler deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->