### PR TITLE
fix(build): add distro-builds rule and fix GOTAGS propagation gaps

### DIFF
--- a/.rules/build-tags.md
+++ b/.rules/build-tags.md
@@ -1,8 +1,9 @@
 # Midstream Build Tags and Companion File Rules
 
-Violations 1-6 apply to **Go source files** (`*.go`, `*_test.go`) - skip them for non-Go diffs.
-Rules 7-8 (GOTAGS build system propagation) apply to **Dockerfiles, Makefiles, and Tekton/CI
-pipeline files** - always check those regardless of whether Go files are in the diff.
+These rules apply to **Go source files** (`*.go`, `*_test.go`) - skip them for non-Go diffs.
+
+For GOTAGS build system propagation (Dockerfiles, Makefiles, Tekton pipelines), see
+`distro-builds.md`.
 
 ## Context - why these rules exist
 
@@ -92,38 +93,6 @@ All midstream companion files use the `_odh.go` suffix (e.g. `router_odh.go`,
 
    Note: additive `*_odh.go` files that only introduce new symbols not called from upstream code
    do NOT require a `*_default.go` companion.
-
-## Build system propagation rules
-
-These rules apply when the diff touches **Dockerfiles**, **Makefile targets**, **Tekton PipelineRuns**,
-or any other CI/build system file that builds Go binaries importing `pkg/scheme` or any
-`//go:build distro` gated code.
-
-The core principle: `GOTAGS=distro` must flow unbroken from the build system into `go build`.
-Every layer in the chain is a potential break point.
-
-7. **Dockerfile missing GOTAGS support** - Any Dockerfile that compiles a Go binary which imports
-   `pkg/scheme` (or any package with `//go:build distro` companion files) must declare `ARG GOTAGS`
-   in the builder stage and pass `-tags "${GOTAGS}"` to `go build`. Without this, `*_odh.go` files
-   are silently skipped - causing missing scheme registrations, CRD watch failures, or runtime
-   crashes. Two valid patterns:
-   - `ARG GOTAGS=""` when the caller always supplies the value (Makefile / generic CI).
-   - `ARG GOTAGS="distro"` when the Dockerfile is exclusively used for distro builds (Konflux).
-   Canonical references: `llmisvc-controller.Dockerfile` (Makefile pattern),
-   `Dockerfiles/llmisvc-controller.Dockerfile.konflux` (Konflux pattern).
-
-8. **Build system invocation not passing GOTAGS** - Every invocation of a Dockerfile covered by
-   rule 7 must pass `GOTAGS=distro` through that build system's mechanism for Docker build
-   arguments. The mechanism varies by system - check each caller type in the diff:
-   - **Makefile**: `--build-arg GOTAGS=${GOTAGS}` on the `buildx build` call.
-     Canonical references: `docker-build` and `docker-build-llmisvc` in `Makefile`.
-   - **Tekton PipelineRun** (`.tekton/*.yaml`): `build-args: ["GOTAGS=distro"]` in `spec.params`.
-     Canonical reference: `odh-kserve-llmisvc-controller-pull-request.yaml` in `.tekton/`.
-   - **Konflux Dockerfiles** (`Dockerfiles/*.Dockerfile.konflux`): prefer `ARG GOTAGS="distro"`
-     as the default so the pipeline does not need to pass it explicitly.
-     Canonical reference: `Dockerfiles/llmisvc-controller.Dockerfile.konflux`.
-   If a new build system is introduced, apply the same principle: locate the equivalent of
-   `--build-arg` for that system and verify GOTAGS reaches the compiler.
 
 ## Exemptions - do not flag
 

--- a/.rules/distro-builds.md
+++ b/.rules/distro-builds.md
@@ -1,0 +1,66 @@
+# Distro Build Propagation Rules
+
+These rules apply when the diff touches **Dockerfiles**, **Makefile targets**, **Tekton PipelineRuns**,
+or any other CI/build system file that builds Go binaries from this repository.
+
+## Context - why GOTAGS must flow through every build layer
+
+Midstream code lives behind `//go:build distro` companion files (see `build-tags.md` for companion
+file rules). These files are compiled only when `-tags distro` is passed to `go build`. The build
+tag must flow unbroken from the outermost build system (Makefile, Tekton, Konflux) through Docker
+build-args into the `go build` command. Every layer in the chain is a potential break point - and
+failures are silent: the binary compiles fine but ships without midstream scheme registrations,
+CRD watches, or runtime behavior. The symptom is a runtime crash or missing functionality, not a
+build error.
+
+The key transitive dependency: any binary whose `cmd/` package imports `pkg/scheme` pulls in
+`pkg/scheme/register_odh.go` (`//go:build distro`), which registers OpenShift/ODH API types.
+Without the tag, those types are never registered and the controller crashes on first reconcile.
+
+## Violations - flag as blocking
+
+1. **Dockerfile missing GOTAGS support** - Any Dockerfile that compiles a Go binary from this
+   repository must declare `ARG GOTAGS` in the builder stage and pass `-tags "${GOTAGS}"` to
+   `go build`. Without this, `*_odh.go` files are silently skipped. Two valid default patterns:
+   - `ARG GOTAGS=""` when the caller supplies the value (Makefile / generic CI).
+   - `ARG GOTAGS="distro"` when the Dockerfile is exclusively used for distro builds (Konflux).
+   Canonical references: `llmisvc-controller.Dockerfile` (Makefile pattern),
+   `localmodel-agent.Dockerfile` (Makefile pattern).
+
+2. **Makefile docker-build target not passing GOTAGS** - Every `docker-build-*` target in the
+   Makefile that builds a Go Dockerfile must include `--build-arg GOTAGS=${GOTAGS}` on the
+   `buildx build` call. `Makefile.overrides.mk` sets `GOTAGS=distro`, but the value only reaches
+   the compiler if each target explicitly passes it as a build-arg.
+   Canonical references: `docker-build` and `docker-build-llmisvc` targets in `Makefile`.
+
+3. **Tekton PipelineRun missing GOTAGS** - Every `odh-*` PipelineRun in `.tekton/` that builds a
+   Go image must include `build-args: ["GOTAGS=distro"]` in `spec.params`. The upstream
+   `kserve-*` PipelineRuns also pass GOTAGS for consistency.
+   Canonical reference: `odh-kserve-llmisvc-controller-pull-request.yaml`.
+
+4. **Konflux Dockerfile without GOTAGS default** - Dockerfiles under `Dockerfiles/` with the
+   `.konflux` suffix are used exclusively for distro builds. They should default to
+   `ARG GOTAGS="distro"` so the pipeline does not need to pass it explicitly. If a Konflux
+   Dockerfile compiles Go and lacks this default, flag it.
+   Note: Konflux Dockerfiles live in the downstream repo (`red-hat-data-services/kserve`), not in
+   midstream. This rule applies when reviewing downstream PRs.
+
+5. **New Go binary without GOTAGS audit** - When a PR adds a new `cmd/` entry point, a new
+   Dockerfile, or a new Makefile `docker-build-*` target, verify the full chain:
+   - Does the Dockerfile declare `ARG GOTAGS` and pass `-tags "${GOTAGS}"`?
+   - Does the Makefile target pass `--build-arg GOTAGS=${GOTAGS}`?
+   - Does the corresponding Tekton PipelineRun include `build-args: ["GOTAGS=distro"]`?
+   - If a Konflux variant exists downstream, does it default to `ARG GOTAGS="distro"`?
+   Flag any gap as blocking. A single missing layer silently disables all distro code.
+
+## Exemptions - do not flag
+
+- **`kserve-module-controller.Dockerfile`** - This Dockerfile builds the kserve-module controller,
+  which is purely midstream code. There is no upstream/distro build-tag split - all code compiles
+  unconditionally. GOTAGS is not needed.
+
+- **Python Dockerfiles** (`python/*.Dockerfile`) - These build Python serving runtimes, not Go
+  binaries. GOTAGS does not apply.
+
+- **Sample/doc Dockerfiles** (`docs/samples/**/*.Dockerfile`) - Example Dockerfiles for
+  documentation purposes. Not part of the production build pipeline.

--- a/Makefile
+++ b/Makefile
@@ -492,22 +492,22 @@ docker-push-llmisvc: docker-build-llmisvc
 	${ENGINE} push ${KO_DOCKER_REPO}/${LLMISVC_CONTROLLER_IMG}
 
 docker-build-localmodel:
-	${ENGINE} buildx build ${ARCH} -t ${KO_DOCKER_REPO}/${LOCALMODEL_CONTROLLER_IMG} -f localmodel.Dockerfile .
+	${ENGINE} buildx build ${ARCH} --build-arg GOTAGS=${GOTAGS} -t ${KO_DOCKER_REPO}/${LOCALMODEL_CONTROLLER_IMG} -f localmodel.Dockerfile .
 
 docker-push-localmodel: docker-build-localmodel
 	${ENGINE} buildx build ${ARCH} --push -t ${KO_DOCKER_REPO}/${LOCALMODEL_CONTROLLER_IMG} -f localmodel.Dockerfile .
 
 docker-build-localmodelnode-agent:
-	${ENGINE} buildx build ${ARCH} -t ${KO_DOCKER_REPO}/${LOCALMODEL_AGENT_IMG} -f localmodel-agent.Dockerfile .
+	${ENGINE} buildx build ${ARCH} --build-arg GOTAGS=${GOTAGS} -t ${KO_DOCKER_REPO}/${LOCALMODEL_AGENT_IMG} -f localmodel-agent.Dockerfile .
 
 docker-push-localmodelnode-agent: docker-build-localmodelnode-agent
 	${ENGINE} buildx build ${ARCH} --push -t ${KO_DOCKER_REPO}/${LOCALMODEL_AGENT_IMG} -f localmodel-agent.Dockerfile .
 
 docker-build-agent:
-	${ENGINE} buildx build ${ARCH} -f agent.Dockerfile . -t ${KO_DOCKER_REPO}/${AGENT_IMG}
+	${ENGINE} buildx build ${ARCH} --build-arg GOTAGS=${GOTAGS} -f agent.Dockerfile . -t ${KO_DOCKER_REPO}/${AGENT_IMG}
 
 docker-build-router:
-	${ENGINE} buildx build ${ARCH} -f router.Dockerfile . -t ${KO_DOCKER_REPO}/${ROUTER_IMG}
+	${ENGINE} buildx build ${ARCH} --build-arg GOTAGS=${GOTAGS} -f router.Dockerfile . -t ${KO_DOCKER_REPO}/${ROUTER_IMG}
 
 docker-push-agent:
 	${ENGINE} push ${KO_DOCKER_REPO}/${AGENT_IMG}

--- a/Makefile
+++ b/Makefile
@@ -495,13 +495,13 @@ docker-build-localmodel:
 	${ENGINE} buildx build ${ARCH} --build-arg GOTAGS=${GOTAGS} -t ${KO_DOCKER_REPO}/${LOCALMODEL_CONTROLLER_IMG} -f localmodel.Dockerfile .
 
 docker-push-localmodel: docker-build-localmodel
-	${ENGINE} buildx build ${ARCH} --push -t ${KO_DOCKER_REPO}/${LOCALMODEL_CONTROLLER_IMG} -f localmodel.Dockerfile .
+	${ENGINE} buildx build ${ARCH} --push --build-arg GOTAGS=${GOTAGS} -t ${KO_DOCKER_REPO}/${LOCALMODEL_CONTROLLER_IMG} -f localmodel.Dockerfile .
 
 docker-build-localmodelnode-agent:
 	${ENGINE} buildx build ${ARCH} --build-arg GOTAGS=${GOTAGS} -t ${KO_DOCKER_REPO}/${LOCALMODEL_AGENT_IMG} -f localmodel-agent.Dockerfile .
 
 docker-push-localmodelnode-agent: docker-build-localmodelnode-agent
-	${ENGINE} buildx build ${ARCH} --push -t ${KO_DOCKER_REPO}/${LOCALMODEL_AGENT_IMG} -f localmodel-agent.Dockerfile .
+	${ENGINE} buildx build ${ARCH} --push --build-arg GOTAGS=${GOTAGS} -t ${KO_DOCKER_REPO}/${LOCALMODEL_AGENT_IMG} -f localmodel-agent.Dockerfile .
 
 docker-build-agent:
 	${ENGINE} buildx build ${ARCH} --build-arg GOTAGS=${GOTAGS} -f agent.Dockerfile . -t ${KO_DOCKER_REPO}/${AGENT_IMG}

--- a/localmodel.Dockerfile
+++ b/localmodel.Dockerfile
@@ -16,11 +16,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM deps AS builder
 
 ARG CMD=localmodel
+ARG GOTAGS=""
 COPY cmd/${CMD}/ cmd/${CMD}/
 COPY pkg/    pkg/
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=readonly go build -a -o localmodel-manager ./cmd/${CMD}
+    CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=readonly go build -tags "${GOTAGS}" -a -o localmodel-manager ./cmd/${CMD}
 
 # ---- License stage (parallel with build on BuildKit) ----
 FROM deps AS license

--- a/router.Dockerfile
+++ b/router.Dockerfile
@@ -13,11 +13,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 FROM deps AS builder
 
 ARG CMD=router
+ARG GOTAGS=""
 COPY cmd/${CMD}/ cmd/${CMD}/
 COPY pkg/    pkg/
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=readonly go build -a -o router ./cmd/${CMD}
+    CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=readonly go build -tags "${GOTAGS}" -a -o router ./cmd/${CMD}
 
 # ---- License stage (parallel with build on BuildKit) ----
 FROM deps AS license


### PR DESCRIPTION
**What this PR does / why we need it**:

Several Go Dockerfiles and Makefile targets were missing GOTAGS support, causing `//go:build distro` code (scheme registrations, ODH-specific controllers) to be silently excluded from built images. This was caught downstream in red-hat-data-services/kserve#4365 for localmodel Konflux images, but the root cause exists across multiple components.

This PR:
- Adds `.rules/distro-builds.md` covering the full GOTAGS propagation chain (Dockerfiles, Makefile targets, Tekton pipelines, Konflux variants) to catch this class of silent build failure during reviews
- Extracts build system rules from `build-tags.md` into the new file for better visibility
- Fixes `localmodel.Dockerfile` (actively broken - imports `pkg/scheme`) and `router.Dockerfile` (future-proofing) to accept GOTAGS
- Adds `--build-arg GOTAGS=${GOTAGS}` to four Makefile `docker-build-*` targets that were not passing it through

**Which issue(s) this PR fixes**:

Related: red-hat-data-services/kserve#4365

**Feature/Issue validation/testing**:

- [x] `grep -n 'GOTAGS' *.Dockerfile` - all Go Dockerfiles now declare `ARG GOTAGS`
- [x] `grep 'build-arg GOTAGS' Makefile` - all Go `docker-build-*` targets now pass it

**Special notes for your reviewer**:

Companion upstream PR will follow to kserve/kserve with the Dockerfile + Makefile changes (without the rule files which are midstream-only).

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive rules for Go build tag propagation across CI and build infrastructure layers.

* **Chores**
  * Enhanced Docker build targets to support parameterized Go build tags for service containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->