### PR TITLE
feat(kserve-module): add nim.opendatahub.io RBAC for account-editor/viewer roles

### DIFF
--- a/kserve-module/config/rbac/role.yaml
+++ b/kserve-module/config/rbac/role.yaml
@@ -162,6 +162,26 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - nim.opendatahub.io
+  resources:
+  - accounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - nim.opendatahub.io
+  resources:
+  - accounts/finalizers
+  - accounts/status
+  verbs:
+  - get
+  - update
+- apiGroups:
   - operator.openshift.io
   resources:
   - leaderworkersets
@@ -204,6 +224,8 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resourceNames:
+  - account-editor-role
+  - account-viewer-role
   - kserve-admin
   - kserve-edit
   - kserve-llmisvc-distro-role

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -42,7 +42,10 @@ import (
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;get;list;patch;watch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=create;delete;get;list;patch;update;watch
 // escalate/bind scoped to the exact roles and clusterroles deployed by this controller
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=bind;escalate,resourceNames=kserve-admin;kserve-edit;kserve-view;kserve-manager-role;kserve-proxy-role;kserve-llmisvc-manager-role;kserve-llmisvc-distro-role;kserve-metrics-reader-cluster-role;openshift-ai-llminferenceservice-scc;odh-model-controller-role;proxy-role;model-serving-api;metrics-reader;kserve-prometheus-k8s
+// +kubebuilder:rbac:groups=nim.opendatahub.io,resources=accounts,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=nim.opendatahub.io,resources=accounts/finalizers,verbs=get;update
+// +kubebuilder:rbac:groups=nim.opendatahub.io,resources=accounts/status,verbs=get;update
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=bind;escalate,resourceNames=account-editor-role;account-viewer-role;kserve-admin;kserve-edit;kserve-view;kserve-manager-role;kserve-proxy-role;kserve-llmisvc-manager-role;kserve-llmisvc-distro-role;kserve-metrics-reader-cluster-role;openshift-ai-llminferenceservice-scc;odh-model-controller-role;proxy-role;model-serving-api;metrics-reader;kserve-prometheus-k8s
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=bind;escalate,resourceNames=kserve-leader-election-role;llmisvc-leader-election-role;leader-election-role
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles/finalizers;rolebindings/finalizers;clusterroles/finalizers;clusterrolebindings/finalizers,verbs=update
 // no delete — CRDs survive CR deletion


### PR DESCRIPTION
kserve-module controller needs nim.opendatahub.io permissions to deploy
account-editor-role and account-viewer-role ClusterRoles from odh-model-controller manifests.

Without these, the controller hits RBAC escalation errors during reconcile:
```
clusterroles.rbac.authorization.k8s.io "account-editor-role" is forbidden:
user is attempting to grant RBAC permissions not currently held
```

Changes:
- Added kubebuilder RBAC markers for nim.opendatahub.io/accounts (CRUD, finalizers, status)
- Added account-editor-role and account-viewer-role to bind/escalate list
- Regenerated role.yaml via `make manifests-kserve-module`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added account editor and viewer roles enabling granular access control for account management operations with distinct permission levels.

* **Chores**
  * Enhanced account lifecycle and status management permissions to support improved authorization configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->