### PR TITLE
feat(kserve-module): add SSA deploy/GC/Rollback feature.

### DIFF
--- a/kserve-module-controller.Dockerfile
+++ b/kserve-module-controller.Dockerfile
@@ -2,6 +2,7 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
 ENV PATH="$PATH:/opt/app-root/src/go/bin"
 
+USER root
 WORKDIR /go/src/github.com/opendatahub-io/kserve-module
 COPY kserve-module/go.mod  go.mod
 COPY kserve-module/go.sum  go.sum

--- a/kserve-module/cmd/kserve-module/main.go
+++ b/kserve-module/cmd/kserve-module/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/opendatahub-io/kserve-module/pkg/kservemodule"
 )
 
-const manifestsPath = "/opt/manifests-template"
+const manifestsTemplatePath = "/opt/manifests-template"
 
 var (
 	scheme   = runtime.NewScheme()
@@ -43,11 +43,11 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zapOpts)))
 
-	if fi, err := os.Stat(manifestsPath); err != nil {
-		setupLog.Error(err, "manifests path is not accessible", "path", manifestsPath)
+	if fi, err := os.Stat(manifestsTemplatePath); err != nil {
+		setupLog.Error(err, "manifests template path is not accessible", "path", manifestsTemplatePath)
 		os.Exit(1)
 	} else if !fi.IsDir() {
-		setupLog.Error(errors.New("not a directory"), "manifests path is not a directory", "path", manifestsPath)
+		setupLog.Error(errors.New("not a directory"), "manifests template path is not a directory", "path", manifestsTemplatePath)
 		os.Exit(1)
 	}
 
@@ -65,7 +65,9 @@ func main() {
 		LeaderElectionNamespace: leaderNS,
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOpts)
+	restCfg := ctrl.GetConfigOrDie()
+
+	mgr, err := ctrl.NewManager(restCfg, mgrOpts)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)
@@ -73,9 +75,10 @@ func main() {
 
 	setupLog.Info("setting up kserve-module controller")
 	if err = (&kservemodule.KserveModuleReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		ManifestsPath: manifestsPath,
+		Client:                mgr.GetClient(),
+		Scheme:                mgr.GetScheme(),
+		ManifestsTemplatePath: manifestsTemplatePath,
+		Deployer:              kservemodule.NewDeployer(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "kserve-module")
 		os.Exit(1)

--- a/kserve-module/config/kustomization.yaml
+++ b/kserve-module/config/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: kserve
+namespace: opendatahub
 
 resources:
 - crd/components.platform.opendatahub.io_kserves.yaml

--- a/kserve-module/config/manager.yaml
+++ b/kserve-module/config/manager.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kserve-module-controller-manager
-  namespace: kserve
   labels:
     app.kubernetes.io/name: kserve-module-controller-manager
     app.kubernetes.io/component: controller

--- a/kserve-module/config/rbac/clusterrolebinding.yaml
+++ b/kserve-module/config/rbac/clusterrolebinding.yaml
@@ -9,4 +9,3 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kserve-module-controller-manager
-    namespace: kserve

--- a/kserve-module/config/rbac/leader_election_role.yaml
+++ b/kserve-module/config/rbac/leader_election_role.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: kserve-module-leader-election-role
-  namespace: kserve
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]

--- a/kserve-module/config/rbac/leader_election_role_binding.yaml
+++ b/kserve-module/config/rbac/leader_election_role_binding.yaml
@@ -2,7 +2,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: kserve-module-leader-election-rolebinding
-  namespace: kserve
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -10,4 +9,3 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: kserve-module-controller-manager
-    namespace: kserve

--- a/kserve-module/config/rbac/role.yaml
+++ b/kserve-module/config/rbac/role.yaml
@@ -5,6 +5,78 @@ metadata:
   name: kserve-module-manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - components.platform.opendatahub.io
   resources:
   - kserves
@@ -23,8 +95,113 @@ rules:
   - patch
   - update
 - apiGroups:
+  - components.platform.opendatahub.io
+  resourceNames:
+  - default-kserve
+  resources:
+  - kserves/finalizers
+  verbs:
+  - update
+- apiGroups:
   - config.openshift.io
   resources:
   - clusterversions
   verbs:
   - get
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
+  verbs:
+  - bind
+  - create
+  - delete
+  - escalate
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings/finalizers
+  - clusterroles/finalizers
+  - rolebindings/finalizers
+  - roles/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - clusterstoragecontainers
+  - llminferenceserviceconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - template.openshift.io
+  resources:
+  - templates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/kserve-module/config/rbac/role.yaml
+++ b/kserve-module/config/rbac/role.yaml
@@ -8,7 +8,6 @@ rules:
   - ""
   resources:
   - configmaps
-  - secrets
   - serviceaccounts
   - services
   verbs:
@@ -34,6 +33,25 @@ rules:
   verbs:
   - create
   - patch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resourceNames:
+  - kserve-webhook-server-secret
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:
@@ -142,6 +160,7 @@ rules:
   - get
   - list
   - patch
+  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -150,10 +169,8 @@ rules:
   - rolebindings
   - roles
   verbs:
-  - bind
   - create
   - delete
-  - escalate
   - get
   - list
   - patch
@@ -168,6 +185,39 @@ rules:
   - roles/finalizers
   verbs:
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - kserve-admin
+  - kserve-edit
+  - kserve-llmisvc-distro-role
+  - kserve-llmisvc-manager-role
+  - kserve-manager-role
+  - kserve-metrics-reader-cluster-role
+  - kserve-prometheus-k8s
+  - kserve-proxy-role
+  - kserve-view
+  - metrics-reader
+  - model-serving-api
+  - odh-model-controller-role
+  - openshift-ai-llminferenceservice-scc
+  - proxy-role
+  resources:
+  - clusterroles
+  verbs:
+  - bind
+  - escalate
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - kserve-leader-election-role
+  - leader-election-role
+  - llmisvc-leader-election-role
+  resources:
+  - roles
+  verbs:
+  - bind
+  - escalate
 - apiGroups:
   - security.openshift.io
   resources:

--- a/kserve-module/config/rbac/service_account.yaml
+++ b/kserve-module/config/rbac/service_account.yaml
@@ -2,4 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kserve-module-controller-manager
-  namespace: kserve

--- a/kserve-module/go.mod
+++ b/kserve-module/go.mod
@@ -102,8 +102,8 @@ require (
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
 	oras.land/oras-go/v2 v2.6.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/kustomize/api v0.20.1 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.21.0 // indirect
+	sigs.k8s.io/kustomize/api v0.21.1 // indirect
+	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect

--- a/kserve-module/go.sum
+++ b/kserve-module/go.sum
@@ -263,10 +263,10 @@ sigs.k8s.io/controller-runtime v0.23.3 h1:VjB/vhoPoA9l1kEKZHBMnQF33tdCLQKJtydy4i
 sigs.k8s.io/controller-runtime v0.23.3/go.mod h1:B6COOxKptp+YaUT5q4l6LqUJTRpizbgf9KSRNdQGns0=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
-sigs.k8s.io/kustomize/api v0.20.1 h1:iWP1Ydh3/lmldBnH/S5RXgT98vWYMaTUL1ADcr+Sv7I=
-sigs.k8s.io/kustomize/api v0.20.1/go.mod h1:t6hUFxO+Ph0VxIk1sKp1WS0dOjbPCtLJ4p8aADLwqjM=
-sigs.k8s.io/kustomize/kyaml v0.21.0 h1:7mQAf3dUwf0wBerWJd8rXhVcnkk5Tvn/q91cGkaP6HQ=
-sigs.k8s.io/kustomize/kyaml v0.21.0/go.mod h1:hmxADesM3yUN2vbA5z1/YTBnzLJ1dajdqpQonwBL1FQ=
+sigs.k8s.io/kustomize/api v0.21.1 h1:lzqbzvz2CSvsjIUZUBNFKtIMsEw7hVLJp0JeSIVmuJs=
+sigs.k8s.io/kustomize/api v0.21.1/go.mod h1:f3wkKByTrgpgltLgySCntrYoq5d3q7aaxveSagwTlwI=
+sigs.k8s.io/kustomize/kyaml v0.21.1 h1:IVlbmhC076nf6foyL6Taw4BkrLuEsXUXNpsE+ScX7fI=
+sigs.k8s.io/kustomize/kyaml v0.21.1/go.mod h1:hmxADesM3yUN2vbA5z1/YTBnzLJ1dajdqpQonwBL1FQ=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=
 sigs.k8s.io/randfill v1.0.0/go.mod h1:XeLlZ/jmk4i1HRopwe7/aU3H5n1zNUcX6TM94b3QxOY=
 sigs.k8s.io/structured-merge-diff/v6 v6.4.0 h1:qmp2e3ZfFi1/jJbDGpD4mt3wyp6PE1NfKHCYLqgNQJo=

--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -13,34 +13,28 @@ import (
 	platformv1alpha1 "github.com/opendatahub-io/kserve-module/pkg/apis/v1alpha1"
 )
 
-const (
-	kserveComponentName          = "kserve"
-	modelControllerComponentName = "modelcontroller"
-
-	kserveManifestSourcePath    = "overlays/odh"
-	kserveManifestSourcePathXKS = "overlays/odh-xks"
-	modelControllerSourcePath   = "base"
-)
 
 type componentConfig struct {
-	name        string
-	sourcePath  string
-	imageMap    map[string]string
-	extraParams func(kserve *platformv1alpha1.Kserve) map[string]string
-	postRender  func(ctx context.Context, r *KserveModuleReconciler,
+	name          string
+	sourcePath    string
+	sourcePathXKS string
+	imageMap      map[string]string
+	extraParams   func(kserve *platformv1alpha1.Kserve) map[string]string
+	postRender    func(ctx context.Context, r *KserveModuleReconciler,
 		kserve *platformv1alpha1.Kserve,
 		resources []unstructured.Unstructured) ([]unstructured.Unstructured, error)
 }
 
 var components = []componentConfig{
 	{
-		name:       kserveComponentName,
-		sourcePath: kserveManifestSourcePath,
-		imageMap:   kserveImageParamMap,
-		postRender: kservePostRender,
+		name:          kserveComponentName,
+		sourcePath:    kserveManifestSourcePath,
+		sourcePathXKS: kserveManifestSourcePathXKS,
+		imageMap:      kserveImageParamMap,
+		postRender:    kservePostRender,
 	},
 	{
-		name:        modelControllerComponentName,
+		name:        odhModelControllerComponentName,
 		sourcePath:  modelControllerSourcePath,
 		imageMap:    modelControllerImageParamMap,
 		extraParams: modelControllerExtraParams,

--- a/kserve-module/pkg/kservemodule/configmap.go
+++ b/kserve-module/pkg/kservemodule/configmap.go
@@ -1,6 +1,3 @@
-// [TEMPORARY] ConfigMap customization adapted from opendatahub-operator
-// (internal/controller/components/kserve/kserve_support.go).
-// Remove this comment once the code diverges from the original.
 package kservemodule
 
 import (
@@ -17,13 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-const (
-	ingressConfigKeyName     = "ingress"
-	serviceConfigKeyName     = "service"
-	kserveConfigMapName      = "inferenceservice-config"
-	isvcControllerDeployment = "kserve-controller-manager"
-	configHashAnnotationKey  = "kserve-module/config-hash"
-)
 
 var (
 	errResourceNotFound = errors.New("resource not found")
@@ -49,7 +39,7 @@ func customizeKserveConfigMap(resources []unstructured.Unstructured, headless bo
 		return nil, err
 	}
 
-	deployIdx, deploy, err := getIndexedResource[appsv1.Deployment](resources, deploymentGVK, isvcControllerDeployment)
+	deployIdx, deploy, err := getIndexedResource[appsv1.Deployment](resources, deploymentGVK, kserveControllerDeployment)
 	if err != nil {
 		if errors.Is(err, errResourceNotFound) {
 			return resources, nil

--- a/kserve-module/pkg/kservemodule/configmap_test.go
+++ b/kserve-module/pkg/kservemodule/configmap_test.go
@@ -47,7 +47,7 @@ func TestCustomizeKserveConfigMap_AddsHashToDeployment(t *testing.T) {
 	result, err := customizeKserveConfigMap(resources, true)
 	g.Expect(err).ShouldNot(HaveOccurred())
 
-	_, deploy, err := getIndexedResource[appsv1.Deployment](result, deploymentGVK, isvcControllerDeployment)
+	_, deploy, err := getIndexedResource[appsv1.Deployment](result, deploymentGVK, kserveControllerDeployment)
 	g.Expect(err).ShouldNot(HaveOccurred())
 	g.Expect(deploy.Spec.Template.Annotations).Should(HaveKey(configHashAnnotationKey))
 	g.Expect(deploy.Spec.Template.Annotations[configHashAnnotationKey]).ShouldNot(BeEmpty())
@@ -79,7 +79,7 @@ func buildTestResources(t *testing.T) []unstructured.Unstructured {
 
 	deploy := &appsv1.Deployment{
 		TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
-		ObjectMeta: metav1.ObjectMeta{Name: isvcControllerDeployment, Namespace: "opendatahub"},
+		ObjectMeta: metav1.ObjectMeta{Name: kserveControllerDeployment, Namespace: "opendatahub"},
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/kserve-module/pkg/kservemodule/constants.go
+++ b/kserve-module/pkg/kservemodule/constants.go
@@ -1,0 +1,42 @@
+package kservemodule
+
+const (
+	// Component names
+	kserveComponentName             = "kserve"
+	odhModelControllerComponentName = "odh-model-controller"
+
+	// Manifest source paths
+	kserveManifestSourcePath    = "overlays/odh"
+	kserveManifestSourcePathXKS = "overlays/odh-xks"
+	modelControllerSourcePath   = "base"
+
+	// Deployment names
+	kserveControllerDeployment  = "kserve-controller-manager"
+	llmISVCControllerDeployment = "llmisvc-controller-manager"
+	//TO-DO
+	// localmodelControllerDeployment = "kserve-localmodel-controller-manager"
+	odhModelControllerDeployment = "odh-model-controller"
+
+	// SSA field manager
+	fieldOwner = "kserve-module-controller"
+
+	// ConfigMap keys
+	kserveConfigMapName     = "inferenceservice-config"
+	ingressConfigKeyName    = "ingress"
+	serviceConfigKeyName    = "service"
+	configHashAnnotationKey = "kserve-module/config-hash"
+
+	// LLMInferenceServiceConfig versioning
+	wellKnownAnnotationKey   = "serving.kserve.io/well-known-config"
+	wellKnownAnnotationValue = "true"
+	llmISVCConfigPrefix      = "LLM_INFERENCE_SERVICE_CONFIG_PREFIX"
+	llmISVCConfigGroup       = "serving.kserve.io"
+	llmISVCConfigKind        = "LLMInferenceServiceConfig"
+
+	// cert-manager defaults
+	defaultCAIssuerName    = "opendatahub-ca-issuer"
+	defaultIssuerRefKind   = "ClusterIssuer"
+	defaultCertName        = "opendatahub-ca"
+	defaultCertManagerNS   = "cert-manager"
+	defaultIstioCACertPath = "/var/run/secrets/opendatahub/ca.crt"
+)

--- a/kserve-module/pkg/kservemodule/images.go
+++ b/kserve-module/pkg/kservemodule/images.go
@@ -1,7 +1,3 @@
-// [TEMPORARY] Image param maps derived from opendatahub-operator and rhods-operator
-// (internal/controller/components/kserve/kserve_support.go,
-//  internal/controller/components/modelcontroller/modelcontroller_support.go).
-// Remove this comment once the code diverges from the original.
 package kservemodule
 
 import "os"
@@ -29,18 +25,7 @@ var modelControllerImageParamMap = map[string]string{
 	"odh-model-controller": "RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE",
 }
 
-const (
-	defaultCAIssuerName    = "opendatahub-ca-issuer"
-	defaultIssuerRefKind   = "ClusterIssuer"
-	defaultCertName        = "opendatahub-ca"
-	defaultCertManagerNS   = "cert-manager"
-	defaultIstioCACertPath = "/var/run/secrets/opendatahub/ca.crt"
-)
 
-// [TEMPORARY] Adapted from rhods-operator (pkg/controller/actions/dependency/certmanager).
-// TODO: replace with certmanager.DefaultBootstrapConfig() from odh-platform-utilities
-// once it is migrated to the shared library. RHOAI uses RHAI_* env var overrides via that package.
-// Remove this comment once migrated.
 func buildCertManagerParams(namespace string) map[string]string {
 	return map[string]string{
 		"NAMESPACE":                 namespace,

--- a/kserve-module/pkg/kservemodule/params.go
+++ b/kserve-module/pkg/kservemodule/params.go
@@ -1,6 +1,3 @@
-// [TEMPORARY] Adapted from opendatahub-operator (pkg/deploy/envParams.go).
-// TODO: migrate to odh-platform-utilities once ApplyParams is moved to the shared library.
-// Remove this comment once migrated.
 package kservemodule
 
 import (

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -27,15 +27,19 @@ import (
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=kserves/status,resourceNames=default-kserve,verbs=get;update;patch
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=kserves/finalizers,resourceNames=default-kserve,verbs=update
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get
-// +kubebuilder:rbac:groups="",resources=configmaps;secrets;services;serviceaccounts,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups="",resources=configmaps;services;serviceaccounts,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=create;delete;patch;update,resourceNames=kserve-webhook-server-secret
 // +kubebuilder:rbac:groups="",resources=configmaps/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=serviceaccounts/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=create;delete;get;list;patch;update;watch
-// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;get;list;patch
-// escalation requires operator to hold all verbs it grants
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=bind;create;delete;escalate;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;get;list;patch;watch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=create;delete;get;list;patch;update;watch
+// escalate/bind scoped to the exact roles and clusterroles deployed by this controller
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=bind;escalate,resourceNames=kserve-admin;kserve-edit;kserve-view;kserve-manager-role;kserve-proxy-role;kserve-llmisvc-manager-role;kserve-llmisvc-distro-role;kserve-metrics-reader-cluster-role;openshift-ai-llminferenceservice-scc;odh-model-controller-role;proxy-role;model-serving-api;metrics-reader;kserve-prometheus-k8s
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=bind;escalate,resourceNames=kserve-leader-election-role;llmisvc-leader-election-role;leader-election-role
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles/finalizers;rolebindings/finalizers;clusterroles/finalizers;clusterrolebindings/finalizers,verbs=update
 // no delete — CRDs survive CR deletion
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=create;get;list;patch;update;watch

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -6,14 +6,17 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
+	"time"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/opendatahub-io/odh-platform-utilities/api/common"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/deploy"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/render/kustomize"
 
 	platformv1alpha1 "github.com/opendatahub-io/kserve-module/pkg/apis/v1alpha1"
@@ -22,13 +25,31 @@ import (
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=kserves,verbs=list;watch
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=kserves,resourceNames=default-kserve,verbs=get;update;patch
 // +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=kserves/status,resourceNames=default-kserve,verbs=get;update;patch
-//
+// +kubebuilder:rbac:groups=components.platform.opendatahub.io,resources=kserves/finalizers,resourceNames=default-kserve,verbs=update
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get
+// +kubebuilder:rbac:groups="",resources=configmaps;secrets;services;serviceaccounts,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups="",resources=configmaps/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=serviceaccounts/finalizers,verbs=update
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;get;list;patch
+// escalation requires operator to hold all verbs it grants
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=bind;create;delete;escalate;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles/finalizers;rolebindings/finalizers;clusterroles/finalizers;clusterrolebindings/finalizers,verbs=update
+// no delete — CRDs survive CR deletion
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=create;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=llminferenceserviceconfigs;clusterstoragecontainers,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=create;delete;get;list;patch;update;watch
 
 type KserveModuleReconciler struct {
 	client.Client
 	Scheme        *runtime.Scheme
-	ManifestsPath string
+	ManifestsTemplatePath string
+	Deployer      *deploy.Deployer
 
 	workDir               string
 	initDone              bool
@@ -44,30 +65,36 @@ func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	mgmtState := platformv1alpha1.GetManagementState(kserve)
-	log.Info("reconciling Kserve CR", "name", kserve.Name, "managementState", mgmtState)
-
-	if mgmtState == common.Removed {
-		// TODO(RHOAIENG-61119): run garbage collection to remove deployed resources,
-		// then update status. Currently no-op because deploy is not yet implemented.
-		log.Info("Kserve is Removed, skipping reconciliation")
-		return ctrl.Result{}, nil
-	}
+	log.Info("reconciling Kserve CR", "name", kserve.Name)
 
 	componentErrors := r.reconcile(ctx, kserve)
 	if len(componentErrors) > 0 {
+		names := make([]string, 0, len(componentErrors))
+		for name := range componentErrors {
+			names = append(names, name)
+		}
+		slices.Sort(names)
+
 		var msgs []string
-		for name, err := range componentErrors {
-			log.Error(err, "component reconciliation failed", "component", name)
-			msgs = append(msgs, name+": "+err.Error())
+		for _, name := range names {
+			log.Error(componentErrors[name], "component reconciliation failed", "component", name)
+			msgs = append(msgs, name+": "+componentErrors[name].Error())
 		}
 		return ctrl.Result{}, fmt.Errorf("reconciliation failed: %s", strings.Join(msgs, "; "))
+	}
+
+	ns := r.getApplicationsNamespace()
+	if err := checkDeploymentReadiness(ctx, r.Client, ns, r.isKubernetes(ctx)); err != nil {
+		log.Info("deployment not ready, requeueing", "reason", err.Error())
+		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
 	}
 
 	return ctrl.Result{}, nil
 }
 
 func (r *KserveModuleReconciler) reconcile(ctx context.Context, kserve *platformv1alpha1.Kserve) map[string]error {
+	log := ctrl.LoggerFrom(ctx)
+
 	manifestDir, err := r.ensureWorkDir()
 	if err != nil {
 		errs := make(map[string]error, len(components))
@@ -77,40 +104,63 @@ func (r *KserveModuleReconciler) reconcile(ctx context.Context, kserve *platform
 		return errs
 	}
 
+	var allResources []unstructured.Unstructured
 	componentErrors := make(map[string]error, len(components))
+
 	for _, comp := range components {
-		if err := r.reconcileComponent(ctx, kserve, manifestDir, comp); err != nil {
+		resources, err := r.reconcileComponent(ctx, kserve, manifestDir, comp)
+		if err != nil {
 			componentErrors[comp.name] = err
+			continue
 		}
+		allResources = append(allResources, resources...)
 	}
 
-	return componentErrors
+	if len(componentErrors) > 0 {
+		return componentErrors
+	}
+
+	if err := r.Deployer.Deploy(ctx, deploy.DeployInput{
+		Client:    r.Client,
+		Owner:     kserve,
+		Resources: allResources,
+	}); err != nil {
+		return map[string]error{"deploy": fmt.Errorf("SSA apply: %w", err)}
+	}
+
+	log.Info("deployed all resources", "count", len(allResources))
+
+	return nil
 }
 
 func (r *KserveModuleReconciler) reconcileComponent(ctx context.Context,
-	kserve *platformv1alpha1.Kserve, manifestDir string, comp componentConfig) error {
+	kserve *platformv1alpha1.Kserve, manifestDir string, comp componentConfig) ([]unstructured.Unstructured, error) {
 
 	log := ctrl.LoggerFrom(ctx)
 
 	sourcePath := comp.sourcePath
-	if comp.name == kserveComponentName && r.isKubernetes(ctx) {
-		sourcePath = kserveManifestSourcePathXKS
+	if r.isKubernetes(ctx) {
+		if comp.sourcePathXKS == "" {
+			log.Info("no XKS overlay, skipping component", "component", comp.name)
+			return nil, nil
+		}
+		sourcePath = comp.sourcePathXKS
 	}
 
 	if err := applyParams(
 		filepath.Join(manifestDir, comp.name, sourcePath),
 		comp.imageMap,
 	); err != nil {
-		return fmt.Errorf("applying %s image params: %w", comp.name, err)
+		return nil, fmt.Errorf("applying %s image params: %w", comp.name, err)
 	}
 
-	if comp.name == kserveComponentName && r.isKubernetes(ctx) {
+	if r.isKubernetes(ctx) {
 		ns := r.getApplicationsNamespace()
 		if err := applyParams(
-			filepath.Join(manifestDir, comp.name, kserveManifestSourcePathXKS),
+			filepath.Join(manifestDir, comp.name, comp.sourcePathXKS),
 			nil, buildCertManagerParams(ns),
 		); err != nil {
-			return fmt.Errorf("applying cert-manager params: %w", err)
+			return nil, fmt.Errorf("applying cert-manager params: %w", err)
 		}
 	}
 
@@ -120,28 +170,28 @@ func (r *KserveModuleReconciler) reconcileComponent(ctx context.Context,
 			filepath.Join(manifestDir, comp.name, sourcePath),
 			nil, extra,
 		); err != nil {
-			return fmt.Errorf("applying %s extra params: %w", comp.name, err)
+			return nil, fmt.Errorf("applying %s extra params: %w", comp.name, err)
 		}
 	}
 
 	renderPath := filepath.Join(manifestDir, comp.name, sourcePath)
 	resources, err := kustomize.Render(renderPath, nil)
 	if err != nil {
-		return fmt.Errorf("rendering %s kustomize: %w", comp.name, err)
+		return nil, fmt.Errorf("rendering %s kustomize: %w", comp.name, err)
 	}
 	log.Info("rendered kustomize manifests", "component", comp.name, "resourceCount", len(resources))
 
 	if comp.postRender != nil {
 		resources, err = comp.postRender(ctx, r, kserve, resources)
 		if err != nil {
-			return fmt.Errorf("%s post-render: %w", comp.name, err)
+			return nil, fmt.Errorf("%s post-render: %w", comp.name, err)
 		}
 	}
 
-	commonPostRender(resources, comp.name)
+	commonPostRender(resources, kserveComponentName)
 
-	log.Info("component reconciliation complete", "component", comp.name, "resources", len(resources))
-	return nil
+	log.Info("component rendering complete", "component", comp.name, "resources", len(resources))
+	return resources, nil
 }
 
 func (r *KserveModuleReconciler) isKubernetes(ctx context.Context) bool {
@@ -172,24 +222,15 @@ func (r *KserveModuleReconciler) getApplicationsNamespace() string {
 	return "opendatahub"
 }
 
-// getVersionPrefix returns a dash-separated version string (e.g. "v3-4-0")
-// used to prefix LLMInferenceServiceConfig names so multiple versions can
-// coexist during upgrades without name collisions.
-//
-// Resolution order:
-// 1. platform.opendatahub.io/version annotation on Kserve CR (set by orchestrator)
-// 2. PlatformContext.Release.Version projected into Kserve CR spec (future, when common.Release is in shared lib)
-// 3. RELEASE_VERSION env var (injected by build pipeline)
-// 4. Fallback "v0-0-0" for local development
+// TODO: clarify with platform team how the release version is delivered to module operators.
+// odh-operator uses cluster.GetRelease().Version (from CSV), but module operators don't have
+// direct CSV access. Current implementation reads annotation; need to confirm this is the
+// agreed contract or if a different mechanism (e.g. ConfigMap, CR spec field) will be used.
 func (r *KserveModuleReconciler) getVersionPrefix(kserve *platformv1alpha1.Kserve) string {
-	// implementated based on current KSERVE CR
 	if ann := kserve.GetAnnotations(); ann != nil {
 		if v := ann["platform.opendatahub.io/version"]; v != "" {
 			return "v" + strings.ReplaceAll(v, ".", "-")
 		}
-	}
-	if v := os.Getenv("RELEASE_VERSION"); v != "" {
-		return "v" + strings.ReplaceAll(v, ".", "-")
 	}
 	return "v0-0-0"
 }
@@ -200,7 +241,7 @@ func (r *KserveModuleReconciler) ensureWorkDir() (string, error) {
 	}
 
 	workDir := "/opt/manifests"
-	srcDir := r.ManifestsPath
+	srcDir := r.ManifestsTemplatePath
 	err := filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -227,3 +268,4 @@ func (r *KserveModuleReconciler) ensureWorkDir() (string, error) {
 	r.initDone = true
 	return workDir, nil
 }
+

--- a/kserve-module/pkg/kservemodule/resource_manager.go
+++ b/kserve-module/pkg/kservemodule/resource_manager.go
@@ -1,0 +1,59 @@
+package kservemodule
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/deploy"
+)
+
+var (
+	kserveDeploymentsOCP = []string{
+		kserveControllerDeployment,
+		llmISVCControllerDeployment,
+		odhModelControllerDeployment,
+		// TODO: add localmodelControllerDeployment once localmodel manifests are included in OCP overlay
+	}
+	kserveDeploymentsXKS = []string{
+		llmISVCControllerDeployment,
+	}
+)
+
+func NewDeployer() *deploy.Deployer {
+	return deploy.NewDeployer(
+		deploy.WithFieldOwner(fieldOwner),
+		deploy.WithApplyOrder(),
+		deploy.WithCache(),
+	)
+}
+
+func checkDeploymentReadiness(ctx context.Context, cli client.Client, namespace string, isXKS bool) error {
+	var deployments []string
+	if isXKS {
+		deployments = append(deployments, kserveDeploymentsXKS...)
+	} else {
+		deployments = append(deployments, kserveDeploymentsOCP...)
+	}
+
+	var notReady []string
+	for _, name := range deployments {
+		dep := &appsv1.Deployment{}
+		key := client.ObjectKey{Namespace: namespace, Name: name}
+		if err := cli.Get(ctx, key, dep); err != nil {
+			notReady = append(notReady, fmt.Sprintf("%s (get: %v)", name, err))
+			continue
+		}
+		if dep.Status.AvailableReplicas < 1 {
+			notReady = append(notReady, fmt.Sprintf("%s (availableReplicas=%d)", name, dep.Status.AvailableReplicas))
+		}
+	}
+
+	if len(notReady) > 0 {
+		return fmt.Errorf("deployments not ready: %s", strings.Join(notReady, ", "))
+	}
+	return nil
+}

--- a/kserve-module/pkg/kservemodule/resource_manager_test.go
+++ b/kserve-module/pkg/kservemodule/resource_manager_test.go
@@ -1,0 +1,109 @@
+package kservemodule
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCheckDeploymentReadiness_OCP_AllReady(t *testing.T) {
+	g := NewWithT(t)
+
+	var deps []appsv1.Deployment
+	for _, name := range kserveDeploymentsOCP {
+		deps = append(deps, buildDeployment(name, 1))
+	}
+
+	objs := make([]client.Object, len(deps))
+	for i := range deps {
+		objs[i] = &deps[i]
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(objs...).
+		WithStatusSubresource(objs...).
+		Build()
+
+	err := checkDeploymentReadiness(context.Background(), cli, "opendatahub", false)
+	g.Expect(err).ShouldNot(HaveOccurred())
+}
+
+func TestCheckDeploymentReadiness_OCP_NotReady(t *testing.T) {
+	g := NewWithT(t)
+
+	deps := []appsv1.Deployment{
+		buildDeployment(kserveControllerDeployment, 1),
+		buildDeployment(llmISVCControllerDeployment, 0),
+		buildDeployment(odhModelControllerDeployment, 1),
+	}
+
+	objs := make([]client.Object, len(deps))
+	for i := range deps {
+		objs[i] = &deps[i]
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(objs...).
+		WithStatusSubresource(objs...).
+		Build()
+
+	err := checkDeploymentReadiness(context.Background(), cli, "opendatahub", false)
+	g.Expect(err).Should(HaveOccurred())
+	g.Expect(err.Error()).Should(ContainSubstring("llmisvc-controller-manager"))
+}
+
+func TestCheckDeploymentReadiness_XKS_AllReady(t *testing.T) {
+	g := NewWithT(t)
+
+	var deps []appsv1.Deployment
+	for _, name := range kserveDeploymentsXKS {
+		deps = append(deps, buildDeployment(name, 1))
+	}
+
+	objs := make([]client.Object, len(deps))
+	for i := range deps {
+		objs[i] = &deps[i]
+	}
+
+	cli := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(objs...).
+		WithStatusSubresource(objs...).
+		Build()
+
+	err := checkDeploymentReadiness(context.Background(), cli, "opendatahub", true)
+	g.Expect(err).ShouldNot(HaveOccurred())
+}
+
+func TestCheckDeploymentReadiness_Missing(t *testing.T) {
+	g := NewWithT(t)
+
+	cli := fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		Build()
+
+	err := checkDeploymentReadiness(context.Background(), cli, "opendatahub", false)
+	g.Expect(err).Should(HaveOccurred())
+}
+
+func buildDeployment(name string, available int32) appsv1.Deployment {
+	return appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "opendatahub"},
+		Status:     appsv1.DeploymentStatus{AvailableReplicas: available},
+	}
+}
+
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = appsv1.AddToScheme(s)
+	return s
+}
+

--- a/kserve-module/pkg/kservemodule/setup.go
+++ b/kserve-module/pkg/kservemodule/setup.go
@@ -1,14 +1,35 @@
 package kservemodule
 
 import (
+	"fmt"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	platformv1alpha1 "github.com/opendatahub-io/kserve-module/pkg/apis/v1alpha1"
 )
 
 func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if r.Deployer == nil {
+		return fmt.Errorf("deployer must not be nil")
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&platformv1alpha1.Kserve{}).
+		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.Secret{}).
+		Owns(&corev1.Service{}).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&rbacv1.Role{}).
+		Owns(&rbacv1.RoleBinding{}).
+		Owns(&rbacv1.ClusterRole{}).
+		Owns(&rbacv1.ClusterRoleBinding{}).
+		Owns(&admissionregistrationv1.MutatingWebhookConfiguration{}).
+		Owns(&admissionregistrationv1.ValidatingWebhookConfiguration{}).
 		Named("kserve-module").
 		Complete(r)
 }

--- a/kserve-module/pkg/kservemodule/setup.go
+++ b/kserve-module/pkg/kservemodule/setup.go
@@ -6,6 +6,7 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -24,6 +25,7 @@ func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ServiceAccount{}).
 		Owns(&appsv1.Deployment{}).
+		Owns(&networkingv1.NetworkPolicy{}).
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).
 		Owns(&rbacv1.ClusterRole{}).

--- a/kserve-module/pkg/kservemodule/versioning.go
+++ b/kserve-module/pkg/kservemodule/versioning.go
@@ -1,8 +1,3 @@
-// [TEMPORARY] LLMInferenceServiceConfig versioning logic adapted from rhods-operator
-// (internal/controller/components/kserve/kserve_controller_actions.go).
-// Prefixes well-known config names with release version to allow multiple
-// versions to coexist during rolling upgrades.
-// Remove this comment once the code diverges from the original.
 package kservemodule
 
 import (
@@ -14,14 +9,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-const (
-	wellKnownAnnotationKey   = "serving.kserve.io/well-known-config"
-	wellKnownAnnotationValue = "true"
-	llmISVCConfigPrefix      = "LLM_INFERENCE_SERVICE_CONFIG_PREFIX"
-	llmISVCControllerName    = "llmisvc-controller-manager"
-	llmISVCConfigGroup       = "serving.kserve.io"
-	llmISVCConfigKind        = "LLMInferenceServiceConfig"
-)
 
 func versionedWellKnownLLMInferenceServiceConfigs(resources []unstructured.Unstructured, versionPrefix string) ([]unstructured.Unstructured, error) {
 	if versionPrefix == "" {
@@ -40,7 +27,7 @@ func versionedWellKnownLLMInferenceServiceConfigs(resources []unstructured.Unstr
 			}
 		}
 
-		if gvk == deploymentGVK && resources[i].GetName() == llmISVCControllerName {
+		if gvk == deploymentGVK && resources[i].GetName() == llmISVCControllerDeployment {
 			deploy := &appsv1.Deployment{}
 			if err := runtime.DefaultUnstructuredConverter.FromUnstructured(resources[i].Object, deploy); err != nil {
 				return nil, err

--- a/kserve-module/pkg/kservemodule/versioning_test.go
+++ b/kserve-module/pkg/kservemodule/versioning_test.go
@@ -18,7 +18,7 @@ func buildLLMISVCDeployment(t *testing.T) []unstructured.Unstructured {
 
 	deploy := &appsv1.Deployment{
 		TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
-		ObjectMeta: metav1.ObjectMeta{Name: llmISVCControllerName, Namespace: "opendatahub"},
+		ObjectMeta: metav1.ObjectMeta{Name: llmISVCControllerDeployment, Namespace: "opendatahub"},
 		Spec: appsv1.DeploymentSpec{
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
@@ -83,7 +83,7 @@ func TestVersionLLMInferenceServiceConfigs_SetsEnvOnLLMISVCController(t *testing
 	g.Expect(err).ShouldNot(HaveOccurred())
 
 	for _, r := range result {
-		if r.GetKind() == "Deployment" && r.GetName() == llmISVCControllerName {
+		if r.GetKind() == "Deployment" && r.GetName() == llmISVCControllerDeployment {
 			containers, _, _ := unstructured.NestedSlice(r.Object, "spec", "template", "spec", "containers")
 			g.Expect(containers).ShouldNot(BeEmpty())
 			c := containers[0].(map[string]any)


### PR DESCRIPTION
**What this PR does / why we need it**:

- SSA with ForceOwnership and dedicated field manager (kserve-module-controller)
- ownerReference with blockOwnerDeletion on operand resources
- Owns() watches on all operand types for drift detection
- escalate/bind verbs for aggregationRule ClusterRoles
- CRDs excluded from ownerReference (survive CR deletion)
- Clean up dead constants, [TEMPORARY] comments, RBAC marker headers

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [RHOAIENG-61119](https://redhat.atlassian.net/browse/RHOAIENG-61119)


**Feature/Issue validation/testing**:

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:

```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure Changes**
  * Moved resources to deploy under opendatahub context by removing explicit kserve namespace entries; adjusted container user behavior for build/runtime.

* **New Features**
  * Added a deployer and automated deployment readiness checks that gate reconciliation completion.

* **Improvements**
  * Reconciliation now renders components collectively and deploys them together with clearer error/requeue behavior.

* **Tests**
  * Added unit tests for deployment readiness and updated existing tests to reflect naming/constants changes.

* **Chores**
  * Bumped module deps and removed temporary comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->