### PR TITLE
[release-v0.17] fix: preserve existing auth proxy containers during RHOAI upgrades

### DIFF
--- a/pkg/constants/constants_odh.go
+++ b/pkg/constants/constants_odh.go
@@ -30,6 +30,7 @@ var (
 // Midstream networking constants
 const (
 	ODHKserveRawAuth               = "security.opendatahub.io/enable-auth"
+	ODHAuthProxyTypeAnnotation     = "security.opendatahub.io/auth-proxy-type"
 	ODHRouteEnabled                = "exposed"
 	ServingCertSecretSuffix        = "-serving-cert"
 	OpenshiftServingCertAnnotation = "service.beta.openshift.io/serving-cert-secret-name"
@@ -50,9 +51,11 @@ const (
 	OauthProxyResourceCPURequest    = "100m"
 	OauthProxySARCMName             = "kube-rbac-proxy-sar-config"
 	// Used for test purposes
-	OauthProxyImage       = "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3"
-	DefaultServiceAccount = "default"
-	KubeRbacContainerName = "kube-rbac-proxy"
+	OauthProxyImage         = "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3"
+	DefaultServiceAccount   = "default"
+	KubeRbacContainerName   = "kube-rbac-proxy"
+	OauthProxyContainerName = "oauth-proxy"
+	KubeRbacProxyType       = "kube-rbac-proxy"
 )
 
 // OpenShift constants

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -794,6 +794,10 @@ func (p *Predictor) reconcileRawDeployment(ctx context.Context, isvc *v1beta1.In
 		return errors.Wrapf(err, "fails to reconcile predictor")
 	}
 
+	if cond, condType := r.Workload.GetAuthProxyCondition(); cond != nil {
+		isvc.Status.SetCondition(condType, cond)
+	}
+
 	if !utils.GetForceStopRuntime(isvc) {
 		isvc.Status.PropagateRawStatus(v1beta1.PredictorComponent, deploymentList, r.URL)
 	}

--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -9031,6 +9031,336 @@ var _ = Describe("v1beta1 inference service controller", func() {
 		})
 	})
 
