### PR TITLE
 feat(kserve-module): add status reporting with conditions and release info

### DIFF
--- a/kserve-module/go.mod
+++ b/kserve-module/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/opendatahub-io/odh-platform-utilities v0.0.0-20260506180717-e15e712db78d
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.2
@@ -94,7 +95,6 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	helm.sh/helm/v4 v4.1.1 // indirect
 	k8s.io/apiextensions-apiserver v0.35.2 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect

--- a/kserve-module/pkg/kservemodule/constants.go
+++ b/kserve-module/pkg/kservemodule/constants.go
@@ -29,7 +29,7 @@ const (
 	// LLMInferenceServiceConfig versioning
 	wellKnownAnnotationKey   = "serving.kserve.io/well-known-config"
 	wellKnownAnnotationValue = "true"
-	llmISVCConfigPrefix      = "LLM_INFERENCE_SERVICE_CONFIG_PREFIX"
+	llmISVCConfigPrefixEnv   = "LLM_INFERENCE_SERVICE_CONFIG_PREFIX"
 	llmISVCConfigGroup       = "serving.kserve.io"
 	llmISVCConfigKind        = "LLMInferenceServiceConfig"
 

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -129,7 +129,7 @@ func (r *KserveModuleReconciler) reconcile(ctx context.Context, kserve *platform
 		Owner:     kserve,
 		Resources: allResources,
 	}); err != nil {
-		return map[string]error{"deploy": fmt.Errorf("SSA apply: %w", err)}
+		return map[string]error{"deploy": fmt.Errorf("applying resources: %w", err)}
 	}
 
 	log.Info("deployed all resources", "count", len(allResources))

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -71,7 +71,11 @@ func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	log.Info("reconciling Kserve CR", "name", kserve.Name)
 
+	condMgr := newConditionManager(kserve)
+	defer r.updateStatus(ctx, kserve, condMgr)
+
 	componentErrors := r.reconcile(ctx, kserve)
+	applyProvisioningCondition(condMgr, componentErrors)
 	if len(componentErrors) > 0 {
 		names := make([]string, 0, len(componentErrors))
 		for name := range componentErrors {
@@ -87,9 +91,10 @@ func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, fmt.Errorf("reconciliation failed: %s", strings.Join(msgs, "; "))
 	}
 
-	ns := r.getApplicationsNamespace()
-	if err := checkDeploymentReadiness(ctx, r.Client, ns, r.isKubernetes(ctx)); err != nil {
-		log.Info("deployment not ready, requeueing", "reason", err.Error())
+	r.updateComponentReadiness(ctx, condMgr)
+
+	if !condMgr.IsHappy() {
+		log.Info("not all components ready, requeueing")
 		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
 	}
 

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -61,7 +61,7 @@ type KserveModuleReconciler struct {
 	clusterType           *cluster.ClusterType
 }
 
-func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
 	log := ctrl.LoggerFrom(ctx)
 
 	kserve := &platformv1alpha1.Kserve{}
@@ -72,7 +72,11 @@ func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	log.Info("reconciling Kserve CR", "name", kserve.Name)
 
 	condMgr := newConditionManager(kserve)
-	defer r.updateStatus(ctx, kserve, condMgr)
+	defer func() {
+		if err := r.updateStatus(ctx, kserve, condMgr); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
 
 	componentErrors := r.reconcile(ctx, kserve)
 	applyProvisioningCondition(condMgr, componentErrors)

--- a/kserve-module/pkg/kservemodule/releases.go
+++ b/kserve-module/pkg/kservemodule/releases.go
@@ -1,0 +1,55 @@
+package kservemodule
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/opendatahub-io/odh-platform-utilities/api/common"
+)
+
+type componentMetadata struct {
+	Releases []common.ComponentRelease `yaml:"releases"`
+}
+
+var fallbackReleases = []common.ComponentRelease{
+	{Name: "KServe", Version: "unknown", RepoURL: "https://github.com/kserve/kserve/"},
+}
+
+func loadComponentReleases(manifestsPath string, componentDirs []string) ([]common.ComponentRelease, error) {
+	seen := make(map[string]bool)
+	var all []common.ComponentRelease
+
+	for _, dir := range componentDirs {
+		path := filepath.Join(manifestsPath, dir, "component_metadata.yaml")
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, fmt.Errorf("reading %s: %w", path, err)
+		}
+
+		var meta componentMetadata
+		if err := yaml.Unmarshal(data, &meta); err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", path, err)
+		}
+
+		for _, r := range meta.Releases {
+			if seen[r.Name] {
+				continue
+			}
+			seen[r.Name] = true
+			all = append(all, r)
+		}
+	}
+
+	if len(all) == 0 {
+		return fallbackReleases, nil
+	}
+
+	return all, nil
+}

