### PR TITLE
refactor(isvc): isolate service reconciler ODH logic behind distro build tag

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/factory.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/factory.go
@@ -50,7 +50,6 @@ type WorkloadReconcilerParams struct {
 type ServiceReconcilerParams struct {
 	Client           client.Client
 	Scheme           *runtime.Scheme
-	ResourceType     constants.ResourceType
 	ComponentMeta    metav1.ObjectMeta
 	ComponentExt     *v1beta1.ComponentExtensionSpec
 	PodSpec          *corev1.PodSpec
@@ -110,7 +109,7 @@ func (f *ReconcilerFactory) CreateServiceReconciler(
 	switch deploymentMode {
 	case constants.Standard, constants.LegacyRawDeployment:
 		return service.NewServiceReconciler(
-			params.Client, params.Scheme, params.ResourceType, params.ComponentMeta, params.ComponentExt,
+			params.Client, params.Scheme, params.ComponentMeta, params.ComponentExt,
 			params.PodSpec, params.MultiNodeEnabled, params.ServiceConfig,
 		), nil
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/raw/raw_kube_reconciler.go
@@ -205,7 +205,6 @@ func NewRawKubeReconciler(ctx context.Context,
 		reconcilers.ServiceReconcilerParams{
 			Client:           client,
 			Scheme:           scheme,
-			ResourceType:     resourceType,
 			ComponentMeta:    componentMeta,
 			ComponentExt:     componentExt,
 			PodSpec:          podSpec,

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
@@ -49,7 +49,6 @@ type ServiceReconciler struct {
 
 func NewServiceReconciler(client client.Client,
 	scheme *runtime.Scheme,
-	resourceType constants.ResourceType,
 	componentMeta metav1.ObjectMeta,
 	componentExt *v1beta1.ComponentExtensionSpec,
 	podSpec *corev1.PodSpec, multiNodeEnabled bool,
@@ -58,7 +57,7 @@ func NewServiceReconciler(client client.Client,
 	return &ServiceReconciler{
 		client:       client,
 		scheme:       scheme,
-		ServiceList:  createService(resourceType, componentMeta, componentExt, podSpec, multiNodeEnabled, serviceConfig),
+		ServiceList:  createService(componentMeta, componentExt, podSpec, multiNodeEnabled, serviceConfig),
 		componentExt: componentExt,
 	}
 }
@@ -78,18 +77,18 @@ func getAppProtocol(port corev1.ContainerPort) *string {
 	return nil
 }
 
-func createService(resourceType constants.ResourceType, componentMeta metav1.ObjectMeta, componentExt *v1beta1.ComponentExtensionSpec,
+func createService(componentMeta metav1.ObjectMeta, componentExt *v1beta1.ComponentExtensionSpec,
 	podSpec *corev1.PodSpec, multiNodeEnabled bool, serviceConfig *v1beta1.ServiceConfig,
 ) []*corev1.Service {
 	var svcList []*corev1.Service
 
 	if !multiNodeEnabled {
 		// If multiNodeEnabled is false, only defaultSvc will be created.
-		defaultSvc := createDefaultSvc(resourceType, componentMeta, componentExt, podSpec, serviceConfig)
+		defaultSvc := createDefaultSvc(componentMeta, componentExt, podSpec, serviceConfig)
 		svcList = append(svcList, defaultSvc)
 	} else {
 		// If multiNodeEnabled is true, create defaultSvc, headSvc and workerSvc.
-		defaultSvc := createDefaultSvc(resourceType, componentMeta, componentExt, podSpec, serviceConfig)
+		defaultSvc := createDefaultSvc(componentMeta, componentExt, podSpec, serviceConfig)
 		svcList = append(svcList, defaultSvc)
 
 		headSvc := createHeadlessSvc(componentMeta)
@@ -102,7 +101,7 @@ func createService(resourceType constants.ResourceType, componentMeta metav1.Obj
 	return svcList
 }
 
-func createDefaultSvc(resourceType constants.ResourceType, componentMeta metav1.ObjectMeta, componentExt *v1beta1.ComponentExtensionSpec,
+func createDefaultSvc(componentMeta metav1.ObjectMeta, componentExt *v1beta1.ComponentExtensionSpec,
 	podSpec *corev1.PodSpec, serviceConfig *v1beta1.ServiceConfig,
 ) *corev1.Service {
 	var servicePorts []corev1.ServicePort
@@ -126,9 +125,6 @@ func createDefaultSvc(resourceType constants.ResourceType, componentMeta metav1.
 				},
 				Protocol:    container.Ports[0].Protocol,
 				AppProtocol: getAppProtocol(container.Ports[0]),
-			}
-			if len(servicePort.Name) == 0 {
-				servicePort.Name = "http"
 			}
 			servicePorts = append(servicePorts, servicePort)
 
@@ -185,44 +181,12 @@ func createDefaultSvc(resourceType constants.ResourceType, componentMeta metav1.
 		},
 	}
 
-	annotations := make(map[string]string, len(service.Annotations)+1)
-	for k, v := range service.Annotations {
-		annotations[k] = v
-	}
-	annotations[constants.OpenshiftServingCertAnnotation] = componentMeta.Name + constants.ServingCertSecretSuffix
-	service.Annotations = annotations
-
-	if resourceType == constants.InferenceGraphResource {
-		servicePorts[0].Port = int32(443)
-	} else {
-		if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && strings.EqualFold(val, "true") {
-			httpsPort := corev1.ServicePort{
-				Name: "https",
-				Port: constants.OauthProxyPort,
-				TargetPort: intstr.IntOrString{
-					Type:   intstr.String,
-					StrVal: "https",
-				},
-				Protocol: corev1.ProtocolTCP,
-			}
-			ports := service.Spec.Ports
-			replaced := false
-			for i, port := range ports {
-				if port.Port == constants.CommonDefaultHttpPort {
-					ports[i] = httpsPort
-					replaced = true
-				}
-			}
-			if !replaced {
-				ports = append(ports, httpsPort)
-			}
-			service.Spec.Ports = ports
-		}
-	}
-
 	if serviceConfig != nil && serviceConfig.ServiceClusterIPNone {
 		service.Spec.ClusterIP = corev1.ClusterIPNone
 	}
+
+	// Allow platform-specific customization of the service (e.g. annotations, port overrides).
+	customizeService(service, componentMeta)
 
 	return service
 }
@@ -254,10 +218,6 @@ func createHeadlessSvc(componentMeta metav1.ObjectMeta) *corev1.Service {
 	isvcGeneration := componentMeta.GetLabels()[constants.InferenceServiceGenerationPodLabelKey]
 	workerComponentMeta.Name = constants.GetHeadServiceName(predictorSvcName, isvcGeneration)
 	workerComponentMeta.Labels[constants.MultiNodeRoleLabelKey] = constants.MultiNodeHead
-	if workerComponentMeta.Annotations == nil {
-		workerComponentMeta.Annotations = make(map[string]string)
-	}
-	workerComponentMeta.Annotations[constants.OpenshiftServingCertAnnotation] = predictorSvcName + constants.ServingCertSecretSuffix
 
 	service := &corev1.Service{
 		ObjectMeta: *workerComponentMeta,
@@ -270,6 +230,10 @@ func createHeadlessSvc(componentMeta metav1.ObjectMeta) *corev1.Service {
 			PublishNotReadyAddresses: true,
 		},
 	}
+
+	// Allow platform-specific customization (e.g. TLS annotations for the head service).
+	customizeHeadSvc(service, predictorSvcName)
+
 	return service
 }
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_default.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_default.go
@@ -1,0 +1,30 @@
+//go:build !distro
+
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// customizeService is the default (upstream) no-op hook for platform-specific service customization.
+func customizeService(_ *corev1.Service, _ metav1.ObjectMeta) {}
+
+// customizeHeadSvc is the default (upstream) no-op hook for platform-specific headless service customization.
+func customizeHeadSvc(_ *corev1.Service, _ string) {}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_odh.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_odh.go
@@ -1,0 +1,92 @@
+//go:build distro
+
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+// customizeService applies ODH-specific customizations to the default service:
+//   - Adds the OpenShift serving certificate annotation for automatic TLS provisioning
+//   - Overrides the service port to 443 for InferenceGraph resources (detected via
+//     constants.InferenceGraphLabel set by the InferenceGraph controller in raw_ig.go)
+//   - Replaces the default HTTP port with an HTTPS port when auth proxy is enabled
+func customizeService(svc *corev1.Service, componentMeta metav1.ObjectMeta) {
+	// Default unnamed ports to "http" - OpenShift Routes and Service Mesh require named ports.
+	for i := range svc.Spec.Ports {
+		if len(svc.Spec.Ports[i].Name) == 0 {
+			svc.Spec.Ports[i].Name = "http"
+		}
+	}
+
+	// Add OpenShift serving cert annotation for automatic TLS certificate provisioning.
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	svc.Annotations[constants.OpenshiftServingCertAnnotation] = componentMeta.Name + constants.ServingCertSecretSuffix
+
+	// InferenceGraph services use port 443 for TLS termination.
+	// Auth proxy port override is skipped for InferenceGraph - TLS is handled at the gateway level.
+	if _, isIG := componentMeta.Labels[constants.InferenceGraphLabel]; isIG {
+		if len(svc.Spec.Ports) > 0 {
+			svc.Spec.Ports[0].Port = int32(443)
+		}
+		return
+	}
+
+	// When auth proxy is enabled, replace the default HTTP port with the HTTPS proxy port.
+	if val, ok := componentMeta.Annotations[constants.ODHKserveRawAuth]; ok && strings.EqualFold(val, "true") {
+		httpsPort := corev1.ServicePort{
+			Name: "https",
+			Port: constants.OauthProxyPort,
+			TargetPort: intstr.IntOrString{
+				Type:   intstr.String,
+				StrVal: "https",
+			},
+			Protocol: corev1.ProtocolTCP,
+		}
+		ports := svc.Spec.Ports
+		replaced := false
+		for i, port := range ports {
+			if port.Port == constants.CommonDefaultHttpPort {
+				ports[i] = httpsPort
+				replaced = true
+			}
+		}
+		if !replaced {
+			ports = append(ports, httpsPort)
+		}
+		svc.Spec.Ports = ports
+	}
+}
+
+// customizeHeadSvc applies ODH-specific customizations to headless (head node) services:
+// - Adds the OpenShift serving certificate annotation using the predictor service name
+func customizeHeadSvc(svc *corev1.Service, predictorSvcName string) {
+	if svc.Annotations == nil {
+		svc.Annotations = make(map[string]string)
+	}
+	svc.Annotations[constants.OpenshiftServingCertAnnotation] = predictorSvcName + constants.ServingCertSecretSuffix
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_odh_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_odh_test.go
@@ -1,0 +1,188 @@
+//go:build distro
+
+/*
+Copyright 2025 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+func TestCustomizeServiceAddsServingCertAnnotation(t *testing.T) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-predictor",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Port: 80}},
+		},
+	}
+	meta := metav1.ObjectMeta{Name: "test-predictor"}
+
+	customizeService(svc, meta)
+
+	assert.Equal(t, "test-predictor"+constants.ServingCertSecretSuffix,
+		svc.Annotations[constants.OpenshiftServingCertAnnotation])
+}
+
+func TestCustomizeServiceInferenceGraphPort(t *testing.T) {
+	svc := &corev1.Service{
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Port: 80}},
+		},
+	}
+	meta := metav1.ObjectMeta{
+		Name: "test-ig",
+		Labels: map[string]string{
+			constants.InferenceGraphLabel: "my-graph",
+		},
+	}
+
+	customizeService(svc, meta)
+
+	assert.Equal(t, int32(443), svc.Spec.Ports[0].Port)
+}
+
+func TestCustomizeServiceAuthProxyPort(t *testing.T) {
+	svc := &corev1.Service{
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "http", Port: constants.CommonDefaultHttpPort},
+			},
+		},
+	}
+	meta := metav1.ObjectMeta{
+		Name: "test-predictor",
+		Annotations: map[string]string{
+			constants.ODHKserveRawAuth: "true",
+		},
+	}
+
+	customizeService(svc, meta)
+
+	assert.Equal(t, int32(constants.OauthProxyPort), svc.Spec.Ports[0].Port)
+	assert.Equal(t, "https", svc.Spec.Ports[0].Name)
+	assert.Equal(t, intstr.IntOrString{Type: intstr.String, StrVal: "https"}, svc.Spec.Ports[0].TargetPort)
+}
+
+func TestCustomizeServiceNoAuthProxyWithoutAnnotation(t *testing.T) {
+	svc := &corev1.Service{
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "http", Port: constants.CommonDefaultHttpPort},
+			},
+		},
+	}
+	meta := metav1.ObjectMeta{Name: "test-predictor"}
+
+	customizeService(svc, meta)
+
+	assert.Equal(t, int32(constants.CommonDefaultHttpPort), svc.Spec.Ports[0].Port)
+}
+
+func TestCustomizeServiceInferenceGraphIgnoresAuthProxy(t *testing.T) {
+	svc := &corev1.Service{
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{{Port: 80}},
+		},
+	}
+	meta := metav1.ObjectMeta{
+		Name: "test-ig",
+		Labels: map[string]string{
+			constants.InferenceGraphLabel: "my-graph",
+		},
+		Annotations: map[string]string{
+			constants.ODHKserveRawAuth: "true",
+		},
+	}
+
+	customizeService(svc, meta)
+
+	// InferenceGraph takes precedence - port should be 443, not the auth proxy port.
+	assert.Equal(t, int32(443), svc.Spec.Ports[0].Port)
+	assert.NotEqual(t, "https", svc.Spec.Ports[0].Name)
+}
+
+func TestCustomizeHeadSvcAddsServingCertAnnotation(t *testing.T) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-head-1",
+		},
+	}
+
+	customizeHeadSvc(svc, "test-predictor")
+
+	assert.Equal(t, "test-predictor"+constants.ServingCertSecretSuffix,
+		svc.Annotations[constants.OpenshiftServingCertAnnotation])
+}
+
+// TestCreateServiceEndToEndWithDistro verifies that the distro hooks are actually wired
+// through the createService path, not just unit-tested in isolation.
+func TestCreateServiceEndToEndWithDistro(t *testing.T) {
+	componentMeta := metav1.ObjectMeta{
+		Name:      "test-predictor",
+		Namespace: "default",
+		Annotations: map[string]string{
+			"annotation": "value",
+		},
+	}
+	podSpec := &corev1.PodSpec{
+		Containers: []corev1.Container{
+			{
+				Name:  "kserve-container",
+				Image: "test-image",
+				Ports: []corev1.ContainerPort{{ContainerPort: 8080, Protocol: corev1.ProtocolTCP}},
+			},
+		},
+	}
+
+	services := createService(componentMeta, &v1beta1.ComponentExtensionSpec{}, podSpec, false, &v1beta1.ServiceConfig{})
+
+	require.Len(t, services, 1)
+	svc := services[0]
+
+	// Verify the distro hook was wired - serving cert annotation must be present.
+	assert.Equal(t, "test-predictor"+constants.ServingCertSecretSuffix,
+		svc.Annotations[constants.OpenshiftServingCertAnnotation],
+		"customizeService hook must be wired through createService")
+}
+
+// TestCreateHeadlessSvcEndToEndWithDistro verifies the head service hook is wired through createHeadlessSvc.
+func TestCreateHeadlessSvcEndToEndWithDistro(t *testing.T) {
+	componentMeta := metav1.ObjectMeta{
+		Name:      "test-predictor",
+		Namespace: "default",
+		Labels: map[string]string{
+			constants.InferenceServiceGenerationPodLabelKey: "1",
+		},
+	}
+
+	svc := createHeadlessSvc(componentMeta)
+
+	assert.Equal(t, "test-predictor"+constants.ServingCertSecretSuffix,
+		svc.Annotations[constants.OpenshiftServingCertAnnotation],
+		"customizeHeadSvc hook must be wired through createHeadlessSvc")
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler_test.go
@@ -18,10 +18,10 @@ package service
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -120,8 +120,7 @@ func TestCreateDefaultDeployment(t *testing.T) {
 						constants.DeploymentMode:  string(constants.Standard),
 					},
 					Annotations: map[string]string{
-						"annotation":                             "annotation-value",
-						constants.OpenshiftServingCertAnnotation: "default-predictor-serving-cert",
+						"annotation": "annotation-value",
 					},
 				},
 				Spec: corev1.ServiceSpec{
@@ -138,7 +137,6 @@ func TestCreateDefaultDeployment(t *testing.T) {
 					},
 				},
 			},
-			nil,
 		},
 		"multiNode-service": {
 			&corev1.Service{
@@ -152,8 +150,7 @@ func TestCreateDefaultDeployment(t *testing.T) {
 						constants.InferenceServiceGenerationPodLabelKey: "1",
 					},
 					Annotations: map[string]string{
-						"annotation":                             "annotation-value",
-						constants.OpenshiftServingCertAnnotation: "default-predictor-serving-cert",
+						"annotation": "annotation-value",
 					},
 				},
 				Spec: corev1.ServiceSpec{
@@ -182,8 +179,7 @@ func TestCreateDefaultDeployment(t *testing.T) {
 						constants.MultiNodeRoleLabelKey:                 constants.MultiNodeHead,
 					},
 					Annotations: map[string]string{
-						"annotation":                             "annotation-value",
-						constants.OpenshiftServingCertAnnotation: "default-predictor-serving-cert",
+						"annotation": "annotation-value",
 					},
 				},
 				Spec: corev1.ServiceSpec{
@@ -250,11 +246,13 @@ func TestCreateDefaultDeployment(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := createService(constants.InferenceServiceResource, tt.args.componentMeta, tt.args.componentExt, tt.args.podSpec, tt.args.multiNodeEnabled, emptyServiceConfig)
-			for i, service := range got {
-				if diff := cmp.Diff(tt.expected[i], service); diff != "" {
-					t.Errorf("Test %q unexpected service (-want +got): %v", tt.name, diff)
-				}
+			got := createService(tt.args.componentMeta, tt.args.componentExt, tt.args.podSpec, tt.args.multiNodeEnabled, emptyServiceConfig)
+			require.Len(t, got, len(tt.expected))
+			for i, svc := range got {
+				// DeepDerivative checks that all non-zero fields in expected are present in actual,
+				// ignoring extra fields (e.g. annotations added by platform-specific hooks).
+				assert.True(t, equality.Semantic.DeepDerivative(tt.expected[i], svc),
+					"service[%d] mismatch: expected %+v, got %+v", i, tt.expected[i], svc)
 			}
 		})
 	}
@@ -302,13 +300,10 @@ func runTestServiceCreate(serviceConfig *v1beta1.ServiceConfig, expectedClusterI
 	componentExt := &v1beta1.ComponentExtensionSpec{}
 	podSpec := &corev1.PodSpec{}
 
-	service := createService(constants.InferenceServiceResource, componentMeta, componentExt, podSpec, false, serviceConfig)
+	service := createService(componentMeta, componentExt, podSpec, false, serviceConfig)
 
-	expectedMeta := *componentMeta.DeepCopy()
-	expectedMeta.Annotations = map[string]string{
-		constants.OpenshiftServingCertAnnotation: "test-service" + constants.ServingCertSecretSuffix,
-	}
-	assert.Equal(t, expectedMeta, service[0].ObjectMeta, "Expected ObjectMeta to be equal")
+	assert.Equal(t, componentMeta.Name, service[0].Name, "Expected Name to be equal")
+	assert.Equal(t, componentMeta.Namespace, service[0].Namespace, "Expected Namespace to be equal")
 	assert.Equal(t, map[string]string{"app": "isvc.test-service"}, service[0].Spec.Selector, "Expected Selector to be equal")
 	assert.Equal(t, expectedClusterIP, service[0].Spec.ClusterIP, "Expected ClusterIP to be equal")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The service reconciler carried OpenShift-specific code inline - serving cert annotations,
InferenceGraph port overrides, and auth proxy port injection - creating merge conflicts on
every upstream sync that touched the service creation path.

This extracts all platform-specific service customization into a build-tagged hook pair:

- `customizeService(svc, componentMeta)` (`//go:build distro`) - adds OpenShift serving cert
  annotation, overrides port to 443 for InferenceGraph (detected via existing
  `InferenceGraphLabel`), and handles auth proxy HTTPS port injection
- `customizeHeadSvc(svc, predictorSvcName)` (`//go:build distro`) - adds serving cert
  annotation to head node services in multi-node deployments

Also removes the midstream-only `ResourceType` parameter from the service reconciler chain.
InferenceGraph detection now uses the label that's already set on the component metadata,
avoiding the need to thread a midstream-only type through the factory and raw reconciler.

The upstream counterpart ([kserve/kserve#5617](https://github.com/kserve/kserve/pull/5617))
adds the hook call points with no-op defaults. When it merges and syncs, the hook calls in
`service_reconciler.go` and `service_reconciler_default.go` will be a no-op merge.

**Which issue(s) this PR fixes**:

Ref: [RHOAIENG-57501](https://redhat.atlassian.net/browse/RHOAIENG-57501)

**Feature/Issue validation/testing**:

- [x] `go build ./...` - upstream path compiles
- [x] `go build -tags distro ./...` - distro path compiles
- [x] `go test ./pkg/.../reconcilers/service/...` - 11 tests pass (no tags)
- [x] `go test -tags distro ./pkg/.../reconcilers/service/...` - 19 tests pass (8 ODH + 11 shared)

Tests include:
- Unit tests for each hook (cert annotation, IG port, auth proxy port, edge cases)
- End-to-end wiring tests that call through `createService`/`createHeadlessSvc` to verify hooks fire
- InferenceGraph + auth proxy interaction test (IG takes precedence)

**Special notes for your reviewer**:

The `raw_ig.go` file in the InferenceGraph controller still has inline ODH code (serving cert
annotation outside build tags). That's tracked by [RHOAIENG-57499](https://redhat.atlassian.net/browse/RHOAIENG-57499)
and out of scope for this PR.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

```release-note
NONE
```