### PR TITLE
feat(kserve-module): add dynamic watch for Subscription and LeaderWorkerSet CRDs

### DIFF
--- a/kserve-module/pkg/kservemodule/dependencies.go
+++ b/kserve-module/pkg/kservemodule/dependencies.go
@@ -189,7 +189,7 @@ func (r *KserveModuleReconciler) checkCRD(ctx context.Context, dep dependencyChe
 		return nil
 	}
 	if err := cluster.CustomResourceDefinitionExists(ctx, r.Client, dep.groupKind); err != nil {
-		return []string{fmt.Sprintf("%s CRD not found (%s)", dep.name, dep.groupKind)}
+		return []string{fmt.Sprintf("%s CRD check failed (%s): %v", dep.name, dep.groupKind, err)}
 	}
 	return nil
 }
@@ -291,6 +291,7 @@ func collectDegradedConditions(cr *unstructured.Unstructured, dep dependencyChec
 	return degraded
 }
 
+// lwsConditionFilter returns true when the given condition indicates an unhealthy state.
 func lwsConditionFilter(condType, condStatus string) bool {
 	switch condType {
 	case "Degraded", "TargetConfigControllerDegraded":

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -9,12 +9,15 @@ import (
 	"maps"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/deploy"
@@ -66,6 +69,11 @@ type KserveModuleReconciler struct {
 	initDone              bool
 	applicationsNamespace string
 	clusterType           *cluster.ClusterType
+
+	controller     controller.Controller
+	cache          cache.Cache
+	dynamicWatches []*dynamicWatch
+	dynamicWatchMu sync.Mutex
 }
 
 func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
@@ -77,6 +85,8 @@ func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	log.Info("reconciling Kserve CR", "name", kserve.Name)
+
+	r.registerDynamicWatches(ctx)
 
 	condMgr := newConditionManager(kserve)
 	defer func() {

--- a/kserve-module/pkg/kservemodule/setup.go
+++ b/kserve-module/pkg/kservemodule/setup.go
@@ -11,12 +11,17 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
 
 	platformv1alpha1 "github.com/opendatahub-io/kserve-module/pkg/apis/v1alpha1"
 )
@@ -35,10 +40,26 @@ var dependencyCRDNames = map[string]bool{
 	"subscriptions.operators.coreos.com":     true,
 }
 
+var watchedSubscriptions = map[string]bool{
+	rhclSubscription:        true,
+	certManagerSubscription: true,
+	lwsSubscription:         true,
+	cmaSubscription:         true,
+}
+
+type dynamicWatch struct {
+	groupKind schema.GroupKind
+	gvk       schema.GroupVersionKind
+	filterFn  func(*unstructured.Unstructured) bool
+	registered bool
+}
+
 func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.Deployer == nil {
 		return fmt.Errorf("deployer must not be nil")
 	}
+
+	r.cache = mgr.GetCache()
 
 	b := ctrl.NewControllerManagedBy(mgr).
 		For(&platformv1alpha1.Kserve{}).
@@ -60,9 +81,91 @@ func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			builder.WithPredicates(crdNamePredicate()),
 		)
 
-	return b.Named("kserve-module").
+	r.dynamicWatches = []*dynamicWatch{
+		{
+			groupKind: schema.GroupKind{Group: "operators.coreos.com", Kind: "Subscription"},
+			gvk:       schema.GroupVersionKind{Group: "operators.coreos.com", Version: "v1alpha1", Kind: "Subscription"},
+			filterFn:  func(obj *unstructured.Unstructured) bool { return watchedSubscriptions[obj.GetName()] },
+		},
+		{
+			groupKind: schema.GroupKind{Group: "operator.openshift.io", Kind: "LeaderWorkerSet"},
+			gvk:       schema.GroupVersionKind{Group: "operator.openshift.io", Version: "v1", Kind: "LeaderWorkerSet"},
+		},
+	}
+
+	for _, dw := range r.dynamicWatches {
+		if !crdAvailable(mgr, dw.groupKind) {
+			continue
+		}
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(dw.gvk)
+		if dw.filterFn != nil {
+			b.Watches(obj,
+				handler.EnqueueRequestsFromMapFunc(mapToKserve),
+				builder.WithPredicates(predicate.NewPredicateFuncs(func(o client.Object) bool {
+					u, ok := o.(*unstructured.Unstructured)
+					if !ok {
+						return false
+					}
+					return dw.filterFn(u)
+				})),
+			)
+		} else {
+			b.Watches(obj, handler.EnqueueRequestsFromMapFunc(mapToKserve))
+		}
+		dw.registered = true
+	}
+
+	c, err := b.Named("kserve-module").
 		WithOptions(controller.Options{MaxConcurrentReconciles: 1}).
-		Complete(r)
+		Build(r)
+	if err != nil {
+		return err
+	}
+	r.controller = c
+
+	return nil
+}
+
+func (r *KserveModuleReconciler) registerDynamicWatches(ctx context.Context) {
+	r.dynamicWatchMu.Lock()
+	defer r.dynamicWatchMu.Unlock()
+
+	if r.controller == nil {
+		return
+	}
+
+	for _, dw := range r.dynamicWatches {
+		if dw.registered {
+			continue
+		}
+
+		if err := cluster.CustomResourceDefinitionExists(ctx, r.Client, dw.groupKind); err != nil {
+			continue
+		}
+
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(dw.gvk)
+
+		var preds []predicate.Predicate
+		if dw.filterFn != nil {
+			preds = append(preds, predicate.NewPredicateFuncs(func(o client.Object) bool {
+				u, ok := o.(*unstructured.Unstructured)
+				if !ok {
+					return false
+				}
+				return dw.filterFn(u)
+			}))
+		}
+
+		if err := r.controller.Watch(source.Kind[client.Object](r.cache, obj, handler.EnqueueRequestsFromMapFunc(mapToKserve), preds...)); err != nil {
+			ctrl.LoggerFrom(ctx).Error(err, "failed to register dynamic watch", "gvk", dw.gvk)
+			continue
+		}
+
+		dw.registered = true
+		ctrl.LoggerFrom(ctx).Info("registered dynamic watch", "gvk", dw.gvk)
+	}
 }
 
 func mapToKserve(_ context.Context, _ client.Object) []ctrl.Request {
@@ -84,4 +187,9 @@ func crdNamePredicate() predicate.Predicate {
 		}
 		return false
 	})
+}
+
+func crdAvailable(mgr ctrl.Manager, gk schema.GroupKind) bool {
+	_, err := mgr.GetRESTMapper().RESTMapping(gk)
+	return err == nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Register watches for CRDs that may not exist at startup. Available CRDs are registered via the builder; missing ones are retried each reconcile via controller.Watch(source.Kind).
- Use Watches (not WatchesMetadata) to avoid PartialObjectMetadata type mismatch in predicates
- Add watch verb to leaderworkersets RBAC
- Preserve MaxConcurrentReconciles: 1 after Complete→Build migration

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://redhat.atlassian.net/browse/RHOAIENG-61201


**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for Custom Resource Definition (CRD) availability checks with detailed error messages.

* **Chores**
  * Enhanced internal resource monitoring to dynamically register and track Kubernetes operator resources at runtime.
  * Strengthened CRD validation during system initialization for increased reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->