### PR TITLE
[RHOAIENG-63040] Fix merge step git config

### DIFF
--- a/.github/workflows/e2e-test-odh-xks-kind.yml
+++ b/.github/workflows/e2e-test-odh-xks-kind.yml
@@ -33,9 +33,12 @@ jobs:
           fetch-depth: 0
 
       - name: Merge target branch
+        if: github.event_name == 'pull_request'
         run: |
-          git fetch origin ${{ github.base_ref }}
-          git merge origin/${{ github.base_ref }} --no-edit
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Free-up disk space
         uses: ./.github/actions/free-up-disk-space

--- a/.github/workflows/e2e-test-odh-xks-kind.yml
+++ b/.github/workflows/e2e-test-odh-xks-kind.yml
@@ -34,11 +34,17 @@ jobs:
 
       - name: Merge target branch
         if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          git fetch origin ${{ github.event.pull_request.base.ref }}
+          if [[ ! "$BASE_REF" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+            echo "::error::Invalid base ref: $BASE_REF"
+            exit 1
+          fi
+          git fetch origin -- "$BASE_REF"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
+          git merge --no-edit "origin/$BASE_REF"
 
       - name: Free-up disk space
         uses: ./.github/actions/free-up-disk-space


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the "Merge target branch" step in `e2e-test-odh-xks-kind.yml` which fails with `fatal: empty ident name` when a non-fast-forward merge is needed. The step was missing `git config user.name` and `user.email` before `git merge`.

Also aligns the step with the canonical pattern used by all other workflows:
- Adds `if: github.event_name == 'pull_request'` guard (workflow also triggers on `workflow_dispatch` where `base_ref` is undefined)
- Uses `github.event.pull_request.base.ref` instead of `github.base_ref` for consistency

**Which issue(s) this PR fixes**:
[RHOAIENG-63040](https://redhat.atlassian.net/browse/RHOAIENG-63040)

**Feature/Issue validation/testing**:

- [x] The fix matches the canonical merge step pattern proven across 22+ other workflow files
- [x] CI-only change — no application code affected
- [x] The `e2e-test-odh-xks-kind` workflow will self-test on this PR (the workflow file is in its own path filter)

**Checklist**:

- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to improve test execution and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->