### PR TITLE
ci: add workflow to auto-assign reviewers on new PRs

### DIFF
--- a/.github/workflows/auto-assign-reviewers.yml
+++ b/.github/workflows/auto-assign-reviewers.yml
@@ -1,0 +1,50 @@
+name: Auto-assign PR Reviewers
+
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-reviewers:
+    name: Assign Reviewers
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Pick random reviewers and request review
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          # Parse the reviewers list from the OWNERS file
+          REVIEWERS=$(yq e '.reviewers[]' OWNERS)
+
+          # Remove the PR author from the candidate list
+          CANDIDATES=$(echo "$REVIEWERS" | grep -v "^${PR_AUTHOR}$" || true)
+
+          if [ -z "$CANDIDATES" ]; then
+            echo "No eligible reviewers found after excluding the PR author."
+            exit 0
+          fi
+
+          COUNT=$(echo "$CANDIDATES" | wc -l | tr -d ' ')
+          NUM_TO_PICK=2
+          if [ "$COUNT" -lt "$NUM_TO_PICK" ]; then
+            NUM_TO_PICK=$COUNT
+          fi
+
+          SELECTED=$(echo "$CANDIDATES" | shuf -n "$NUM_TO_PICK")
+
+          echo "Selected reviewers:"
+          echo "$SELECTED"
+
+          for REVIEWER in $SELECTED; do
+            gh pr edit "$PR_NUMBER" --add-reviewer "$REVIEWER"
+          done


### PR DESCRIPTION
Adds a GitHub Actions workflow that triggers when a PR is opened, picks two random reviewers from the OWNERS file's reviewers section (excluding the PR author), and requests their review.


**What this PR does / why we need it**:
Helps to get reviewers assigned to the PR.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:


- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:


**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated pull request reviewer assignment now randomly selects and assigns reviewers based on project ownership information when new PRs are opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->