### PR TITLE
chore: [RHOAIENG-59102] use Konflux :odh-stable tags in params.env

### DIFF
--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -1,8 +1,8 @@
-kserve-controller=quay.io/opendatahub/kserve-controller:latest
-llmisvc-controller=ghcr.io/opendatahub-io/kserve/odh-kserve-llmisvc-controller:release-v0.17
-kserve-agent=quay.io/opendatahub/kserve-agent:latest
-kserve-router=quay.io/opendatahub/kserve-router:latest
-kserve-storage-initializer=quay.io/opendatahub/kserve-storage-initializer:latest
+kserve-controller=quay.io/opendatahub/kserve-controller:odh-stable
+llmisvc-controller=quay.io/opendatahub/odh-kserve-llmisvc-controller:odh-stable
+kserve-agent=quay.io/opendatahub/kserve-agent:odh-stable
+kserve-router=quay.io/opendatahub/kserve-router:odh-stable
+kserve-storage-initializer=quay.io/opendatahub/kserve-storage-initializer:odh-stable
 kserve-llm-d=registry.redhat.io/rhaiis/vllm-cuda-rhel9@sha256:fc68d623d1bfc36c8cb2fe4a71f19c8578cfb420ce8ce07b20a02c1ee0be0cf3
 kserve-llm-d-inference-scheduler=quay.io/opendatahub/llm-d-inference-scheduler:odh-stable
 kserve-llm-d-routing-sidecar=quay.io/opendatahub/llm-d-routing-sidecar:odh-stable
@@ -13,5 +13,5 @@ kserve-llm-d-intel-gaudi=registry.redhat.io/rhaii-early-access/vllm-gaudi-rhel9:
 kserve-llm-d-ibm-spyre=registry.redhat.io/rhaiis/vllm-spyre-rhel9@sha256:80ae3e435a5be2c1f117f36599103ab05357917dd6e37f0df6613cb3ac2c13ea
 # TODO update when our changes are introduced in the official image
 kube-rbac-proxy=quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3
-kserve-localmodel-controller=quay.io/opendatahub/kserve-localmodel-controller:latest
-kserve-localmodelnode-agent=quay.io/opendatahub/kserve-localmodelnode-agent:latest
+kserve-localmodel-controller=quay.io/opendatahub/odh-kserve-localmodel-controller:odh-stable
+kserve-localmodelnode-agent=quay.io/opendatahub/odh-kserve-localmodelnode-agent:odh-stable


### PR DESCRIPTION
## What

Switch default image refs in `config/overlays/odh/params.env` from GHA-built `:latest` tags to Konflux-built `:odh-stable` tags.

## Why

The odh-operator pulls kserve manifests from the `release-v0.17` branch (the stable branch). The `:latest` tags in `params.env` are built by GitHub Actions from `master`, so the stable branch was pointing at images built from a different branch. Switching to `:odh-stable` aligns `params.env` with the Konflux push pipelines that build from this same `release-v0.17` branch.

## Changes

| Image | Before | After |
|---|---|---|
| kserve-controller | `quay.io/opendatahub/kserve-controller:latest` | `:odh-stable` |
| llmisvc-controller | `ghcr.io/.../odh-kserve-llmisvc-controller:release-v0.17` | `quay.io/opendatahub/odh-kserve-llmisvc-controller:odh-stable` |
| kserve-agent | `:latest` | `:odh-stable` |
| kserve-router | `:latest` | `:odh-stable` |
| kserve-storage-initializer | `:latest` | `:odh-stable` |
| kserve-localmodel-controller | `:latest` | `odh-kserve-localmodel-controller:odh-stable` |
| kserve-localmodelnode-agent | `:latest` | `odh-kserve-localmodelnode-agent:odh-stable` |

All `:odh-stable` image refs verified to exist on quay.io via `skopeo inspect`.

The `llmisvc-controller` also moves from `ghcr.io` (GHA-built, amd64-only) to `quay.io` (Konflux-built, multi-arch), and the localmodel image names are updated to match their Konflux output-image names.

Images not changed (already pinned or using non-Konflux sources):
- `kserve-llm-d*` -- `registry.redhat.io` digests or already `:odh-stable`
- `kube-rbac-proxy` -- pinned `@sha256` digest

Made with [Cursor](https://cursor.com)