### PR TITLE
fix(ci): restart kuadrant operator pod on MissingDependency retry

### DIFF
--- a/test/scripts/openshift-ci/infra/deploy.kuadrant.sh
+++ b/test/scripts/openshift-ci/infra/deploy.kuadrant.sh
@@ -94,10 +94,14 @@ while (( kuadrant_ready_attempt <= KUADRANT_READY_MAX_ATTEMPTS )); do
     oc logs -n "${KUADRANT_NS}" deployment/kuadrant-operator-controller-manager --tail=200 || true
     exit 1
   fi
-  echo "Kuadrant not Ready; deleting and recreating CR to trigger a new Create reconcile (helps operator versions that only subscribe to Create)…"
+  echo "Kuadrant not Ready; attempting to fix…"
+  echo "  Recreating CR (triggers fresh Create reconcile for operator versions that only subscribe to Create)…"
   oc delete kuadrant kuadrant -n "${KUADRANT_NS}" --ignore-not-found=true --wait=true --timeout=300s
+  echo "  Restarting operator pod (clears stale dependency cache)…"
+  oc delete pod -n "${KUADRANT_NS}" -l app=kuadrant,control-plane=controller-manager --wait=true --timeout=120s || true
   echo "⏳ sleeping ${KUADRANT_POST_DELETE_SLEEP}s before recreating Kuadrant…"
   sleep "${KUADRANT_POST_DELETE_SLEEP}"
+  wait_for_pod_ready "${KUADRANT_NS}" "app=kuadrant,control-plane=controller-manager" 120s || true
   create_kuadrant_cr || true
   kuadrant_ready_attempt=$((kuadrant_ready_attempt + 1))
 done


### PR DESCRIPTION
## Summary

The Kuadrant operator checks dependencies (Limitador, Authorino, DNS) only at startup. If it starts before a dependency CSV is fully ready, it caches `MissingDependency` and never re-checks -- even after the dependency finishes installing.

The existing retry loop (added in #1301) deleted and recreated the Kuadrant CR, which helps operator versions that only subscribe to Create events. However, it does not clear the stale dependency cache inside the running operator pod.

This adds an operator pod restart between retry attempts so the new pod performs a fresh dependency check against the now-ready CSVs. This matches what the operator itself requests in its status message: *"please restart Kuadrant Operator pod once dependency has been installed"*.

## Changes

- Delete the kuadrant operator pod (`app=kuadrant,control-plane=controller-manager`) after deleting the CR
- Wait for the restarted pod to become ready before recreating the CR
- Both new commands use `|| true` to preserve the diagnostic dump on final failure

## Test plan

- [ ] Trigger `e2e-llm-inference-service` Konflux group test and verify Kuadrant installs successfully
- [ ] Verify the retry path works by inspecting logs for the "Restarting operator pod" message

Follow-up to #1301.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced deployment remediation logic for Kuadrant in OpenShift CI environments, improving operator recovery and readiness verification procedures when deployment issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->