### PR TITLE
fix(ci): collect pod logs on fail, tune maxfail

### DIFF
--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -234,6 +234,7 @@ jobs:
         run: |
           # Run only CPU tests for now using pytest markers (cluster_)
           # Available GPU vendors: amd, nvidia, intel
+          export PYTEST_MAXFAIL=3
           ./test/scripts/gh-actions/run-e2e-tests.sh "llminferenceservice and cluster_cpu and not autoscaling" 0 "envoy-gateway"
 
       - name: Check system status
@@ -342,8 +343,9 @@ jobs:
 
       - name: Run HPA autoscaling E2E tests
         id: autoscaling-hpa-tests
-        timeout-minutes: 40
+        timeout-minutes: 60
         run: |
+          export PYTEST_MAXFAIL=2
           ./test/scripts/gh-actions/run-e2e-tests.sh "llminferenceservice and autoscaling_hpa and cluster_cpu" 0 "envoy-gateway"
 
       - name: Check system status
@@ -454,8 +456,9 @@ jobs:
 
       - name: Run KEDA autoscaling E2E tests
         id: autoscaling-keda-tests
-        timeout-minutes: 40
+        timeout-minutes: 60
         run: |
+          export PYTEST_MAXFAIL=2
           ./test/scripts/gh-actions/run-e2e-tests.sh "llminferenceservice and autoscaling_keda and cluster_cpu" 0 "envoy-gateway"
 
       - name: Check system status

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1340,7 +1340,7 @@ jobs:
           kubectl describe pods -n kserve
 
       - name: Run E2E tests
-        timeout-minutes: 30
+        timeout-minutes: 45
         run: |
           ./test/scripts/gh-actions/run-e2e-tests.sh "llm" "2"
 
@@ -1417,8 +1417,9 @@ jobs:
           kubectl describe pods -n kserve
 
       - name: Run E2E tests
-        timeout-minutes: 30
+        timeout-minutes: 45
         run: |
+          export PYTEST_MAXFAIL=3
           ./test/scripts/gh-actions/run-e2e-tests.sh "vllm" "1"
 
       - name: Check system status

--- a/test/e2e/llmisvc/diagnostic.py
+++ b/test/e2e/llmisvc/diagnostic.py
@@ -13,14 +13,20 @@
 # limitations under the License.
 
 import itertools
+import logging
 from datetime import datetime
 from kubernetes import client, config, dynamic
 from kubernetes.client import api_client
+from typing import Callable, Optional
+
+_log = logging.getLogger(__name__)
 
 
-def print_all_events_table(namespace: str, max_events: int = 50):
+def print_all_events_table(
+    namespace: str, max_events: int = 50, log: Callable = _log.info
+):
     """
-    Print the most recent `max_events` events in `namespace` as a nice table.
+    Emit the most recent `max_events` events in `namespace` as a nice table.
     """
     core = client.CoreV1Api()
 
@@ -28,12 +34,12 @@ def print_all_events_table(namespace: str, max_events: int = 50):
         events = core.list_namespaced_event(namespace=namespace).items
 
         if not events:
-            print("ℹ️ # No events found in namespace", namespace)
+            log("ℹ️ # No events found in namespace %s", namespace)
             return
 
         header = f"{'TIME':<25} {'NAMESPACE':<12} {'SOURCE':<20} {'TYPE':<8} {'REASON':<20} MESSAGE"
-        print(header)
-        print("-" * len(header))
+        log(header)
+        log("-" * len(header))
 
         for ev in events:
             ts = ev.last_timestamp or ev.first_timestamp
@@ -44,13 +50,18 @@ def print_all_events_table(namespace: str, max_events: int = 50):
             )
             src = f"{ev.source.component or ''}/{ev.source.host or ''}".strip("/")
             msg = (ev.message or "").replace("\n", " ")
