### PR TITLE
feat(kserve-module): add dependency checking and CRD watch

### DIFF
--- a/Makefile.kserve-module.mk
+++ b/Makefile.kserve-module.mk
@@ -39,5 +39,5 @@ test-kserve-module: envtest
 setup-envtest-kserve-module: envtest
 	@$(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path
 
-precommit-km: generate-kserve-module manifests-kserve-module test-kserve-module
+precommit-km: fmt go-lint generate-kserve-module manifests-kserve-module test-kserve-module
 	cd kserve-module && go mod tidy && go vet ./... && go build ./...

--- a/kserve-module/cmd/kserve-module/main.go
+++ b/kserve-module/cmd/kserve-module/main.go
@@ -7,6 +7,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -25,6 +26,7 @@ var (
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 	utilruntime.Must(platformv1alpha1.AddToScheme(scheme))
 }
 

--- a/kserve-module/config/rbac/role.yaml
+++ b/kserve-module/config/rbac/role.yaml
@@ -162,6 +162,21 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - operator.openshift.io
+  resources:
+  - leaderworkersets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - subscriptions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings

--- a/kserve-module/config/rbac/role.yaml
+++ b/kserve-module/config/rbac/role.yaml
@@ -168,6 +168,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - operators.coreos.com
   resources:

--- a/kserve-module/go.mod
+++ b/kserve-module/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/opendatahub-io/odh-platform-utilities v0.0.0-20260506180717-e15e712db78d
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.2
+	k8s.io/apiextensions-apiserver v0.35.2
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.2
 	sigs.k8s.io/controller-runtime v0.23.3
@@ -96,7 +97,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	helm.sh/helm/v4 v4.1.1 // indirect
-	k8s.io/apiextensions-apiserver v0.35.2 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260414162039-ec9c827d403f // indirect
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect

--- a/kserve-module/pkg/kservemodule/dependencies.go
+++ b/kserve-module/pkg/kservemodule/dependencies.go
@@ -1,0 +1,303 @@
+package kservemodule
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster/olm"
+)
+
+type checkType string
+
+const (
+	checkCRD          checkType = "crd"
+	checkSubscription checkType = "subscription"
+	checkOperator     checkType = "operator"
+
+	// Dependency group condition types
+	conditionLLMISVCDeps       = "LLMInferenceServiceDependencies"
+	conditionLLMISVCWideEPDeps = "LLMInferenceServiceWideEPDependencies"
+	conditionLLMDWVADeps       = "LLMDWVADependencies"
+
+	// OLM subscription names
+	rhclSubscription        = "rhcl-operator"
+	certManagerSubscription = "openshift-cert-manager-operator"
+	lwsSubscription         = "leader-worker-set"
+	cmaSubscription         = "openshift-custom-metrics-autoscaler-operator"
+)
+
+type conditionFilterFunc func(conditionType string, status string) bool
+
+type dependencyCheck struct {
+	name             string
+	checkType        checkType
+	groupKind        schema.GroupKind        // CRD check
+	subscriptionName string                  // Subscription check
+	operatorGVK      schema.GroupVersionKind // Operator CR GVK
+	operatorCRName   string                  // Operator CR name (empty = list first)
+	conditionFilter  conditionFilterFunc     // Operator condition filter
+	critical         bool                    // true → Ready=False, false → Degraded
+	platform         string                  // "ocp", "xks", "" (both)
+	conditionGroup   string                  // group into same condition
+}
+
+type dependencyResult struct {
+	degradedReasons []string
+	criticalErrors  []string
+	groupReasons    map[string][]string
+}
+
+func crdDep(name, group, kind, platform string, critical bool) dependencyCheck {
+	return dependencyCheck{
+		name:      name,
+		checkType: checkCRD,
+		groupKind: schema.GroupKind{Group: group, Kind: kind},
+		platform:  platform,
+		critical:  critical,
+	}
+}
+
+func subscriptionDep(name, subName, condGroup, platform string, critical bool) dependencyCheck {
+	return dependencyCheck{
+		name:             name,
+		checkType:        checkSubscription,
+		subscriptionName: subName,
+		conditionGroup:   condGroup,
+		platform:         platform,
+		critical:         critical,
+	}
+}
+
+func operatorDep(name string, gvk schema.GroupVersionKind, crName, condGroup, platform string, critical bool, filter conditionFilterFunc) dependencyCheck {
+	return dependencyCheck{
+		name:            name,
+		checkType:       checkOperator,
+		operatorGVK:     gvk,
+		operatorCRName:  crName,
+		conditionGroup:  condGroup,
+		platform:        platform,
+		critical:        critical,
+		conditionFilter: filter,
+	}
+}
+
+var kserveDependencies = []dependencyCheck{
+	// xks only checks
+	// Istio CRDs
+	crdDep("istio-destinationrule", "networking.istio.io", "DestinationRule", "xks", false),
+	crdDep("istio-envoyfilter", "networking.istio.io", "EnvoyFilter", "xks", false),
+	crdDep("istio-gateway", "networking.istio.io", "Gateway", "xks", false),
+	crdDep("istio-proxyconfig", "networking.istio.io", "ProxyConfig", "xks", false),
+	crdDep("istio-serviceentry", "networking.istio.io", "ServiceEntry", "xks", false),
+	crdDep("istio-sidecar", "networking.istio.io", "Sidecar", "xks", false),
+	crdDep("istio-workloadentry", "networking.istio.io", "WorkloadEntry", "xks", false),
+	crdDep("istio-workloadgroup", "networking.istio.io", "WorkloadGroup", "xks", false),
+	crdDep("istio-authorizationpolicy", "security.istio.io", "AuthorizationPolicy", "xks", false),
+	crdDep("istio-peerauthentication", "security.istio.io", "PeerAuthentication", "xks", false),
+	crdDep("istio-requestauthentication", "security.istio.io", "RequestAuthentication", "xks", false),
+	crdDep("istio-telemetry", "telemetry.istio.io", "Telemetry", "xks", false),
+	crdDep("istio-wasmplugin", "extensions.istio.io", "WasmPlugin", "xks", false),
+
+	// cert-manager CRDs
+	crdDep("cert-manager-certificate", "cert-manager.io", "Certificate", "xks", true),
+	crdDep("cert-manager-certificaterequest", "cert-manager.io", "CertificateRequest", "xks", true),
+	crdDep("cert-manager-issuer", "cert-manager.io", "Issuer", "xks", true),
+	crdDep("cert-manager-clusterissuer", "cert-manager.io", "ClusterIssuer", "xks", true),
+
+	// LeaderWorkerSet CRD
+	crdDep("leaderworkerset", "leaderworkerset.x-k8s.io", "LeaderWorkerSet", "xks", false),
+
+	// OCP Subscription checks
+	subscriptionDep("Red Hat Connectivity Link", rhclSubscription, conditionLLMISVCDeps, "ocp", false),
+	subscriptionDep("Red Hat Connectivity Link (Wide EP)", rhclSubscription, conditionLLMISVCWideEPDeps, "ocp", false),
+	subscriptionDep("cert-manager operator", certManagerSubscription, conditionLLMISVCDeps, "ocp", false),
+	subscriptionDep("cert-manager operator (Wide EP)", certManagerSubscription, conditionLLMISVCWideEPDeps, "ocp", false),
+	subscriptionDep("LeaderWorkerSet", lwsSubscription, conditionLLMISVCWideEPDeps, "ocp", false),
+
+	// OCP LWS Operator health
+	operatorDep("leaderworkerset-operator",
+		schema.GroupVersionKind{Group: "operator.openshift.io", Version: "v1", Kind: "LeaderWorkerSet"},
+		"", conditionLLMISVCWideEPDeps, "ocp", false, lwsConditionFilter),
+}
+
+var modelControllerDependencies = []dependencyCheck{
+	subscriptionDep("Custom Metrics Autoscaler", cmaSubscription, conditionLLMDWVADeps, "ocp", false),
+}
+
+var allDependencies = slices.Concat(kserveDependencies, modelControllerDependencies)
+
+func (r *KserveModuleReconciler) checkDependencies(ctx context.Context) dependencyResult {
+	log := ctrl.LoggerFrom(ctx)
+	isXKS := r.isKubernetes(ctx)
+
+	result := dependencyResult{
+		groupReasons: map[string][]string{
+			conditionLLMISVCDeps:       {},
+			conditionLLMISVCWideEPDeps: {},
+			conditionLLMDWVADeps:       {},
+		},
+	}
+
+	for _, dep := range allDependencies {
+		if dep.platform == "ocp" && isXKS {
+			continue
+		}
+		if dep.platform == "xks" && !isXKS {
+			continue
+		}
+
+		var reasons []string
+		switch dep.checkType {
+		case checkCRD:
+			reasons = r.checkCRD(ctx, dep)
+		case checkSubscription:
+			reasons = r.checkSubscription(ctx, dep)
+		case checkOperator:
+			reasons = r.checkOperatorHealth(ctx, dep)
+		}
+
+		for _, msg := range reasons {
+			log.Info("dependency not satisfied", "dependency", dep.name,
+				"type", dep.checkType, "critical", dep.critical, "message", msg)
+
+			if dep.critical {
+				result.criticalErrors = append(result.criticalErrors, msg)
+			} else if dep.conditionGroup != "" {
+				result.groupReasons[dep.conditionGroup] = append(
+					result.groupReasons[dep.conditionGroup], msg)
+			} else {
+				result.degradedReasons = append(result.degradedReasons, msg)
+			}
+		}
+	}
+
+	return result
+}
+
+func (r *KserveModuleReconciler) checkCRD(ctx context.Context, dep dependencyCheck) []string {
+  	// Skip checks when context is cancelled to avoid false-positive dependency errors.
+	if ctx.Err() != nil {
+		return nil
+	}
+	if err := cluster.CustomResourceDefinitionExists(ctx, r.Client, dep.groupKind); err != nil {
+		return []string{fmt.Sprintf("%s CRD not found (%s)", dep.name, dep.groupKind)}
+	}
+	return nil
+}
+
+func (r *KserveModuleReconciler) checkSubscription(ctx context.Context, dep dependencyCheck) []string {
+	// Skip checks when context is cancelled to avoid false-positive dependency errors.
+	if ctx.Err() != nil {
+		return nil
+	}
+	found, err := olm.SubscriptionExists(ctx, r.Client, dep.subscriptionName)
+	if err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil
+		}
+		return []string{fmt.Sprintf("%s subscription check failed: %v", dep.name, err)}
+	}
+	if !found {
+		return []string{fmt.Sprintf("%s not installed", dep.name)}
+	}
+	return nil
+}
+
+func (r *KserveModuleReconciler) checkOperatorHealth(ctx context.Context, dep dependencyCheck) []string {
+	if dep.conditionFilter == nil {
+		return nil
+	}
+
+	cr, err := r.fetchOperatorCR(ctx, dep)
+	if err != nil {
+		if meta.IsNoMatchError(err) || k8serr.IsNotFound(err) {
+			return nil
+		}
+		return []string{fmt.Sprintf("%s: failed to get operator CR: %v", dep.operatorGVK.Kind, err)}
+	}
+
+	return collectDegradedConditions(cr, dep)
+}
+
+func (r *KserveModuleReconciler) fetchOperatorCR(ctx context.Context, dep dependencyCheck) (*unstructured.Unstructured, error) {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(dep.operatorGVK)
+
+	if dep.operatorCRName != "" {
+		err := r.Client.Get(ctx, client.ObjectKey{Name: dep.operatorCRName}, obj)
+		return obj, err
+	}
+
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(dep.operatorGVK)
+	if err := r.Client.List(ctx, list, client.Limit(1)); err != nil {
+		return nil, err
+	}
+	if len(list.Items) == 0 {
+		return nil, k8serr.NewNotFound(
+			schema.GroupResource{Group: dep.operatorGVK.Group, Resource: dep.operatorGVK.Kind}, "")
+	}
+	return &list.Items[0], nil
+}
+
+func collectDegradedConditions(cr *unstructured.Unstructured, dep dependencyCheck) []string {
+	conditions, found, err := unstructured.NestedSlice(cr.Object, "status", "conditions")
+	if err != nil || !found {
+		return nil
+	}
+
+	var degraded []string
+	for _, c := range conditions {
+		condMap, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		condType, found, _ := unstructured.NestedString(condMap, "type")
+		if !found {
+			continue
+		}
+		condStatus, found, _ := unstructured.NestedString(condMap, "status")
+		if !found {
+			continue
+		}
+
+		if !dep.conditionFilter(condType, condStatus) {
+			continue
+		}
+
+		reason, _, _ := unstructured.NestedString(condMap, "reason")
+		message, _, _ := unstructured.NestedString(condMap, "message")
+
+		detail := fmt.Sprintf("%s %s: %s=%s", dep.operatorGVK.Kind, cr.GetName(), condType, condStatus)
+		if reason != "" {
+			detail += fmt.Sprintf(" (%s)", reason)
+		}
+		if message != "" {
+			detail += fmt.Sprintf(": %s", message)
+		}
+		degraded = append(degraded, detail)
+	}
+
+	return degraded
+}
+
+func lwsConditionFilter(condType, condStatus string) bool {
+	switch condType {
+	case "Degraded", "TargetConfigControllerDegraded":
+		return condStatus == "True"
+	case "Available":
+		return condStatus == "False"
+	default:
+		return false
+	}
+}

