### PR TITLE
fix(llmisvc): extend storage migration retry window

### DIFF
--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -28,12 +28,10 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	apixclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -76,24 +74,28 @@ func init() {
 }
 
 type Options struct {
-	metricsAddr          string
-	webhookPort          int
-	enableLeaderElection bool
-	probeAddr            string
-	metricsSecure        bool
-	enableHTTP2          bool
-	zapOpts              zap.Options
+	metricsAddr           string
+	webhookPort           int
+	enableLeaderElection  bool
+	probeAddr             string
+	metricsSecure         bool
+	enableHTTP2           bool
+	migrationTimeout      time.Duration
+	migrationPollInterval time.Duration
+	zapOpts               zap.Options
 }
 
 func DefaultOptions() Options {
 	return Options{
-		metricsAddr:          ":8443",
-		webhookPort:          9443,
-		enableLeaderElection: false,
-		probeAddr:            ":8081",
-		metricsSecure:        true,
-		enableHTTP2:          false,
-		zapOpts:              zap.Options{},
+		metricsAddr:           ":8443",
+		webhookPort:           9443,
+		enableLeaderElection:  false,
+		probeAddr:             ":8081",
+		metricsSecure:         true,
+		enableHTTP2:           false,
+		migrationTimeout:      1 * time.Hour,
+		migrationPollInterval: 30 * time.Second,
+		zapOpts:               zap.Options{},
 	}
 }
 
@@ -108,6 +110,8 @@ func GetOptions() Options {
 	flag.StringVar(&opts.probeAddr, "health-probe-addr", opts.probeAddr, "The address the probe endpoint binds to.")
 	flag.BoolVar(&opts.metricsSecure, "metrics-secure", opts.metricsSecure, "Whether to serve metric via HTTPS.")
 	flag.BoolVar(&opts.enableHTTP2, "enable-http2", false, "If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	flag.DurationVar(&opts.migrationTimeout, "storage-migration-timeout", opts.migrationTimeout, "Total retry budget for storage version migration.")
+	flag.DurationVar(&opts.migrationPollInterval, "storage-migration-poll-interval", opts.migrationPollInterval, "Polling interval for storage version migration retries after initial backoff.")
 	opts.zapOpts.BindFlags(flag.CommandLine)
 	flag.Parse()
 	return opts
@@ -117,6 +121,18 @@ func main() {
 	ctx := signals.SetupSignalHandler()
 	options := GetOptions()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&options.zapOpts)))
+
+	defaults := DefaultOptions()
+	if options.migrationTimeout <= 0 {
+		setupLog.Info("--storage-migration-timeout must be positive, using default",
+			"invalid", options.migrationTimeout, "default", defaults.migrationTimeout)
+		options.migrationTimeout = defaults.migrationTimeout
+	}
+	if options.migrationPollInterval <= 0 {
+		setupLog.Info("--storage-migration-poll-interval must be positive, using default",
+			"invalid", options.migrationPollInterval, "default", defaults.migrationPollInterval)
+		options.migrationPollInterval = defaults.migrationPollInterval
+	}
 
 	// Get a config to talk to the apiserver
 	setupLog.Info("Setting up client for manager")
