### PR TITLE
fix(samples): add active-request-scorer and fix pluginRef typo

### DIFF
--- a/docs/samples/llmisvc/e2e-gpt-oss/README.md
+++ b/docs/samples/llmisvc/e2e-gpt-oss/README.md
@@ -200,7 +200,7 @@ kubectl apply -f llmisvc_config_prefix_cache.yaml -n kserve-lab
 This creates `llmisvc-prefix-caching`. It adds:
 
 - vLLM args: `--prefix-caching-hash-algo sha256_cbor`, `--block-size 64`, `--kv_transfer_config`, `--kv-events-config` (ZMQ to EPP)
-- Router scheduler with `precise-prefix-cache-scorer`, `queue-scorer`, `kv-cache-utilization-scorer`, and tokenizers (HF) for the indexer
+- Router scheduler with `precise-prefix-cache-scorer`, `queue-scorer`, `kv-cache-utilization-scorer`, `active-request-scorer`, and tokenizers (HF) for the indexer
 - Scheduler needs `hf-token` secret for tokenizer download (already created above)
 
 ### 8.2 Switch Inference Service to precise prefix cache aware routing

--- a/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_prefix_cache.yaml
+++ b/docs/samples/llmisvc/e2e-gpt-oss/llmisvc_config_prefix_cache.yaml
@@ -68,17 +68,24 @@ spec:
                     modelName: "{{ .Spec.Model.Name }}"
                     hf:
                       tokenizersCacheDir: "/mnt/tokenizers"
-            - type: queue-scorer
             - type: kv-cache-utilization-scorer
+            - type: queue-scorer
+            - type: active-request-scorer
+              parameters:
+                requestTimeout: "2m"
+                idleThreshold: 0        # Pods with ≤0 requests are idle
+                maxBusyScore: 0         # Busy pods score 0, idle pods score 1.0
             - type: max-score-picker
           schedulingProfiles:
             - name: default
               plugins:
-                - pluginRef: queue-scorer
-                  weight: 2
+                - pluginRef: precise-prefix-cache-scorer
+                  weight: 3
                 - pluginRef: kv-cache-utilization-scorer
                   weight: 2
-                - pluginRef: precise-prefix-cache-scorer
+                - pluginRef: queue-scorer
+                  weight: 2
+                - pluginRef: active-request-scorer
                   weight: 3
                 - pluginRef: max-score-picker
       pool:

--- a/docs/samples/llmisvc/precise-prefix-kv-cache-routing/README.md
+++ b/docs/samples/llmisvc/precise-prefix-kv-cache-routing/README.md
@@ -29,8 +29,10 @@ This example demonstrates precise prefix cache routing with cache block tracking
 
 **Key Features:**
 
-- **Prefix Cache Scorer**: Routes requests to endpoints with matching KV cache blocks (weight: 2.0)
-- **Load-Aware Scorer**: Balances load across endpoints (weight: 1.0)
+- **Prefix Cache Scorer**: Routes requests to endpoints with matching KV cache blocks (weight: 3)
+- **KV Cache Utilization Scorer**: Considers KV cache memory pressure per endpoint (weight: 2)
+- **Queue Scorer**: Balances load across endpoints based on queue depth (weight: 2)
+- **Active Request Scorer**: Prefers idle pods to spread prefix caches during cold starts, preventing all requests with a shared prefix from piling onto one endpoint (weight: 3)
 - **Cache Tracking Mode**: Real-time tracking of KV cache blocks using ZMQ events
 - **KV Transfer**: Enabled via NixlConnector for cache sharing between instances
 - **Block Size**: 64 tokens (configurable, must match between vLLM and scheduler)
@@ -43,7 +45,7 @@ This example demonstrates precise prefix cache routing with cache block tracking
 3. **Request Routing**: When a request arrives, the scheduler:
    - Computes the prefix hash using the same algorithm as vLLM
    - Queries the cache index to find endpoints with matching blocks
-   - Scores endpoints based on cache hit potential (weight 2.0) and current load (weight 1.0)
+   - Scores endpoints based on cache hit potential, load, and idle status
    - Routes to the endpoint with the highest combined score
 
 ## Scheduler Configuration
@@ -51,12 +53,14 @@ This example demonstrates precise prefix cache routing with cache block tracking
 The example uses a custom scheduler configuration with the following plugins:
 
 - **single-profile-handler**: Single scheduling profile for all requests
-- **prefix-cache-scorer**:
-  - Mode: `cache_tracking` (real-time tracking via ZMQ)
+- **precise-prefix-cache-scorer**:
+  - Real-time tracking of KV cache blocks via ZMQ
   - Block size: 64 tokens (must match vLLM `--block-size`)
   - Hash seed: 42 (must match `PYTHONHASHSEED`)
   - Metrics enabled with 60-second logging interval
