### PR TITLE
fix: skip INFERENCE_SERVICE_NAME injection on pre-existing deployments to avoid pod restart on upgrade (RHOAIENG-59268)

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/component.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/component.go
@@ -23,13 +23,19 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/controller/v1alpha1/trainedmodel/sharding/memory"
 	v1beta1utils "github.com/kserve/kserve/pkg/controller/v1beta1/inferenceservice/utils"
 	"github.com/kserve/kserve/pkg/credentials"
+	"github.com/kserve/kserve/pkg/utils"
 )
 
 // Component can be reconciled to create underlying resources for an InferenceService
@@ -102,4 +108,28 @@ func addAgentAnnotations(isvc *v1beta1.InferenceService, annotations map[string]
 		return true
 	}
 	return false
+}
+
+// shouldInjectInferenceServiceName returns true when INFERENCE_SERVICE_NAME should be
+// injected into pod containers. For pre-existing deployments that do not yet carry the
+// env var it returns false, preventing rolling restarts during operator upgrades (RHOAIENG-59268).
+func shouldInjectInferenceServiceName(ctx context.Context, c client.Client, deploymentName types.NamespacedName, containerName string, log logr.Logger) (bool, error) {
+	existing := &appsv1.Deployment{}
+	err := c.Get(ctx, deploymentName, existing)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	for _, container := range existing.Spec.Template.Spec.Containers {
+		if container.Name == containerName {
+			_, exists := utils.GetEnvVarValue(container.Env, constants.InferenceServiceNameEnvVarKey)
+			if !exists {
+				log.Info("Skipping INFERENCE_SERVICE_NAME injection to avoid pod restart on upgrade", "deployment", deploymentName.String())
+			}
+			return exists, nil
+		}
+	}
+	return true, nil
 }

