### PR TITLE
  ci: disable master branch builds in GHA docker-publish workflows

### DIFF
--- a/.github/workflows/agent-docker-publish.yml
+++ b/.github/workflows/agent-docker-publish.yml
@@ -4,7 +4,8 @@ on:
   push:
     # Publish `master` as Docker `latest` image.
     branches:
-      - master
+      # Tekton now handles master branch builds
+      # - master
       - release-*
 
     # Publish `v1.2.3` tags as releases.

--- a/.github/workflows/kserve-controller-docker-publish.yml
+++ b/.github/workflows/kserve-controller-docker-publish.yml
@@ -4,7 +4,8 @@ on:
   push:
     # Publish `master` as Docker `latest` image.
     branches:
-      - master
+      # Tekton now handles master branch builds
+      # - master
       - release-*
 
     # Publish `v1.2.3` tags as releases.

--- a/.github/workflows/kserve-llmisvc-controller-docker-publish.yml
+++ b/.github/workflows/kserve-llmisvc-controller-docker-publish.yml
@@ -2,10 +2,7 @@ name: KServe llmisvc controller Docker Publisher
 
 on:
   push:
-    # Publish `master` as Docker `latest` image.
-    branches:
-      - master
-
+    # Tekton now handles master branch builds (previously: branches: [master])
     # Publish `v1.2.3` tags as releases.
     tags:
       - v*

--- a/.github/workflows/kserve-localmodel-agent-docker-publish.yml
+++ b/.github/workflows/kserve-localmodel-agent-docker-publish.yml
@@ -2,10 +2,7 @@ name: Kserve localmodel agent Docker Publisher
 
 on:
   push:
-    # Publish `master` as Docker `latest` image.
-    branches:
-      - master
-
+    # Tekton now handles master branch builds (previously: branches: [master])
     # Publish `v1.2.3` tags as releases.
     tags:
       - v*

--- a/.github/workflows/kserve-localmodel-controller-docker-publish.yml
+++ b/.github/workflows/kserve-localmodel-controller-docker-publish.yml
@@ -2,10 +2,7 @@ name: Kserve localmodel controller Docker Publisher
 
 on:
   push:
-    # Publish `master` as Docker `latest` image.
-    branches:
-      - master
-
+    # Tekton now handles master branch builds (previously: branches: [master])
     # Publish `v1.2.3` tags as releases.
     tags:
       - v*

--- a/.github/workflows/router-docker-publish.yml
+++ b/.github/workflows/router-docker-publish.yml
@@ -4,7 +4,8 @@ on:
   push:
     # Publish `master` as Docker `latest` image.
     branches:
-      - master
+      # Tekton now handles master branch builds
+      # - master
       - release-*
 
     # Publish `v1.2.3` tags as releases.

--- a/.github/workflows/storage-initializer-docker-publisher.yml
+++ b/.github/workflows/storage-initializer-docker-publisher.yml
@@ -4,7 +4,8 @@ on:
   push:
     # Publish `master` as Docker `latest` image.
     branches:
-      - master
+      # Tekton now handles master branch builds
+      # - master
       - release-*
 
     # Publish `v1.2.3` tags as releases.


### PR DESCRIPTION
## Description

  Disable master branch triggers in GitHub Actions `docker-publish` workflows to
   prevent duplicate image builds now that Tekton handles `:latest` image
  production.

  ## Background

  PR #1544 added Tekton pipelines that build `:latest` images from the master
  branch with the `GOTAGS=distro` flag. To avoid duplicate builds and image
  pushes, the corresponding GHA workflows need to have master branch triggers
  disabled.

  ## Changes

  ### Modified GHA Workflows (.github/workflows/)

  Disabled master branch triggers in 7 workflows while preserving:
  - ✅ Pull request validation (still runs on PRs)
  - ✅ Release branch builds (still runs on `release-*` branches where
  applicable)
  - ✅ Tag-based releases (still runs on version tags)

  **Workflows updated:**

  1. `kserve-controller-docker-publish.yml` - commented out `- master` under
  branches
  2. `agent-docker-publish.yml` - commented out `- master` under branches
  3. `router-docker-publish.yml` - commented out `- master` under branches
  4. `storage-initializer-docker-publisher.yml` - commented out `- master` under
   branches
  5. `kserve-llmisvc-controller-docker-publish.yml` - removed branches section
  (now tags-only)
  6. `kserve-localmodel-controller-docker-publish.yml` - removed branches
  section (now tags-only)
  7. `kserve-localmodel-agent-docker-publish.yml` - removed branches section
  (now tags-only)

  **Pattern used:**
  - Workflows with both `master` and `release-*` triggers: commented out just `#
   - master`
  - Workflows with only `master` trigger: removed entire `branches:` section
  (now trigger only on version tags)

  ## Testing

  After merge:

  1. **Verify GHA workflows disabled on master** - Push to master should NOT
  trigger these 7 workflows
  2. **Verify PR validation still works** - Open a test PR and confirm workflows
   still run
  3. **Verify Tekton builds working** - Confirm Tekton pipelines from #1544 are
  building `:latest` images successfully
  4. **Verify no duplicate builds** - Only Tekton should build/push `:latest`,
  not both GHA and Tekton

  ## Dependencies

  - **Depends on:** #1544 (Tekton pipelines must be in place before merging
  this)
  - **Merge order:** #1544 should merge first, then this PR

  ## Rollback Plan

  If Tekton builds fail:
  1. Revert this PR (or create a new PR uncommenting master branches)
  2. GHA workflows resume building `:latest` immediately

  ## Related Issues

  [RHOAIENG-59131](https://redhat.atlassian.net/browse/RHOAIENG-59131)

  ## Related PRs

  - #1544 - Adds Tekton pipelines for master branch `:latest` builds