--- a/kserve-module/pkg/kservemodule/releases_test.go
+++ b/kserve-module/pkg/kservemodule/releases_test.go
@@ -1,0 +1,78 @@
+package kservemodule
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestLoadComponentReleases_ParsesBothFiles(t *testing.T) {
+	g := NewWithT(t)
+
+	dir := t.TempDir()
+	writeMetadata(t, dir, "kserve", `releases:
+  - name: ComponentA
+    version: v0.0.1
+    repoUrl: https://example.com/a
+  - name: ComponentB
+    version: v0.0.2
+    repoUrl: https://example.com/b
+`)
+	writeMetadata(t, dir, "odh-model-controller", `releases:
+  - name: ComponentA
+    version: v0.0.3
+    repoUrl: https://example.com/a
+  - name: ComponentC
+    version: v0.0.4
+    repoUrl: https://example.com/c
+`)
+
+	releases, err := loadComponentReleases(dir, []string{"kserve", "odh-model-controller"})
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(releases).Should(HaveLen(3))
+	g.Expect(releases[0].Name).Should(Equal("ComponentA"))
+	g.Expect(releases[0].Version).Should(Equal("v0.0.1"))
+	g.Expect(releases[1].Name).Should(Equal("ComponentB"))
+	g.Expect(releases[2].Name).Should(Equal("ComponentC"))
+}
+
+func TestLoadComponentReleases_MissingFile(t *testing.T) {
+	g := NewWithT(t)
+
+	dir := t.TempDir()
+	writeMetadata(t, dir, "kserve", `releases:
+  - name: ComponentA
+    version: v0.0.1
+    repoUrl: https://example.com/a
+`)
+
+	releases, err := loadComponentReleases(dir, []string{"kserve", "nonexistent"})
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(releases).Should(HaveLen(1))
+}
+
+func TestLoadComponentReleases_Fallback(t *testing.T) {
+	g := NewWithT(t)
+
+	dir := t.TempDir()
+
+	releases, err := loadComponentReleases(dir, []string{"kserve", "odh-model-controller"})
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(releases).Should(HaveLen(1))
+	g.Expect(releases[0].Name).Should(Equal("KServe"))
+	g.Expect(releases[0].Version).Should(Equal("unknown"))
+	g.Expect(releases[0].RepoURL).Should(Equal("https://github.com/kserve/kserve/"))
+}
+
+func writeMetadata(t *testing.T, base, component, content string) {
+	t.Helper()
+	dir := filepath.Join(base, component)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "component_metadata.yaml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/kserve-module/pkg/kservemodule/resource_manager.go
+++ b/kserve-module/pkg/kservemodule/resource_manager.go
@@ -15,11 +15,13 @@ var (
 	kserveDeploymentsOCP = []string{
 		kserveControllerDeployment,
 		llmISVCControllerDeployment,
-		odhModelControllerDeployment,
 		// TODO: add localmodelControllerDeployment once localmodel manifests are included in OCP overlay
 	}
 	kserveDeploymentsXKS = []string{
 		llmISVCControllerDeployment,
+	}
+	modelControllerDeploymentsOCP = []string{
+		odhModelControllerDeployment,
 	}
 )
 
@@ -31,14 +33,21 @@ func NewDeployer() *deploy.Deployer {
 	)
 }
 