-- **load-aware-scorer**: Balances load across endpoints
+- **kv-cache-utilization-scorer**: Considers KV cache memory pressure per endpoint
+- **queue-scorer**: Balances load across endpoints based on queue depth
+- **active-request-scorer**: Prefers idle pods (binary mode: idle pods score 1.0, busy pods score 0.0) to distribute prefix caches across endpoints during cold starts
 - **max-score-picker**: Selects endpoint with highest combined score
 
 ## vLLM Configuration

--- a/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-opt-125m-cpu-kv-cache-routing-simulator.yaml
+++ b/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-opt-125m-cpu-kv-cache-routing-simulator.yaml
@@ -36,17 +36,24 @@ spec:
                   kvBlockIndexConfig:
                     enableMetrics: true
                     metricsLoggingInterval: 60000000000
-            - type: queue-scorer
             - type: kv-cache-utilization-scorer
+            - type: queue-scorer
+            - type: active-request-scorer
+              parameters:
+                requestTimeout: "2m"
+                idleThreshold: 0        # Pods with ≤0 requests are idle
+                maxBusyScore: 0         # Busy pods score 0, idle pods score 1.0
             - type: max-score-picker
           schedulingProfiles:
             - name: default
               plugins:
-                - pluginRef: queue-scorer
-                  weight: 2
+                - pluginRef: precise-prefix-cache-scorer
+                  weight: 3
                 - pluginRef: kv-cache-utilization-scorer
                   weight: 2
-                - pluginRef: precise-prefix-cache-scorer
+                - pluginRef: queue-scorer
+                  weight: 2
+                - pluginRef: active-request-scorer
                   weight: 3
                 - pluginRef: max-score-picker
     route: { }

--- a/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-qwen2-7b-gpu-kv-cache-routing.yaml
+++ b/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-qwen2-7b-gpu-kv-cache-routing.yaml
@@ -28,17 +28,24 @@ spec:
                   kvBlockIndexConfig:
                     enableMetrics: true                   # Enable Prometheus metrics for KV cache index
                     metricsLoggingInterval: 60000000000   # Log metrics every 60 seconds (in nanoseconds)
-            - type: queue-scorer
             - type: kv-cache-utilization-scorer
+            - type: queue-scorer
+            - type: active-request-scorer
+              parameters:
+                requestTimeout: "2m"
+                idleThreshold: 0        # Pods with ≤0 requests are idle
+                maxBusyScore: 0         # Busy pods score 0, idle pods score 1.0
             - type: max-score-picker
           schedulingProfiles:
             - name: default
               plugins:
-                - pluginRef: queue-scorer
-                  weight: 2
+                - pluginRef: precise-prefix-cache-scorer
+                  weight: 3
                 - pluginRef: kv-cache-utilization-scorer
                   weight: 2
-                - pluginRef: prefix-cache-scorer
+                - pluginRef: queue-scorer
+                  weight: 2
+                - pluginRef: active-request-scorer
                   weight: 3
                 - pluginRef: max-score-picker
     route: { }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. Re-running failed tests: comment `/rerun-all` to rerun all failed workflows.
-->

**What this PR does / why we need it**:
This PR updates the samples in docs/samples/llmisvc which use the llm-d prefix-aware-scorer routing configuration to add the active-requests scorer.
- Add active-request-scorer to prefix cache routing examples to improve load distribution.
- Fix pluginRef "prefix-cache-scorer" → "precise-prefix-cache-scorer" which would prevent scheduler startup.

This is needed because in some cases the default scorer/weight configuration with the prefix-cache-scorer can lead to all requests being routed to one Pod, and not balanced evenly. For example, a benchmark which ramps up traffic slowly where all requests share a common prefix / system prompt. The router scorer will dominate routing decisions and continue sending all requests to the Pod where the prefix is cached until load is high enough to cause queuing. This can be avoided by using the active-requests-scorer. 


**Feature/Issue validation/testing**:
This is related to https://redhat.atlassian.net/browse/INFERENG-5395

[See this llm-d-inference-scheduler PR](https://github.com/llm-d/llm-d-inference-scheduler/pull/669) for more details on how this works and the benchmarks I ran to test this.

**Checklist**:
- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated LLMInferenceService routing configuration documentation and examples to reflect enhanced scheduler plugin strategy.
  * Revised scoring profiles with reordered plugins and updated weights for improved request routing.

* **Chores**
  * Updated YAML configuration files to add new `active-request-scorer` plugin and reorganize scheduler plugin order across multiple samples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->