### PR TITLE
feat(llmisvc): discover OpenShift Routes 

### DIFF
--- a/.rules/build-tags.md
+++ b/.rules/build-tags.md
@@ -79,8 +79,9 @@ All midstream companion files use the `_odh.go` suffix (e.g. `router_odh.go`,
    - If the upstream file needs to call the new logic: add a **hook function** - define the
      function signature in a `*_default.go` (no-op, `//go:build !distro`) and provide the real
      implementation in a `*_odh.go` (`//go:build distro`). The upstream file just calls the hook.
-     Reference the canonical pattern: `controller.go` calls `extendControllerSetup()`, implemented
-     as no-op in `controller_setup_default.go` and as ODH setup in `controller_setup_odh.go`.
+     Reference the canonical pattern: `controller.go` calls `r.extendControllerSetup()` (a receiver
+     method on the reconciler), implemented as no-op in `controller_setup_default.go` and as ODH
+     setup in `controller_setup_odh.go`.
    - **Hook functions that need the reconciler must be receiver methods** - When a hook is called
      from a reconciler and the distro implementation needs API client access (via the reconciler),
      define the hook as a receiver method on the reconciler type, not as a standalone function

--- a/config/overlays/odh/rbac/llmisvc/role.yaml
+++ b/config/overlays/odh/rbac/llmisvc/role.yaml
@@ -16,6 +16,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - security.openshift.io
   resourceNames:
   - openshift-ai-llminferenceservice-scc

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_route_ocp_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_route_ocp_test.go
@@ -1,0 +1,154 @@
+//go:build distro
+
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
+)
+
+var _ = Describe("LLMInferenceService Route Discovery", func() {
+	It("should advertise Route host when gateway has no external URLs", func(ctx SpecContext) {
+		svcName := "test-llm-route-discovery"
+		testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+		gatewayNs := testNs.Name
+
+		gateway := Gateway("route-test-gateway",
+			InNamespace[*gwapiv1.Gateway](gatewayNs),
+			WithListener(gwapiv1.HTTPProtocolType),
+			WithHostnameAddresses("route-test-gateway-svc."+gatewayNs+".svc.cluster.local"),
+		)
+		Expect(envTest.Client.Create(ctx, gateway)).To(Succeed())
+		ensureGatewayReady(ctx, envTest.Client, gateway)
+
+		gwService := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "route-test-gateway-svc",
+				Namespace: gatewayNs,
+				Labels: map[string]string{
+					"gateway.networking.k8s.io/gateway-name": "route-test-gateway",
+				},
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					"gateway.networking.k8s.io/gateway-name": "route-test-gateway",
+				},
+				Ports: []corev1.ServicePort{
+					{Name: "https", Port: 443, Protocol: corev1.ProtocolTCP},
+				},
+			},
+		}
+		Expect(envTest.Client.Create(ctx, gwService)).To(Succeed())
+
+		route := &routev1.Route{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "route-test-gateway",
+				Namespace: gatewayNs,
+			},
+			Spec: routev1.RouteSpec{
+				Host: "route-test-gateway.apps.example.com",
+				To: routev1.RouteTargetReference{
+					Kind: "Service",
+					Name: gwService.Name,
+				},
+				TLS: &routev1.TLSConfig{
+					Termination: routev1.TLSTerminationReencrypt,
+				},
+			},
+		}
+		Expect(envTest.Client.Create(ctx, route)).To(Succeed())
+		ensureRouteAdmitted(ctx, envTest.Client, route)
+
+		defer func() {
+			testNs.DeleteAndWait(ctx, route)
+			testNs.DeleteAndWait(ctx, gwService)
+			testNs.DeleteAndWait(ctx, gateway)
+		}()
+
+		llmSvc := LLMInferenceService(svcName,
+			InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+			WithModelURI("hf://facebook/opt-125m"),
+			WithManagedRoute(),
+			WithGatewayRefs(LLMGatewayRef("route-test-gateway", gatewayNs)),
+		)
+		Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+		defer func() {
+			testNs.DeleteAndWait(ctx, llmSvc)
+		}()
+
+		Eventually(func(g Gomega, ctx context.Context) {
+			current := &v1alpha2.LLMInferenceService{}
+			g.Expect(envTest.Client.Get(ctx, client.ObjectKeyFromObject(llmSvc), current)).To(Succeed())
+
+			g.Expect(current.Status.Addresses).ToNot(BeEmpty(), "expected addresses in status")
+
+			var hasRouteAddress bool
+			for _, addr := range current.Status.Addresses {
+				if addr.Origin != nil && string(addr.Origin.Kind) == "Route" {
+					hasRouteAddress = true
+					g.Expect(addr.URL.Scheme).To(Equal("https"))
+					g.Expect(addr.URL.String()).To(ContainSubstring("route-test-gateway.apps.example.com"))
+					g.Expect(string(addr.Origin.Group)).To(Equal(routev1.GroupName))
+					g.Expect(string(addr.Origin.Name)).To(Equal("route-test-gateway"))
+					g.Expect(string(*addr.Origin.Namespace)).To(Equal(gatewayNs))
+				}
+			}
+			g.Expect(hasRouteAddress).To(BeTrue(), "expected at least one address with Route origin")
+		}).WithTimeout(30 * time.Second).WithPolling(time.Second).WithContext(ctx).Should(Succeed())
+	})
+})
+
+func ensureRouteAdmitted(ctx context.Context, c client.Client, route *routev1.Route) {
+	if envTest.UsingExistingCluster() {
+		return
+	}
+
+	created := &routev1.Route{}
+	Expect(c.Get(ctx, client.ObjectKeyFromObject(route), created)).To(Succeed())
+
+	created.Status = routev1.RouteStatus{
+		Ingress: []routev1.RouteIngress{
+			{
+				Host:       route.Spec.Host,
+				RouterName: "default",
+				Conditions: []routev1.RouteIngressCondition{
+					{
+						Type:               routev1.RouteAdmitted,
+						Status:             corev1.ConditionTrue,
+						LastTransitionTime: &metav1.Time{Time: metav1.Now().Time},
+					},
+				},
+			},
+		},
+	}
+
+	Expect(c.Status().Update(ctx, created)).To(Succeed())
+}

--- a/pkg/controller/v1alpha2/llmisvc/controller_setup_odh.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_setup_odh.go
@@ -27,6 +27,7 @@ import (
 	istioapi "istio.io/client-go/pkg/apis/networking/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -65,7 +66,7 @@ func (r *LLMISVCReconciler) extendControllerSetup(mgr manager.Manager, b *builde
 }
 
 // routeChangePredicate fires on Route events that could affect URL discovery:
-// admission state changes, host changes, or backend retargeting.
+// admission state changes, host changes, path changes, or backend retargeting.
 func routeChangePredicate() predicate.Predicate {
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
@@ -84,7 +85,8 @@ func routeChangePredicate() predicate.Predicate {
 				return true
 			}
 
-			return oldRoute.Spec.To.Name != newRoute.Spec.To.Name ||
+			return oldRoute.Spec.Path != newRoute.Spec.Path ||
+				oldRoute.Spec.To.Name != newRoute.Spec.To.Name ||
 				oldRoute.Spec.To.Kind != newRoute.Spec.To.Kind ||
 				!equality.Semantic.DeepEqual(oldRoute.Spec.TLS, newRoute.Spec.TLS)
 		},