-            print(
-                f"{ts_str:<25} {ev.metadata.namespace:<12} {src:<20} {ev.type or '':<8} "
-                f"{ev.reason or '':<20} {msg}"
+            log(
+                "%s %s %s %s %s %s",
+                ts_str.ljust(25),
+                ev.metadata.namespace.ljust(12),
+                src.ljust(20),
+                (ev.type or "").ljust(8),
+                (ev.reason or "").ljust(20),
+                msg,
             )
 
     except Exception as e:
-        print(f"# ❌ failed to list events: {e}")
+        log("# ❌ failed to list events: %s", e)
 
 
 def kinds_matching_by_labels(namespace: str, labels, skip_api_kinds=None):
@@ -86,18 +97,105 @@ def kinds_matching_by_labels(namespace: str, labels, skip_api_kinds=None):
             if not rsrc.namespaced or "list" not in rsrc.verbs:
                 continue
         except Exception as e:
-            print(
-                f"failed to check resource properties for {getattr(rsrc, 'kind', 'unknown')}, skipping: {e}"
+            _log.debug(
+                "failed to check resource properties for %s, skipping: %s",
+                getattr(rsrc, "kind", "unknown"),
+                e,
             )
             continue
 
         try:
             resp = rsrc.get(namespace=namespace, label_selector=selector)
         except Exception as e:
-            print(f"failed to get {rsrc.kind}, skipping: {e}")
+            _log.debug("failed to get %s, skipping: %s", rsrc.kind, e)
             continue
 
         items = getattr(resp, "items", [])
         found.extend(items)
 
     return found
+
+
+def collect_pod_logs(namespace: str, labels, log: Callable = _log.info):
+    """
+    For every pod in `namespace` matching `labels`, emit logs for all init
+    containers and regular containers (current and, when restarted, previous).
+    """
+    core = client.CoreV1Api()
+    selector = (
+        ",".join(f"{k}={v}" for k, v in labels.items())
+        if isinstance(labels, dict)
+        else labels
+    )
+    try:
+        pods = core.list_namespaced_pod(
+            namespace=namespace, label_selector=selector
+        ).items
+    except Exception as e:
+        log("# failed to list pods: %s", e)
+        return
+
+    if not pods:
+        log("# no pods found in %s matching %s", namespace, selector)
+        return
+
+    for pod in pods:
+        pod_name = pod.metadata.name
+        phase = pod.status.phase if pod.status else "Unknown"
+        log("### Pod %s (phase=%s)", pod_name, phase)
+
+        init_specs = pod.spec.init_containers or []
+        init_statuses = {s.name: s for s in (pod.status.init_container_statuses or [])}
+        for c in init_specs:
+            _emit_container_logs(
+                core,
+                namespace,
+                pod_name,
+                c.name,
+                is_init=True,
+                status=init_statuses.get(c.name),
+                log=log,
+            )
+
+        c_specs = pod.spec.containers or []
+        c_statuses = {s.name: s for s in (pod.status.container_statuses or [])}
+        for c in c_specs:
+            _emit_container_logs(
+                core,
+                namespace,
+                pod_name,
+                c.name,
+                is_init=False,
+                status=c_statuses.get(c.name),
+                log=log,
+            )
+
+
+def _emit_container_logs(
+    core: client.CoreV1Api,
+    namespace: str,
+    pod_name: str,
+    container_name: str,
+    is_init: bool,
+    status: Optional[object],
+    log: Callable = _log.info,
+):
+    kind = "init-container" if is_init else "container"
+    restart_count = status.restart_count if status else 0
+    log("#### %s %r (restarts=%d)", kind, container_name, restart_count)
+
+    revisions = [False, True] if restart_count > 0 else [False]
+    for previous in revisions:
+        label = "previous" if previous else "current"
+        try:
+            logs = core.read_namespaced_pod_log(
+                name=pod_name,
+                namespace=namespace,
+                container=container_name,
+                previous=previous,
+                tail_lines=200,
+            )
+            log("# -- logs (%s) --", label)
+            log("%s", logs or "(empty)")
+        except Exception as e:
+            log("# -- logs (%s): unavailable (%s)", label, e)

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -25,8 +25,9 @@ from kubernetes import client
 from typing import Any, Callable, Dict, List, Optional
 
 from .diagnostic import (
-    print_all_events_table,
+    collect_pod_logs,
     kinds_matching_by_labels,
+    print_all_events_table,
 )
 from .fixtures import (
     create_router_resources,
@@ -412,7 +413,10 @@ def test_llm_inference_service(test_case: TestCase):  # noqa: F811
         )
         wait_for_model_response(kserve_client, test_case, test_case.wait_timeout)
     except Exception as e:
-        print(f"❌ ERROR: Failed to call llm inference service {service_name}: {e}")
+        test_failed = True
+        logger.error(
+            "❌ ERROR: Failed to call llm inference service %s: %s", service_name, e
+        )
         _collect_diagnostics(kserve_client, test_case.llm_service)
         raise
     finally:
@@ -639,24 +643,24 @@ def _collect_diagnostics(
     name = llm_isvc.metadata.name
     ns = llm_isvc.metadata.namespace
 
-    svc = get_llmisvc(kserve_client, name, ns)
-
     labels = {
         "app.kubernetes.io/part-of": "llminferenceservice",
         "app.kubernetes.io/name": name,
     }
 
-    print(f"🔍 # Diagnostics for {name!r} in {ns!r}")
-    print("---")
-    print(f"# LLMInferenceService {name}")
+    logger.info("🔍 # Diagnostics for %r in %r", name, ns)
+    logger.info("---")
+    logger.info("# LLMInferenceService %s", name)
     try:
-        print(yaml.safe_dump(svc, sort_keys=False))
+        svc = get_llmisvc(kserve_client, name, ns)
+        logger.info(yaml.safe_dump(svc, sort_keys=False))
     except Exception as e:
-        print(f"# ❌ failed to dump LLMInferenceService: {e}")
+        logger.info("# ❌ failed to dump LLMInferenceService: %s", e)
 
-    print_all_events_table(ns)
+    print_all_events_table(ns, log=logger.info)
+    collect_pod_logs(ns, labels, log=logger.info)
 
     all_resources = kinds_matching_by_labels(ns, labels)
     for obj in all_resources:
-        print("---")
-        print(yaml.safe_dump(obj.to_dict(), sort_keys=False))
+        logger.info("---")
+        logger.info(yaml.safe_dump(obj.to_dict(), sort_keys=False))

--- a/test/scripts/gh-actions/run-e2e-tests.sh
+++ b/test/scripts/gh-actions/run-e2e-tests.sh
@@ -44,9 +44,11 @@ NETWORK_LAYER="${3:-'istio'}"
 
 echo "Parallelism requested for pytest is ${PARALLELISM}"
 
+MAXFAIL="${PYTEST_MAXFAIL:-5}"
+
 source python/kserve/.venv/bin/activate
 
-PYTEST_COMMON_ARGS=(--ignore=qpext --log-cli-level=INFO -n "$PARALLELISM" --dist worksteal --network-layer "$NETWORK_LAYER" --maxfail=10 -vv --tb=long -s)
+PYTEST_COMMON_ARGS=(--ignore=qpext --log-cli-level=INFO -n "$PARALLELISM" --dist worksteal --network-layer "$NETWORK_LAYER" --maxfail="$MAXFAIL" -vv --tb=long -s)
 
 MARKER_ARGS=()
 if [[ -n "$MARKER" ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry-pick of kserve/kserve@aeb623f55a396dfc7f5ca8ce5ec5d389f3b4af29 (upstream #5528).

- Collects pod logs (init + regular containers, current + previous) on test failure for better diagnostics
- Makes `--maxfail` configurable via `PYTEST_MAXFAIL` env var (default 5), with per-workflow overrides
- Switches diagnostic output from `print()` to `logging` for consistent CI log formatting
- Increases autoscaling and vLLM test timeouts (40→60 min, 30→45 min)

Conflict resolution: kept the ODH array-based pytest invocation style from #1356 while integrating the `$MAXFAIL` variable into `PYTEST_COMMON_ARGS`.

**Feature/Issue validation/testing**:

- [x] Upstream CI validated in kserve/kserve#5528

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

```release-note
NONE
```