--- a/pkg/controller/v1beta1/inferenceservice/components/component_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/component_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2024 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package components
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+func TestShouldInjectInferenceServiceName(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+
+	log := ctrl.Log.WithName("test")
+	ns := "default"
+	isvcName := "my-isvc"
+	deploymentName := types.NamespacedName{Name: constants.PredictorServiceName(isvcName), Namespace: ns}
+	containerName := constants.InferenceServiceContainerName
+
+	makeDeployment := func(envVars ...corev1.EnvVar) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      deploymentName.Name,
+				Namespace: ns,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: containerName, Env: envVars},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name             string
+		existingDeployment *appsv1.Deployment
+		wantInject       bool
+		wantErr          bool
+	}{
+		{
+			name:             "new ISVC — no existing deployment, should inject",
+			existingDeployment: nil,
+			wantInject:       true,
+		},
+		{
+			name: "pre-upgrade deployment — env var absent, should skip to avoid restart",
+			existingDeployment: makeDeployment(),
+			wantInject:         false,
+		},
+		{
+			name: "post-upgrade deployment — env var already present, should inject (idempotent)",
+			existingDeployment: makeDeployment(corev1.EnvVar{
+				Name:  constants.InferenceServiceNameEnvVarKey,
+				Value: isvcName,
+			}),
+			wantInject: true,
+		},
+		{
+			name: "existing deployment without matching container — treat as new, should inject",
+			existingDeployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: deploymentName.Name, Namespace: ns},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "some-other-container"},
+							},
+						},
+					},
+				},
+			},
+			wantInject: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			if tt.existingDeployment != nil {
+				builder = builder.WithObjects(tt.existingDeployment)
+			}
+			c := builder.Build()
+
+			got, err := shouldInjectInferenceServiceName(context.Background(), c, deploymentName, containerName, log)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantInject, got)
+		})
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/components/component_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/component_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The KServe Authors.
+Copyright 2026 The KServe Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/v1beta1/inferenceservice/components/component_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/component_test.go
@@ -61,18 +61,18 @@ func TestShouldInjectInferenceServiceName(t *testing.T) {
 	}
 
 	tests := []struct {
-		name             string
+		name               string
 		existingDeployment *appsv1.Deployment
-		wantInject       bool
-		wantErr          bool
+		wantInject         bool
+		wantErr            bool
 	}{
 		{
-			name:             "new ISVC — no existing deployment, should inject",
+			name:               "new ISVC — no existing deployment, should inject",
 			existingDeployment: nil,
-			wantInject:       true,
+			wantInject:         true,
 		},
 		{
-			name: "pre-upgrade deployment — env var absent, should skip to avoid restart",
+			name:               "pre-upgrade deployment — env var absent, should skip to avoid restart",
 			existingDeployment: makeDeployment(),
 			wantInject:         false,
 		},

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -25,9 +25,11 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/apis"
@@ -155,10 +157,30 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 	// Add InferenceService name as environment variable to all containers
 	// In collocation mode, there may be multiple containers (predictor + transformer)
 	// https://kserve.github.io/website/docs/model-serving/predictive-inference/transformers/collocation
-	for i := range podSpec.Containers {
-		containerName := podSpec.Containers[i].Name
-		if err := isvcutils.AddEnvVarToPodSpec(&podSpec, containerName, constants.InferenceServiceNameEnvVarKey, isvc.Name); err != nil {
-			return ctrl.Result{}, errors.Wrapf(err, "failed to add INFERENCE_SERVICE_NAME environment variable to container %s", containerName)
+	// Only inject INFERENCE_SERVICE_NAME if the existing deployment already has it,
+	// or if no deployment exists yet (new ISVC). This avoids triggering a rolling restart
+	// of pre-existing deployments during operator upgrades (RHOAIENG-59268).
+	existingDeployment := &appsv1.Deployment{}
+	errGet := p.client.Get(ctx, types.NamespacedName{Name: constants.PredictorServiceName(isvc.Name), Namespace: isvc.Namespace}, existingDeployment)
+	injectEnvVar := true
+	if errGet == nil {
+		// Deployment already exists — only inject if it already has the env var
+		for _, container := range existingDeployment.Spec.Template.Spec.Containers {
+			if container.Name == constants.InferenceServiceContainerName {
+				if _, exists := utils.GetEnvVarValue(container.Env, constants.InferenceServiceNameEnvVarKey); !exists {
+					injectEnvVar = false
+					p.Log.Info("Skipping INFERENCE_SERVICE_NAME injection to avoid pod restart on upgrade", "isvc", isvc.Name)
+				}
+				break
+			}
+		}
+	}
+	if injectEnvVar {
+		for i := range podSpec.Containers {
+			containerName := podSpec.Containers[i].Name
+			if err := isvcutils.AddEnvVarToPodSpec(&podSpec, containerName, constants.InferenceServiceNameEnvVarKey, isvc.Name); err != nil {
+				return ctrl.Result{}, errors.Wrapf(err, "failed to add INFERENCE_SERVICE_NAME environment variable to container %s", containerName)
+			}
 		}
 	}
 

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -25,9 +25,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -155,31 +153,16 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 		}
 	}
 
-	// Add InferenceService name as environment variable to all containers
-	// In collocation mode, there may be multiple containers (predictor + transformer)
+	// Add InferenceService name as environment variable to all containers.
+	// In collocation mode, there may be multiple containers (predictor + transformer).
 	// https://kserve.github.io/website/docs/model-serving/predictive-inference/transformers/collocation
-	// Only inject INFERENCE_SERVICE_NAME if the existing deployment already has it,
-	// or if no deployment exists yet (new ISVC). This avoids triggering a rolling restart
-	// of pre-existing deployments during operator upgrades (RHOAIENG-59268).
-	existingDeployment := &appsv1.Deployment{}
-	errGet := p.client.Get(ctx, types.NamespacedName{Name: constants.PredictorServiceName(isvc.Name), Namespace: isvc.Namespace}, existingDeployment)
-	injectEnvVar := true
-	if errGet != nil && !apierrors.IsNotFound(errGet) {
-		return ctrl.Result{}, errors.Wrapf(errGet, "failed to get existing deployment for %s", isvc.Name)
+	inject, err := shouldInjectInferenceServiceName(ctx, p.client,
+		types.NamespacedName{Name: constants.PredictorServiceName(isvc.Name), Namespace: isvc.Namespace},
+		constants.InferenceServiceContainerName, p.Log)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to check existing predictor deployment for %s", isvc.Name)
 	}
-	if errGet == nil {
-		// Deployment already exists — only inject if it already has the env var
-		for _, container := range existingDeployment.Spec.Template.Spec.Containers {
-			if container.Name == constants.InferenceServiceContainerName {
-				if _, exists := utils.GetEnvVarValue(container.Env, constants.InferenceServiceNameEnvVarKey); !exists {
-					injectEnvVar = false
-					p.Log.Info("Skipping INFERENCE_SERVICE_NAME injection to avoid pod restart on upgrade", "isvc", isvc.Name)
-				}
-				break
-			}
-		}
-	}
-	if injectEnvVar {
+	if inject {
 		for i := range podSpec.Containers {
 			containerName := podSpec.Containers[i].Name
 			if err := isvcutils.AddEnvVarToPodSpec(&podSpec, containerName, constants.InferenceServiceNameEnvVarKey, isvc.Name); err != nil {

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -163,6 +164,9 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 	existingDeployment := &appsv1.Deployment{}
 	errGet := p.client.Get(ctx, types.NamespacedName{Name: constants.PredictorServiceName(isvc.Name), Namespace: isvc.Namespace}, existingDeployment)
 	injectEnvVar := true
+	if errGet != nil && !apierrors.IsNotFound(errGet) {
+		return ctrl.Result{}, errors.Wrapf(errGet, "failed to get existing deployment for %s", isvc.Name)
+	}
 	if errGet == nil {
 		// Deployment already exists — only inject if it already has the env var
 		for _, container := range existingDeployment.Spec.Template.Spec.Containers {

--- a/pkg/controller/v1beta1/inferenceservice/components/transformer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/transformer.go
@@ -24,9 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -161,27 +159,14 @@ func (p *Transformer) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServ
 	podSpec := corev1.PodSpec(isvc.Spec.Transformer.PodSpec)
 
 	// Add InferenceService name as environment variable to transformer container.
-	// Only inject if the existing deployment already has it, or if no deployment exists yet (new ISVC).
-	// This avoids triggering a rolling restart of pre-existing deployments during operator upgrades (RHOAIENG-59268).
 	transformerContainerName := podSpec.Containers[0].Name
-	existingTransformerDeployment := &appsv1.Deployment{}
-	errGetTransformer := p.client.Get(ctx, types.NamespacedName{Name: constants.TransformerServiceName(isvc.Name), Namespace: isvc.Namespace}, existingTransformerDeployment)
-	injectTransformerEnvVar := true
-	if errGetTransformer != nil && !apierrors.IsNotFound(errGetTransformer) {
-		return ctrl.Result{}, errors.Wrapf(errGetTransformer, "failed to get existing transformer deployment for %s", isvc.Name)
+	inject, err := shouldInjectInferenceServiceName(ctx, p.client,
+		types.NamespacedName{Name: constants.TransformerServiceName(isvc.Name), Namespace: isvc.Namespace},
+		transformerContainerName, p.Log)
+	if err != nil {
+		return ctrl.Result{}, errors.Wrapf(err, "failed to check existing transformer deployment for %s", isvc.Name)
 	}
-	if errGetTransformer == nil {
-		for _, container := range existingTransformerDeployment.Spec.Template.Spec.Containers {
-			if container.Name == transformerContainerName {
-				if _, exists := utils.GetEnvVarValue(container.Env, constants.InferenceServiceNameEnvVarKey); !exists {
-					injectTransformerEnvVar = false
-					p.Log.Info("Skipping INFERENCE_SERVICE_NAME injection to avoid pod restart on upgrade", "isvc", isvc.Name)
-				}
-				break
-			}
-		}
-	}
-	if injectTransformerEnvVar {
+	if inject {
 		if err := isvcutils.AddEnvVarToPodSpec(&podSpec, transformerContainerName, constants.InferenceServiceNameEnvVarKey, isvc.Name); err != nil {
 			return ctrl.Result{}, errors.Wrapf(err, "failed to add INFERENCE_SERVICE_NAME environment variable to container %s", transformerContainerName)
 		}

--- a/pkg/controller/v1beta1/inferenceservice/components/transformer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/transformer.go
@@ -24,9 +24,12 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/apis"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -157,11 +160,31 @@ func (p *Transformer) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServ
 
 	podSpec := corev1.PodSpec(isvc.Spec.Transformer.PodSpec)
 
-	// Add InferenceService name as environment variable to transformer container
-	// Use the actual container name from the podSpec (first container)
+	// Add InferenceService name as environment variable to transformer container.
+	// Only inject if the existing deployment already has it, or if no deployment exists yet (new ISVC).
+	// This avoids triggering a rolling restart of pre-existing deployments during operator upgrades (RHOAIENG-59268).
 	transformerContainerName := podSpec.Containers[0].Name
-	if err := isvcutils.AddEnvVarToPodSpec(&podSpec, transformerContainerName, constants.InferenceServiceNameEnvVarKey, isvc.Name); err != nil {
-		return ctrl.Result{}, errors.Wrapf(err, "failed to add INFERENCE_SERVICE_NAME environment variable to container %s", transformerContainerName)
+	existingTransformerDeployment := &appsv1.Deployment{}
+	errGetTransformer := p.client.Get(ctx, types.NamespacedName{Name: constants.TransformerServiceName(isvc.Name), Namespace: isvc.Namespace}, existingTransformerDeployment)
+	injectTransformerEnvVar := true
+	if errGetTransformer != nil && !apierrors.IsNotFound(errGetTransformer) {
+		return ctrl.Result{}, errors.Wrapf(errGetTransformer, "failed to get existing transformer deployment for %s", isvc.Name)
+	}
+	if errGetTransformer == nil {
+		for _, container := range existingTransformerDeployment.Spec.Template.Spec.Containers {
+			if container.Name == transformerContainerName {
+				if _, exists := utils.GetEnvVarValue(container.Env, constants.InferenceServiceNameEnvVarKey); !exists {
+					injectTransformerEnvVar = false
+					p.Log.Info("Skipping INFERENCE_SERVICE_NAME injection to avoid pod restart on upgrade", "isvc", isvc.Name)
+				}
+				break
+			}
+		}
+	}
+	if injectTransformerEnvVar {
+		if err := isvcutils.AddEnvVarToPodSpec(&podSpec, transformerContainerName, constants.InferenceServiceNameEnvVarKey, isvc.Name); err != nil {
+			return ctrl.Result{}, errors.Wrapf(err, "failed to add INFERENCE_SERVICE_NAME environment variable to container %s", transformerContainerName)
+		}
 	}
 
 	// Here we allow switch between knative and vanilla deployment


### PR DESCRIPTION
## Summary

- Fixes a bug where upgrading from RHOAI 3.3.2 to 3.4 caused all RawDeployment InferenceServices in the cluster to restart simultaneously
- Root cause: upstream commit `be2cb412f` (feat: new env var INFERENCE_SERVICE_NAME #5013) unconditionally injects `INFERENCE_SERVICE_NAME` into every pod template on reconcile, changing the pod template hash and triggering a rolling restart for every existing deployment
- Fix: before injecting the env var, check if the existing Deployment already has it; if not (pre-upgrade state), skip injection to preserve the pod template hash; new ISVCs always get the env var on creation

## Test plan

- [x] Reproduced the bug: swapping to the 3.4 controller against a 3.3.2 ISVC deployment created a new ReplicaSet and injected `INFERENCE_SERVICE_NAME`
- [x] Verified the fix: swapping to the fixed controller against the same pre-upgrade ISVC left the ReplicaSet unchanged and did not inject the env var
- [x] Confirmed new ISVCs still receive `INFERENCE_SERVICE_NAME` on creation

## Related

- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-59268
- Downstream PR: https://github.com/red-hat-data-services/kserve/pull/4335

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized environment-variable injection for InferenceService predictors and transformers to avoid unnecessary pod rollouts during upgrades. The controller now detects existing deployments and skips reinjecting variables when already present, reducing service disruption and outages during operator upgrades. Error handling for deployment lookups was also improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->