### PR TITLE
RHOAIENG-59339: Avoid scheduler restarts on upgrades from 3.3

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_ocp_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_ocp_test.go
@@ -1,0 +1,68 @@
+//go:build distro
+
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
+)
+
+var _ = Describe("LLMInferenceService Scheduler Config OCP", func() {
+	Context("Certificate expiration annotation", func() {
+		It("should set certificates.kserve.io/expiration-v2 annotation on scheduler pod template", func(ctx SpecContext) {
+			// given
+			svcName := "test-llm-cert-expiration-annotation"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+			)
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// then - verify the scheduler deployment pod template has the certificate expiration annotation
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, types.NamespacedName{
+					Name:      svcName + "-kserve-router-scheduler",
+					Namespace: testNs.Name,
+				}, expectedDeployment)
+			}).WithContext(ctx).Should(Succeed())
+
+			Expect(expectedDeployment.Spec.Template.Annotations).To(
+				HaveKeyWithValue("certificates.kserve.io/expiration-v2", "true"),
+			)
+		})
+	})
+})

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -362,6 +362,10 @@ func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llm
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
+					// Ensure we don't restart the scheduler.
+					Annotations: map[string]string{
+						"certificates.kserve.io/expiration-v2": "true",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
ReplicaSet diff:
```
  -  "certificates.kserve.io/expiration-v2": "true"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation tests to verify LLMInferenceService scheduler configuration behavior, including managed route and gateway setup with scheduler enablement.

* **Bug Fixes**
  * Improved scheduler pod stability by preventing unnecessary restarts related to certificate operations and expiration events, ensuring more reliable and consistent service operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->