### PR TITLE
restoring odh exclusive s3 endpoint handling logic

### DIFF
--- a/pkg/constants/constants_odh.go
+++ b/pkg/constants/constants_odh.go
@@ -63,6 +63,9 @@ const (
 	OpenShiftServiceCaConfigMapName = "openshift-service-ca.crt"
 )
 
+// ODH Connections API
+const ODHS3Endpoint = "AWS_S3_ENDPOINT"
+
 type ResourceType string
 
 const (

--- a/pkg/credentials/s3/s3_secret_odh_test.go
+++ b/pkg/credentials/s3/s3_secret_odh_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package s3
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+func TestODHS3Secret(t *testing.T) {
+	scenarios := map[string]struct {
+		config   S3Config
+		secret   *corev1.Secret
+		expected []corev1.EnvVar
+	}{
+		"S3SecretODHS3EndpointEnvs": {
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "s3-secret",
+					Annotations: map[string]string{
+						InferenceServiceS3SecretEndpointAnnotation: "s3.aws.com",
+					},
+				},
+				Data: map[string][]byte{
+					constants.ODHS3Endpoint: []byte("odh-s3.aws.com"),
+				},
+			},
+			expected: []corev1.EnvVar{
+				{
+					Name: AWSAccessKeyId,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "s3-secret",
+							},
+							Key: AWSAccessKeyIdName,
+						},
+					},
+				},
+				{
+					Name: AWSSecretAccessKey,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "s3-secret",
+							},
+							Key: AWSSecretAccessKeyName,
+						},
+					},
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "odh-s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "https://odh-s3.aws.com",
+				},
+			},
+		},
+
+		"S3SecretODHS3EndpointWithProtocol": {
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "s3-secret",
+					Annotations: map[string]string{
+						InferenceServiceS3SecretEndpointAnnotation: "s3.aws.com",
+					},
+				},
+				Data: map[string][]byte{
+					constants.ODHS3Endpoint: []byte("https://odh-s3.aws.com"),
+					S3UseHttps:              []byte("0"),
+					S3VerifySSL:             []byte("1"),
+				},
+			},
+			expected: []corev1.EnvVar{
+				{
+					Name: AWSAccessKeyId,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "s3-secret",
+							},
+							Key: AWSAccessKeyIdName,
+						},
+					},
+				},
+				{
+					Name: AWSSecretAccessKey,
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "s3-secret",
+							},
+							Key: AWSSecretAccessKeyName,
+						},
+					},
+				},
+				{
+					Name:  S3UseHttps,
+					Value: "1",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "odh-s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "https://odh-s3.aws.com",
+				},
+				{
+					Name:  S3VerifySSL,
+					Value: "1",
+				},
+			},
+		},
+	}
+
+	for name, scenario := range scenarios {
+		envs := BuildSecretEnvs(scenario.secret, &scenario.config)
+
+		if diff := cmp.Diff(scenario.expected, envs); diff != "" {
+			t.Errorf("Test %q unexpected result (-want +got): %v", name, diff)
+		}
+	}
+}

--- a/pkg/credentials/s3/utils.go
+++ b/pkg/credentials/s3/utils.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kserve/kserve/pkg/constants"
 )
 
 // BuildS3EnvVars sets s3 related env variables based on the provided configuration.