@@ -275,37 +291,36 @@ func main() {
 	// after the webhook server and cache sync are ready. This avoids the
 	// chicken-and-egg problem where migration patches trigger validating webhooks
 	// that aren't serving yet.
-	// migrationBackoff allows enough time for Service endpoints to propagate
-	// after the webhook server starts.
-	migrationBackoff := wait.Backoff{
-		Duration: 2 * time.Second,
-		Factor:   1.5,
-		Jitter:   0.1,
-		Steps:    10,
-	}
+	//
+	// Local copies pin the values into the closure by value. If Options were ever
+	// mutated after mgr.Add returns (it is not today, but nothing prevents it),
+	// closures capturing options directly would see stale or live values depending
+	// on timing. Copies make the intent explicit and safe.
+	migrationTimeout := options.migrationTimeout
+	migrationPollInterval := options.migrationPollInterval
 	if err := mgr.Add(leaderRunnable(func(ctx context.Context) error {
-		setupLog.Info("running storage version migration")
+		setupLog.Info("running storage version migration",
+			"timeout", migrationTimeout, "pollInterval", migrationPollInterval)
+		// Single context bounds the total migration budget across all resource groups.
+		// runMigrationWithRetry inherits this deadline via context.WithTimeout, which
+		// takes min(parent deadline, now+timeout), so each group draws from the same pool.
+		migrationCtx, cancel := context.WithTimeout(ctx, migrationTimeout)
+		defer cancel()
 		migrator := storageversion.NewMigrator(dynamic.NewForConfigOrDie(cfg), apixclient.NewForConfigOrDie(cfg))
 		for _, gr := range []schema.GroupResource{
 			{Group: v1alpha2.SchemeGroupVersion.Group, Resource: "llminferenceservices"},
 			{Group: v1alpha2.SchemeGroupVersion.Group, Resource: "llminferenceserviceconfigs"},
 		} {
-			var lastErr error
-			if err := wait.ExponentialBackoffWithContext(ctx, migrationBackoff, func(ctx context.Context) (bool, error) {
-				if err := migrator.Migrate(ctx, gr); err != nil {
-					lastErr = err
-					if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) || apierrors.IsNotFound(err) {
-						return false, err
-					}
-					setupLog.Error(err, "storage version migration attempt failed, retrying", "resource", gr)
-					return false, nil
-				}
-				return true, nil
+			// Pre-key the logger with the resource name so per-attempt retry messages
+			// are identifiable without grep. The error message reports the full
+			// migrationTimeout, not the remaining time, because retryCtx inside
+			// runMigrationWithRetry inherits migrationCtx's narrowed deadline via
+			// context.WithTimeout's min(parent, now+d) semantics.
+			grLog := setupLog.WithValues("resource", gr)
+			if err := runMigrationWithRetry(migrationCtx, migrationTimeout, migrationPollInterval, grLog, func(ctx context.Context) error {
+				return migrator.Migrate(ctx, gr)
 			}); err != nil {
-				if lastErr != nil && wait.Interrupted(err) {
-					return fmt.Errorf("storage version migration for %s timed out: %w", gr, lastErr)
-				}
-				return fmt.Errorf("storage version migration for %s failed: %w", gr, err)
+				return fmt.Errorf("storage version migration for %s: %w", gr, err)
 			}
 		}
 		setupLog.Info("storage version migration completed")

--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -291,7 +291,6 @@ func main() {
 	// after the webhook server and cache sync are ready. This avoids the
 	// chicken-and-egg problem where migration patches trigger validating webhooks
 	// that aren't serving yet.
-	//
 	// Local copies pin the values into the closure by value. If Options were ever
 	// mutated after mgr.Add returns (it is not today, but nothing prevents it),
 	// closures capturing options directly would see stale or live values depending

--- a/cmd/llmisvc/migration.go
+++ b/cmd/llmisvc/migration.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// fastMigrationBackoff is the phase-1 exponential backoff configuration.
+// Cap must not be set: setting Cap zeroes Steps on first hit, causing early exit.
+var fastMigrationBackoff = wait.Backoff{
+	Duration: 2 * time.Second,
+	Factor:   1.5,
+	Jitter:   0.1,
+	Steps:    10,
+}
+
+// runMigrationWithRetry attempts migrate using a two-phase retry strategy against
+// a total deadline of timeout. Phase 1 uses exponential backoff for quick initial
+// detection. Phase 2 switches to fixed-interval polling for the remaining budget.
+// Fatal Kubernetes API errors (Forbidden, Unauthorized, NotFound) are not retried.
+// log should be pre-keyed with the resource name for per-attempt retry messages.
+func runMigrationWithRetry(ctx context.Context, timeout, pollInterval time.Duration, log logr.Logger, migrate func(context.Context) error) error {
+	return runMigrationWithRetryBackoff(ctx, timeout, pollInterval, fastMigrationBackoff, log, migrate)
+}
+
+// runMigrationWithRetryBackoff is the internal implementation. phase1Backoff is
+// separated from the public API so tests can pass tiny durations without sleeping.
+func runMigrationWithRetryBackoff(ctx context.Context, timeout, pollInterval time.Duration, phase1Backoff wait.Backoff, log logr.Logger, migrate func(context.Context) error) error {
+	// Child context with deadline. Using ctx (not context.Background()) so SIGTERM
+	// from the manager still propagates and migration aborts cleanly on shutdown.
+	retryCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	var lastErr error
+	condition := func(ctx context.Context) (bool, error) {
+		if err := migrate(ctx); err != nil {
+			lastErr = err
+			if apierrors.IsForbidden(err) || apierrors.IsUnauthorized(err) || apierrors.IsNotFound(err) {
+				return false, err
+			}
+			log.Error(err, "storage version migration attempt failed, retrying")
+			return false, nil
+		}
+		return true, nil
+	}
+
+	// reportErr classifies the final error into one of three categories:
+	//   - timed out: wait was interrupted AND the deadline was exceeded
+	//   - cancelled: wait was interrupted AND the parent context was cancelled
+	//   - failed: a non-retryable (fatal) error was returned by condition
+	//
+	// Gating on wait.Interrupted(err) rather than retryCtx.Err() != nil prevents
+	// a fatal API error (e.g. 403 Forbidden) from being misreported as a timeout if
+	// the deadline happens to expire at the same instant.
+	reportErr := func(err error) error {
+		if wait.Interrupted(err) && retryCtx.Err() != nil {
+			underlying := lastErr
+			if underlying == nil {
+				underlying = retryCtx.Err()
+			}
+			if errors.Is(retryCtx.Err(), context.DeadlineExceeded) {
+				return fmt.Errorf("timed out after %s: %w", timeout, underlying)
+			}
+			return fmt.Errorf("cancelled: %w", underlying)
+		}
+		return fmt.Errorf("failed: %w", err)
+	}
+
+	// Phase 1: exponential backoff for quick initial detection.
+	if err := wait.ExponentialBackoffWithContext(retryCtx, phase1Backoff, condition); err == nil {
+		return nil
+	} else if !wait.Interrupted(err) {
+		return reportErr(err)
+	}
+
+	// Phase 2: fixed-interval polling for the remaining timeout budget.
+	// If budget is already exhausted after phase 1, skip the log and return
+	// immediately - avoids a misleading "switching to steady-state polling" message
+	// when PollUntilContextCancel would return instantly anyway.
+	if retryCtx.Err() != nil {
+		return reportErr(retryCtx.Err())
+	}
+	// immediate=false: phase 1 already attempted on its last step.
+	log.Info("fast migration retries exhausted, switching to steady-state polling",
+		"pollInterval", pollInterval)
+	if err := wait.PollUntilContextCancel(retryCtx, pollInterval, false, condition); err != nil {
+		return reportErr(err)
+	}
+	return nil
+}

--- a/cmd/llmisvc/migration_test.go
+++ b/cmd/llmisvc/migration_test.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// testPhase1Backoff replaces the 2s/10-step production backoff with 1ms/3-step
+// so unit tests run in milliseconds without sleep.
+var testPhase1Backoff = wait.Backoff{
+	Duration: 1 * time.Millisecond,
+	Factor:   1.0,
+	Jitter:   0,
+	Steps:    3,
+}
+
+const testPollInterval = 1 * time.Millisecond
+
+// retry is a test helper that calls runMigrationWithRetryBackoff with tiny
+// backoff durations so tests run fast.
+func retry(ctx context.Context, timeout time.Duration, migrate func(context.Context) error) error {
+	return runMigrationWithRetryBackoff(ctx, timeout, testPollInterval, testPhase1Backoff, logr.Discard(), migrate)
+}
+
+func TestRunMigration_SuccessFirstAttempt(t *testing.T) {
+	calls := 0
+	err := retry(context.Background(), time.Hour, func(_ context.Context) error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil, got: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestRunMigration_SuccessAfterTransientFailures(t *testing.T) {
+	calls := 0
+	err := retry(context.Background(), time.Hour, func(_ context.Context) error {
+		calls++
+		if calls < 2 {
+			return errors.New("transient")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil after transient failures, got: %v", err)
+	}
+}
+
+func TestRunMigration_Phase2Fallthrough(t *testing.T) {
+	// Phase 1 has Steps=3. Failing those forces a fallthrough to phase 2.
+	calls := 0
+	err := retry(context.Background(), time.Hour, func(_ context.Context) error {
+		calls++
+		if calls <= testPhase1Backoff.Steps {
+			return errors.New("not ready yet")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("expected nil after phase 2 success, got: %v", err)
+	}
+	if calls <= testPhase1Backoff.Steps {
+		t.Fatalf("expected migration to succeed in phase 2 (calls > %d), got %d",
+			testPhase1Backoff.Steps, calls)
+	}
+}
+
+func TestRunMigration_FatalErrorShortCircuits(t *testing.T) {
+	forbidden := apierrors.NewForbidden(
+		schema.GroupResource{Group: "test", Resource: "things"}, "name", errors.New("forbidden"))
+	calls := 0
+	err := retry(context.Background(), time.Hour, func(_ context.Context) error {
+		calls++
+		return forbidden
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 call before fatal error short-circuits, got %d", calls)
+	}
+	if !errors.Is(err, forbidden) {
+		t.Fatalf("expected error to wrap forbidden, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("fatal API error must not be reported as timeout, got: %q", err.Error())
+	}
+}
+
+func TestRunMigration_TimeoutReportsLastError(t *testing.T) {
+	sentinel := errors.New("always failing")
+	err := retry(context.Background(), 20*time.Millisecond, func(_ context.Context) error {
+		return sentinel
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected error to wrap sentinel, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected 'timed out' in error message, got: %q", err.Error())
+	}
+}
+
+func TestRunMigration_CancelledReportsCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	calls := 0
+	err := retry(ctx, time.Hour, func(_ context.Context) error {
+		calls++
+		if calls == 1 {
+			cancel()
+		}
+		return errors.New("transient")
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("cancelled context must not produce 'timed out', got: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "cancelled") {
+		t.Fatalf("expected 'cancelled' in error message, got: %q", err.Error())
+	}
+}
+
+func TestRunMigration_FatalErrorNotMisclassifiedAsTimeout(t *testing.T) {
+	// Regression guard: previously reportErr gated on `lastErr != nil && ctx.Err() != nil`,
+	// which could classify a fatal Forbidden error as "timed out" if the context deadline
+	// happened to expire at the same instant. The fix gates on wait.Interrupted(err).
+	forbidden := apierrors.NewForbidden(
+		schema.GroupResource{Group: "test", Resource: "things"}, "name", errors.New("forbidden"))
+
+	// Use a 1-step backoff so the function returns immediately with the fatal error.
+	// The timeout is short enough that the context may already be expired on return,
+	// which is the scenario the old code mishandled.
+	err := runMigrationWithRetryBackoff(
+		context.Background(), 5*time.Millisecond, testPollInterval,
+		wait.Backoff{Duration: 1 * time.Millisecond, Factor: 1, Steps: 1},
+		logr.Discard(),
+		func(_ context.Context) error { return forbidden },
+	)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("fatal API error must not be classified as timeout, got: %q", err.Error())
+	}
+	if !errors.Is(err, forbidden) {
+		t.Fatalf("expected error to wrap forbidden, got: %v", err)
+	}
+}
+
+func TestRunMigration_PreExpiredContextReportsTimeout(t *testing.T) {
+	// Simulates resource 1 consuming the entire shared budget; resource 2's call
+	// receives an already-expired context. Must classify as "timed out", not panic.
+	ctx, cancel := context.WithTimeout(context.Background(), 0)
+	defer cancel()
+	err := retry(ctx, time.Hour, func(_ context.Context) error { return errors.New("never called") })
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("pre-expired context must report 'timed out', got: %q", err.Error())
+	}
+}

--- a/test/e2e/llmisvc/test_storage_version_migration.py
+++ b/test/e2e/llmisvc/test_storage_version_migration.py
@@ -226,10 +226,11 @@ class TestStorageVersionMigration:
                     f"got {crd.status.stored_versions} for {crd_name}"
                 )
 
-        # Allow enough time for the controller's exponential backoff to exhaust
-        # on slow clusters: 10 steps at 2s*1.5^n gives ~150s per resource group,
-        # two groups sequential = ~300s worst case. Default 360s adds buffer.
-        migration_timeout = float(os.getenv("STORAGE_MIGRATION_TIMEOUT", "360"))
+        # Match the controller's total migration budget so the test never times out
+        # before the controller does. The controller defaults to 1 hour (3600s);
+        # phase 1 (exponential backoff) takes ~150s per resource group worst case,
+        # phase 2 (steady-state polling) consumes the remaining budget.
+        migration_timeout = float(os.getenv("STORAGE_MIGRATION_TIMEOUT", "3600"))
         wait_for(
             assert_stored_versions_migrated, timeout=migration_timeout, interval=5.0
         )


### PR DESCRIPTION
**What this PR does / why we need it**:

Storage version migration could exhaust its retry budget during a rolling upgrade before the old pod was removed from Service Endpoints, leaving the controller in CrashLoopBackOff. Webhook calls hitting the old pod returned transient errors with no way out under the original fixed window.

Replaces the single exponential backoff (~150s worst case per resource group) with a two-phase strategy - fast backoff for quick initial detection, then steady-state polling for the remainder of a 1-hour configurable budget. Adds `--storage-migration-timeout` and `--storage-migration-poll-interval` flags for tuning.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes [RHOAIENG-58364](https://issues.redhat.com/browse/RHOAIENG-58364)

**Feature/Issue validation/testing**:

- [x] Unit tests for the two-phase retry state machine (phase fallthrough, fatal error short-circuit, timeout/cancellation error classification)
- [x] Existing e2e storage version migration test (default timeout updated to 900s to account for the new steady-state phase)

**Special notes for your reviewer**:

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Extends storage version migration retry strategy to survive rolling upgrades.
The migration now retries for up to 1 hour (configurable) instead of a fixed
exponential backoff window (~150s), preventing CrashLoopBackOff when old pods
linger in Service Endpoints during upgrades.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New CLI flags to customize storage migration timeout and poll interval, with sensible defaults and validation.
  * Migration flow now enforces a single deadline and uses a two-phase retry strategy (exponential backoff then steady polling).

* **Bug Fixes**
  * Improved error classification so fatal API errors short-circuit and aren’t misreported as timeouts.

* **Tests**
  * Added unit tests covering migration retry behaviors and edge cases.
  * Extended end-to-end migration timeout to match the new default budget.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->