### PR TITLE
feat: centralize OpenShift operator subscription configurations

### DIFF
--- a/test/scripts/openshift-ci/common.sh
+++ b/test/scripts/openshift-ci/common.sh
@@ -1,7 +1,7 @@
 
 # Source operator subscription configurations
-# Use BASH_SOURCE[-1] to get the path of this common.sh file itself, not the calling script
-COMMON_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[-1]}")" && pwd)"
+# Use BASH_SOURCE[0] to get the path of this common.sh file itself, not the calling script
+COMMON_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${COMMON_SCRIPT_DIR}/operator-subscriptions.sh"
 
 # find_project_root [start_dir] [marker]

--- a/test/scripts/openshift-ci/common.sh
+++ b/test/scripts/openshift-ci/common.sh
@@ -1,4 +1,9 @@
 
+# Source operator subscription configurations
+# Use BASH_SOURCE[-1] to get the path of this common.sh file itself, not the calling script
+COMMON_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[-1]}")" && pwd)"
+source "${COMMON_SCRIPT_DIR}/operator-subscriptions.sh"
+
 # find_project_root [start_dir] [marker]
 #   start_dir : directory to begin the search (defaults to this script’s dir)
 #   marker    : filename or directory name to look for (defaults to "go.mod")

--- a/test/scripts/openshift-ci/deploy.cma.sh
+++ b/test/scripts/openshift-ci/deploy.cma.sh
@@ -17,8 +17,8 @@ set -eu # Exit on error and undefined variables
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 source "${SCRIPT_DIR}/common.sh"
 
-: "${SUBSCRIPTION_NAME:=openshift-custom-metrics-autoscaler-operator}"
-: "${KEDA_NAMESPACE:=openshift-keda}"
+: "${SUBSCRIPTION_NAME:=${CMA_NAME}}"
+: "${KEDA_NAMESPACE:=${CMA_NAMESPACE}}"
 : "${KEDA_OPERATOR_POD_LABEL:=app=keda-operator}"
 : "${KEDA_METRICS_API_SERVER_POD_LABEL:=app=keda-metrics-apiserver}"
 : "${KEDA_WEBHOOK_POD_LABEL:=app=keda-admission-webhooks}"
@@ -60,7 +60,7 @@ metadata:
   name: ${SUBSCRIPTION_NAME}
   namespace: ${KEDA_NAMESPACE}
 spec:
-  channel: stable
+  channel: ${CMA_CHANNEL}
   installPlanApproval: Automatic
   name: ${SUBSCRIPTION_NAME}
   source: redhat-operators

--- a/test/scripts/openshift-ci/infra/deploy.cert-manager.sh
+++ b/test/scripts/openshift-ci/infra/deploy.cert-manager.sh
@@ -17,7 +17,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../common.sh"
 
 echo "⏳ Installing cert-manager"
-oc create namespace ${CERT_MANAGER_NAMESPACE} || true
+oc create namespace "${CERT_MANAGER_NAMESPACE}" || true
 
 {
 cat<<EOF | oc create -f -

--- a/test/scripts/openshift-ci/infra/deploy.cert-manager.sh
+++ b/test/scripts/openshift-ci/infra/deploy.cert-manager.sh
@@ -17,33 +17,33 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../common.sh"
 
 echo "⏳ Installing cert-manager"
-oc create namespace cert-manager-operator || true
+oc create namespace ${CERT_MANAGER_NAMESPACE} || true
 
 {
 cat<<EOF | oc create -f -
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: cert-manager-operator
-  namespace: cert-manager-operator
+  name: ${CERT_MANAGER_NAME}
+  namespace: ${CERT_MANAGER_NAMESPACE}
 spec:
   upgradeStrategy: Default
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: openshift-cert-manager-operator
-  namespace: cert-manager-operator
+  name: ${CERT_MANAGER_NAME}
+  namespace: ${CERT_MANAGER_NAMESPACE}
 spec:
-  channel: stable-v1
+  channel: ${CERT_MANAGER_CHANNEL}
   installPlanApproval: Automatic
-  name: openshift-cert-manager-operator
+  name: ${CERT_MANAGER_NAME}
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 EOF
 } || true
 
-wait_for_subscription_csv "openshift-cert-manager-operator" "cert-manager-operator" 300
+wait_for_subscription_csv "${CERT_MANAGER_NAME}" "${CERT_MANAGER_NAMESPACE}" 300
 wait_for_crd certificates.cert-manager.io 90s
 
 echo "✅ Cert-manager installed"

--- a/test/scripts/openshift-ci/infra/deploy.kuadrant.sh
+++ b/test/scripts/openshift-ci/infra/deploy.kuadrant.sh
@@ -16,7 +16,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../common.sh"
-KUADRANT_NS="${KUADRANT_NS:-kuadrant-system}"
 # Seconds to sleep after discovery passes (apiserver RESTMapper can lag discovery).
 KUADRANT_PRE_CREATE_SLEEP="${KUADRANT_PRE_CREATE_SLEEP:-30}"
 # How many times to wait for Ready before delete/recreate and final failure (default: initial + one retry).
@@ -44,12 +43,12 @@ cat <<EOF | oc create -f -
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: rhcl-operator
+  name: ${RHCL_NAME}
   namespace: ${KUADRANT_NS}
 spec:
-  channel: stable
+  channel: ${RHCL_CHANNEL}
   installPlanApproval: Automatic
-  name: rhcl-operator
+  name: ${RHCL_NAME}
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ---
@@ -63,7 +62,7 @@ spec:
 EOF
 } || true
 