@@ -152,8 +154,6 @@ func (r *LLMISVCReconciler) mapRouteToRequests(ctx context.Context, logger logr.
 	httpRouteList := &gwapiv1.HTTPRouteList{}
 	if err := r.List(ctx, httpRouteList, client.MatchingLabels(ChildResourcesLabelSelector.MatchLabels)); err != nil {
 		logger.Error(err, "failed to list HTTPRoutes")
-
-		return reqs
 	}
 
 	for i := range httpRouteList.Items {
@@ -258,8 +258,13 @@ func (r *LLMISVCReconciler) resolveGatewayFromRoute(ctx context.Context, logger 
 		Namespace: route.Namespace,
 		Name:      route.Spec.To.Name,
 	}, svc); err != nil {
-		logger.V(1).Info("service not found for route",
-			"route", route.Name, "service", route.Spec.To.Name)
+		if apierrors.IsNotFound(err) {
+			logger.V(1).Info("service not found for route",
+				"route", route.Name, "service", route.Spec.To.Name)
+		} else {
+			logger.Error(err, "failed to get service for route",
+				"route", route.Name, "service", route.Spec.To.Name)
+		}
 
 		return "", ""
 	}

--- a/pkg/controller/v1alpha2/llmisvc/controller_setup_odh.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_setup_odh.go
@@ -19,12 +19,25 @@ limitations under the License.
 package llmisvc
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
+	routev1 "github.com/openshift/api/route/v1"
 	istioapi "istio.io/client-go/pkg/apis/networking/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/utils"
 )
 