+	Context("When an existing ISVC has oauth-proxy container", func() {
+		configs := map[string]string{
+			"oauthProxy":         `{"image": "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m"}`,
+			"ingress":            `{"ingressGateway": "knative-serving/knative-ingress-gateway", "ingressService": "test-destination", "localGateway": "knative-serving/knative-local-gateway", "localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local"}`,
+			"storageInitializer": `{"image": "kserve/storage-initializer:latest", "memoryRequest": "100Mi", "memoryLimit": "1Gi", "cpuRequest": "100m", "cpuLimit": "1", "CaBundleConfigMapName": "", "caBundleVolumeMountPath": "/etc/ssl/custom-certs", "enableDirectPvcVolumeMount": false}`,
+		}
+
+		It("Should preserve oauth-proxy and set LatestDeploymentReady=False", func() {
+			By("Creating configmap and serving runtime")
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: configs,
+			}
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), configMap)
+
+			servingRuntime := &v1alpha1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tf-serving-oauth-test",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.ServingRuntimeSpec{
+					SupportedModelFormats: []v1alpha1.SupportedModelFormat{
+						{
+							Name:       "tensorflow",
+							Version:    ptr.To("1"),
+							AutoSelect: ptr.To(true),
+						},
+					},
+					ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:    "kserve-container",
+								Image:   "tensorflow/serving:1.14.0",
+								Command: []string{"/usr/bin/tensorflow_model_server"},
+								Args: []string{
+									"--port=9000",
+									"--rest_api_port=8080",
+									"--model_base_path=/mnt/models",
+									"--rest_api_timeout_in_ms=60000",
+								},
+								Resources: defaultResource,
+							},
+						},
+					},
+					Disabled: ptr.To(false),
+				},
+			}
+			Expect(k8sClient.Create(context.TODO(), servingRuntime)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), servingRuntime)
+
+			serviceName := "oauth-preserve-test"
+			serviceKey := types.NamespacedName{Name: serviceName, Namespace: "default"}
+			storageUri := "s3://test/mnist/export"
+			ctx := context.Background()
+
+			By("Creating InferenceService with auth enabled")
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceKey.Name,
+					Namespace: serviceKey.Namespace,
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode": "RawDeployment",
+						constants.ODHKserveRawAuth:         "true",
+					},
+					Labels: map[string]string{
+						constants.NetworkVisibility: constants.ODHRouteEnabled,
+					},
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: ptr.To(int32(1)),
+							MaxReplicas: 3,
+						},
+						Tensorflow: &v1beta1.TFServingSpec{
+							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+								StorageURI:     &storageUri,
+								RuntimeVersion: ptr.To("1.14.0"),
+								Container: corev1.Container{
+									Name:      constants.InferenceServiceContainerName,
+									Resources: defaultResource,
+								},
+							},
+						},
+					},
+				},
+			}
+			isvc.DefaultInferenceService(nil, nil, &v1beta1.SecurityConfig{AutoMountServiceAccountToken: false}, nil, nil)
+			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
+			defer k8sClient.Delete(ctx, isvc)
+
+			By("Waiting for deployment with kube-rbac-proxy")
+			predictorDeploymentKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace,
+			}
+			actualDeployment := &appsv1.Deployment{}
+			Eventually(func() bool {
+				err := k8sClient.Get(context.TODO(), predictorDeploymentKey, actualDeployment)
+				if err != nil {
+					return false
+				}
+				for _, c := range actualDeployment.Spec.Template.Spec.Containers {
+					if c.Name == constants.KubeRbacContainerName {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Patching deployment to replace kube-rbac-proxy with oauth-proxy")
+			newContainers := make([]corev1.Container, 0, len(actualDeployment.Spec.Template.Spec.Containers))
+			for _, c := range actualDeployment.Spec.Template.Spec.Containers {
+				if c.Name == constants.KubeRbacContainerName {
+					c.Name = constants.OauthProxyContainerName
+				}
+				newContainers = append(newContainers, c)
+			}
+			actualDeployment.Spec.Template.Spec.Containers = newContainers
+			Expect(k8sClient.Update(ctx, actualDeployment)).Should(Succeed())
+
+			By("Triggering reconciliation by updating ISVC annotation")
+			Eventually(func() error {
+				if err := k8sClient.Get(ctx, serviceKey, isvc); err != nil {
+					return err
+				}
+				if isvc.Annotations == nil {
+					isvc.Annotations = make(map[string]string)
+				}
+				isvc.Annotations["test-trigger"] = "reconcile"
+				return k8sClient.Update(ctx, isvc)
+			}, timeout, interval).Should(Succeed())
+
+			By("Verifying oauth-proxy is preserved")
+			Eventually(func() bool {
+				err := k8sClient.Get(context.TODO(), predictorDeploymentKey, actualDeployment)
+				if err != nil {
+					return false
+				}
+				hasOauthProxy := false
+				hasKubeRbacProxy := false
+				for _, c := range actualDeployment.Spec.Template.Spec.Containers {
+					if c.Name == constants.OauthProxyContainerName {
+						hasOauthProxy = true
+					}
+					if c.Name == constants.KubeRbacContainerName {
+						hasKubeRbacProxy = true
+					}
+				}
+				return hasOauthProxy && !hasKubeRbacProxy
+			}, timeout, interval).Should(BeTrue())
+
+			By("Verifying LatestDeploymentReady condition is False with AuthProxyPreserved reason")
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, serviceKey, isvc); err != nil {
+					return false
+				}
+				cond := isvc.Status.GetCondition(v1beta1.LatestDeploymentReady)
+				return cond != nil && cond.Status == corev1.ConditionFalse && cond.Reason == "AuthProxyPreserved"
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	Context("When kube-rbac-proxy image changes in config", func() {
+		It("Should not update deployment and set LatestDeploymentReady=False", func() {
+			originalImage := "quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3"
+			newImage := "quay.io/opendatahub/odh-kube-auth-proxy@sha256:newimagesha256"
+
+			configs := map[string]string{
+				"oauthProxy":         fmt.Sprintf(`{"image": "%s", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m"}`, originalImage),
+				"ingress":            `{"ingressGateway": "knative-serving/knative-ingress-gateway", "ingressService": "test-destination", "localGateway": "knative-serving/knative-local-gateway", "localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local"}`,
+				"storageInitializer": `{"image": "kserve/storage-initializer:latest", "memoryRequest": "100Mi", "memoryLimit": "1Gi", "cpuRequest": "100m", "cpuLimit": "1", "CaBundleConfigMapName": "", "caBundleVolumeMountPath": "/etc/ssl/custom-certs", "enableDirectPvcVolumeMount": false}`,
+			}
+
+			By("Creating configmap and serving runtime")
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: configs,
+			}
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), configMap)
+
+			servingRuntime := &v1alpha1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "tf-serving-image-change-test",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.ServingRuntimeSpec{
+					SupportedModelFormats: []v1alpha1.SupportedModelFormat{
+						{
+							Name:       "tensorflow",
+							Version:    ptr.To("1"),
+							AutoSelect: ptr.To(true),
+						},
+					},
+					ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:    "kserve-container",
+								Image:   "tensorflow/serving:1.14.0",
+								Command: []string{"/usr/bin/tensorflow_model_server"},
+								Args: []string{
+									"--port=9000",
+									"--rest_api_port=8080",
+									"--model_base_path=/mnt/models",
+									"--rest_api_timeout_in_ms=60000",
+								},
+								Resources: defaultResource,
+							},
+						},
+					},
+					Disabled: ptr.To(false),
+				},
+			}
+			Expect(k8sClient.Create(context.TODO(), servingRuntime)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), servingRuntime)
+
+			serviceName := "image-change-test"
+			serviceKey := types.NamespacedName{Name: serviceName, Namespace: "default"}
+			storageUri := "s3://test/mnist/export"
+			ctx := context.Background()
+
+			By("Creating InferenceService with auth enabled")
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceKey.Name,
+					Namespace: serviceKey.Namespace,
+					Annotations: map[string]string{
+						"serving.kserve.io/deploymentMode": "RawDeployment",
+						constants.ODHKserveRawAuth:         "true",
+					},
+					Labels: map[string]string{
+						constants.NetworkVisibility: constants.ODHRouteEnabled,
+					},
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: ptr.To(int32(1)),
+							MaxReplicas: 3,
+						},
+						Tensorflow: &v1beta1.TFServingSpec{
+							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+								StorageURI:     &storageUri,
+								RuntimeVersion: ptr.To("1.14.0"),
+								Container: corev1.Container{
+									Name:      constants.InferenceServiceContainerName,
+									Resources: defaultResource,
+								},
+							},
+						},
+					},
+				},
+			}
+			isvc.DefaultInferenceService(nil, nil, &v1beta1.SecurityConfig{AutoMountServiceAccountToken: false}, nil, nil)
+			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
+			defer k8sClient.Delete(ctx, isvc)
+
+			By("Waiting for deployment with kube-rbac-proxy")
+			predictorDeploymentKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace,
+			}
+			actualDeployment := &appsv1.Deployment{}
+			Eventually(func() bool {
+				err := k8sClient.Get(context.TODO(), predictorDeploymentKey, actualDeployment)
+				if err != nil {
+					return false
+				}
+				for _, c := range actualDeployment.Spec.Template.Spec.Containers {
+					if c.Name == constants.KubeRbacContainerName && c.Image == originalImage {
+						return true
+					}
+				}
+				return false
+			}, timeout, interval).Should(BeTrue())
+
+			By("Updating configmap with new image")
+			Eventually(func() error {
+				if err := k8sClient.Get(ctx, types.NamespacedName{Name: constants.InferenceServiceConfigMapName, Namespace: constants.KServeNamespace}, configMap); err != nil {
+					return err
+				}
+				configMap.Data["oauthProxy"] = fmt.Sprintf(`{"image": "%s", "memoryRequest": "64Mi", "memoryLimit": "128Mi", "cpuRequest": "100m", "cpuLimit": "200m"}`, newImage)
+				return k8sClient.Update(ctx, configMap)
+			}, timeout, interval).Should(Succeed())
+
+			By("Triggering reconciliation by updating ISVC annotation")
+			Eventually(func() error {
+				if err := k8sClient.Get(ctx, serviceKey, isvc); err != nil {
+					return err
+				}
+				if isvc.Annotations == nil {
+					isvc.Annotations = make(map[string]string)
+				}
+				isvc.Annotations["test-trigger"] = "image-change"
+				return k8sClient.Update(ctx, isvc)
+			}, timeout, interval).Should(Succeed())
+
+			By("Verifying deployment still has original image")
+			Consistently(func() bool {
+				err := k8sClient.Get(context.TODO(), predictorDeploymentKey, actualDeployment)
+				if err != nil {
+					return false
+				}
+				for _, c := range actualDeployment.Spec.Template.Spec.Containers {
+					if c.Name == constants.KubeRbacContainerName {
+						return c.Image == originalImage
+					}
+				}
+				return false
+			}, "5s", interval).Should(BeTrue())
+
+			By("Verifying LatestDeploymentReady condition is False with AuthProxyPreserved reason")
+			Eventually(func() bool {
+				if err := k8sClient.Get(ctx, serviceKey, isvc); err != nil {
+					return false
+				}
+				cond := isvc.Status.GetCondition(v1beta1.LatestDeploymentReady)
+				return cond != nil && cond.Status == corev1.ConditionFalse && cond.Reason == "AuthProxyPreserved"
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
 	Context("When creating inference service with raw kube predictor with workerSpec", func() {
 		var (
 			serviceKey types.NamespacedName

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -984,8 +984,9 @@ func (r *DeploymentReconciler) GetAuthProxyCondition() (*apis.Condition, apis.Co
 	return r.condition, r.conditionType
 }
 
-// copyAuthProxyFromExisting copies the auth proxy container, its volumes, and related
-// configuration from an existing deployment to the desired deployment.
+// copyAuthProxyFromExisting copies the auth proxy container and only its related
+// volumes/mounts from an existing deployment into the desired deployment, preserving
+// any user-defined volumes and mounts already present on the desired spec.
 func copyAuthProxyFromExisting(existing, desired *appsv1.Deployment, containerName string) {
 	if existing == nil || desired == nil {
 		return
@@ -1006,14 +1007,29 @@ func copyAuthProxyFromExisting(existing, desired *appsv1.Deployment, containerNa
 	}
 
 	desiredSpec.Containers = append(desiredSpec.Containers, *authProxyContainer)
-	desiredSpec.Volumes = existingSpec.Volumes
 	desiredSpec.AutomountServiceAccountToken = existingSpec.AutomountServiceAccountToken
 
-	for i, desiredContainer := range desiredSpec.Containers {
-		if desiredContainer.Name == constants.InferenceServiceContainerName {
-			for _, existingContainer := range existingSpec.Containers {
-				if existingContainer.Name == constants.InferenceServiceContainerName {
-					desiredSpec.Containers[i].VolumeMounts = existingContainer.VolumeMounts
+	authVolumeNames := make(map[string]bool, len(authProxyContainer.VolumeMounts))
+	for _, vm := range authProxyContainer.VolumeMounts {
+		authVolumeNames[vm.Name] = true
+	}
+
+	for _, v := range existingSpec.Volumes {
+		if authVolumeNames[v.Name] {
+			desiredSpec.Volumes = append(desiredSpec.Volumes, v)
+		}
+	}
+
+	for i, c := range desiredSpec.Containers {
+		if c.Name == constants.InferenceServiceContainerName {
+			for _, existingC := range existingSpec.Containers {
+				if existingC.Name == constants.InferenceServiceContainerName {
+					for _, vm := range existingC.VolumeMounts {
+						if authVolumeNames[vm.Name] {
+							desiredSpec.Containers[i].VolumeMounts = append(
+								desiredSpec.Containers[i].VolumeMounts, vm)
+						}
+					}
 					break
 				}
 			}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/utils/ptr"
+	"knative.dev/pkg/apis"
 	"knative.dev/pkg/kmp"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -58,6 +59,8 @@ type DeploymentReconciler struct {
 	scheme         *runtime.Scheme
 	DeploymentList []*appsv1.Deployment
 	componentExt   *v1beta1.ComponentExtensionSpec
+	condition      *apis.Condition
+	conditionType  apis.ConditionType
 }
 
 const (
@@ -75,17 +78,29 @@ func NewDeploymentReconciler(ctx context.Context,
 	podSpec *corev1.PodSpec, workerPodSpec *corev1.PodSpec,
 	deployConfig *v1beta1.DeployConfig,
 ) (*DeploymentReconciler, error) {
-	deploymentList, err := createRawDeploymentODH(ctx, client, clientset, resourceType, componentMeta, workerComponentMeta, componentExt, podSpec, workerPodSpec, deployConfig)
+	deploymentList, authProxyPreserved, err := createRawDeploymentODH(ctx, client, clientset, resourceType, componentMeta, workerComponentMeta, componentExt, podSpec, workerPodSpec, deployConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	return &DeploymentReconciler{
+	reconciler := &DeploymentReconciler{
 		client:         client,
 		scheme:         scheme,
 		DeploymentList: deploymentList,
 		componentExt:   componentExt,
-	}, nil
+	}
+
+	if authProxyPreserved {
+		reconciler.conditionType = v1beta1.LatestDeploymentReady
+		reconciler.condition = &apis.Condition{
+			Type:    v1beta1.LatestDeploymentReady,
+			Status:  corev1.ConditionFalse,
+			Reason:  "AuthProxyPreserved",
+			Message: "Preserving existing auth proxy container to avoid pod restart",
+		}
+	}
+
+	return reconciler, nil
 }
 
 func createRawDeploymentODH(ctx context.Context,
@@ -97,10 +112,10 @@ func createRawDeploymentODH(ctx context.Context,
 	componentExt *v1beta1.ComponentExtensionSpec,
 	podSpec *corev1.PodSpec, workerPodSpec *corev1.PodSpec,
 	deployConfig *v1beta1.DeployConfig,
-) ([]*appsv1.Deployment, error) {
+) ([]*appsv1.Deployment, bool, error) {
 	deploymentList, err := createRawDeployment(componentMeta, workerComponentMeta, componentExt, podSpec, workerPodSpec, deployConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create raw deployment: %w", err)
+		return nil, false, fmt.Errorf("failed to create raw deployment: %w", err)
 	}
 
 	// get the Inference Service Name
@@ -112,22 +127,78 @@ func createRawDeploymentODH(ctx context.Context,
 	}
 
 	enableAuth := false
-	// Deployment list is for multi-node, we only need to add oauth proxy and serving sercret certs to the head deployment
+	addNewAuthProxy := false
+	authProxyPreserved := false
+	// Deployment list is for multi-node, we only need to add oauth proxy and serving secret certs to the head deployment
 	headDeployment := deploymentList[0]
 	if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && strings.EqualFold(val, "true") {
 		enableAuth = true
 
+		wantsMigration := false
+		if val, ok := componentMeta.Annotations[constants.ODHAuthProxyTypeAnnotation]; ok {
+			wantsMigration = (val == constants.KubeRbacProxyType)
+		}
+
+		existingProxyType, existingProxyImage, existingDeployment, err := getExistingAuthProxyType(ctx, client,
+			componentMeta.Namespace, componentMeta.Name)
+		if err != nil {
+			return nil, false, err
+		}
+
+		oauthConfig, cfgErr := getOauthProxyConfig(ctx, clientset)
+		if cfgErr != nil {
+			oauthConfig = nil
+		}
+
 		if resourceType != constants.InferenceGraphResource { // InferenceGraphs don't use rbac-proxy
-			err := addOauthContainerToDeployment(ctx, client, clientset, headDeployment, componentMeta, componentExt, podSpec, isvcname)
-			if err != nil {
-				return nil, err
+			if existingProxyType != "" {
+				switch existingProxyType {
+				case constants.OauthProxyContainerName:
+					if wantsMigration {
+						addNewAuthProxy = true
+						err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname)
+						if err != nil {
+							return nil, false, err
+						}
+					} else {
+						log.Info("Preserving existing auth proxy container", "isvc", isvcname, "type", existingProxyType)
+						authProxyPreserved = true
+						copyAuthProxyFromExisting(existingDeployment, headDeployment, existingProxyType)
+					}
+				case constants.KubeRbacContainerName:
+					configuredKubeRbacImage := ""
+					if oauthConfig != nil {
+						configuredKubeRbacImage = oauthConfig.Image
+					}
+					if configuredKubeRbacImage != "" && existingProxyImage == configuredKubeRbacImage {
+						addNewAuthProxy = true
+						err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname)
+						if err != nil {
+							return nil, false, err
+						}
+					} else {
+						log.Info("Preserving existing auth proxy container (image differs from config)",
+							"isvc", isvcname, "type", existingProxyType,
+							"existingImage", existingProxyImage, "configImage", configuredKubeRbacImage)
+						authProxyPreserved = true
+						copyAuthProxyFromExisting(existingDeployment, headDeployment, existingProxyType)
+					}
+				}
+			} else {
+				addNewAuthProxy = true
+				err := addOauthContainerToDeployment(ctx, client, clientset, oauthConfig, headDeployment, componentMeta, componentExt, podSpec, isvcname)
+				if err != nil {
+					return nil, false, err
+				}
 			}
 		}
 	}
 	if (resourceType == constants.InferenceServiceResource && enableAuth) || resourceType == constants.InferenceGraphResource {
-		mountServingSecretCMVolumeToDeployment(headDeployment, componentMeta, resourceType, isvcname)
+		if addNewAuthProxy || resourceType == constants.InferenceGraphResource {
+			mountServingSecretCMVolumeToDeployment(headDeployment, componentMeta, resourceType, isvcname)
+		}
 	}
-	return deploymentList, nil
+	return deploymentList, authProxyPreserved, nil
 }
 
 func createRawDeployment(componentMeta metav1.ObjectMeta, workerComponentMeta metav1.ObjectMeta,
@@ -284,6 +355,7 @@ func mountServingSecretCMVolumeToDeployment(deployment *appsv1.Deployment, compo
 func addOauthContainerToDeployment(ctx context.Context,
 	client kclient.Client,
 	clientset kubernetes.Interface,
+	oauthConfig *v1beta1.OauthConfig,
 	deployment *appsv1.Deployment,
 	componentMeta metav1.ObjectMeta,
 	componentExt *v1beta1.ComponentExtensionSpec,
@@ -308,14 +380,11 @@ func addOauthContainerToDeployment(ctx context.Context,
 			upstreamTimeout = strconv.FormatInt(*componentExt.TimeoutSeconds, 10)
 		}
 
-		oauthProxyContainer, err := generateOauthProxyContainer(ctx, client, clientset, isvcName, componentMeta.Namespace, upstreamPort, upstreamTimeout)
+		oauthProxyContainer, err := generateOauthProxyContainer(ctx, client, clientset, oauthConfig, isvcName, componentMeta.Namespace, upstreamPort, upstreamTimeout)
 		if err != nil {
-			// return the deployment without the oauth proxy container if there was an error
-			// This is required for the deployment_reconciler_tests
 			return err
 		}
 		updatedPodSpec := deployment.Spec.Template.Spec.DeepCopy()
-		//	updatedPodSpec := podSpec.DeepCopy()
 		// ODH override. See : https://issues.redhat.com/browse/RHOAIENG-19904
 		updatedPodSpec.AutomountServiceAccountToken = proto.Bool(true)
 		updatedPodSpec.Containers = append(updatedPodSpec.Containers, *oauthProxyContainer)
@@ -395,8 +464,8 @@ func GetKServeContainerPort(podSpec *corev1.PodSpec) string {
 	return kserveContainerPort
 }
 
-func generateOauthProxyContainer(ctx context.Context, client kclient.Client, clientset kubernetes.Interface, isvc string,
-	namespace string, upstreamPort string, upstreamTimeout string,
+func generateOauthProxyContainer(ctx context.Context, client kclient.Client, clientset kubernetes.Interface,
+	oauthConfig *v1beta1.OauthConfig, isvc string, namespace string, upstreamPort string, upstreamTimeout string,
 ) (*corev1.Container, error) {
 	// Create SAR ConfigMap for this specific InferenceService
 	err := createSarCm(ctx, client, clientset, namespace, isvc)
@@ -404,25 +473,19 @@ func generateOauthProxyContainer(ctx context.Context, client kclient.Client, cli
 		return nil, fmt.Errorf("failed to create SAR configmap: %w", err)
 	}
 
-	isvcConfigMap, err := clientset.CoreV1().ConfigMaps(constants.KServeNamespace).Get(ctx, constants.InferenceServiceConfigMapName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
+	if oauthConfig == nil {
+		return nil, errors.New("oauthProxy config is nil")
 	}
-	oauthProxyJSON := strings.TrimSpace(isvcConfigMap.Data["oauthProxy"])
-	oauthProxyConfig := v1beta1.OauthConfig{}
-	if err := json.Unmarshal([]byte(oauthProxyJSON), &oauthProxyConfig); err != nil {
-		return nil, err
-	}
-	if oauthProxyConfig.Image == "" || oauthProxyConfig.MemoryRequest == "" || oauthProxyConfig.MemoryLimit == "" ||
-		oauthProxyConfig.CpuRequest == "" || oauthProxyConfig.CpuLimit == "" {
+	if oauthConfig.Image == "" || oauthConfig.MemoryRequest == "" || oauthConfig.MemoryLimit == "" ||
+		oauthConfig.CpuRequest == "" || oauthConfig.CpuLimit == "" {
 		return nil, errors.New("one or more required oauthProxyConfig fields are empty")
 	}
-	oauthImage := oauthProxyConfig.Image
-	oauthMemoryRequest := oauthProxyConfig.MemoryRequest
-	oauthMemoryLimit := oauthProxyConfig.MemoryLimit
-	oauthCpuRequest := oauthProxyConfig.CpuRequest
-	oauthCpuLimit := oauthProxyConfig.CpuLimit
-	oauthUpstreamTimeout := strings.TrimSpace(oauthProxyConfig.UpstreamTimeoutSeconds)
+	oauthImage := oauthConfig.Image
+	oauthMemoryRequest := oauthConfig.MemoryRequest
+	oauthMemoryLimit := oauthConfig.MemoryLimit
+	oauthCpuRequest := oauthConfig.CpuRequest
+	oauthCpuLimit := oauthConfig.CpuLimit
+	oauthUpstreamTimeout := strings.TrimSpace(oauthConfig.UpstreamTimeoutSeconds)
 	if upstreamTimeout != "" {
 		oauthUpstreamTimeout = upstreamTimeout
 	}
@@ -913,4 +976,92 @@ func (r *DeploymentReconciler) SetControllerReferences(owner metav1.Object, sche
 		}
 	}
 	return nil
+}
+
+// GetAuthProxyCondition returns a condition to set on the ISVC status when an
+// existing auth proxy container has been preserved to avoid pod restart.
+func (r *DeploymentReconciler) GetAuthProxyCondition() (*apis.Condition, apis.ConditionType) {
+	return r.condition, r.conditionType
+}
+
+// copyAuthProxyFromExisting copies the auth proxy container, its volumes, and related
+// configuration from an existing deployment to the desired deployment.
+func copyAuthProxyFromExisting(existing, desired *appsv1.Deployment, containerName string) {
+	if existing == nil || desired == nil {
+		return
+	}
+
+	existingSpec := &existing.Spec.Template.Spec
+	desiredSpec := &desired.Spec.Template.Spec
+
+	var authProxyContainer *corev1.Container
+	for i, c := range existingSpec.Containers {
+		if c.Name == containerName {
+			authProxyContainer = &existingSpec.Containers[i]
+			break
+		}
+	}
+	if authProxyContainer == nil {
+		return
+	}
+
+	desiredSpec.Containers = append(desiredSpec.Containers, *authProxyContainer)
+	desiredSpec.Volumes = existingSpec.Volumes
+	desiredSpec.AutomountServiceAccountToken = existingSpec.AutomountServiceAccountToken
+
+	for i, desiredContainer := range desiredSpec.Containers {
+		if desiredContainer.Name == constants.InferenceServiceContainerName {
+			for _, existingContainer := range existingSpec.Containers {
+				if existingContainer.Name == constants.InferenceServiceContainerName {
+					desiredSpec.Containers[i].VolumeMounts = existingContainer.VolumeMounts
+					break
+				}
+			}
+			break
+		}
+	}
+}
+
+// getExistingAuthProxyType checks if the deployment already has an auth proxy container.
+// Returns the container name ("oauth-proxy" or "kube-rbac-proxy"), its image, and the
+// existing deployment for use in preservation logic.
+func getExistingAuthProxyType(ctx context.Context, client kclient.Client,
+	namespace, deploymentName string,
+) (containerName string, containerImage string, existing *appsv1.Deployment, err error) {
+	existing = &appsv1.Deployment{}
+	err = client.Get(ctx, types.NamespacedName{
+		Namespace: namespace,
+		Name:      deploymentName,
+	}, existing)
+
+	if apierr.IsNotFound(err) {
+		return "", "", nil, nil
+	}
+	if err != nil {
+		return "", "", nil, err
+	}
+
+	for _, container := range existing.Spec.Template.Spec.Containers {
+		if container.Name == constants.OauthProxyContainerName {
+			return constants.OauthProxyContainerName, container.Image, existing, nil
+		}
+		if container.Name == constants.KubeRbacContainerName {
+			return constants.KubeRbacContainerName, container.Image, existing, nil
+		}
+	}
+	return "", "", existing, nil
+}
+
+// getOauthProxyConfig fetches and parses the oauth proxy configuration from the inferenceservice configmap.
+func getOauthProxyConfig(ctx context.Context, clientset kubernetes.Interface) (*v1beta1.OauthConfig, error) {
+	isvcConfigMap, err := clientset.CoreV1().ConfigMaps(constants.KServeNamespace).Get(ctx, constants.InferenceServiceConfigMapName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	oauthProxyJSON := strings.TrimSpace(isvcConfigMap.Data["oauthProxy"])
+	oauthProxyConfig := &v1beta1.OauthConfig{}
+	if err := json.Unmarshal([]byte(oauthProxyJSON), oauthProxyConfig); err != nil {
+		return nil, err
+	}
+	return oauthProxyConfig, nil
 }

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
@@ -2031,6 +2031,14 @@ func TestCopyAuthProxyFromExisting(t *testing.T) {
 		},
 	}
 
+	userVolume := corev1.Volume{
+		Name: "user-data",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+	userVolumeMount := corev1.VolumeMount{Name: "user-data", MountPath: "/data"}
+
 	desiredDeployment := &appsv1.Deployment{
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{
@@ -2038,10 +2046,12 @@ func TestCopyAuthProxyFromExisting(t *testing.T) {
 					AutomountServiceAccountToken: &falseVal,
 					Containers: []corev1.Container{
 						{
-							Name:  constants.InferenceServiceContainerName,
-							Image: "test-image",
+							Name:         constants.InferenceServiceContainerName,
+							Image:        "test-image",
+							VolumeMounts: []corev1.VolumeMount{userVolumeMount},
 						},
 					},
+					Volumes: []corev1.Volume{userVolume},
 				},
 			},
 		},
@@ -2060,7 +2070,15 @@ func TestCopyAuthProxyFromExisting(t *testing.T) {
 	assert.Equal(t, existingContainer.Image, foundContainer.Image)
 	assert.Equal(t, existingContainer.Args, foundContainer.Args)
 
-	assert.Len(t, desiredDeployment.Spec.Template.Spec.Volumes, 2)
+	// 1 user volume + 2 auth proxy volumes (proxy-tls, test-sar-config)
+	assert.Len(t, desiredDeployment.Spec.Template.Spec.Volumes, 3)
+	volumeNames := make([]string, 0, len(desiredDeployment.Spec.Template.Spec.Volumes))
+	for _, v := range desiredDeployment.Spec.Template.Spec.Volumes {
+		volumeNames = append(volumeNames, v.Name)
+	}
+	assert.Contains(t, volumeNames, "user-data", "user volume should be preserved")
+	assert.Contains(t, volumeNames, "proxy-tls", "proxy-tls volume should be added")
+	assert.Contains(t, volumeNames, "test-sar-config", "sar-config volume should be added")
 
 	require.NotNil(t, desiredDeployment.Spec.Template.Spec.AutomountServiceAccountToken)
 	assert.True(t, *desiredDeployment.Spec.Template.Spec.AutomountServiceAccountToken)
@@ -2073,14 +2091,12 @@ func TestCopyAuthProxyFromExisting(t *testing.T) {
 		}
 	}
 	require.NotNil(t, kserveContainer)
-	hasProxyTlsMount := false
+	mountNames := make([]string, 0, len(kserveContainer.VolumeMounts))
 	for _, vm := range kserveContainer.VolumeMounts {
-		if vm.Name == "proxy-tls" {
-			hasProxyTlsMount = true
-			break
-		}
+		mountNames = append(mountNames, vm.Name)
 	}
-	assert.True(t, hasProxyTlsMount, "kserve-container should have proxy-tls mount")
+	assert.Contains(t, mountNames, "user-data", "user volume mount should be preserved")
+	assert.Contains(t, mountNames, "proxy-tls", "proxy-tls mount should be added")
 }
 
 func TestOauthProxyPreservation(t *testing.T) {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_test.go
@@ -981,7 +981,7 @@ func TestOauthProxyUpstreamTimeout(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			deployments, err := createRawDeploymentODH(
+			deployments, _, err := createRawDeploymentODH(
 				t.Context(),
 				tt.args.client,
 				tt.args.clientset,
@@ -1854,4 +1854,585 @@ func TestSetControllerReferences(t *testing.T) {
 	assert.Equal(t, owner.Name, deployment1.GetOwnerReferences()[0].Name)
 	assert.Len(t, deployment2.GetOwnerReferences(), 1)
 	assert.Equal(t, owner.Name, deployment2.GetOwnerReferences()[0].Name)
+}
+
+// mockClientForAuthProxyDetection is a mock client for testing auth proxy preservation
+type mockClientForAuthProxyDetection struct {
+	kclient.Client
+	existingDeployment *appsv1.Deployment
+	deploymentNotFound bool
+}
+
+func (m *mockClientForAuthProxyDetection) Get(ctx context.Context, key kclient.ObjectKey, obj kclient.Object, opts ...kclient.GetOption) error {
+	switch o := obj.(type) {
+	case *appsv1.Deployment:
+		if m.deploymentNotFound {
+			return errors.NewNotFound(appsv1.Resource("deployments"), key.Name)
+		}
+		if m.existingDeployment != nil {
+			*o = *m.existingDeployment.DeepCopy()
+		}
+	case *v1beta1.InferenceService:
+		o.ObjectMeta = metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+			UID:       "test-uid-12345",
+		}
+	}
+	return nil
+}
+
+func (m *mockClientForAuthProxyDetection) Update(ctx context.Context, obj kclient.Object, opts ...kclient.UpdateOption) error {
+	return nil
+}
+
+func (m *mockClientForAuthProxyDetection) Create(ctx context.Context, obj kclient.Object, opts ...kclient.CreateOption) error {
+	return nil
+}
+
+func TestGetExistingAuthProxyType(t *testing.T) {
+	tests := []struct {
+		name               string
+		existingDeployment *appsv1.Deployment
+		deploymentNotFound bool
+		expectedName       string
+		expectedImage      string
+		expectErr          bool
+	}{
+		{
+			name:               "deployment not found returns empty string",
+			deploymentNotFound: true,
+			expectedName:       "",
+			expectedImage:      "",
+		},
+		{
+			name: "deployment with oauth-proxy container",
+			existingDeployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: constants.InferenceServiceContainerName},
+								{Name: constants.OauthProxyContainerName, Image: "quay.io/oauth-proxy:v1"},
+							},
+						},
+					},
+				},
+			},
+			expectedName:  constants.OauthProxyContainerName,
+			expectedImage: "quay.io/oauth-proxy:v1",
+		},
+		{
+			name: "deployment with kube-rbac-proxy container",
+			existingDeployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: constants.InferenceServiceContainerName},
+								{Name: constants.KubeRbacContainerName, Image: "quay.io/kube-rbac-proxy:v2"},
+							},
+						},
+					},
+				},
+			},
+			expectedName:  constants.KubeRbacContainerName,
+			expectedImage: "quay.io/kube-rbac-proxy:v2",
+		},
+		{
+			name: "deployment without any auth proxy",
+			existingDeployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: constants.InferenceServiceContainerName},
+							},
+						},
+					},
+				},
+			},
+			expectedName:  "",
+			expectedImage: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockClientForAuthProxyDetection{
+				existingDeployment: tt.existingDeployment,
+				deploymentNotFound: tt.deploymentNotFound,
+			}
+
+			resultName, resultImage, _, err := getExistingAuthProxyType(t.Context(), client, "test-ns", "test-deployment")
+
+			if tt.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expectedName, resultName)
+				assert.Equal(t, tt.expectedImage, resultImage)
+			}
+		})
+	}
+}
+
+func TestCopyAuthProxyFromExisting(t *testing.T) {
+	existingContainer := corev1.Container{
+		Name:  constants.KubeRbacContainerName,
+		Image: "quay.io/opendatahub/odh-kube-auth-proxy@sha256:originalimage",
+		Args:  []string{"--arg1", "--arg2"},
+		Ports: []corev1.ContainerPort{
+			{Name: "https", ContainerPort: 8443},
+		},
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "proxy-tls", MountPath: "/etc/tls/private"},
+			{Name: "test-sar-config", MountPath: "/etc/kube-rbac-proxy", ReadOnly: true},
+		},
+	}
+
+	existingVolumes := []corev1.Volume{
+		{
+			Name: "proxy-tls",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{SecretName: "test-cert"},
+			},
+		},
+		{
+			Name: "test-sar-config",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: "test-sar-config"},
+				},
+			},
+		},
+	}
+
+	trueVal := true
+	falseVal := false
+	existingDeployment := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					AutomountServiceAccountToken: &trueVal,
+					Containers: []corev1.Container{
+						{
+							Name:  constants.InferenceServiceContainerName,
+							Image: "test-image",
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "proxy-tls", MountPath: "/etc/tls/private"},
+							},
+						},
+						existingContainer,
+					},
+					Volumes: existingVolumes,
+				},
+			},
+		},
+	}
+
+	desiredDeployment := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					AutomountServiceAccountToken: &falseVal,
+					Containers: []corev1.Container{
+						{
+							Name:  constants.InferenceServiceContainerName,
+							Image: "test-image",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	copyAuthProxyFromExisting(existingDeployment, desiredDeployment, constants.KubeRbacContainerName)
+
+	var foundContainer *corev1.Container
+	for i, c := range desiredDeployment.Spec.Template.Spec.Containers {
+		if c.Name == constants.KubeRbacContainerName {
+			foundContainer = &desiredDeployment.Spec.Template.Spec.Containers[i]
+			break
+		}
+	}
+	require.NotNil(t, foundContainer, "auth proxy container should be copied")
+	assert.Equal(t, existingContainer.Image, foundContainer.Image)
+	assert.Equal(t, existingContainer.Args, foundContainer.Args)
+
+	assert.Len(t, desiredDeployment.Spec.Template.Spec.Volumes, 2)
+
+	require.NotNil(t, desiredDeployment.Spec.Template.Spec.AutomountServiceAccountToken)
+	assert.True(t, *desiredDeployment.Spec.Template.Spec.AutomountServiceAccountToken)
+
+	var kserveContainer *corev1.Container
+	for i, c := range desiredDeployment.Spec.Template.Spec.Containers {
+		if c.Name == constants.InferenceServiceContainerName {
+			kserveContainer = &desiredDeployment.Spec.Template.Spec.Containers[i]
+			break
+		}
+	}
+	require.NotNil(t, kserveContainer)
+	hasProxyTlsMount := false
+	for _, vm := range kserveContainer.VolumeMounts {
+		if vm.Name == "proxy-tls" {
+			hasProxyTlsMount = true
+			break
+		}
+	}
+	assert.True(t, hasProxyTlsMount, "kserve-container should have proxy-tls mount")
+}
+
+func TestOauthProxyPreservation(t *testing.T) {
+	oauthProxyConfig := fmt.Sprintf(`{"image": "%s", "memoryRequest": "%s", "memoryLimit": "%s", "cpuRequest": "%s", "cpuLimit": "%s"}`,
+		constants.OauthProxyImage,
+		constants.OauthProxyResourceMemoryRequest,
+		constants.OauthProxyResourceMemoryLimit,
+		constants.OauthProxyResourceCPURequest,
+		constants.OauthProxyResourceCPULimit,
+	)
+
+	tests := []struct {
+		name                      string
+		existingDeployment        *appsv1.Deployment
+		deploymentNotFound        bool
+		annotations               map[string]string
+		expectKubeRbacProxy       bool
+		expectOauthProxyPreserved bool
+		expectedProxyImage        string
+	}{
+		{
+			name:               "new ISVC with auth enabled gets kube-rbac-proxy",
+			deploymentNotFound: true,
+			annotations: map[string]string{
+				constants.ODHKserveRawAuth: "true",
+			},
+			expectKubeRbacProxy:       true,
+			expectOauthProxyPreserved: false,
+			expectedProxyImage:        constants.OauthProxyImage,
+		},
+		{
+			name: "existing ISVC with oauth-proxy is preserved",
+			existingDeployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: constants.InferenceServiceContainerName},
+								{Name: constants.OauthProxyContainerName, Image: "quay.io/oauth-proxy:old"},
+							},
+						},
+					},
+				},
+			},
+			annotations: map[string]string{
+				constants.ODHKserveRawAuth: "true",
+			},
+			expectKubeRbacProxy:       false,
+			expectOauthProxyPreserved: true,
+		},
+		{
+			name: "existing ISVC with oauth-proxy and migration annotation gets kube-rbac-proxy",
+			existingDeployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: constants.InferenceServiceContainerName},
+								{Name: constants.OauthProxyContainerName, Image: "quay.io/oauth-proxy:old"},
+							},
+						},
+					},
+				},
+			},
+			annotations: map[string]string{
+				constants.ODHKserveRawAuth:           "true",
+				constants.ODHAuthProxyTypeAnnotation: constants.KubeRbacProxyType,
+			},
+			expectKubeRbacProxy:       true,
+			expectOauthProxyPreserved: false,
+			expectedProxyImage:        constants.OauthProxyImage,
+		},
+		{
+			name: "existing ISVC with kube-rbac-proxy matching config image regenerates normally",
+			existingDeployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: constants.InferenceServiceContainerName},
+								{Name: constants.KubeRbacContainerName, Image: constants.OauthProxyImage},
+							},
+						},
+					},
+				},
+			},
+			annotations: map[string]string{
+				constants.ODHKserveRawAuth: "true",
+			},
+			expectKubeRbacProxy:       true,
+			expectOauthProxyPreserved: false,
+			expectedProxyImage:        constants.OauthProxyImage,
+		},
+		{
+			name: "existing ISVC with kube-rbac-proxy different image is preserved",
+			existingDeployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: constants.InferenceServiceContainerName},
+								{Name: constants.KubeRbacContainerName, Image: "quay.io/different/image:v1.0.0"},
+							},
+						},
+					},
+				},
+			},
+			annotations: map[string]string{
+				constants.ODHKserveRawAuth: "true",
+			},
+			expectKubeRbacProxy:       true,
+			expectOauthProxyPreserved: false,
+			expectedProxyImage:        "quay.io/different/image:v1.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockClientForAuthProxyDetection{
+				existingDeployment: tt.existingDeployment,
+				deploymentNotFound: tt.deploymentNotFound,
+			}
+
+			clientset := fake.NewSimpleClientset(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: map[string]string{
+					oauthProxyISVCConfigKey: oauthProxyConfig,
+				},
+			})
+
+			objectMeta := metav1.ObjectMeta{
+				Name:        "test-predictor",
+				Namespace:   "test-ns",
+				Annotations: tt.annotations,
+				Labels: map[string]string{
+					constants.InferenceServicePodLabelKey: "test-isvc",
+				},
+			}
+
+			podSpec := &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  constants.InferenceServiceContainerName,
+						Image: "test-image",
+						Ports: []corev1.ContainerPort{
+							{ContainerPort: 8080},
+						},
+					},
+				},
+			}
+
+			deploymentList, _, err := createRawDeploymentODH(
+				t.Context(),
+				client,
+				clientset,
+				constants.InferenceServiceResource,
+				objectMeta,
+				metav1.ObjectMeta{},
+				&v1beta1.ComponentExtensionSpec{},
+				podSpec,
+				nil,
+				nil,
+			)
+
+			require.NoError(t, err)
+			require.Len(t, deploymentList, 1)
+
+			deployment := deploymentList[0]
+			var kubeRbacProxyContainer *corev1.Container
+			for i, container := range deployment.Spec.Template.Spec.Containers {
+				if container.Name == constants.KubeRbacContainerName {
+					kubeRbacProxyContainer = &deployment.Spec.Template.Spec.Containers[i]
+					break
+				}
+			}
+
+			hasKubeRbacProxy := kubeRbacProxyContainer != nil
+			assert.Equal(t, tt.expectKubeRbacProxy, hasKubeRbacProxy,
+				"kube-rbac-proxy presence mismatch")
+
+			if tt.expectOauthProxyPreserved {
+				assert.False(t, hasKubeRbacProxy, "oauth-proxy should be preserved, kube-rbac-proxy should not be added")
+			}
+
+			if tt.expectedProxyImage != "" && kubeRbacProxyContainer != nil {
+				assert.Equal(t, tt.expectedProxyImage, kubeRbacProxyContainer.Image,
+					"kube-rbac-proxy image mismatch")
+			}
+		})
+	}
+}
+
+func TestDeploymentReconcilerCondition(t *testing.T) {
+	oauthProxyConfig := fmt.Sprintf(`{"image": "%s", "memoryRequest": "%s", "memoryLimit": "%s", "cpuRequest": "%s", "cpuLimit": "%s"}`,
+		constants.OauthProxyImage,
+		constants.OauthProxyResourceMemoryRequest,
+		constants.OauthProxyResourceMemoryLimit,
+		constants.OauthProxyResourceCPURequest,
+		constants.OauthProxyResourceCPULimit,
+	)
+
+	tests := []struct {
+		name               string
+		existingDeployment *appsv1.Deployment
+		deploymentNotFound bool
+		annotations        map[string]string
+		expectCondition    bool
+		expectedReason     string
+	}{
+		{
+			name:               "new ISVC does not set condition",
+			deploymentNotFound: true,
+			annotations: map[string]string{
+				constants.ODHKserveRawAuth: "true",
+			},
+			expectCondition: false,
+		},
+		{
+			name: "existing ISVC with oauth-proxy sets AuthProxyPreserved condition",
+			existingDeployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: constants.InferenceServiceContainerName},
+								{Name: constants.OauthProxyContainerName},
+							},
+						},
+					},
+				},
+			},
+			annotations: map[string]string{
+				constants.ODHKserveRawAuth: "true",
+			},
+			expectCondition: true,
+			expectedReason:  "AuthProxyPreserved",
+		},
+		{
+			name: "existing ISVC with kube-rbac-proxy matching config does NOT set condition",
+			existingDeployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: constants.InferenceServiceContainerName},
+								{Name: constants.KubeRbacContainerName, Image: constants.OauthProxyImage},
+							},
+						},
+					},
+				},
+			},
+			annotations: map[string]string{
+				constants.ODHKserveRawAuth: "true",
+			},
+			expectCondition: false,
+		},
+		{
+			name: "existing ISVC with kube-rbac-proxy different image sets AuthProxyPreserved condition",
+			existingDeployment: &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: constants.InferenceServiceContainerName},
+								{Name: constants.KubeRbacContainerName, Image: "quay.io/different/image:v1.0.0"},
+							},
+						},
+					},
+				},
+			},
+			annotations: map[string]string{
+				constants.ODHKserveRawAuth: "true",
+			},
+			expectCondition: true,
+			expectedReason:  "AuthProxyPreserved",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &mockClientForAuthProxyDetection{
+				existingDeployment: tt.existingDeployment,
+				deploymentNotFound: tt.deploymentNotFound,
+			}
+
+			clientset := fake.NewSimpleClientset(&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: map[string]string{
+					oauthProxyISVCConfigKey: oauthProxyConfig,
+				},
+			})
+
+			objectMeta := metav1.ObjectMeta{
+				Name:        "test-predictor",
+				Namespace:   "test-ns",
+				Annotations: tt.annotations,
+				Labels: map[string]string{
+					constants.InferenceServicePodLabelKey: "test-isvc",
+				},
+			}
+
+			podSpec := &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  constants.InferenceServiceContainerName,
+						Image: "test-image",
+						Ports: []corev1.ContainerPort{
+							{ContainerPort: 8080},
+						},
+					},
+				},
+			}
+
+			reconciler, err := NewDeploymentReconciler(
+				t.Context(),
+				client,
+				clientset,
+				nil,
+				constants.InferenceServiceResource,
+				objectMeta,
+				metav1.ObjectMeta{},
+				&v1beta1.ComponentExtensionSpec{},
+				podSpec,
+				nil,
+				nil,
+			)
+
+			require.NoError(t, err)
+			require.NotNil(t, reconciler)
+
+			cond, condType := reconciler.GetAuthProxyCondition()
+			if tt.expectCondition {
+				require.NotNil(t, cond, "expected condition to be set")
+				assert.Equal(t, tt.expectedReason, cond.Reason)
+				assert.Equal(t, corev1.ConditionFalse, cond.Status)
+				assert.Equal(t, v1beta1.LatestDeploymentReady, condType)
+			} else {
+				assert.Nil(t, cond, "expected condition to be nil")
+			}
+		})
+	}
+}
+
+func TestGetAuthProxyConditionNoCondition(t *testing.T) {
+	reconciler := &DeploymentReconciler{}
+	cond, condType := reconciler.GetAuthProxyCondition()
+	assert.Nil(t, cond)
+	assert.Empty(t, condType)
 }

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/interfaces.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/interfaces.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"knative.dev/pkg/apis"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
@@ -36,6 +37,10 @@ type WorkloadReconciler interface {
 
 	// SetControllerReferences sets owner references on all workloads
 	SetControllerReferences(owner metav1.Object, scheme *runtime.Scheme) error
+
+	// GetAuthProxyCondition returns a condition to set on the ISVC status when an
+	// existing auth proxy container has been preserved to avoid pod restart.
+	GetAuthProxyCondition() (*apis.Condition, apis.ConditionType)
 }
 
 // ServiceReconciler reconciles service resources


### PR DESCRIPTION
Cherry-pick of https://github.com/opendatahub-io/kserve/pull/1407 to `release-v0.17`.

**What this PR does / why we need it**:

Preserve existing auth proxy containers (oauth-proxy or kube-rbac-proxy with stale images) during RHOAI version upgrades to prevent unnecessary InferenceService pod restarts.

See the original PR for full details.

**Which issue(s) this PR fixes**:
Fixes https://issues.redhat.com/browse/RHOAIENG-58248

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] `make test` passes
- [x] `make precommit` passes

```release-note
Preserve existing auth proxy containers during RHOAI version upgrades to prevent unnecessary InferenceService pod restarts.
```