--- a/kserve-module/pkg/kservemodule/dependencies_test.go
+++ b/kserve-module/pkg/kservemodule/dependencies_test.go
@@ -1,0 +1,79 @@
+package kservemodule
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestKserveDependencies_Defined(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(kserveDependencies).ShouldNot(BeEmpty())
+
+	for _, dep := range kserveDependencies {
+		assertDependencyValid(g, dep)
+	}
+}
+
+func TestModelControllerDependencies_Defined(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(modelControllerDependencies).ShouldNot(BeEmpty())
+
+	for _, dep := range modelControllerDependencies {
+		assertDependencyValid(g, dep)
+	}
+}
+
+func assertDependencyValid(g Gomega, dep dependencyCheck) {
+	g.Expect(dep.name).ShouldNot(BeEmpty(), "dependency must have a name")
+	g.Expect(dep.checkType).ShouldNot(BeEmpty(), "dependency %s must have a checkType", dep.name)
+	g.Expect(dep.platform).Should(BeElementOf("", "ocp", "xks"),
+		"dependency %s has invalid platform %q", dep.name, dep.platform)
+
+	switch dep.checkType {
+	case checkCRD:
+		g.Expect(dep.groupKind.Group).ShouldNot(BeEmpty(),
+			"CRD dependency %s must have groupKind.Group", dep.name)
+		g.Expect(dep.groupKind.Kind).ShouldNot(BeEmpty(),
+			"CRD dependency %s must have groupKind.Kind", dep.name)
+	case checkSubscription:
+		g.Expect(dep.subscriptionName).ShouldNot(BeEmpty(),
+			"subscription dependency %s must have subscriptionName", dep.name)
+		g.Expect(dep.conditionGroup).ShouldNot(BeEmpty(),
+			"subscription dependency %s must have conditionGroup", dep.name)
+	case checkOperator:
+		g.Expect(dep.operatorGVK.Kind).ShouldNot(BeEmpty(),
+			"operator dependency %s must have operatorGVK.Kind", dep.name)
+		g.Expect(dep.conditionFilter).ShouldNot(BeNil(),
+			"operator dependency %s must have conditionFilter", dep.name)
+	}
+}
+
+func TestLwsConditionFilter_Healthy(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(lwsConditionFilter("Available", "True")).Should(BeFalse())
+	g.Expect(lwsConditionFilter("Degraded", "False")).Should(BeFalse())
+}
+
+func TestLwsConditionFilter_Degraded(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(lwsConditionFilter("Degraded", "True")).Should(BeTrue())
+	g.Expect(lwsConditionFilter("Available", "False")).Should(BeTrue())
+}
+
+func TestLwsConditionFilter_TargetConfigDegraded(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(lwsConditionFilter("TargetConfigControllerDegraded", "True")).Should(BeTrue())
+}
+
+func TestLwsConditionFilter_Unknown(t *testing.T) {
+	g := NewWithT(t)
+
+	g.Expect(lwsConditionFilter("SomeOther", "True")).Should(BeFalse())
+	g.Expect(lwsConditionFilter("", "")).Should(BeFalse())
+}