@@ -35,5 +48,226 @@ func (r *LLMISVCReconciler) extendControllerSetup(mgr manager.Manager, b *builde
 	if ok, err := utils.IsCrdAvailable(mgr.GetConfig(), istioapi.SchemeGroupVersion.String(), "DestinationRule"); ok && err == nil {
 		b.Owns(&istioapi.DestinationRule{}, builder.WithPredicates(childResourcesPredicate))
 	}
+
+	if err := routev1.Install(mgr.GetScheme()); err != nil {
+		return fmt.Errorf("failed to add Route v1 APIs to scheme: %w", err)
+	}
+	if ok, err := utils.IsCrdAvailable(mgr.GetConfig(), routev1.GroupVersion.String(), "Route"); ok && err == nil {
+		logger := mgr.GetLogger().WithName("LLMInferenceService.SetupWithManager")
+
+		b.Watches(&routev1.Route{},
+			r.enqueueOnRouteChange(logger),
+			builder.WithPredicates(routeChangePredicate()),
+		)
+	}
+
 	return nil
+}
+
+// routeChangePredicate fires on Route events that could affect URL discovery:
+// admission state changes, host changes, or backend retargeting.
+func routeChangePredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			route, ok := e.Object.(*routev1.Route)
+
+			return ok && admittedHost(route) != ""
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldRoute, ok1 := e.ObjectOld.(*routev1.Route)
+			newRoute, ok2 := e.ObjectNew.(*routev1.Route)
+			if !ok1 || !ok2 {
+				return false
+			}
+
+			if admittedHost(oldRoute) != admittedHost(newRoute) {
+				return true
+			}
+
+			return oldRoute.Spec.To.Name != newRoute.Spec.To.Name ||
+				oldRoute.Spec.To.Kind != newRoute.Spec.To.Kind ||
+				!equality.Semantic.DeepEqual(oldRoute.Spec.TLS, newRoute.Spec.TLS)
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool {
+			return true
+		},
+	}
+}
+
+// enqueueOnRouteChange maps a Route change to reconcile requests for
+// LLMInferenceServices affected by this Route. See mapRouteToRequests for details.
+func (r *LLMISVCReconciler) enqueueOnRouteChange(logger logr.Logger) handler.EventHandler {
+	logger = logger.WithName("enqueueOnRouteChange")
+
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, object client.Object) []reconcile.Request {
+		route, ok := object.(*routev1.Route)
+		if !ok {
+			return nil
+		}
+
+		return r.mapRouteToRequests(ctx, logger, route)
+	})
+}
+
+// mapRouteToRequests resolves which LLMInferenceServices should be reconciled
+// when an OpenShift Route changes. Uses reverse lookup (status.addresses) and
+// three forward strategies (managed HTTPRoute owners, explicit refs, observed status).
+func (r *LLMISVCReconciler) mapRouteToRequests(ctx context.Context, logger logr.Logger, route *routev1.Route) []reconcile.Request {
+	llmSvcList := &v1alpha2.LLMInferenceServiceList{}
+	if err := r.List(ctx, llmSvcList); err != nil {
+		logger.Error(err, "failed to list LLMInferenceServices")
+
+		return nil
+	}
+
+	seen := make(map[types.NamespacedName]bool)
+	var reqs []reconcile.Request
+
+	enqueue := func(key types.NamespacedName) {
+		if !seen[key] {
+			seen[key] = true
+			reqs = append(reqs, reconcile.Request{NamespacedName: key})
+		}
+	}
+
+	// Reverse: enqueue services that currently publish this Route in status.
+	for i := range llmSvcList.Items {
+		if hasRouteOrigin(&llmSvcList.Items[i], route.Name, route.Namespace) {
+			enqueue(types.NamespacedName{Namespace: llmSvcList.Items[i].Namespace, Name: llmSvcList.Items[i].Name})
+		}
+	}
+
+	// Forward: trace Route - Service - gateway, then match via three strategies:
+	//   a) Managed HTTPRoutes: check parentRefs for the gateway, enqueue owning LLMISvc.
+	//   b) Refs-based services: look up explicitly referenced HTTPRoutes and check
+	//      their parentRefs for the gateway.
+	//   c) Previously observed state: fall back to status.router.gateways for services
+	//      whose gateway linkage is derived from merged configs/baseRefs.
+	gwName, gwNamespace := r.resolveGatewayFromRoute(ctx, logger, route)
+	if gwName == "" {
+		return reqs
+	}
+
+	// Only managed HTTPRoutes - external refs handled in strategy (b) below.
+	httpRouteList := &gwapiv1.HTTPRouteList{}
+	if err := r.List(ctx, httpRouteList, client.MatchingLabels(ChildResourcesLabelSelector.MatchLabels)); err != nil {
+		logger.Error(err, "failed to list HTTPRoutes")
+
+		return reqs
+	}
+
+	for i := range httpRouteList.Items {
+		httpRoute := &httpRouteList.Items[i]
+		if !httpRouteReferencesGateway(httpRoute, gwName, gwNamespace) {
+			continue
+		}
+
+		for _, ownerRef := range httpRoute.GetOwnerReferences() {
+			if ownerRef.Kind == "LLMInferenceService" {
+				enqueue(types.NamespacedName{Namespace: httpRoute.Namespace, Name: ownerRef.Name})
+			}
+		}
+	}
+
+	// Catch services using external HTTPRoute refs (no managed HTTPRoute with owner ref).
+	// Check if any LLMISvc references an HTTPRoute whose parentRefs target this gateway.
+	for i := range llmSvcList.Items {
+		llmSvc := &llmSvcList.Items[i]
+		if llmSvc.Spec.Router == nil || llmSvc.Spec.Router.Route == nil || !llmSvc.Spec.Router.Route.HTTP.HasRefs() {
+			continue
+		}
+
+		for _, ref := range llmSvc.Spec.Router.Route.HTTP.Refs {
+			if ref.Name == "" {
+				continue
+			}
+
+			httpRoute := &gwapiv1.HTTPRoute{}
+			if err := r.Get(ctx, types.NamespacedName{Namespace: llmSvc.Namespace, Name: ref.Name}, httpRoute); err != nil {
+				logger.Error(err, "failed to get referenced HTTPRoute",
+					"llmSvc", llmSvc.Name, "httpRoute", ref.Name)
+
+				continue
+			}
+
+			if httpRouteReferencesGateway(httpRoute, gwName, gwNamespace) {
+				enqueue(types.NamespacedName{Namespace: llmSvc.Namespace, Name: llmSvc.Name})
+
+				break
+			}
+		}
+	}
+
+	// Last resort: check previously observed gateway associations from status.
+	// Covers services whose gateway linkage is derived from merged configs/baseRefs
+	// and isn't visible on the raw spec or managed HTTPRoutes.
+	for i := range llmSvcList.Items {
+		if hasRoutingGatewayRef(&llmSvcList.Items[i], gwapiv1.ObjectName(gwName), gwapiv1.Namespace(gwNamespace)) {
+			enqueue(types.NamespacedName{Namespace: llmSvcList.Items[i].Namespace, Name: llmSvcList.Items[i].Name})
+		}
+	}
+
+	return reqs
+}
+
+func httpRouteReferencesGateway(httpRoute *gwapiv1.HTTPRoute, gwName, gwNamespace string) bool {
+	for _, ref := range httpRoute.Spec.ParentRefs {
+		if ref.Group != nil && string(*ref.Group) != gwapiv1.GroupName {
+			continue
+		}
+		if ref.Kind != nil && string(*ref.Kind) != "Gateway" {
+			continue
+		}
+
+		refNS := httpRoute.Namespace
+		if ref.Namespace != nil {
+			refNS = string(*ref.Namespace)
+		}
+
+		if string(ref.Name) == gwName && refNS == gwNamespace {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasRouteOrigin(llmSvc *v1alpha2.LLMInferenceService, routeName, routeNamespace string) bool {
+	for _, addr := range llmSvc.Status.Addresses {
+		if addr.Origin != nil &&
+			addr.Origin.Kind == "Route" &&
+			string(addr.Origin.Name) == routeName &&
+			addr.Origin.Namespace != nil &&
+			string(*addr.Origin.Namespace) == routeNamespace {
+			return true
+		}
+	}
+
+	return false
+}
+
+// resolveGatewayFromRoute traces Route - target Service - gateway name.
+// Returns empty strings if the chain can't be resolved.
+func (r *LLMISVCReconciler) resolveGatewayFromRoute(ctx context.Context, logger logr.Logger, route *routev1.Route) (gwName, gwNamespace string) {
+	if route.Spec.To.Kind != "" && route.Spec.To.Kind != "Service" {
+		return "", ""
+	}
+
+	svc := &corev1.Service{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Namespace: route.Namespace,
+		Name:      route.Spec.To.Name,
+	}, svc); err != nil {
+		logger.V(1).Info("service not found for route",
+			"route", route.Name, "service", route.Spec.To.Name)
+
+		return "", ""
+	}
+
+	name := svc.Spec.Selector[gatewayNameLabel]
+	if name == "" {
+		return "", ""
+	}
+
+	return name, route.Namespace
 }

--- a/pkg/controller/v1alpha2/llmisvc/distro/controller_rbac_odh.go
+++ b/pkg/controller/v1alpha2/llmisvc/distro/controller_rbac_odh.go
@@ -21,4 +21,5 @@ package distro
 // to generate a dedicated ClusterRole included only in distro overlays.
 
 //+kubebuilder:rbac:groups=networking.istio.io,resources=destinationrules,verbs=get;list;watch;create;update;delete
+//+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;watch
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=openshift-ai-llminferenceservice-scc,verbs=use

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_additional_ocp_export_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_additional_ocp_export_test.go
@@ -1,0 +1,71 @@
+//go:build distro
+
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc
+
+import (
+	"context"
+
+	routev1 "github.com/openshift/api/route/v1"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+)
+
+const GatewayNameLabelForTest = gatewayNameLabel
+
+func HasRouteOriginForTest(llmSvc *v1alpha2.LLMInferenceService, routeName, routeNamespace string) bool {
+	return hasRouteOrigin(llmSvc, routeName, routeNamespace)
+}
+
+func HTTPRouteReferencesGatewayForTest(httpRoute *gwapiv1.HTTPRoute, gwName, gwNamespace string) bool {
+	return httpRouteReferencesGateway(httpRoute, gwName, gwNamespace)
+}
+
+func DiscoverRouteURLsForTest(ctx context.Context, c client.Client, gw gatewayWithPaths) ([]DiscoveredURL, error) {
+	return discoverRouteURLs(ctx, c, gw)
+}
+
+func DiscoverAdditionalURLsForTest(r *LLMISVCReconciler, ctx context.Context, discovered []DiscoveredURL) ([]DiscoveredURL, error) {
+	return r.discoverAdditionalURLs(ctx, discovered)
+}
+
+func RouteChangePredicateForTest() predicate.Predicate {
+	return routeChangePredicate()
+}
+
+func MapRouteToRequestsForTest(r *LLMISVCReconciler, ctx context.Context, route *routev1.Route) []reconcile.Request {
+	return r.mapRouteToRequests(ctx, ctrl.Log.WithName("test"), route)
+}
+
+func NewGatewayWithPaths(name, ns string, paths ...string) gatewayWithPaths {
+	return gatewayWithPaths{
+		ref: gwapiv1.ObjectReference{
+			Group:     gwapiv1.GroupName,
+			Kind:      "Gateway",
+			Name:      gwapiv1.ObjectName(name),
+			Namespace: ptr.To(gwapiv1.Namespace(ns)),
+		},
+		paths: paths,
+	}
+}

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_additional_ocp_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_additional_ocp_test.go
@@ -1,0 +1,812 @@
+//go:build distro
+
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llmisvc_test
+
+import (
+	"testing"
+
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	"knative.dev/pkg/apis"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	. "github.com/onsi/gomega"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc"
+)
+
+func gatewayOrigin(name, ns string) *gwapiv1.ObjectReference {
+	return &gwapiv1.ObjectReference{
+		Group:     gwapiv1.GroupName,
+		Kind:      "Gateway",
+		Name:      gwapiv1.ObjectName(name),
+		Namespace: ptr.To(gwapiv1.Namespace(ns)),
+	}
+}
+
+func clusterLocalURL(host, path string) *apis.URL {
+	u := apis.HTTPS(host)
+	u.Path = path
+
+	return u
+}
+
+func notAdmittedRoute(name, ns, host, targetServiceName string) *routev1.Route {
+	r := admittedRoute(name, ns, host, targetServiceName)
+	r.Status.Ingress[0].Conditions[0].Status = corev1.ConditionFalse
+
+	return r
+}
+
+func admittedRoute(name, ns, host, targetServiceName string) *routev1.Route {
+	return &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: routev1.RouteSpec{
+			Host: host,
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: targetServiceName,
+			},
+			TLS: &routev1.TLSConfig{
+				Termination: routev1.TLSTerminationReencrypt,
+			},
+		},
+		Status: routev1.RouteStatus{
+			Ingress: []routev1.RouteIngress{
+				{
+					Host: host,
+					Conditions: []routev1.RouteIngressCondition{
+						{
+							Type:   routev1.RouteAdmitted,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func gwService(name, ns, gwName string) *corev1.Service { //nolint:unparam // ns varies in envtest tests
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels: map[string]string{
+				llmisvc.GatewayNameLabelForTest: gwName,
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				llmisvc.GatewayNameLabelForTest: gwName,
+			},
+		},
+	}
+}
+
+func newFakeClient(objects ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = routev1.Install(scheme)
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()
+}
+
+func TestDiscoverRouteURLs(t *testing.T) {
+	const (
+		gwName = "my-gateway"
+		gwNS   = "openshift-ingress"
+		path   = "/demo-ns/my-model"
+	)
+
+	tests := []struct {
+		name     string
+		objects  []client.Object
+		wantURLs []string
+		wantNil  bool
+	}{
+		{
+			name: "Route fronting gateway backing service",
+			objects: []client.Object{
+				gwService("my-gateway-openshift-default", gwNS, gwName),
+				admittedRoute("my-gateway", gwNS,
+					"my-gateway.apps.example.com",
+					"my-gateway-openshift-default"),
+			},
+			wantURLs: []string{"https://my-gateway.apps.example.com/demo-ns/my-model"},
+		},
+		{
+			name: "Route targeting operator-created service with same pod selector",
+			objects: []client.Object{
+				gwService("my-gateway-openshift-default", gwNS, gwName),
+				gwService("my-gateway-data-science-gateway-class", gwNS, gwName),
+				admittedRoute("my-gateway", gwNS,
+					"my-gateway.apps.example.com",
+					"my-gateway-data-science-gateway-class"),
+			},
+			wantURLs: []string{"https://my-gateway.apps.example.com/demo-ns/my-model"},
+		},
+		{
+			name: "no Route exists",
+			objects: []client.Object{
+				gwService("my-gateway-openshift-default", gwNS, gwName),
+			},
+			wantNil: true,
+		},
+		{
+			name: "Route not admitted",
+			objects: []client.Object{
+				gwService("my-gateway-openshift-default", gwNS, gwName),
+				notAdmittedRoute("my-gateway", gwNS, "host.example.com", "my-gateway-openshift-default"),
+			},
+			wantNil: true,
+		},
+		{
+			name: "Route targets unrelated service",
+			objects: []client.Object{
+				gwService("my-gateway-openshift-default", gwNS, gwName),
+				admittedRoute("unrelated", gwNS,
+					"unrelated.apps.example.com",
+					"some-other-service"),
+			},
+			wantNil: true,
+		},
+		{
+			name: "Route with Edge TLS termination",
+			objects: []client.Object{
+				gwService("my-gateway-openshift-default", gwNS, gwName),
+				func() *routev1.Route {
+					r := admittedRoute("my-gateway", gwNS,
+						"my-gateway.apps.example.com",
+						"my-gateway-openshift-default")
+					r.Spec.TLS = &routev1.TLSConfig{
+						Termination:                   routev1.TLSTerminationEdge,
+						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+					}
+
+					return r
+				}(),
+			},
+			wantURLs: []string{"https://my-gateway.apps.example.com/demo-ns/my-model"},
+		},
+		{
+			name: "disconnected environment topology - Route targets <gw>-data-science-gateway-class with Edge TLS",
+			objects: []client.Object{
+				gwService("my-gateway-data-science-gateway-class", gwNS, gwName),
+				func() *routev1.Route {
+					r := admittedRoute("my-gateway-route", gwNS,
+						"my-gateway.apps.example.com",
+						"my-gateway-data-science-gateway-class")
+					r.Spec.TLS = &routev1.TLSConfig{
+						Termination:                   routev1.TLSTerminationEdge,
+						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+					}
+					r.Spec.Port = &routev1.RoutePort{TargetPort: intstr.FromString("https")}
+
+					return r
+				}(),
+			},
+			wantURLs: []string{"https://my-gateway.apps.example.com/demo-ns/my-model"},
+		},
+		{
+			name: "Route with Spec.Path composes with gateway path",
+			objects: []client.Object{
+				gwService("my-gateway-openshift-default", gwNS, gwName),
+				func() *routev1.Route {
+					r := admittedRoute("my-gateway", gwNS,
+						"my-gateway.apps.example.com",
+						"my-gateway-openshift-default")
+					r.Spec.Path = "/prefix"
+
+					return r
+				}(),
+			},
+			wantURLs: []string{"https://my-gateway.apps.example.com/prefix/demo-ns/my-model"},
+		},
+		{
+			name: "no services with gateway selector",
+			objects: []client.Object{
+				admittedRoute("my-gateway", gwNS,
+					"my-gateway.apps.example.com",
+					"my-gateway-openshift-default"),
+			},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			gw := llmisvc.NewGatewayWithPaths(gwName, gwNS, path)
+
+			urls, err := llmisvc.DiscoverRouteURLsForTest(t.Context(), newFakeClient(tt.objects...), gw)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			if tt.wantNil {
+				g.Expect(urls).To(BeEmpty())
+
+				return
+			}
+
+			var actual []string
+			for _, u := range urls {
+				actual = append(actual, u.URL.String())
+			}
+			g.Expect(actual).To(Equal(tt.wantURLs))
+
+			for _, u := range urls {
+				g.Expect(u.Origin).ToNot(BeNil())
+				g.Expect(string(u.Origin.Kind)).To(Equal("Route"))
+				g.Expect(string(u.Origin.Group)).To(Equal(routev1.GroupName))
+			}
+		})
+	}
+}
+
+func TestDiscoverAdditionalURLs_SkipsGatewaysWithExternalURLs(t *testing.T) {
+	g := NewWithT(t)
+
+	origin := gatewayOrigin("my-gateway", "gw-ns")
+
+	discovered := []llmisvc.DiscoveredURL{
+		{URL: apis.HTTPS("my-model.example.com"), Origin: origin},
+		{URL: clusterLocalURL("gw.gw-ns.svc.cluster.local", "/ns/model"), Origin: origin},
+	}
+
+	r := &llmisvc.LLMISVCReconciler{Client: newFakeClient()}
+	additional, err := llmisvc.DiscoverAdditionalURLsForTest(r, t.Context(), discovered)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(additional).To(BeEmpty())
+}
+
+func TestDiscoverAdditionalURLs_DiscoversRouteForGatewayWithoutExternalURLs(t *testing.T) {
+	g := NewWithT(t)
+
+	const (
+		gwName = "ai-gateway"
+		gwNS   = "openshift-ingress"
+	)
+
+	origin := gatewayOrigin(gwName, gwNS)
+
+	discovered := []llmisvc.DiscoveredURL{
+		{URL: clusterLocalURL("ai-gateway-openshift-default.openshift-ingress.svc.cluster.local", "/demo/model"), Origin: origin},
+	}
+
+	fc := newFakeClient(
+		gwService("ai-gateway-openshift-default", gwNS, gwName),
+		gwService("ai-gateway-data-science-gateway-class", gwNS, gwName),
+		admittedRoute("ai-gateway", gwNS,
+			"ai-gateway.apps.cluster.example.com",
+			"ai-gateway-data-science-gateway-class"),
+	)
+
+	r := &llmisvc.LLMISVCReconciler{Client: fc}
+	additional, err := llmisvc.DiscoverAdditionalURLsForTest(r, t.Context(), discovered)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(additional).To(HaveLen(1))
+	g.Expect(additional[0].URL.String()).To(Equal("https://ai-gateway.apps.cluster.example.com/demo/model"))
+	g.Expect(string(additional[0].Origin.Kind)).To(Equal("Route"))
+	g.Expect(string(additional[0].Origin.Name)).To(Equal("ai-gateway"))
+}
+
+func TestDiscoverAdditionalURLs_MultiplePathsPerGateway(t *testing.T) {
+	g := NewWithT(t)
+
+	const (
+		gwName = "ai-gateway"
+		gwNS   = "openshift-ingress"
+	)
+
+	origin := gatewayOrigin(gwName, gwNS)
+
+	discovered := []llmisvc.DiscoveredURL{
+		{URL: clusterLocalURL("gw.openshift-ingress.svc.cluster.local", "/ns/model-a"), Origin: origin},
+		{URL: clusterLocalURL("gw.openshift-ingress.svc.cluster.local", "/ns/model-b"), Origin: origin},
+	}
+
+	fc := newFakeClient(
+		gwService("ai-gateway-svc", gwNS, gwName),
+		admittedRoute("ai-gateway", gwNS,
+			"ai-gateway.apps.example.com",
+			"ai-gateway-svc"),
+	)
+
+	r := &llmisvc.LLMISVCReconciler{Client: fc}
+	additional, err := llmisvc.DiscoverAdditionalURLsForTest(r, t.Context(), discovered)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(additional).To(HaveLen(2))
+
+	urls := make(map[string]bool)
+	for _, a := range additional {
+		urls[a.URL.String()] = true
+	}
+	g.Expect(urls).To(HaveKey("https://ai-gateway.apps.example.com/ns/model-a"))
+	g.Expect(urls).To(HaveKey("https://ai-gateway.apps.example.com/ns/model-b"))
+}
+
+func TestDiscoverAdditionalURLs_DeduplicatesAgainstExistingURLs(t *testing.T) {
+	g := NewWithT(t)
+
+	const (
+		gwName = "ai-gateway"
+		gwNS   = "openshift-ingress"
+	)
+
+	origin := gatewayOrigin(gwName, gwNS)
+
+	// Simulate a case where the Route URL is already in the discovered set
+	// (e.g. if the gateway status address happens to match the Route host)
+	discovered := []llmisvc.DiscoveredURL{
+		{URL: clusterLocalURL("gw.openshift-ingress.svc.cluster.local", "/demo/model"), Origin: origin},
+		{URL: clusterLocalURL("ai-gateway.apps.example.com", "/demo/model"), Origin: origin},
+	}
+
+	fc := newFakeClient(
+		gwService("ai-gateway-svc", gwNS, gwName),
+		admittedRoute("ai-gateway", gwNS,
+			"ai-gateway.apps.example.com",
+			"ai-gateway-svc"),
+	)
+
+	r := &llmisvc.LLMISVCReconciler{Client: fc}
+	additional, err := llmisvc.DiscoverAdditionalURLsForTest(r, t.Context(), discovered)
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(additional).To(BeEmpty(), "Route URL should be deduplicated against existing discovered URLs")
+}
+
+func TestRouteChangePredicate(t *testing.T) {
+	pred := llmisvc.RouteChangePredicateForTest()
+
+	tests := []struct {
+		name   string
+		old    *routev1.Route
+		new    *routev1.Route
+		expect bool
+	}{
+		{
+			name:   "host change triggers update",
+			old:    admittedRoute("r", "ns", "old.example.com", "svc"),
+			new:    admittedRoute("r", "ns", "new.example.com", "svc"),
+			expect: true,
+		},
+		{
+			name:   "backend retarget triggers update",
+			old:    admittedRoute("r", "ns", "host.example.com", "svc-a"),
+			new:    admittedRoute("r", "ns", "host.example.com", "svc-b"),
+			expect: true,
+		},
+		{
+			name: "TLS termination mode change triggers update",
+			old:  admittedRoute("r", "ns", "host.example.com", "svc"),
+			new: func() *routev1.Route {
+				r := admittedRoute("r", "ns", "host.example.com", "svc")
+				r.Spec.TLS.Termination = routev1.TLSTerminationPassthrough
+
+				return r
+			}(),
+			expect: true,
+		},
+		{
+			name: "TLS added triggers update",
+			old: func() *routev1.Route {
+				r := admittedRoute("r", "ns", "host.example.com", "svc")
+				r.Spec.TLS = nil
+
+				return r
+			}(),
+			new:    admittedRoute("r", "ns", "host.example.com", "svc"),
+			expect: true,
+		},
+		{
+			name:   "no change does not trigger",
+			old:    admittedRoute("r", "ns", "host.example.com", "svc"),
+			new:    admittedRoute("r", "ns", "host.example.com", "svc"),
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			result := pred.Update(event.UpdateEvent{
+				ObjectOld: tt.old,
+				ObjectNew: tt.new,
+			})
+			g.Expect(result).To(Equal(tt.expect))
+		})
+	}
+}
+
+func TestHasRouteOrigin(t *testing.T) {
+	origin := func(kind, name, ns string) *gwapiv1.ObjectReference {
+		return &gwapiv1.ObjectReference{
+			Kind:      gwapiv1.Kind(kind),
+			Name:      gwapiv1.ObjectName(name),
+			Namespace: ptr.To(gwapiv1.Namespace(ns)),
+		}
+	}
+
+	tests := []struct {
+		name      string
+		addresses []v1alpha2.SourcedAddress
+		expect    bool
+	}{
+		{
+			name: "matches Route origin",
+			addresses: []v1alpha2.SourcedAddress{
+				{Origin: origin("Route", "my-route", "gw-ns")},
+			},
+			expect: true,
+		},
+		{
+			name: "different Route name",
+			addresses: []v1alpha2.SourcedAddress{
+				{Origin: origin("Route", "other-route", "gw-ns")},
+			},
+			expect: false,
+		},
+		{
+			name: "Gateway origin not matched",
+			addresses: []v1alpha2.SourcedAddress{
+				{Origin: origin("Gateway", "my-route", "gw-ns")},
+			},
+			expect: false,
+		},
+		{
+			name:      "empty addresses",
+			addresses: nil,
+			expect:    false,
+		},
+		{
+			name: "nil origin skipped",
+			addresses: []v1alpha2.SourcedAddress{
+				{Origin: nil},
+			},
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			llmSvc := &v1alpha2.LLMInferenceService{}
+			llmSvc.Status.Addresses = tt.addresses
+
+			g.Expect(llmisvc.HasRouteOriginForTest(llmSvc, "my-route", "gw-ns")).To(Equal(tt.expect))
+		})
+	}
+}
+
+func TestHTTPRouteReferencesGateway(t *testing.T) {
+	tests := []struct {
+		name   string
+		route  *gwapiv1.HTTPRoute
+		gwName string
+		gwNS   string
+		expect bool
+	}{
+		{
+			name: "parentRef matches gateway",
+			route: &gwapiv1.HTTPRoute{
+				Spec: gwapiv1.HTTPRouteSpec{
+					CommonRouteSpec: gwapiv1.CommonRouteSpec{
+						ParentRefs: []gwapiv1.ParentReference{
+							{Name: "my-gw", Namespace: ptr.To(gwapiv1.Namespace("gw-ns"))},
+						},
+					},
+				},
+			},
+			gwName: "my-gw",
+			gwNS:   "gw-ns",
+			expect: true,
+		},
+		{
+			name: "parentRef does not match",
+			route: &gwapiv1.HTTPRoute{
+				Spec: gwapiv1.HTTPRouteSpec{
+					CommonRouteSpec: gwapiv1.CommonRouteSpec{
+						ParentRefs: []gwapiv1.ParentReference{
+							{Name: "other-gw", Namespace: ptr.To(gwapiv1.Namespace("other-ns"))},
+						},
+					},
+				},
+			},
+			gwName: "my-gw",
+			gwNS:   "gw-ns",
+			expect: false,
+		},
+		{
+			name: "parentRef namespace defaults to HTTPRoute namespace",
+			route: &gwapiv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "route-ns"},
+				Spec: gwapiv1.HTTPRouteSpec{
+					CommonRouteSpec: gwapiv1.CommonRouteSpec{
+						ParentRefs: []gwapiv1.ParentReference{
+							{Name: "my-gw"},
+						},
+					},
+				},
+			},
+			gwName: "my-gw",
+			gwNS:   "route-ns",
+			expect: true,
+		},
+		{
+			name: "matches when one of multiple parentRefs targets the gateway",
+			route: &gwapiv1.HTTPRoute{
+				Spec: gwapiv1.HTTPRouteSpec{
+					CommonRouteSpec: gwapiv1.CommonRouteSpec{
+						ParentRefs: []gwapiv1.ParentReference{
+							{Name: "other-gw", Namespace: ptr.To(gwapiv1.Namespace("other-ns"))},
+							{Name: "my-gw", Namespace: ptr.To(gwapiv1.Namespace("gw-ns"))},
+						},
+					},
+				},
+			},
+			gwName: "my-gw",
+			gwNS:   "gw-ns",
+			expect: true,
+		},
+		{
+			name: "parentRef targeting non-Gateway kind is ignored",
+			route: &gwapiv1.HTTPRoute{
+				Spec: gwapiv1.HTTPRouteSpec{
+					CommonRouteSpec: gwapiv1.CommonRouteSpec{
+						ParentRefs: []gwapiv1.ParentReference{
+							{
+								Group:     ptr.To(gwapiv1.Group("")),
+								Kind:      ptr.To(gwapiv1.Kind("Service")),
+								Name:      "my-gw",
+								Namespace: ptr.To(gwapiv1.Namespace("gw-ns")),
+							},
+						},
+					},
+				},
+			},
+			gwName: "my-gw",
+			gwNS:   "gw-ns",
+			expect: false,
+		},
+		{
+			name: "no parentRefs",
+			route: &gwapiv1.HTTPRoute{
+				Spec: gwapiv1.HTTPRouteSpec{},
+			},
+			gwName: "my-gw",
+			gwNS:   "gw-ns",
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			g.Expect(llmisvc.HTTPRouteReferencesGatewayForTest(tt.route, tt.gwName, tt.gwNS)).To(Equal(tt.expect))
+		})
+	}
+}
+
+func newMapperFakeClient(objects ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	_ = routev1.Install(scheme)
+	_ = gwapiv1.Install(scheme)
+	_ = v1alpha2.AddToScheme(scheme)
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		WithStatusSubresource(&v1alpha2.LLMInferenceService{}).
+		Build()
+}
+
+func TestMapRouteToRequests(t *testing.T) {
+	const (
+		gwName = "my-gateway"
+		gwNS   = "gw-ns"
+	)
+
+	route := admittedRoute("my-route", gwNS, "my-route.apps.example.com", "my-gateway-svc")
+
+	tests := []struct {
+		name    string
+		objects []client.Object
+		want    []types.NamespacedName
+	}{
+		{
+			name: "reverse: enqueues service with Route origin in status",
+			objects: []client.Object{
+				gwService("my-gateway-svc", gwNS, gwName),
+				&v1alpha2.LLMInferenceService{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-with-origin", Namespace: "app-ns"},
+					Status: v1alpha2.LLMInferenceServiceStatus{
+						Addresses: []v1alpha2.SourcedAddress{
+							{Origin: &gwapiv1.ObjectReference{
+								Kind:      "Route",
+								Name:      "my-route",
+								Namespace: ptr.To(gwapiv1.Namespace(gwNS)),
+							}},
+						},
+					},
+				},
+			},
+			want: []types.NamespacedName{{Namespace: "app-ns", Name: "svc-with-origin"}},
+		},
+		{
+			name: "forward (a): enqueues owner of managed HTTPRoute targeting gateway",
+			objects: []client.Object{
+				gwService("my-gateway-svc", gwNS, gwName),
+				&gwapiv1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "managed-route",
+						Namespace: "app-ns",
+						Labels:    map[string]string{constants.KubernetesPartOfLabelKey: constants.LLMInferenceServicePartOfValue},
+						OwnerReferences: []metav1.OwnerReference{
+							{Kind: "LLMInferenceService", Name: "svc-managed", APIVersion: "serving.kserve.io/v1alpha2"},
+						},
+					},
+					Spec: gwapiv1.HTTPRouteSpec{
+						CommonRouteSpec: gwapiv1.CommonRouteSpec{
+							ParentRefs: []gwapiv1.ParentReference{
+								{Name: gwapiv1.ObjectName(gwName), Namespace: ptr.To(gwapiv1.Namespace(gwNS))},
+							},
+						},
+					},
+				},
+				&v1alpha2.LLMInferenceService{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-managed", Namespace: "app-ns"},
+				},
+			},
+			want: []types.NamespacedName{{Namespace: "app-ns", Name: "svc-managed"}},
+		},
+		{
+			name: "forward (b): enqueues service with explicit refs to HTTPRoute targeting gateway",
+			objects: []client.Object{
+				gwService("my-gateway-svc", gwNS, gwName),
+				&gwapiv1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{Name: "external-route", Namespace: "app-ns"},
+					Spec: gwapiv1.HTTPRouteSpec{
+						CommonRouteSpec: gwapiv1.CommonRouteSpec{
+							ParentRefs: []gwapiv1.ParentReference{
+								{Name: gwapiv1.ObjectName(gwName), Namespace: ptr.To(gwapiv1.Namespace(gwNS))},
+							},
+						},
+					},
+				},
+				&v1alpha2.LLMInferenceService{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-refs", Namespace: "app-ns"},
+					Spec: v1alpha2.LLMInferenceServiceSpec{
+						Router: &v1alpha2.RouterSpec{
+							Route: &v1alpha2.GatewayRoutesSpec{
+								HTTP: &v1alpha2.HTTPRouteSpec{
+									Refs: []corev1.LocalObjectReference{{Name: "external-route"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: []types.NamespacedName{{Namespace: "app-ns", Name: "svc-refs"}},
+		},
+		{
+			name: "forward (c): enqueues service with gateway in status.router.gateways",
+			objects: []client.Object{
+				gwService("my-gateway-svc", gwNS, gwName),
+				&v1alpha2.LLMInferenceService{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-status", Namespace: "app-ns"},
+					Status: v1alpha2.LLMInferenceServiceStatus{
+						Router: &v1alpha2.RouterStatus{
+							Gateways: []v1alpha2.ObservedGateway{
+								{ObjectReference: gwapiv1.ObjectReference{
+									Kind:      "Gateway",
+									Name:      gwapiv1.ObjectName(gwName),
+									Namespace: ptr.To(gwapiv1.Namespace(gwNS)),
+								}},
+							},
+						},
+					},
+				},
+			},
+			want: []types.NamespacedName{{Namespace: "app-ns", Name: "svc-status"}},
+		},
+		{
+			name: "deduplicates across strategies",
+			objects: []client.Object{
+				gwService("my-gateway-svc", gwNS, gwName),
+				&gwapiv1.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "managed-route",
+						Namespace: "app-ns",
+						Labels:    map[string]string{constants.KubernetesPartOfLabelKey: constants.LLMInferenceServicePartOfValue},
+						OwnerReferences: []metav1.OwnerReference{
+							{Kind: "LLMInferenceService", Name: "svc-both", APIVersion: "serving.kserve.io/v1alpha2"},
+						},
+					},
+					Spec: gwapiv1.HTTPRouteSpec{
+						CommonRouteSpec: gwapiv1.CommonRouteSpec{
+							ParentRefs: []gwapiv1.ParentReference{
+								{Name: gwapiv1.ObjectName(gwName), Namespace: ptr.To(gwapiv1.Namespace(gwNS))},
+							},
+						},
+					},
+				},
+				&v1alpha2.LLMInferenceService{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-both", Namespace: "app-ns"},
+					Status: v1alpha2.LLMInferenceServiceStatus{
+						Router: &v1alpha2.RouterStatus{
+							Gateways: []v1alpha2.ObservedGateway{
+								{ObjectReference: gwapiv1.ObjectReference{
+									Kind:      "Gateway",
+									Name:      gwapiv1.ObjectName(gwName),
+									Namespace: ptr.To(gwapiv1.Namespace(gwNS)),
+								}},
+							},
+						},
+					},
+				},
+			},
+			want: []types.NamespacedName{{Namespace: "app-ns", Name: "svc-both"}},
+		},
+		{
+			name: "no match returns empty",
+			objects: []client.Object{
+				gwService("my-gateway-svc", gwNS, gwName),
+				&v1alpha2.LLMInferenceService{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-unrelated", Namespace: "app-ns"},
+				},
+			},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			fc := newMapperFakeClient(tt.objects...)
+			r := &llmisvc.LLMISVCReconciler{Client: fc}
+
+			reqs := llmisvc.MapRouteToRequestsForTest(r, t.Context(), route)
+
+			var got []types.NamespacedName
+			for _, req := range reqs {
+				got = append(got, req.NamespacedName)
+			}
+			if tt.want == nil {
+				g.Expect(got).To(BeEmpty())
+			} else {
+				g.Expect(got).To(Equal(tt.want))
+			}
+		})
+	}
+}

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_additional_ocp_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_additional_ocp_test.go
@@ -93,7 +93,7 @@ func admittedRoute(name, ns, host, targetServiceName string) *routev1.Route {
 	}
 }
 
-func gwService(name, ns, gwName string) *corev1.Service { //nolint:unparam // ns varies in envtest tests
+func gwService(name, ns, gwName string) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -218,7 +218,7 @@ func TestDiscoverRouteURLs(t *testing.T) {
 			wantURLs: []string{"https://my-gateway.apps.example.com/demo-ns/my-model"},
 		},
 		{
-			name: "Route with Spec.Path composes with gateway path",
+			name: "Route with path-based routing is skipped",
 			objects: []client.Object{
 				gwService("my-gateway-openshift-default", gwNS, gwName),
 				func() *routev1.Route {
@@ -230,7 +230,25 @@ func TestDiscoverRouteURLs(t *testing.T) {
 					return r
 				}(),
 			},
-			wantURLs: []string{"https://my-gateway.apps.example.com/prefix/demo-ns/my-model"},
+			wantNil: true,
+		},
+		{
+			name: "mixed: host-only Route discovered, path-based Route skipped",
+			objects: []client.Object{
+				gwService("my-gateway-openshift-default", gwNS, gwName),
+				admittedRoute("host-only", gwNS,
+					"my-gateway.apps.example.com",
+					"my-gateway-openshift-default"),
+				func() *routev1.Route {
+					r := admittedRoute("path-based", gwNS,
+						"my-gateway-alt.apps.example.com",
+						"my-gateway-openshift-default")
+					r.Spec.Path = "/prefix"
+
+					return r
+				}(),
+			},
+			wantURLs: []string{"https://my-gateway.apps.example.com/demo-ns/my-model"},
 		},
 		{
 			name: "no services with gateway selector",
@@ -421,6 +439,44 @@ func TestRouteChangePredicate(t *testing.T) {
 			old: func() *routev1.Route {
 				r := admittedRoute("r", "ns", "host.example.com", "svc")
 				r.Spec.TLS = nil
+
+				return r
+			}(),
+			new:    admittedRoute("r", "ns", "host.example.com", "svc"),
+			expect: true,
+		},
+		{
+			name: "path added triggers update",
+			old:  admittedRoute("r", "ns", "host.example.com", "svc"),
+			new: func() *routev1.Route {
+				r := admittedRoute("r", "ns", "host.example.com", "svc")
+				r.Spec.Path = "/prefix"
+
+				return r
+			}(),
+			expect: true,
+		},
+		{
+			name: "path changed triggers update",
+			old: func() *routev1.Route {
+				r := admittedRoute("r", "ns", "host.example.com", "svc")
+				r.Spec.Path = "/old"
+
+				return r
+			}(),
+			new: func() *routev1.Route {
+				r := admittedRoute("r", "ns", "host.example.com", "svc")
+				r.Spec.Path = "/new"
+
+				return r
+			}(),
+			expect: true,
+		},
+		{
+			name: "path removed triggers update",
+			old: func() *routev1.Route {
+				r := admittedRoute("r", "ns", "host.example.com", "svc")
+				r.Spec.Path = "/prefix"
 
 				return r
 			}(),

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_additional_odh.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_additional_odh.go
@@ -19,12 +19,220 @@ limitations under the License.
 package llmisvc
 
 import (
+	"cmp"
 	"context"
+	"fmt"
+	"slices"
+
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/utils/ptr"
+	"knative.dev/pkg/apis"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-// discoverAdditionalURLs is a hook for distribution-specific URL discovery
-// (e.g. OpenShift Routes fronting ClusterIP-backed Gateways).
-// TODO: implement OpenShift Route discovery
-func (r *LLMISVCReconciler) discoverAdditionalURLs(_ context.Context, _ []DiscoveredURL) ([]DiscoveredURL, error) {
-	return nil, nil
+const gatewayNameLabel = "gateway.networking.k8s.io/gateway-name"
+
+// gatewayWithPaths pairs a gateway reference with the URL paths discovered for it.
+type gatewayWithPaths struct {
+	ref   gwapiv1.ObjectReference
+	paths []string
+}
+
+// discoverAdditionalURLs discovers OpenShift Routes that provide external
+// access to Gateways lacking external URLs in their status addresses.
+func (r *LLMISVCReconciler) discoverAdditionalURLs(ctx context.Context, discovered []DiscoveredURL) ([]DiscoveredURL, error) {
+	gateways := gatewaysWithoutExternalURLs(discovered)
+	if len(gateways) == 0 {
+		return nil, nil
+	}
+
+	existingURLs := make(map[string]bool, len(discovered))
+	for _, d := range discovered {
+		existingURLs[d.URL.String()] = true
+	}
+
+	var additional []DiscoveredURL
+
+	for _, gw := range gateways {
+		routeURLs, err := discoverRouteURLs(ctx, r.Client, gw)
+		if err != nil {
+			return nil, fmt.Errorf("failed to discover Routes for gateway %s/%s: %w",
+				ptr.Deref(gw.ref.Namespace, ""), gw.ref.Name, err)
+		}
+
+		for _, u := range routeURLs {
+			if !existingURLs[u.URL.String()] {
+				additional = append(additional, u)
+				existingURLs[u.URL.String()] = true
+			}
+		}
+	}
+
+	return additional, nil
+}
+
+// discoverRouteURLs finds OpenShift Routes that front a gateway's services
+// and returns DiscoveredURLs with Route origin - one per Route per path.
+func discoverRouteURLs(ctx context.Context, c client.Client, gw gatewayWithPaths) ([]DiscoveredURL, error) {
+	ns := string(ptr.Deref(gw.ref.Namespace, ""))
+	gwName := string(gw.ref.Name)
+
+	svcNames, err := gatewayServiceNames(ctx, c, ns, gwName)
+	if err != nil {
+		return nil, err
+	}
+	if len(svcNames) == 0 {
+		return nil, nil
+	}
+
+	routeList := &routev1.RouteList{}
+	if err := c.List(ctx, routeList, client.InNamespace(ns)); err != nil {
+		if meta.IsNoMatchError(err) {
+			log.FromContext(ctx).V(1).Info("OpenShift Route CRD (route.openshift.io/v1) not available, skipping Route discovery")
+
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("failed to list Routes in %s: %w", ns, err)
+	}
+
+	var urls []DiscoveredURL
+	for i := range routeList.Items {
+		route := &routeList.Items[i]
+
+		// Kind defaults to "Service" when empty per OpenShift API
+		if (route.Spec.To.Kind != "" && route.Spec.To.Kind != "Service") || !svcNames[route.Spec.To.Name] {
+			continue
+		}
+
+		host := admittedHost(route)
+		if host == "" {
+			continue
+		}
+
+		origin := &gwapiv1.ObjectReference{
+			Group:     gwapiv1.Group(routev1.GroupName),
+			Kind:      "Route",
+			Name:      gwapiv1.ObjectName(route.Name),
+			Namespace: ptr.To(gwapiv1.Namespace(route.Namespace)),
+		}
+
+		for _, gwPath := range gw.paths {
+			u := routeURL(route, host)
+			if route.Spec.Path != "" {
+				u.Path = route.Spec.Path + gwPath
+			} else {
+				u.Path = gwPath
+			}
+
+			urls = append(urls, DiscoveredURL{URL: u, Origin: origin})
+		}
+	}
+
+	return urls, nil
+}
+
+// gatewayServiceNames returns the names of all Services in the namespace whose
+// pod selector routes traffic to the given gateway's pods.
+// Uses Spec.Selector (not metadata labels) because operator-created services
+// (e.g. <gw>-data-science-gateway-class) may lack the gateway label on their
+// metadata but still select the same pods via the pod selector.
+func gatewayServiceNames(ctx context.Context, c client.Client, ns, gwName string) (map[string]bool, error) {
+	svcList := &corev1.ServiceList{}
+	if err := c.List(ctx, svcList, client.InNamespace(ns)); err != nil {
+		return nil, fmt.Errorf("failed to list Services in %s: %w", ns, err)
+	}
+
+	names := make(map[string]bool)
+	for _, svc := range svcList.Items {
+		if svc.Spec.Selector[gatewayNameLabel] == gwName {
+			names[svc.Name] = true
+		}
+	}
+
+	return names, nil
+}
+
+// routeURL builds a URL from a Route's host, deriving the scheme from its TLS config.
+func routeURL(route *routev1.Route, host string) *apis.URL {
+	if route.Spec.TLS == nil {
+		return apis.HTTP(host)
+	}
+
+	return apis.HTTPS(host)
+}
+
+// admittedHost returns the host of an admitted Route, or empty string if not admitted.
+func admittedHost(route *routev1.Route) string {
+	for _, ingress := range route.Status.Ingress {
+		for _, cond := range ingress.Conditions {
+			if cond.Type == routev1.RouteAdmitted && cond.Status == corev1.ConditionTrue {
+				return ingress.Host
+			}
+		}
+	}
+
+	return ""
+}
+
+// gatewaysWithoutExternalURLs returns gateways that have no external URLs
+// in their discovered addresses, paired with the unique paths for each.
+func gatewaysWithoutExternalURLs(discovered []DiscoveredURL) []gatewayWithPaths {
+	type gwKey struct{ ns, name string }
+	pathsByGW := make(map[gwKey]map[string]bool)
+	hasExternal := make(map[gwKey]bool)
+	orderSeen := make(map[gwKey]gwapiv1.ObjectReference)
+
+	for _, d := range discovered {
+		if d.Origin == nil || d.Origin.Kind != "Gateway" {
+			continue
+		}
+
+		key := gwKey{
+			ns:   string(ptr.Deref(d.Origin.Namespace, "")),
+			name: string(d.Origin.Name),
+		}
+
+		if _, ok := orderSeen[key]; !ok {
+			orderSeen[key] = *d.Origin
+		}
+
+		if IsExternalURL(d.URL) {
+			hasExternal[key] = true
+		}
+
+		if pathsByGW[key] == nil {
+			pathsByGW[key] = make(map[string]bool)
+		}
+		pathsByGW[key][d.URL.Path] = true
+	}
+
+	var result []gatewayWithPaths
+	for key, ref := range orderSeen {
+		if hasExternal[key] {
+			continue
+		}
+
+		paths := make([]string, 0, len(pathsByGW[key]))
+		for p := range pathsByGW[key] {
+			paths = append(paths, p)
+		}
+		slices.Sort(paths)
+
+		result = append(result, gatewayWithPaths{ref: ref, paths: paths})
+	}
+
+	slices.SortFunc(result, func(a, b gatewayWithPaths) int {
+		if c := cmp.Compare(string(ptr.Deref(a.ref.Namespace, "")), string(ptr.Deref(b.ref.Namespace, ""))); c != 0 {
+			return c
+		}
+
+		return cmp.Compare(string(a.ref.Name), string(b.ref.Name))
+	})
+
+	return result
 }

--- a/pkg/controller/v1alpha2/llmisvc/router_discovery_additional_odh.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery_additional_odh.go
@@ -114,6 +114,19 @@ func discoverRouteURLs(ctx context.Context, c client.Client, gw gatewayWithPaths
 			continue
 		}
 
+		// Routes with path-based routing are incompatible with gateway URL
+		// discovery. HAProxy uses different regex patterns for rewrite-target
+		// "/" vs other values, making reliable reverse-computation of the
+		// client-facing URL fragile. In practice, Routes fronting gateway
+		// services are host-only; path-based variants are rare and likely
+		// misconfigured for this use case.
+		if route.Spec.Path != "" {
+			log.FromContext(ctx).V(1).Info("skipping Route with path-based routing incompatible with gateway URL discovery",
+				"route", route.Name, "namespace", route.Namespace, "path", route.Spec.Path)
+
+			continue
+		}
+
 		origin := &gwapiv1.ObjectReference{
 			Group:     gwapiv1.Group(routev1.GroupName),
 			Kind:      "Route",
@@ -123,11 +136,7 @@ func discoverRouteURLs(ctx context.Context, c client.Client, gw gatewayWithPaths
 
 		for _, gwPath := range gw.paths {
 			u := routeURL(route, host)
-			if route.Spec.Path != "" {
-				u.Path = route.Spec.Path + gwPath
-			} else {
-				u.Path = gwPath
-			}
+			u.Path = gwPath
 
 			urls = append(urls, DiscoveredURL{URL: u, Origin: origin})
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

On environments without LoadBalancer support (bare-metal, disconnected clusters), Gateways only report cluster-local addresses. The external endpoint comes from an OpenShift Route fronting the gateway service, but the controller had no awareness of Routes - leaving the status without any externally reachable URL.

The controller now watches OpenShift Routes and populates status addresses with Route-provided hosts when a gateway lacks external URLs. This enables consumers to find the correct endpoint without manual Route inspection, regardless of how the gateway service is exposed

Also adds a Route watch with predicate filtering (admission state, backend retargeting, TLS changes) so status updates promptly when Routes are admitted or reconfigured.

Upstreamed as kserve/kserve#5651 for the `extendControllerSetup` signature change.

**Which issue(s) this PR fixes**:

[RHOAIENG-62915](https://redhat.atlassian.net/browse/RHOAIENG-62915)

**Feature/Issue validation/testing**:

- [x] Unit tests for Route discovery (8 cases), discoverAdditionalURLs (4 cases), routeChangePredicate (5 cases)
- [x] Envtest integration test: full reconciliation with cluster-local gateway + admitted Route
- [x] Validated against disconnected environment gateway configuration doc

**Special notes for your reviewer**:

The Route watch mapper follows the same pattern as enqueueOnGatewayChange - fast path via status.Router.Gateways, fallback via combineBaseRefsConfig.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?

```release-note
Automatically discover OpenShift Routes for gateways without external URLs and surface their hosts in LLMInferenceService status addresses.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LLMInferenceService now automatically discovers OpenShift Routes targeting associated gateways and exposes external URLs via service status, synchronized as Routes change.

* **Bug Fixes**
  * Completed and expanded additional external URL discovery for admitted OpenShift Routes, including proper TLS scheme/URL handling and deduplication.

* **Security / RBAC**
  * Added required read permissions for OpenShift Routes to support the new discovery behavior.

* **Tests**
  * Added distro-gated integration and unit tests covering route/gateway resolution and reconcile request mapping.

* **Documentation**
  * Updated the build-tag guidance example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->