@@ -36,7 +38,12 @@ import (
 func BuildS3EnvVars(annotations map[string]string, secretData *map[string][]byte, s3Config *S3Config) []corev1.EnvVar {
 	envs := []corev1.EnvVar{}
 
-	s3Endpoint := getEnvValue(annotations, secretData, InferenceServiceS3SecretEndpointAnnotation, S3Endpoint, s3Config.S3Endpoint)
+	var s3Endpoint string
+	if odhS3Endpoint, ok := getSecretValueFromPtr(secretData, constants.ODHS3Endpoint); ok {
+		s3Endpoint = odhS3Endpoint // ODH only
+	} else {
+		s3Endpoint = getEnvValue(annotations, secretData, InferenceServiceS3SecretEndpointAnnotation, S3Endpoint, s3Config.S3Endpoint)
+	}
 	if s3Endpoint != "" {
 		s3UseHttps, formattedS3Endpoint, s3EndpointUrl := getEndpointConfiguration(s3Endpoint, annotations, secretData, s3Config)
 		if s3UseHttps != "" {
@@ -45,7 +52,6 @@ func BuildS3EnvVars(annotations map[string]string, secretData *map[string][]byte
 				Value: s3UseHttps,
 			})
 		}
-
 		envs = append(envs, corev1.EnvVar{
 			Name:  S3Endpoint,
 			Value: formattedS3Endpoint,

--- a/pkg/credentials/s3/utils_odh_test.go
+++ b/pkg/credentials/s3/utils_odh_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2022 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package s3
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+func TestBuildODHS3EnvVars(t *testing.T) {
+	scenarios := map[string]struct {
+		annotations map[string]string
+		secret      *map[string][]byte
+		config      S3Config
+		expected    []corev1.EnvVar
+	}{
+		"ODHS3Endpoint": {
+			annotations: map[string]string{
+				InferenceServiceS3SecretEndpointAnnotation: "s3.aws.com",
+			},
+			secret: &map[string][]byte{
+				constants.ODHS3Endpoint: []byte("odh-s3.aws.com"),
+			},
+			expected: []corev1.EnvVar{
+				{
+					Name:  S3Endpoint,
+					Value: "odh-s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "https://odh-s3.aws.com",
+				},
+			},
+		},
+		"ODHS3EndpointWithHttpsProtocol": {
+			annotations: map[string]string{
+				InferenceServiceS3SecretEndpointAnnotation: "https://s3.aws.com",
+			},
+			secret: &map[string][]byte{
+				constants.ODHS3Endpoint: []byte("https://odh-s3.aws.com"),
+				S3UseHttps:              []byte("0"),
+				S3VerifySSL:             []byte("1"),
+			},
+			expected: []corev1.EnvVar{
+				{
+					Name:  S3UseHttps,
+					Value: "1",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "odh-s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "https://odh-s3.aws.com",
+				},
+				{
+					Name:  S3VerifySSL,
+					Value: "1",
+				},
+			},
+		},
+		"ODHS3EndpointWithHttpProtocol": {
+			annotations: map[string]string{
+				InferenceServiceS3SecretEndpointAnnotation: "http://s3.aws.com",
+			},
+			secret: &map[string][]byte{
+				constants.ODHS3Endpoint: []byte("http://odh-s3.aws.com"),
+				S3UseHttps:              []byte("1"),
+				S3VerifySSL:             []byte("0"),
+			},
+			expected: []corev1.EnvVar{
+				{
+					Name:  S3UseHttps,
+					Value: "0",
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "odh-s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "http://odh-s3.aws.com",
+				},
+				{
+					Name:  S3VerifySSL,
+					Value: "0",
+				},
+			},
+		},
+	}
+	for name, scenario := range scenarios {
+		envs := BuildS3EnvVars(scenario.annotations, scenario.secret, &scenario.config)
+
+		if diff := cmp.Diff(scenario.expected, envs); diff != "" {
+			t.Errorf("Test %q unexpected result (-want +got): %v", name, diff)
+		}
+	}
+}

--- a/pkg/credentials/s3/utils_test.go
+++ b/pkg/credentials/s3/utils_test.go
@@ -224,7 +224,7 @@ func TestBuildS3EnvVars(t *testing.T) {
 			secret: &map[string][]byte{
 				S3Endpoint:             []byte("s3.aws.com-secret"),
 				S3VerifySSL:            []byte("1"),
-				AWSAnonymousCredential: []byte("fase"),
+				AWSAnonymousCredential: []byte("false"),
 				AWSRegion:              []byte("us-east-2-secret"),
 				S3UseVirtualBucket:     []byte("false"),
 				S3UseAccelerate:        []byte("false"),

--- a/pkg/credentials/service_account_credentials_odh_test.go
+++ b/pkg/credentials/service_account_credentials_odh_test.go
@@ -1,0 +1,531 @@
+/*
+Copyright 2021 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package credentials
+
+import (
+	"testing"
+
+	"github.com/kserve/kserve/pkg/credentials/s3"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
+
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+func TestS3CredentialBuilderWithODHSecretData(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	existingODHServiceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "odh-default",
+			Namespace: "default",
+		},
+		Secrets: []corev1.ObjectReference{
+			{
+				Name:      "odh-s3-secret",
+				Namespace: "default",
+			},
+		},
+	}
+	existingODHS3Secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "odh-s3-secret",
+			Namespace: "default",
+			Annotations: map[string]string{
+				s3.InferenceServiceS3SecretEndpointAnnotation: "s3.aws.com",
+			},
+		},
+		Data: map[string][]byte{
+			"awsAccessKeyID":        {},
+			"awsSecretAccessKey":    {},
+			constants.ODHS3Endpoint: []byte("odh-s3.aws.com"),
+		},
+	}
+
+	existingODHServiceAccountWithProtocol := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "odh-default-with-protocol",
+			Namespace: "default",
+		},
+		Secrets: []corev1.ObjectReference{
+			{
+				Name:      "odh-s3-secret-with-protocol",
+				Namespace: "default",
+			},
+		},
+	}
+	existingODHS3SecretWithProtocol := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "odh-s3-secret-with-protocol",
+			Namespace: "default",
+			Annotations: map[string]string{
+				s3.InferenceServiceS3SecretEndpointAnnotation: "http://s3.aws.com",
+			},
+		},
+		Data: map[string][]byte{
+			"awsAccessKeyID":        {},
+			"awsSecretAccessKey":    {},
+			constants.ODHS3Endpoint: []byte("http://odh-s3.aws.com"),
+			s3.S3VerifySSL:          []byte("0"),
+		},
+	}
+	scenarios := map[string]struct {
+		serviceAccount        *corev1.ServiceAccount
+		secret                *corev1.Secret
+		inputConfiguration    *knservingv1.Configuration
+		expectedConfiguration *knservingv1.Configuration
+		shouldFail            bool
+	}{
+		"Build odh s3 secret data envs": {
+			serviceAccount: existingODHServiceAccount,
+			secret:         existingODHS3Secret,
+			inputConfiguration: &knservingv1.Configuration{
+				Spec: knservingv1.ConfigurationSpec{
+					Template: knservingv1.RevisionTemplateSpec{
+						Spec: knservingv1.RevisionSpec{
+							PodSpec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedConfiguration: &knservingv1.Configuration{
+				Spec: knservingv1.ConfigurationSpec{
+					Template: knservingv1.RevisionTemplateSpec{
+						Spec: knservingv1.RevisionSpec{
+							PodSpec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Env: []corev1.EnvVar{
+											{
+												Name: s3.AWSAccessKeyId,
+												ValueFrom: &corev1.EnvVarSource{
+													SecretKeyRef: &corev1.SecretKeySelector{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "odh-s3-secret",
+														},
+														Key: "awsAccessKeyID",
+													},
+												},
+											},
+											{
+												Name: s3.AWSSecretAccessKey,
+												ValueFrom: &corev1.EnvVarSource{
+													SecretKeyRef: &corev1.SecretKeySelector{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "odh-s3-secret",
+														},
+														Key: "awsSecretAccessKey",
+													},
+												},
+											},
+											{
+												Name:  s3.S3UseHttps,
+												Value: "1",
+											},
+											{
+												Name:  s3.S3Endpoint,
+												Value: "odh-s3.aws.com",
+											},
+											{
+												Name:  s3.AWSEndpointUrl,
+												Value: "https://odh-s3.aws.com",
+											},
+											{
+												Name:  s3.S3VerifySSL,
+												Value: "1",
+											},
+											{
+												Name:  s3.AWSAnonymousCredential,
+												Value: "false",
+											},
+											{
+												Name:  s3.AWSRegion,
+												Value: "us-east-2",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldFail: false,
+		},
+		"Build odh s3 secret data envs with protocol": {
+			serviceAccount: existingODHServiceAccountWithProtocol,
+			secret:         existingODHS3SecretWithProtocol,
+			inputConfiguration: &knservingv1.Configuration{
+				Spec: knservingv1.ConfigurationSpec{
+					Template: knservingv1.RevisionTemplateSpec{
+						Spec: knservingv1.RevisionSpec{
+							PodSpec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedConfiguration: &knservingv1.Configuration{
+				Spec: knservingv1.ConfigurationSpec{
+					Template: knservingv1.RevisionTemplateSpec{
+						Spec: knservingv1.RevisionSpec{
+							PodSpec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Env: []corev1.EnvVar{
+											{
+												Name: s3.AWSAccessKeyId,
+												ValueFrom: &corev1.EnvVarSource{
+													SecretKeyRef: &corev1.SecretKeySelector{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "odh-s3-secret-with-protocol",
+														},
+														Key: "awsAccessKeyID",
+													},
+												},
+											},
+											{
+												Name: s3.AWSSecretAccessKey,
+												ValueFrom: &corev1.EnvVarSource{
+													SecretKeyRef: &corev1.SecretKeySelector{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "odh-s3-secret-with-protocol",
+														},
+														Key: "awsSecretAccessKey",
+													},
+												},
+											},
+											{
+												Name:  s3.S3UseHttps,
+												Value: "0",
+											},
+											{
+												Name:  s3.S3Endpoint,
+												Value: "odh-s3.aws.com",
+											},
+											{
+												Name:  s3.AWSEndpointUrl,
+												Value: "http://odh-s3.aws.com",
+											},
+											{
+												Name:  s3.S3VerifySSL,
+												Value: "0",
+											},
+											{
+												Name:  s3.AWSAnonymousCredential,
+												Value: "false",
+											},
+											{
+												Name:  s3.AWSRegion,
+												Value: "us-east-2",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldFail: false,
+		},
+	}
+
+	builder := NewCredentialBuilder(c, clientset, configMap)
+	for name, scenario := range scenarios {
+		g.Expect(c.Create(t.Context(), scenario.serviceAccount)).NotTo(gomega.HaveOccurred())
+		g.Expect(c.Create(t.Context(), scenario.secret)).NotTo(gomega.HaveOccurred())
+
+		err := builder.CreateSecretVolumeAndEnv(
+			t.Context(),
+			scenario.serviceAccount.Namespace,
+			nil,
+			scenario.serviceAccount.Name,
+			&scenario.inputConfiguration.Spec.Template.Spec.Containers[0],
+			&scenario.inputConfiguration.Spec.Template.Spec.Volumes,
+		)
+		if scenario.shouldFail && err == nil {
+			t.Errorf("Test %q failed: returned success but expected error", name)
+		}
+		// Validate
+		if !scenario.shouldFail {
+			if err != nil {
+				t.Errorf("Test %q failed: returned error: %v", name, err)
+			}
+			if diff := cmp.Diff(scenario.expectedConfiguration, scenario.inputConfiguration); diff != "" {
+				t.Errorf("Test %q unexpected configuration spec (-want +got): %v", name, diff)
+			}
+		}
+		g.Expect(c.Delete(t.Context(), scenario.serviceAccount)).NotTo(gomega.HaveOccurred())
+		g.Expect(c.Delete(t.Context(), scenario.secret)).NotTo(gomega.HaveOccurred())
+	}
+}
+
+func TestS3CredentialBuilderWithODHStorageSecretData(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	existingODHServiceAccount := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "odh-default",
+			Namespace: "default",
+		},
+	}
+	existingODHS3Secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "odh-s3-secret",
+			Namespace: "default",
+			Annotations: map[string]string{
+				s3.InferenceServiceS3SecretEndpointAnnotation: "s3.aws.com",
+			},
+		},
+		Data: map[string][]byte{
+			"awsAccessKeyID":        {},
+			"awsSecretAccessKey":    {},
+			constants.ODHS3Endpoint: []byte("odh-s3.aws.com"),
+		},
+	}
+
+	existingODHServiceAccountWithProtocol := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "odh-default-with-protocol",
+			Namespace: "default",
+		},
+	}
+	existingODHS3SecretWithProtocol := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "odh-s3-secret-with-protocol",
+			Namespace: "default",
+			Annotations: map[string]string{
+				s3.InferenceServiceS3SecretEndpointAnnotation: "http://s3.aws.com",
+			},
+		},
+		Data: map[string][]byte{
+			"awsAccessKeyID":        {},
+			"awsSecretAccessKey":    {},
+			constants.ODHS3Endpoint: []byte("http://odh-s3.aws.com"),
+			s3.S3VerifySSL:          []byte("0"),
+		},
+	}
+	scenarios := map[string]struct {
+		serviceAccount        *corev1.ServiceAccount
+		secret                *corev1.Secret
+		inputConfiguration    *knservingv1.Configuration
+		expectedConfiguration *knservingv1.Configuration
+		shouldFail            bool
+	}{
+		"Build odh s3 secret data envs": {
+			serviceAccount: existingODHServiceAccount,
+			secret:         existingODHS3Secret,
+			inputConfiguration: &knservingv1.Configuration{
+				Spec: knservingv1.ConfigurationSpec{
+					Template: knservingv1.RevisionTemplateSpec{
+						Spec: knservingv1.RevisionSpec{
+							PodSpec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedConfiguration: &knservingv1.Configuration{
+				Spec: knservingv1.ConfigurationSpec{
+					Template: knservingv1.RevisionTemplateSpec{
+						Spec: knservingv1.RevisionSpec{
+							PodSpec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Env: []corev1.EnvVar{
+											{
+												Name: s3.AWSAccessKeyId,
+												ValueFrom: &corev1.EnvVarSource{
+													SecretKeyRef: &corev1.SecretKeySelector{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "odh-s3-secret",
+														},
+														Key: "awsAccessKeyID",
+													},
+												},
+											},
+											{
+												Name: s3.AWSSecretAccessKey,
+												ValueFrom: &corev1.EnvVarSource{
+													SecretKeyRef: &corev1.SecretKeySelector{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "odh-s3-secret",
+														},
+														Key: "awsSecretAccessKey",
+													},
+												},
+											},
+											{
+												Name:  s3.S3UseHttps,
+												Value: "1",
+											},
+											{
+												Name:  s3.S3Endpoint,
+												Value: "odh-s3.aws.com",
+											},
+											{
+												Name:  s3.AWSEndpointUrl,
+												Value: "https://odh-s3.aws.com",
+											},
+											{
+												Name:  s3.S3VerifySSL,
+												Value: "1",
+											},
+											{
+												Name:  s3.AWSAnonymousCredential,
+												Value: "false",
+											},
+											{
+												Name:  s3.AWSRegion,
+												Value: "us-east-2",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldFail: false,
+		},
+		"Build odh s3 secret data envs with protocol": {
+			serviceAccount: existingODHServiceAccountWithProtocol,
+			secret:         existingODHS3SecretWithProtocol,
+			inputConfiguration: &knservingv1.Configuration{
+				Spec: knservingv1.ConfigurationSpec{
+					Template: knservingv1.RevisionTemplateSpec{
+						Spec: knservingv1.RevisionSpec{
+							PodSpec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedConfiguration: &knservingv1.Configuration{
+				Spec: knservingv1.ConfigurationSpec{
+					Template: knservingv1.RevisionTemplateSpec{
+						Spec: knservingv1.RevisionSpec{
+							PodSpec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Env: []corev1.EnvVar{
+											{
+												Name: s3.AWSAccessKeyId,
+												ValueFrom: &corev1.EnvVarSource{
+													SecretKeyRef: &corev1.SecretKeySelector{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "odh-s3-secret-with-protocol",
+														},
+														Key: "awsAccessKeyID",
+													},
+												},
+											},
+											{
+												Name: s3.AWSSecretAccessKey,
+												ValueFrom: &corev1.EnvVarSource{
+													SecretKeyRef: &corev1.SecretKeySelector{
+														LocalObjectReference: corev1.LocalObjectReference{
+															Name: "odh-s3-secret-with-protocol",
+														},
+														Key: "awsSecretAccessKey",
+													},
+												},
+											},
+											{
+												Name:  s3.S3UseHttps,
+												Value: "0",
+											},
+											{
+												Name:  s3.S3Endpoint,
+												Value: "odh-s3.aws.com",
+											},
+											{
+												Name:  s3.AWSEndpointUrl,
+												Value: "http://odh-s3.aws.com",
+											},
+											{
+												Name:  s3.S3VerifySSL,
+												Value: "0",
+											},
+											{
+												Name:  s3.AWSAnonymousCredential,
+												Value: "false",
+											},
+											{
+												Name:  s3.AWSRegion,
+												Value: "us-east-2",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			shouldFail: false,
+		},
+	}
+
+	builder := NewCredentialBuilder(c, clientset, configMap)
+	for name, scenario := range scenarios {
+		g.Expect(c.Create(t.Context(), scenario.serviceAccount)).NotTo(gomega.HaveOccurred())
+		g.Expect(c.Create(t.Context(), scenario.secret)).NotTo(gomega.HaveOccurred())
+		annotations := map[string]string{
+			"serving.kserve.io/storageSecretName": scenario.secret.Name,
+		}
+		err := builder.CreateSecretVolumeAndEnv(
+			t.Context(),
+			scenario.serviceAccount.Namespace,
+			annotations,
+			scenario.serviceAccount.Name,
+			&scenario.inputConfiguration.Spec.Template.Spec.Containers[0],
+			&scenario.inputConfiguration.Spec.Template.Spec.Volumes,
+		)
+		if scenario.shouldFail && err == nil {
+			t.Errorf("Test %q failed: returned success but expected error", name)
+		}
+		// Validate
+		if !scenario.shouldFail {
+			if err != nil {
+				t.Errorf("Test %q failed: returned error: %v", name, err)
+			}
+			if diff := cmp.Diff(scenario.expectedConfiguration, scenario.inputConfiguration); diff != "" {
+				t.Errorf("Test %q unexpected configuration spec (-want +got): %v", name, diff)
+			}
+		}
+		g.Expect(c.Delete(t.Context(), scenario.serviceAccount)).NotTo(gomega.HaveOccurred())
+		g.Expect(c.Delete(t.Context(), scenario.secret)).NotTo(gomega.HaveOccurred())
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. Re-running failed tests: comment `/rerun-all` to rerun all failed workflows.
-->

**What this PR does / why we need it**:
[RHOAIENG-65587](https://redhat.atlassian.net/browse/RHOAIENG-65587)
Restoring ODH exclusive S3 endpoint handling logic: 
To add support for the AWS_S3_ENDPOINT key used exclusively in ODH, a condition has been added to first check for this key in the secret data when setting the S3_ENDPOINT env variable in the container. If this key is not present in the secret data, then the default search logic utilizing the S3_ENDPOINT key will be executed.

Additionally decoupling the tests and constant from upstream logic to avoid sync conflicts.

**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- Unit tests added
- E2E tests already exist

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
ODH Dashboard S3 Endpoint Handling
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed invalid test input in credential validation tests.

* **New Features**
  * S3 endpoint resolution now accepts an additional high-priority secret source for endpoint values, affecting derived S3/endpoint environment settings.

* **Tests**
  * Added and expanded tests covering endpoint formats, protocol variants, HTTPS/SSL flags, and env-var generation for S3 credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->