### PR TITLE
localmodel: fix PVC binding and add local-storage StorageClass for odh-modelcache

### DIFF
--- a/config/overlays/odh-modelcache/kustomization.yaml
+++ b/config/overlays/odh-modelcache/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 - localmodel-scc.yaml
 - localmodel-permissions-scc.yaml
 - localmodel-permfix-sa.yaml
+- localmodelnode-storageclass.yaml
 - rbac/
 # This will be created by the operator
 # - localmodelnode-pv-pvc.yaml

--- a/config/overlays/odh-modelcache/localmodelnode-pv-pvc.yaml
+++ b/config/overlays/odh-modelcache/localmodelnode-pv-pvc.yaml
@@ -34,3 +34,4 @@ spec:
     requests:
       storage: 100Gi
   storageClassName: local-storage
+  volumeName: kserve-localmodelnode-pv

--- a/config/overlays/odh-modelcache/localmodelnode-storageclass.yaml
+++ b/config/overlays/odh-modelcache/localmodelnode-storageclass.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-storage
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: Immediate
+reclaimPolicy: Retain


### PR DESCRIPTION
**What this PR does / why we need it**:

During end-to-end testing of the `LocalModelCache` feature on OpenShift
(RHOAI 3.5), two manifest issues in the `odh-modelcache` overlay prevent
the model-cache agent and download Jobs from running. This PR fixes both.

---

### Issue 1 — Missing `local-storage` StorageClass

Both the kserve `localmodel` controller and the RHOAI operator hard-code
`storageClassName: local-storage` in every PV and PVC they create, but no
`StorageClass` with that name is ever deployed by the `odh-modelcache`
overlay.

**Observed failure chain:**
1. `kserve-localmodelnode-pvc` stays `Pending` (no `local-storage` SC).
2. The `fix-permissions-<node>` Job cannot mount its volume → pod stuck in
   `ContainerCreating` / `FailedMount`.
3. The kserve `LocalModelNode` agent never creates the model download Job
   because `ensureModelRootFolderExistsAndIsWritable` never completes.
4. `LocalModelCache` stays in `NodeDownloadPending` forever.

**Fix:** Add `config/overlays/odh-modelcache/localmodelnode-storageclass.yaml`
with `provisioner: kubernetes.io/no-provisioner` and
`volumeBindingMode: Immediate`, and include it in the kustomization.

`volumeBindingMode` **must** be `Immediate` (not `WaitForFirstConsumer`)
because the `fix-permissions` and model download Jobs explicitly set
`spec.nodeName` on their pod templates, bypassing the Kubernetes scheduler.
`WaitForFirstConsumer` waits for the scheduler to place the pod before
binding; when the scheduler is bypassed the PVC never leaves `Pending`.

---

### Issue 2 — Non-deterministic PVC binding (missing `volumeName`)

`kserve-localmodelnode-pvc` did not specify `spec.volumeName`, so the
Kubernetes PV binder could bind it to **any** PV that satisfies the
access-mode and storage-class constraints. On clusters with more than one
`local-storage` PV this is non-deterministic and can bind the PVC to the
wrong volume.

**Fix:** Add `volumeName: kserve-localmodelnode-pv` to the PVC manifest so
the binder always selects the intended PV.

---

**Which issue(s) this PR fixes**:
Fixes https://issues.redhat.com/browse/RHOAIENG-33258

**Feature/Issue validation/testing**:

Validated on an OpenShift 4.17 cluster (us-west-1) with RHOAI 3.5-ea.1:

- [ ] `kserve-localmodelnode-pvc` transitions to `Bound` immediately after
      the overlay is applied (previously stuck in `Pending` indefinitely).
- [ ] `fix-permissions-<node>` Job pod reaches `Completed` (previously
      stuck in `ContainerCreating`).
- [ ] `LocalModelCache` reaches `NodeDownloaded` status within the timeout
      after the download Job completes.
- [ ] MNIST ONNX inference via the cached PVC path returns HTTP 200.

**Special notes for your reviewer**:

The `localmodelnode-pv-pvc.yaml` static manifest is intentionally kept
commented-out in `kustomization.yaml` (the PV/PVC are operator-managed);
this PR only adds the `StorageClass` to the deployed overlay and fixes the
`volumeName` in the reference manifest for correctness.

**Checklist**:

- [x] Manifest changes validated on a live OpenShift cluster
- [ ] Unit/e2e tests — the existing `opendatahub-tests` smoke suite
      (`tests/model_serving/model_server/kserve/model_cache/`) covers the
      end-to-end path; these manifests are a prerequisite for those tests.
- [x] No code logic changes — manifests only

**Release note**:
```release-note
Fix model-cache overlay: add missing `local-storage` StorageClass
(volumeBindingMode: Immediate) required for PVC binding, and pin
kserve-localmodelnode-pvc to its intended PV via spec.volumeName.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced storage management for the model cache overlay with explicit storage binding and new storage class configuration, improving storage resource allocation reliability.

* **Chores**
  * Updated storage configuration manifests to enable more deterministic PersistentVolume selection and added new StorageClass resource to the deployment overlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->