-wait_for_subscription_csv "rhcl-operator" "${KUADRANT_NS}" 600
+wait_for_subscription_csv "${RHCL_NAME}" "${KUADRANT_NS}" 600
 wait_for_crd  kuadrants.kuadrant.io  90s
 # Let apiserver discovery include kuadrants before first reconcile creates child resources with owner refs.
 wait_for_api_discovery "kuadrant.io/v1beta1" "kuadrants" 120

--- a/test/scripts/openshift-ci/infra/deploy.lws.sh
+++ b/test/scripts/openshift-ci/infra/deploy.lws.sh
@@ -19,34 +19,34 @@ source "$SCRIPT_DIR/../common.sh"
 
 echo "⏳ Installing openshift-lws-operator"
 
-oc create ns openshift-lws-operator || true
+oc create ns ${LWS_NAMESPACE} || true
 
 {
 cat <<EOF | oc create -f -
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: leader-worker-set
-  namespace: openshift-lws-operator
+  name: ${LWS_NAME}
+  namespace: ${LWS_NAMESPACE}
 spec:
   targetNamespaces:
-  - openshift-lws-operator
+  - ${LWS_NAMESPACE}
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: leader-worker-set
-  namespace: openshift-lws-operator
+  name: ${LWS_NAME}
+  namespace: ${LWS_NAMESPACE}
 spec:
-  channel: stable-v1.0
+  channel: ${LWS_CHANNEL}
   installPlanApproval: Automatic
-  name: leader-worker-set
+  name: ${LWS_NAME}
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 EOF
 } || true
 
-wait_for_subscription_csv "leader-worker-set" "openshift-lws-operator" 300
+wait_for_subscription_csv "${LWS_NAME}" "${LWS_NAMESPACE}" 300
 wait_for_crd leaderworkersetoperators.operator.openshift.io 90s
 
 {
@@ -55,7 +55,7 @@ apiVersion: operator.openshift.io/v1
 kind: LeaderWorkerSetOperator
 metadata:
   name: cluster
-  namespace: openshift-lws-operator
+  namespace: ${LWS_NAMESPACE}
 spec:
   managementState: Managed
   logLevel: Normal
@@ -64,6 +64,6 @@ EOF
 } || true
 
 echo "⏳ waiting for openshift-lws-operator to be ready.…"
-wait_for_pod_ready "openshift-lws-operator" "name=openshift-lws-operator"
+wait_for_pod_ready "${LWS_NAMESPACE}" "name=openshift-lws-operator"
 
 echo "✅ openshift-lws-operator installed"

--- a/test/scripts/openshift-ci/infra/deploy.lws.sh
+++ b/test/scripts/openshift-ci/infra/deploy.lws.sh
@@ -19,7 +19,7 @@ source "$SCRIPT_DIR/../common.sh"
 
 echo "⏳ Installing openshift-lws-operator"
 
-oc create ns ${LWS_NAMESPACE} || true
+oc create ns "${LWS_NAMESPACE}" || true
 
 {
 cat <<EOF | oc create -f -

--- a/test/scripts/openshift-ci/operator-subscriptions.sh
+++ b/test/scripts/openshift-ci/operator-subscriptions.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# OpenShift Operator Subscription Configurations
+#
+# Single source of truth for operator names, channels, and namespaces
+# Used by both E2E setup scripts and CI infra deployment scripts
+
+# Cert Manager
+CERT_MANAGER_NAME="openshift-cert-manager-operator"
+CERT_MANAGER_NAMESPACE="cert-manager-operator"
+CERT_MANAGER_CHANNEL="stable-v1"
+
+# Leader Worker Set
+LWS_NAME="leader-worker-set"
+LWS_NAMESPACE="openshift-lws-operator"
+LWS_CHANNEL="stable-v1.0"
+
+# Kuadrant (RHCL)
+RHCL_NAME="rhcl-operator"
+KUADRANT_NS="${KUADRANT_NS:-kuadrant-system}"
+RHCL_NAMESPACE="${KUADRANT_NS}"
+RHCL_CHANNEL="stable"
+
+# Custom Metrics Autoscaler (KEDA)
+CMA_NAME="openshift-custom-metrics-autoscaler-operator"
+CMA_NAMESPACE="openshift-keda"
+CMA_CHANNEL="stable"


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactor: centralize OpenShift operator subscription configurations to share with kserve-module

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Parameterized operator subscription configuration in test deployment scripts with environment variables instead of hardcoded values
  * Centralized operator subscription configuration (names, namespaces, channels) for cert-manager, Leader Worker Set, RHCL, and Custom Metrics Autoscaler operators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->