--- a/kserve-module/pkg/kservemodule/params.go
+++ b/kserve-module/pkg/kservemodule/params.go
@@ -3,6 +3,7 @@ package kservemodule
 import (
 	"bufio"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -48,14 +49,8 @@ func writeParamsEnv(params map[string]string, dir string) (string, error) {
 		}
 	}()
 
-	keys := make([]string, 0, len(params))
-	for k := range params {
-		keys = append(keys, k)
-	}
-	slices.Sort(keys)
-
 	writer := bufio.NewWriter(tmp)
-	for _, key := range keys {
+	for _, key := range slices.Sorted(maps.Keys(params)) {
 		if _, err := fmt.Fprintf(writer, "%s=%s\n", key, params[key]); err != nil {
 			return "", err
 		}

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -50,7 +50,7 @@ import (
 // +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions,verbs=get;list;watch
-// +kubebuilder:rbac:groups=operator.openshift.io,resources=leaderworkersets,verbs=get;list
+// +kubebuilder:rbac:groups=operator.openshift.io,resources=leaderworkersets,verbs=get;list;watch
 
 type ResourceDeployer interface {
 	Deploy(ctx context.Context, input deploy.DeployInput) error
@@ -88,6 +88,9 @@ func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	depResult := r.checkDependencies(ctx)
 	applyDependencyConditions(condMgr, depResult)
 	if len(depResult.criticalErrors) > 0 {
+		applyProvisioningCondition(condMgr, map[string]error{
+			"dependencies": fmt.Errorf("critical dependencies unavailable"),
+		})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -48,6 +48,8 @@ import (
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions,verbs=get;list;watch
+// +kubebuilder:rbac:groups=operator.openshift.io,resources=leaderworkersets,verbs=get;list
 
 type ResourceDeployer interface {
 	Deploy(ctx context.Context, input deploy.DeployInput) error
@@ -81,6 +83,12 @@ func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			retErr = err
 		}
 	}()
+
+	depResult := r.checkDependencies(ctx)
+	applyDependencyConditions(condMgr, depResult)
+	if len(depResult.criticalErrors) > 0 {
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
 
 	componentErrors := r.reconcile(ctx, kserve)
 	applyProvisioningCondition(condMgr, componentErrors)
@@ -239,10 +247,8 @@ func (r *KserveModuleReconciler) getApplicationsNamespace() string {
 	return "opendatahub"
 }
 
-// TODO: clarify with platform team how the release version is delivered to module operators.
-// odh-operator uses cluster.GetRelease().Version (from CSV), but module operators don't have
-// direct CSV access. Current implementation reads annotation; need to confirm this is the
-// agreed contract or if a different mechanism (e.g. ConfigMap, CR spec field) will be used.
+// TODO: for now, we can use the annotation but the version will be set by data of configmap
+// We need to confirm with platform team what configmap name is used for the version.
 func (r *KserveModuleReconciler) getVersionPrefix(kserve *platformv1alpha1.Kserve) string {
 	if ann := kserve.GetAnnotations(); ann != nil {
 		if v := ann["platform.opendatahub.io/version"]; v != "" {

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -93,14 +94,8 @@ func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	componentErrors := r.reconcile(ctx, kserve)
 	applyProvisioningCondition(condMgr, componentErrors)
 	if len(componentErrors) > 0 {
-		names := make([]string, 0, len(componentErrors))
-		for name := range componentErrors {
-			names = append(names, name)
-		}
-		slices.Sort(names)
-
 		var msgs []string
-		for _, name := range names {
+		for _, name := range slices.Sorted(maps.Keys(componentErrors)) {
 			log.Error(componentErrors[name], "component reconciliation failed", "component", name)
 			msgs = append(msgs, name+": "+componentErrors[name].Error())
 		}

--- a/kserve-module/pkg/kservemodule/releases.go
+++ b/kserve-module/pkg/kservemodule/releases.go
@@ -39,8 +39,11 @@ func loadComponentReleases(manifestsPath string, componentDirs []string) ([]comm
 		}
 
 		for _, r := range meta.Releases {
-			if seen[r.Name] {
+			if r.Name == "" || seen[r.Name] {
 				continue
+			}
+			if r.Version == "" {
+				r.Version = "unknown"
 			}
 			seen[r.Name] = true
 			all = append(all, r)

--- a/kserve-module/pkg/kservemodule/setup.go
+++ b/kserve-module/pkg/kservemodule/setup.go
@@ -1,24 +1,46 @@
 package kservemodule
 
 import (
+	"context"
 	"fmt"
+	"strings"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	platformv1alpha1 "github.com/opendatahub-io/kserve-module/pkg/apis/v1alpha1"
 )
+
+var dependencyCRDSuffixes = []string{
+	".networking.istio.io",
+	".security.istio.io",
+	".telemetry.istio.io",
+	".extensions.istio.io",
+	".cert-manager.io",
+	".leaderworkerset.x-k8s.io",
+}
+
+var dependencyCRDNames = map[string]bool{
+	"leaderworkersets.operator.openshift.io": true,
+	"subscriptions.operators.coreos.com":     true,
+}
 
 func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.Deployer == nil {
 		return fmt.Errorf("deployer must not be nil")
 	}
 
-	return ctrl.NewControllerManagedBy(mgr).
+	b := ctrl.NewControllerManagedBy(mgr).
 		For(&platformv1alpha1.Kserve{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Secret{}).
@@ -32,6 +54,34 @@ func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&rbacv1.ClusterRoleBinding{}).
 		Owns(&admissionregistrationv1.MutatingWebhookConfiguration{}).
 		Owns(&admissionregistrationv1.ValidatingWebhookConfiguration{}).
-		Named("kserve-module").
+		WatchesMetadata(
+			&apiextensionsv1.CustomResourceDefinition{},
+			handler.EnqueueRequestsFromMapFunc(mapToKserve),
+			builder.WithPredicates(crdNamePredicate()),
+		)
+
+	return b.Named("kserve-module").
+		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
 		Complete(r)
+}
+
+func mapToKserve(_ context.Context, _ client.Object) []ctrl.Request {
+	return []ctrl.Request{{
+		NamespacedName: client.ObjectKey{Name: platformv1alpha1.KserveInstanceName},
+	}}
+}
+
+func crdNamePredicate() predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		name := obj.GetName()
+		if dependencyCRDNames[name] {
+			return true
+		}
+		for _, suffix := range dependencyCRDSuffixes {
+			if strings.HasSuffix(name, suffix) {
+				return true
+			}
+		}
+		return false
+	})
 }

--- a/kserve-module/pkg/kservemodule/status.go
+++ b/kserve-module/pkg/kservemodule/status.go
@@ -2,6 +2,7 @@ package kservemodule
 
 import (
 	"context"
+	"maps"
 	"slices"
 	"strings"
 
@@ -74,14 +75,8 @@ func applyProvisioningCondition(condMgr *conditions.Manager, componentErrors map
 		return
 	}
 
-	names := make([]string, 0, len(componentErrors))
-	for name := range componentErrors {
-		names = append(names, name)
-	}
-	slices.Sort(names)
-
-	msgs := make([]string, 0, len(names))
-	for _, name := range names {
+	msgs := make([]string, 0, len(componentErrors))
+	for _, name := range slices.Sorted(maps.Keys(componentErrors)) {
 		msgs = append(msgs, name+": "+componentErrors[name].Error())
 	}
 	condMgr.MarkFalse(string(common.ConditionTypeProvisioningSucceeded),

--- a/kserve-module/pkg/kservemodule/status.go
+++ b/kserve-module/pkg/kservemodule/status.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	ConditionKServeReady          = "KServeReady"
-	ConditionModelControllerReady = "ModelControllerReady"
+	ConditionKServeReady           = "KServeReady"
+	ConditionModelControllerReady  = "ModelControllerReady"
+	ConditionDependenciesAvailable = "DependenciesAvailable"
 )
 
 func newConditionManager(kserve *platformv1alpha1.Kserve) *conditions.Manager {
@@ -24,7 +25,46 @@ func newConditionManager(kserve *platformv1alpha1.Kserve) *conditions.Manager {
 		string(common.ConditionTypeProvisioningSucceeded),
 		ConditionKServeReady,
 		ConditionModelControllerReady,
+		ConditionDependenciesAvailable,
 	)
+}
+
+func applyDependencyConditions(condMgr *conditions.Manager, result dependencyResult) {
+	if len(result.criticalErrors) > 0 {
+		condMgr.MarkFalse(ConditionDependenciesAvailable,
+			conditions.WithReason("DependencyDegraded"),
+			conditions.WithMessage("%s", strings.Join(result.criticalErrors, "; ")))
+		condMgr.MarkTrue(string(common.ConditionTypeDegraded),
+			conditions.WithSeverity(common.ConditionSeverityError),
+			conditions.WithReason("MissingCriticalDependency"),
+			conditions.WithMessage("%s", strings.Join(result.criticalErrors, "; ")))
+	} else if len(result.degradedReasons) > 0 {
+		condMgr.MarkTrue(ConditionDependenciesAvailable,
+			conditions.WithReason("AllCriticalDependenciesMet"))
+		condMgr.MarkTrue(string(common.ConditionTypeDegraded),
+			conditions.WithSeverity(common.ConditionSeverityInfo),
+			conditions.WithReason("MissingOptionalDependency"),
+			conditions.WithMessage("%s", strings.Join(result.degradedReasons, "; ")))
+	} else {
+		condMgr.MarkTrue(ConditionDependenciesAvailable,
+			conditions.WithReason("AllDependenciesMet"))
+		condMgr.MarkFalse(string(common.ConditionTypeDegraded),
+			conditions.WithSeverity(common.ConditionSeverityInfo),
+			conditions.WithReason("NoDegradation"))
+	}
+
+	for group, reasons := range result.groupReasons {
+		if len(reasons) > 0 {
+			condMgr.MarkTrue(group,
+				conditions.WithSeverity(common.ConditionSeverityInfo),
+				conditions.WithReason("MissingDependency"),
+				conditions.WithMessage("%s", strings.Join(reasons, "; ")))
+		} else {
+			condMgr.MarkFalse(group,
+				conditions.WithSeverity(common.ConditionSeverityInfo),
+				conditions.WithReason("AllDependenciesSatisfied"))
+		}
+	}
 }
 
 func applyProvisioningCondition(condMgr *conditions.Manager, componentErrors map[string]error) {

--- a/kserve-module/pkg/kservemodule/status_test.go
+++ b/kserve-module/pkg/kservemodule/status_test.go
@@ -56,6 +56,35 @@ func TestApplyProvisioningCondition_Failure(t *testing.T) {
 	g.Expect(cond.Reason).Should(Equal("DeployFailed"))
 }
 
+func TestApplyDependencyConditions_NoDegradation(t *testing.T) {
+	g := NewWithT(t)
+
+	kserve := &platformv1alpha1.Kserve{}
+	condMgr := newConditionManager(kserve)
+
+	applyDependencyConditions(condMgr, dependencyResult{})
+
+	cond := condMgr.GetCondition(string(common.ConditionTypeDegraded))
+	g.Expect(cond).ShouldNot(BeNil())
+	g.Expect(cond.Status).Should(Equal(metav1.ConditionFalse))
+}
+
+func TestApplyDependencyConditions_Degraded(t *testing.T) {
+	g := NewWithT(t)
+
+	kserve := &platformv1alpha1.Kserve{}
+	condMgr := newConditionManager(kserve)
+
+	applyDependencyConditions(condMgr, dependencyResult{
+		degradedReasons: []string{"Istio CRD not found"},
+	})
+
+	cond := condMgr.GetCondition(string(common.ConditionTypeDegraded))
+	g.Expect(cond).ShouldNot(BeNil())
+	g.Expect(cond.Status).Should(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Severity).Should(Equal(common.ConditionSeverityInfo))
+}
+
 func markAllHealthy(condMgr *conditions.Manager) {
 	condMgr.MarkTrue(string(common.ConditionTypeProvisioningSucceeded),
 		conditions.WithReason("AllResourcesApplied"))
@@ -63,6 +92,8 @@ func markAllHealthy(condMgr *conditions.Manager) {
 		conditions.WithReason("AllDeploymentsAvailable"))
 	condMgr.MarkTrue(ConditionModelControllerReady,
 		conditions.WithReason("AllDeploymentsAvailable"))
+	condMgr.MarkTrue(ConditionDependenciesAvailable,
+		conditions.WithReason("AllDependenciesMet"))
 }
 
 func TestHappyCondition_AllHealthy(t *testing.T) {
@@ -88,3 +119,85 @@ func TestHappyCondition_DeploymentNotReady(t *testing.T) {
 	g.Expect(condMgr.IsHappy()).Should(BeFalse())
 }
 
+func TestHappyCondition_DependenciesNotAvailable(t *testing.T) {
+	g := NewWithT(t)
+
+	kserve := &platformv1alpha1.Kserve{}
+	condMgr := newConditionManager(kserve)
+	markAllHealthy(condMgr)
+
+	condMgr.MarkFalse(ConditionDependenciesAvailable,
+		conditions.WithReason("DependencyDegraded"))
+
+	g.Expect(condMgr.IsHappy()).Should(BeFalse())
+}
+
+func TestDegradedDoesNotAffectReady(t *testing.T) {
+	g := NewWithT(t)
+
+	kserve := &platformv1alpha1.Kserve{}
+	condMgr := newConditionManager(kserve)
+	markAllHealthy(condMgr)
+
+	applyDependencyConditions(condMgr, dependencyResult{
+		degradedReasons: []string{"optional dep missing"},
+	})
+
+	g.Expect(condMgr.IsHappy()).Should(BeTrue())
+}
+
+func TestApplyDependencyConditions_GroupCondition(t *testing.T) {
+	g := NewWithT(t)
+
+	kserve := &platformv1alpha1.Kserve{}
+	condMgr := newConditionManager(kserve)
+
+	applyDependencyConditions(condMgr, dependencyResult{
+		groupReasons: map[string][]string{
+			conditionLLMISVCDeps: {"RHCL not installed", "cert-manager not installed"},
+		},
+	})
+
+	cond := condMgr.GetCondition(conditionLLMISVCDeps)
+	g.Expect(cond).ShouldNot(BeNil())
+	g.Expect(cond.Status).Should(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Severity).Should(Equal(common.ConditionSeverityInfo))
+	g.Expect(cond.Message).Should(ContainSubstring("RHCL"))
+}
+
+func TestGroupConditionDoesNotAffectReady(t *testing.T) {
+	g := NewWithT(t)
+
+	kserve := &platformv1alpha1.Kserve{}
+	condMgr := newConditionManager(kserve)
+	markAllHealthy(condMgr)
+
+	applyDependencyConditions(condMgr, dependencyResult{
+		groupReasons: map[string][]string{
+			conditionLLMISVCDeps:       {"RHCL not installed"},
+			conditionLLMISVCWideEPDeps: {"LWS not installed"},
+		},
+	})
+
+	g.Expect(condMgr.IsHappy()).Should(BeTrue())
+}
+
+func TestGroupConditionsSetByApply(t *testing.T) {
+	g := NewWithT(t)
+
+	kserve := &platformv1alpha1.Kserve{}
+	condMgr := newConditionManager(kserve)
+
+	g.Expect(condMgr.GetCondition(conditionLLMISVCDeps)).Should(BeNil(),
+		"group conditions should not be registered as dependents")
+
+	applyDependencyConditions(condMgr, dependencyResult{
+		groupReasons: map[string][]string{
+			conditionLLMISVCDeps: {"RHCL not installed"},
+		},
+	})
+
+	cond := condMgr.GetCondition(conditionLLMISVCDeps)
+	g.Expect(cond).ShouldNot(BeNil(), "group condition should be set after apply")
+	g.Expect(cond.Status).Should(Equal(metav1.ConditionTrue))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- follow-up changes
  - https://github.com/opendatahub-io/kserve/pull/1521#discussion_r3275066168
  - https://github.com/opendatahub-io/kserve/pull/1521#discussion_r3277441398
- Check CRD, OLM subscription, and operator health before reconciling.  Critical deps block reconcile, optional deps reported via group conditions.  Watch dependency CRDs to trigger re-evaluation on install/removal.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [RHOAIENG-61201](https://redhat.atlassian.net/browse/RHOAIENG-61201)


**Feature/Issue validation/testing**:

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dependency health checks, dependency-driven status conditions, CRD-based watches, and controller naming/concurrency to improve reconciliation behavior

* **Bug Fixes**
  * Skip empty/duplicate component releases and default missing versions to "unknown"

* **Chores**
  * Pre-commit now runs formatting and linting; extended RBAC for operator resources; registered CRD API types; made parameter and error ordering deterministic

* **Tests**
  * Added unit tests covering dependency checks and dependency-related status behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->