-func checkDeploymentReadiness(ctx context.Context, cli client.Client, namespace string, isXKS bool) error {
-	var deployments []string
+func checkKServeReadiness(ctx context.Context, cli client.Client, namespace string, isXKS bool) error {
 	if isXKS {
-		deployments = append(deployments, kserveDeploymentsXKS...)
-	} else {
-		deployments = append(deployments, kserveDeploymentsOCP...)
+		return checkDeploymentsReady(ctx, cli, namespace, kserveDeploymentsXKS)
 	}
+	return checkDeploymentsReady(ctx, cli, namespace, kserveDeploymentsOCP)
+}
 
+func checkModelControllerReadiness(ctx context.Context, cli client.Client, namespace string, isXKS bool) error {
+	if isXKS {
+		return nil
+	}
+	return checkDeploymentsReady(ctx, cli, namespace, modelControllerDeploymentsOCP)
+}
+
+func checkDeploymentsReady(ctx context.Context, cli client.Client, namespace string, deployments []string) error {
 	var notReady []string
 	for _, name := range deployments {
 		dep := &appsv1.Deployment{}

--- a/kserve-module/pkg/kservemodule/resource_manager_test.go
+++ b/kserve-module/pkg/kservemodule/resource_manager_test.go
@@ -12,85 +12,76 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestCheckDeploymentReadiness_OCP_AllReady(t *testing.T) {
+func TestCheckKServeReadiness_OCP_AllReady(t *testing.T) {
 	g := NewWithT(t)
 
-	var deps []appsv1.Deployment
-	for _, name := range kserveDeploymentsOCP {
-		deps = append(deps, buildDeployment(name, 1))
+	deps := []appsv1.Deployment{
+		buildDeployment(kserveControllerDeployment, 1),
+		buildDeployment(llmISVCControllerDeployment, 1),
 	}
 
-	objs := make([]client.Object, len(deps))
-	for i := range deps {
-		objs[i] = &deps[i]
-	}
+	cli := buildFakeClient(deps...)
 
-	cli := fake.NewClientBuilder().
-		WithScheme(testScheme()).
-		WithObjects(objs...).
-		WithStatusSubresource(objs...).
-		Build()
-
-	err := checkDeploymentReadiness(context.Background(), cli, "opendatahub", false)
+	err := checkKServeReadiness(context.Background(), cli, "opendatahub", false)
 	g.Expect(err).ShouldNot(HaveOccurred())
 }
 
-func TestCheckDeploymentReadiness_OCP_NotReady(t *testing.T) {
+func TestCheckKServeReadiness_OCP_NotReady(t *testing.T) {
 	g := NewWithT(t)
 
 	deps := []appsv1.Deployment{
 		buildDeployment(kserveControllerDeployment, 1),
 		buildDeployment(llmISVCControllerDeployment, 0),
-		buildDeployment(odhModelControllerDeployment, 1),
 	}
 
-	objs := make([]client.Object, len(deps))
-	for i := range deps {
-		objs[i] = &deps[i]
-	}
+	cli := buildFakeClient(deps...)
 
-	cli := fake.NewClientBuilder().
-		WithScheme(testScheme()).
-		WithObjects(objs...).
-		WithStatusSubresource(objs...).
-		Build()
-
-	err := checkDeploymentReadiness(context.Background(), cli, "opendatahub", false)
+	err := checkKServeReadiness(context.Background(), cli, "opendatahub", false)
 	g.Expect(err).Should(HaveOccurred())
 	g.Expect(err.Error()).Should(ContainSubstring("llmisvc-controller-manager"))
 }
 
-func TestCheckDeploymentReadiness_XKS_AllReady(t *testing.T) {
+func TestCheckModelControllerReadiness_OCP_Ready(t *testing.T) {
 	g := NewWithT(t)
 
-	var deps []appsv1.Deployment
-	for _, name := range kserveDeploymentsXKS {
-		deps = append(deps, buildDeployment(name, 1))
+	deps := []appsv1.Deployment{
+		buildDeployment(odhModelControllerDeployment, 1),
 	}
 
-	objs := make([]client.Object, len(deps))
-	for i := range deps {
-		objs[i] = &deps[i]
-	}
+	cli := buildFakeClient(deps...)
 
-	cli := fake.NewClientBuilder().
-		WithScheme(testScheme()).
-		WithObjects(objs...).
-		WithStatusSubresource(objs...).
-		Build()
-
-	err := checkDeploymentReadiness(context.Background(), cli, "opendatahub", true)
+	err := checkModelControllerReadiness(context.Background(), cli, "opendatahub", false)
 	g.Expect(err).ShouldNot(HaveOccurred())
 }
 
-func TestCheckDeploymentReadiness_Missing(t *testing.T) {
+func TestCheckModelControllerReadiness_XKS_Skipped(t *testing.T) {
 	g := NewWithT(t)
 
-	cli := fake.NewClientBuilder().
-		WithScheme(testScheme()).
-		Build()
+	cli := fake.NewClientBuilder().WithScheme(testScheme()).Build()
 
-	err := checkDeploymentReadiness(context.Background(), cli, "opendatahub", false)
+	err := checkModelControllerReadiness(context.Background(), cli, "opendatahub", true)
+	g.Expect(err).ShouldNot(HaveOccurred())
+}
+
+func TestCheckKServeReadiness_XKS_AllReady(t *testing.T) {
+	g := NewWithT(t)
+
+	deps := []appsv1.Deployment{
+		buildDeployment(llmISVCControllerDeployment, 1),
+	}
+
+	cli := buildFakeClient(deps...)
+
+	err := checkKServeReadiness(context.Background(), cli, "opendatahub", true)
+	g.Expect(err).ShouldNot(HaveOccurred())
+}
+
+func TestCheckKServeReadiness_Missing(t *testing.T) {
+	g := NewWithT(t)
+
+	cli := fake.NewClientBuilder().WithScheme(testScheme()).Build()
+
+	err := checkKServeReadiness(context.Background(), cli, "opendatahub", false)
 	g.Expect(err).Should(HaveOccurred())
 }
 
@@ -101,9 +92,20 @@ func buildDeployment(name string, available int32) appsv1.Deployment {
 	}
 }
 
+func buildFakeClient(deps ...appsv1.Deployment) client.Client {
+	objs := make([]client.Object, len(deps))
+	for i := range deps {
+		objs[i] = &deps[i]
+	}
+	return fake.NewClientBuilder().
+		WithScheme(testScheme()).
+		WithObjects(objs...).
+		WithStatusSubresource(objs...).
+		Build()
+}
+
 func testScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
 	_ = appsv1.AddToScheme(s)
 	return s
 }
-

--- a/kserve-module/pkg/kservemodule/status.go
+++ b/kserve-module/pkg/kservemodule/status.go
@@ -1,0 +1,100 @@
+package kservemodule
+
+import (
+	"context"
+	"strings"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/opendatahub-io/odh-platform-utilities/api/common"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/controller/conditions"
+
+	platformv1alpha1 "github.com/opendatahub-io/kserve-module/pkg/apis/v1alpha1"
+)
+
+const (
+	conditionKServeReady            = "KServeReady"
+	conditionModelControllerReady   = "ModelControllerReady"
+)
+
+func newConditionManager(kserve *platformv1alpha1.Kserve) *conditions.Manager {
+	return conditions.NewManager(kserve,
+		string(common.ConditionTypeReady),
+		string(common.ConditionTypeProvisioningSucceeded),
+		conditionKServeReady,
+		conditionModelControllerReady,
+	)
+}
+
+func applyProvisioningCondition(condMgr *conditions.Manager, componentErrors map[string]error) {
+	if len(componentErrors) == 0 {
+		condMgr.MarkTrue(string(common.ConditionTypeProvisioningSucceeded),
+			conditions.WithReason("AllResourcesApplied"))
+		return
+	}
+
+	var msgs []string
+	for name, err := range componentErrors {
+		msgs = append(msgs, name+": "+err.Error())
+	}
+	condMgr.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
+		conditions.WithReason("DeployFailed"),
+		conditions.WithMessage("%s", strings.Join(msgs, "; ")))
+}
+
+func (r *KserveModuleReconciler) updateComponentReadiness(ctx context.Context, condMgr *conditions.Manager) {
+	ns := r.getApplicationsNamespace()
+	isXKS := r.isKubernetes(ctx)
+
+	if err := checkKServeReadiness(ctx, r.Client, ns, isXKS); err != nil {
+		condMgr.MarkFalse(conditionKServeReady,
+			conditions.WithReason("DeploymentNotReady"),
+			conditions.WithMessage("%s", err.Error()))
+	} else {
+		condMgr.MarkTrue(conditionKServeReady,
+			conditions.WithReason("AllDeploymentsAvailable"))
+	}
+
+	if err := checkModelControllerReadiness(ctx, r.Client, ns, isXKS); err != nil {
+		condMgr.MarkFalse(conditionModelControllerReady,
+			conditions.WithReason("DeploymentNotReady"),
+			conditions.WithMessage("%s", err.Error()))
+	} else {
+		condMgr.MarkTrue(conditionModelControllerReady,
+			conditions.WithReason("AllDeploymentsAvailable"))
+	}
+}
+
+func (r *KserveModuleReconciler) updateStatus(ctx context.Context, kserve *platformv1alpha1.Kserve, condMgr *conditions.Manager) {
+	log := ctrl.LoggerFrom(ctx)
+
+	r.setReleaseStatus(kserve)
+
+	condMgr.Sort()
+	kserve.Status.ObservedGeneration = kserve.Generation
+
+	if condMgr.IsHappy() {
+		kserve.Status.Phase = common.PhaseReady
+	} else {
+		kserve.Status.Phase = common.PhaseNotReady
+	}
+
+	if err := r.Status().Update(ctx, kserve); err != nil {
+		log.Error(err, "failed to update status")
+	}
+}
+
+func (r *KserveModuleReconciler) setReleaseStatus(kserve *platformv1alpha1.Kserve) {
+	if len(kserve.Status.Releases) > 0 {
+		return
+	}
+
+	releases, err := loadComponentReleases(r.ManifestsTemplatePath,
+		[]string{kserveComponentName, odhModelControllerComponentName})
+	if err != nil {
+		ctrl.Log.Error(err, "failed to load component releases")
+		return
+	}
+
+	kserve.SetReleaseStatus(common.ComponentReleaseStatus{Releases: releases})
+}

--- a/kserve-module/pkg/kservemodule/status.go
+++ b/kserve-module/pkg/kservemodule/status.go
@@ -2,6 +2,7 @@ package kservemodule
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -33,9 +34,15 @@ func applyProvisioningCondition(condMgr *conditions.Manager, componentErrors map
 		return
 	}
 
-	var msgs []string
-	for name, err := range componentErrors {
-		msgs = append(msgs, name+": "+err.Error())
+	names := make([]string, 0, len(componentErrors))
+	for name := range componentErrors {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	msgs := make([]string, 0, len(names))
+	for _, name := range names {
+		msgs = append(msgs, name+": "+componentErrors[name].Error())
 	}
 	condMgr.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),
 		conditions.WithReason("DeployFailed"),
@@ -65,7 +72,7 @@ func (r *KserveModuleReconciler) updateComponentReadiness(ctx context.Context, c
 	}
 }
 
-func (r *KserveModuleReconciler) updateStatus(ctx context.Context, kserve *platformv1alpha1.Kserve, condMgr *conditions.Manager) {
+func (r *KserveModuleReconciler) updateStatus(ctx context.Context, kserve *platformv1alpha1.Kserve, condMgr *conditions.Manager) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	r.setReleaseStatus(kserve)
@@ -81,7 +88,9 @@ func (r *KserveModuleReconciler) updateStatus(ctx context.Context, kserve *platf
 
 	if err := r.Status().Update(ctx, kserve); err != nil {
 		log.Error(err, "failed to update status")
+		return err
 	}
+	return nil
 }
 
 func (r *KserveModuleReconciler) setReleaseStatus(kserve *platformv1alpha1.Kserve) {

--- a/kserve-module/pkg/kservemodule/status_test.go
+++ b/kserve-module/pkg/kservemodule/status_test.go
@@ -1,0 +1,90 @@
+package kservemodule
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/opendatahub-io/odh-platform-utilities/api/common"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/controller/conditions"
+
+	platformv1alpha1 "github.com/opendatahub-io/kserve-module/pkg/apis/v1alpha1"
+)
+
+func TestNewConditionManager_InitializesConditions(t *testing.T) {
+	g := NewWithT(t)
+
+	kserve := &platformv1alpha1.Kserve{}
+	condMgr := newConditionManager(kserve)
+
+	g.Expect(condMgr.GetCondition(string(common.ConditionTypeReady))).ShouldNot(BeNil())
+	g.Expect(condMgr.GetCondition(string(common.ConditionTypeProvisioningSucceeded))).ShouldNot(BeNil())
+	g.Expect(condMgr.GetCondition(conditionKServeReady)).ShouldNot(BeNil())
+	g.Expect(condMgr.GetCondition(conditionModelControllerReady)).ShouldNot(BeNil())
+}
+
+func TestApplyProvisioningCondition_Success(t *testing.T) {
+	g := NewWithT(t)
+
+	kserve := &platformv1alpha1.Kserve{}
+	condMgr := newConditionManager(kserve)
+
+	applyProvisioningCondition(condMgr, nil)
+
+	cond := condMgr.GetCondition(string(common.ConditionTypeProvisioningSucceeded))
+	g.Expect(cond).ShouldNot(BeNil())
+	g.Expect(cond.Status).Should(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Reason).Should(Equal("AllResourcesApplied"))
+}
+
+func TestApplyProvisioningCondition_Failure(t *testing.T) {
+	g := NewWithT(t)
+
+	kserve := &platformv1alpha1.Kserve{}
+	condMgr := newConditionManager(kserve)
+
+	errs := map[string]error{
+		"kserve": fmt.Errorf("render failed"),
+	}
+	applyProvisioningCondition(condMgr, errs)
+
+	cond := condMgr.GetCondition(string(common.ConditionTypeProvisioningSucceeded))
+	g.Expect(cond).ShouldNot(BeNil())
+	g.Expect(cond.Status).Should(Equal(metav1.ConditionFalse))
+	g.Expect(cond.Reason).Should(Equal("DeployFailed"))
+}
+
+func markAllHealthy(condMgr *conditions.Manager) {
+	condMgr.MarkTrue(string(common.ConditionTypeProvisioningSucceeded),
+		conditions.WithReason("AllResourcesApplied"))
+	condMgr.MarkTrue(conditionKServeReady,
+		conditions.WithReason("AllDeploymentsAvailable"))
+	condMgr.MarkTrue(conditionModelControllerReady,
+		conditions.WithReason("AllDeploymentsAvailable"))
+}
+
+func TestHappyCondition_AllHealthy(t *testing.T) {
+	g := NewWithT(t)
+
+	kserve := &platformv1alpha1.Kserve{}
+	condMgr := newConditionManager(kserve)
+	markAllHealthy(condMgr)
+
+	g.Expect(condMgr.IsHappy()).Should(BeTrue())
+}
+
+func TestHappyCondition_DeploymentNotReady(t *testing.T) {
+	g := NewWithT(t)
+
+	kserve := &platformv1alpha1.Kserve{}
+	condMgr := newConditionManager(kserve)
+	markAllHealthy(condMgr)
+
+	condMgr.MarkFalse(conditionKServeReady,
+		conditions.WithReason("DeploymentNotReady"))
+
+	g.Expect(condMgr.IsHappy()).Should(BeFalse())
+}
+

--- a/kserve-module/pkg/kservemodule/versioning.go
+++ b/kserve-module/pkg/kservemodule/versioning.go
@@ -37,7 +37,7 @@ func versionedWellKnownLLMInferenceServiceConfigs(resources []unstructured.Unstr
 				c := &deploy.Spec.Template.Spec.Containers[j]
 				found := false
 				for k := range c.Env {
-					if c.Env[k].Name == llmISVCConfigPrefix {
+					if c.Env[k].Name == llmISVCConfigPrefixEnv {
 						c.Env[k].Value = envValue
 						found = true
 						break
@@ -45,7 +45,7 @@ func versionedWellKnownLLMInferenceServiceConfigs(resources []unstructured.Unstr
 				}
 				if !found {
 					c.Env = append(c.Env, corev1.EnvVar{
-						Name:  llmISVCConfigPrefix,
+						Name:  llmISVCConfigPrefixEnv,
 						Value: envValue,
 					})
 				}

--- a/kserve-module/pkg/kservemodule/versioning_test.go
+++ b/kserve-module/pkg/kservemodule/versioning_test.go
@@ -91,7 +91,7 @@ func TestVersionLLMInferenceServiceConfigs_SetsEnvOnLLMISVCController(t *testing
 			found := false
 			for _, e := range envs {
 				env := e.(map[string]any)
-				if env["name"] == llmISVCConfigPrefix {
+				if env["name"] == llmISVCConfigPrefixEnv {
 					g.Expect(env["value"]).Should(Equal("v3-4-0-kserve-"))
 					found = true
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Follow-up changes 
- Split deployment readiness check into per-component functions  (checkKServeReadiness, checkModelControllerReadiness) and report each as a separate condition on the Kserve CR status. Condition manager  tracks ProvisioningSucceeded, KServeReady, and ModelControllerReady to derive the top-level Ready condition. Add release status populated from component_metadata.yaml files shipped alongside manifests, with a fallback when metadata is missing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [RHOAIENG-61201](https://redhat.atlassian.net/browse/RHOAIENG-61201)


**Feature/Issue validation/testing**:

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added component release tracking to display deployed component versions and metadata.
  * Enhanced status and condition management for clearer KServe module readiness visibility.

* **Bug Fixes**
  * Improved readiness verification and error reporting for KServe and model controller components.

* **Tests**
  * Added unit tests covering release loading, readiness checks, and condition management.

* **Chores**
  * Internal refactors and small dependency housekeeping for maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->