### PR TITLE
fix: Narrow path traversal check in createNewFile

### DIFF
--- a/pkg/agent/storage/https.go
+++ b/pkg/agent/storage/https.go
@@ -146,6 +146,11 @@ func createNewFile(fileFullName string) (*os.File, error) {
 	protectedPaths := []string{"/etc", "/bin", "/dev", "/usr/bin", "/sbin", "/usr/sbin"}
 	fileFullName = filepath.Clean(fileFullName)
 
+	// Reject root, current directory, and empty paths
+	if fileFullName == "." || fileFullName == "" || fileFullName == "/" {
+		return nil, fmt.Errorf("please provide the full file path. The provided path [%s] is not valid", fileFullName)
+	}
+
 	// Check if path starts with any protected directory
 	for _, protectedPath := range protectedPaths {
 		if strings.HasPrefix(fileFullName, protectedPath+"/") || fileFullName == protectedPath {
@@ -153,13 +158,10 @@ func createNewFile(fileFullName string) (*os.File, error) {
 		}
 	}
 
-	// Reject any path containing traversal sequences upfront
-	if strings.Contains(fileFullName, "..") {
+	// Reject relative paths that escape upward. After filepath.Clean,
+	// ".." components can only remain at the start of a relative path.
+	if strings.HasPrefix(fileFullName, "..") {
 		return nil, fmt.Errorf("path traversal detected in file path: %s", fileFullName)
-	}
-	// Reject paths that resolve to current directory or empty
-	if fileFullName == "." || fileFullName == "" {
-		return nil, fmt.Errorf("please provide the full file path. The provided path [%s] is not valid", fileFullName)
 	}
 
 	if FileExists(fileFullName) {

--- a/pkg/agent/storage/https_test.go
+++ b/pkg/agent/storage/https_test.go
@@ -59,6 +59,12 @@ func TestCreateNewFileValidation(t *testing.T) {
 			description:   "Should reject empty paths",
 		},
 		{
+			name:          "Root path",
+			inputPath:     "/",
+			shouldSucceed: false,
+			description:   "Should reject root filesystem path",
+		},
+		{
 			name:          "Path that resolves to current dir",
 			inputPath:     "./././.",
 			shouldSucceed: false,
@@ -71,10 +77,10 @@ func TestCreateNewFileValidation(t *testing.T) {
 			description:   "Should reject paths that resolve to parent directory",
 		},
 		{
-			name:          "Path with traversal but valid destination",
-			inputPath:     "/tmp/../model.bin",
-			shouldSucceed: false,
-			description:   "Should reject any path containing '..' even if it resolves to valid location",
+			name:          "Path with traversal resolving to valid absolute path",
+			inputPath:     "/tmp/foo/../model.bin",
+			shouldSucceed: true,
+			description:   "filepath.Clean resolves /tmp/foo/../model.bin to /tmp/model.bin which is a valid path",
 		},
 		// Protected paths test cases
 		{


### PR DESCRIPTION
## Summary
- Cherry-pick of downstream fix `bb03ddbbe` that refines the path traversal protection added in #1111
- Changes `strings.Contains(fileFullName, "..")` → `strings.HasPrefix(fileFullName, "..")` — after `filepath.Clean`, `..` can only remain at the start of a relative path, so `Contains` is overly broad and rejects valid absolute paths like `/tmp/foo/../model.bin`
- Adds rejection of root path `/`
- Updates test cases to match the narrower check

This also unblocks the downstream auto-sync job (stable-2.x → rhoai-2.25) which is currently failing due to merge conflicts between this function's two implementations.

Assisted-by: Claude Code (claude.ai/code)