### PR TITLE
 feat(kserve-module): add E2E lifecycle tests, cert-manager RBAC, and testing doc

### DIFF
--- a/Makefile.kserve-module.mk
+++ b/Makefile.kserve-module.mk
@@ -5,7 +5,7 @@ E2E_IMG ?=
 .PHONY: docker-build-kserve-module docker-push-kserve-module deploy-kserve-module \
 	kustomize-build-kserve-module generate-kserve-module manifests-kserve-module \
 	test-kserve-module setup-envtest-kserve-module precommit-km \
-	e2e-setup-kserve-module e2e-cleanup-kserve-module
+	e2e-setup-kserve-module e2e-cleanup-kserve-module e2e-kserve-module
 
 docker-build-kserve-module:
 	${ENGINE} buildx build ${ARCH} --load \
@@ -48,6 +48,9 @@ e2e-setup-kserve-module:
 
 e2e-cleanup-kserve-module:
 	bash kserve-module/tests/scripts/setup-cluster.sh --platform $(PLATFORM) --cleanup
+
+e2e-kserve-module:
+	cd kserve-module/tests/e2e && python -m pytest -v
 
 precommit-km: fmt go-lint generate-kserve-module manifests-kserve-module test-kserve-module
 	cd kserve-module && go mod tidy && go vet ./... && go build ./...

--- a/kserve-module/config/rbac/role.yaml
+++ b/kserve-module/config/rbac/role.yaml
@@ -95,6 +95,20 @@ rules:
   - update
   - watch
 - apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  - clusterissuers
+  - issuers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - components.platform.opendatahub.io
   resources:
   - kserves

--- a/kserve-module/docs/e2e-testing.md
+++ b/kserve-module/docs/e2e-testing.md
@@ -1,0 +1,54 @@
+# E2E Testing
+
+## Prerequisites
+
+- kind or minikube cluster running
+- kubectl, kustomize, helm installed
+- Python 3.9+ with `pytest` and `pyyaml`
+- Controller image (build or use existing)
+
+## Quick Start
+
+```bash
+export KO_DOCKER_REPO=quay.io/your-org
+export TAG=latest
+export PLATFORM=xks  # xks or ocp
+
+# 1. Build and push controller image
+make docker-build-kserve-module
+make docker-push-kserve-module
+
+# 2. Setup cluster and deploy controller with the built image
+make e2e-setup-kserve-module E2E_IMG=${KO_DOCKER_REPO}/kserve-module-controller:${TAG}
+
+# 3. Run tests
+make e2e-kserve-module
+
+# 4. Cleanup
+make e2e-cleanup-kserve-module
+```
+
+## Platforms
+
+| Platform | Flag | Dependencies installed via |
+|----------|------|--------------------------|
+| xks | `PLATFORM=xks` (default) | Helm scripts |
+| ocp | `PLATFORM=ocp` | OLM subscriptions |
+
+## Test Markers
+
+- `sanity` — core lifecycle tests (create, update, delete, CEL validation)
+
+Run specific markers:
+
+```bash
+make e2e-kserve-module
+```
+
+## Make Targets
+
+| Target | Description |
+|--------|-------------|
+| `e2e-setup-kserve-module` | Install dependencies and deploy controller |
+| `e2e-kserve-module` | Run E2E tests |
+| `e2e-cleanup-kserve-module` | Uninstall controller and dependencies |

--- a/kserve-module/docs/e2e-testing.md
+++ b/kserve-module/docs/e2e-testing.md
@@ -37,7 +37,7 @@ make e2e-cleanup-kserve-module
 
 ## Test Markers
 
-- `sanity` — core lifecycle tests (create, update, delete, CEL validation)
+- `sanity` - core lifecycle tests (create, update, delete, CEL validation)
 
 Run specific markers:
 

--- a/kserve-module/go.mod
+++ b/kserve-module/go.mod
@@ -11,6 +11,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.35.2
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.2
+	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
 	sigs.k8s.io/controller-runtime v0.23.3
 )
 
@@ -99,7 +100,6 @@ require (
 	helm.sh/helm/v4 v4.1.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260414162039-ec9c827d403f // indirect
-	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
 	oras.land/oras-go/v2 v2.6.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect

--- a/kserve-module/pkg/kservemodule/fixture/envtest.go
+++ b/kserve-module/pkg/kservemodule/fixture/envtest.go
@@ -119,7 +119,7 @@ data:
 `
 	writeKustomizeDir(filepath.Join(workDir, "kserve", "overlays", "odh"), kserveManifest)
 	writeKustomizeDir(filepath.Join(workDir, "kserve", "overlays", "odh-xks"), kserveManifest)
-	writeKustomizeDir(filepath.Join(workDir, "odh-model-controller", "base"), modelCtrlManifest)
+	writeKustomizeDir(filepath.Join(workDir, "modelcontroller", "base"), modelCtrlManifest)
 }
 
 func writeKustomizeDir(dir, manifest string) {

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -50,6 +50,8 @@ import (
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles/finalizers;rolebindings/finalizers;clusterroles/finalizers;clusterrolebindings/finalizers,verbs=update
 // no delete — CRDs survive CR deletion
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=create;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=cert-manager.io,resources=certificates;issuers,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=cert-manager.io,resources=clusterissuers,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=llminferenceserviceconfigs;clusterstoragecontainers,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=create;delete;get;list;patch;update;watch

--- a/kserve-module/tests/e2e/conftest.py
+++ b/kserve-module/tests/e2e/conftest.py
@@ -1,0 +1,189 @@
+"""Shared fixtures for kserve-module E2E tests."""
+
+import subprocess
+import time
+from dataclasses import dataclass
+
+import pytest
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+KSERVE_CR_NAME = "default-kserve"
+NAMESPACE = "opendatahub"
+OPERATOR_DEPLOYMENT = "kserve-module-controller-manager"
+
+OPERAND_DEPLOYMENTS_XKS = [
+    "llmisvc-controller-manager",
+]
+OPERAND_DEPLOYMENTS_OCP = [
+    "kserve-controller-manager",
+    "llmisvc-controller-manager",
+    "odh-model-controller",
+    "model-serving-api",
+]
+
+KSERVE_CR_TEMPLATE = {
+    "apiVersion": "components.platform.opendatahub.io/v1alpha1",
+    "kind": "Kserve",
+    "metadata": {"name": KSERVE_CR_NAME},
+    "spec": {"managementState": "Managed"},
+}
+
+
+@dataclass
+class ClusterInfo:
+    is_openshift: bool
+    kubectl: str  # "oc" or "kubectl"
+
+
+# ---------------------------------------------------------------------------
+# Helper functions — pure
+# ---------------------------------------------------------------------------
+def operand_deployments(is_openshift):
+    """Return the expected operand deployments for the detected platform."""
+    return OPERAND_DEPLOYMENTS_OCP if is_openshift else OPERAND_DEPLOYMENTS_XKS
+
+
+def is_cr_ready(cr):
+    """Check if a Kserve CR dict has Ready=True."""
+    conditions = cr.get("status", {}).get("conditions", [])
+    return any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions)
+
+
+# ---------------------------------------------------------------------------
+# Helper functions — shell / kubectl
+# ---------------------------------------------------------------------------
+def run(cmd, check=True, timeout=60):
+    """Run a shell command and return the result."""
+    result = subprocess.run(
+        cmd, shell=True, capture_output=True, text=True, timeout=timeout
+    )
+    if check and result.returncode != 0:
+        raise RuntimeError(
+            f"Command failed: {cmd}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+    return result
+
+
+def get_cr(kubectl_bin, name=KSERVE_CR_NAME, check=True):
+    """Fetch the Kserve CR and return parsed YAML. Returns None on failure when check=False."""
+    result = run(f"{kubectl_bin} get kserve {name} -o yaml", check=False)
+    if result.returncode != 0:
+        if check:
+            raise RuntimeError(
+                f"Failed to get kserve {name}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+            )
+        return None
+    return yaml.safe_load(result.stdout)
+
+
+def cr_exists(kubectl_bin, name=KSERVE_CR_NAME):
+    """Check if the Kserve CR already exists."""
+    return get_cr(kubectl_bin, name, check=False) is not None
+
+
+def trigger_reconcile(kubectl_bin, name=KSERVE_CR_NAME, trigger_id=None):
+    """Trigger reconcile by patching an annotation."""
+    trigger_id = trigger_id or f"e2e-{int(time.time())}"
+    run(
+        f"{kubectl_bin} annotate kserve {name} "
+        f"test-trigger={trigger_id} --overwrite"
+    )
+
+
+def create_kserve_cr(kubectl_bin, cr_dict=None):
+    """Create a Kserve CR if it doesn't already exist."""
+    if cr_exists(kubectl_bin):
+        return _poll_cr(kubectl_bin, KSERVE_CR_NAME, is_cr_ready, 120,
+                        f"Kserve CR {KSERVE_CR_NAME} not ready within 120s")
+    cr = yaml.dump(cr_dict or KSERVE_CR_TEMPLATE)
+    run(f"echo '{cr}' | {kubectl_bin} create -f -")
+    return _poll_cr(kubectl_bin, KSERVE_CR_NAME, is_cr_ready, 120,
+                    f"Kserve CR {KSERVE_CR_NAME} not ready within 120s")
+
+
+# ---------------------------------------------------------------------------
+# Helper functions — polling / wait
+# ---------------------------------------------------------------------------
+def _poll_cr(kubectl_bin, name, predicate, timeout, msg):
+    """Poll the Kserve CR until predicate(cr) returns True."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        cr = get_cr(kubectl_bin, name, check=False)
+        if cr is None:
+            time.sleep(5)
+            continue
+        if predicate(cr):
+            return cr
+        time.sleep(5)
+    raise TimeoutError(msg)
+
+
+def wait_for_kserve_cleanup(kubectl_bin, name=KSERVE_CR_NAME, is_openshift=False, timeout=120):
+    """Wait until the Kserve CR is fully deleted."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not cr_exists(kubectl_bin, name):
+            break
+        time.sleep(5)
+    else:
+        raise TimeoutError(f"Kserve CR {name} not deleted within {timeout}s")
+    _wait_for_managed_deployments_gc(kubectl_bin, is_openshift, timeout=60)
+
+
+def _wait_for_managed_deployments_gc(kubectl_bin, is_openshift, timeout=60):
+    """Wait until managed deployments are cleaned up by garbage collection."""
+    expected = operand_deployments(is_openshift)
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        result = run(
+            f"{kubectl_bin} get deployments -n {NAMESPACE} -o yaml", check=False
+        )
+        if result.returncode != 0:
+            return
+        deployments = yaml.safe_load(result.stdout)
+        dep_names = [d["metadata"]["name"] for d in deployments.get("items", [])]
+        if all(op not in dep_names for op in expected):
+            return
+        time.sleep(5)
+    raise TimeoutError(f"Operand deployments not cleaned up within {timeout}s")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="session")
+def cluster_info():
+    """Detect cluster type by checking for OpenShift API resources."""
+    result = subprocess.run(
+        ["kubectl", "api-resources", "--api-group=config.openshift.io"],
+        capture_output=True, text=True, timeout=10
+    )
+    is_ocp = result.returncode == 0 and "clusterversions" in result.stdout.lower()
+    return ClusterInfo(is_openshift=is_ocp, kubectl="kubectl")
+
+
+@pytest.fixture(scope="session")
+def kubectl(cluster_info):
+    """Return the kubectl binary name for the cluster."""
+    return cluster_info.kubectl
+
+
+@pytest.fixture
+def ensure_kserve_cr(kubectl):
+    """Ensure a Kserve CR exists; create if missing, leave in place after test."""
+    return create_kserve_cr(kubectl)
+
+
+@pytest.fixture
+def apply_kserve_cr(kubectl, cluster_info):
+    """Create a Kserve CR and delete after test."""
+    created = not cr_exists(kubectl)
+    cr = create_kserve_cr(kubectl)
+    yield cr
+    if created:
+        run(f"{kubectl} delete kserve {KSERVE_CR_NAME} --ignore-not-found", check=False)
+        wait_for_kserve_cleanup(kubectl, is_openshift=cluster_info.is_openshift)

--- a/kserve-module/tests/e2e/conftest.py
+++ b/kserve-module/tests/e2e/conftest.py
@@ -14,6 +14,8 @@ import yaml
 KSERVE_CR_NAME = "default-kserve"
 NAMESPACE = "opendatahub"
 OPERATOR_DEPLOYMENT = "kserve-module-controller-manager"
+TIMEOUT_120S = 120
+TIMEOUT_60S = 60
 
 OPERAND_DEPLOYMENTS_XKS = [
     "llmisvc-controller-manager",
@@ -97,12 +99,12 @@ def trigger_reconcile(kubectl_bin, name=KSERVE_CR_NAME, trigger_id=None):
 def create_kserve_cr(kubectl_bin, cr_dict=None):
     """Create a Kserve CR if it doesn't already exist."""
     if cr_exists(kubectl_bin):
-        return _poll_cr(kubectl_bin, KSERVE_CR_NAME, is_cr_ready, 120,
-                        f"Kserve CR {KSERVE_CR_NAME} not ready within 120s")
+        return _poll_cr(kubectl_bin, KSERVE_CR_NAME, is_cr_ready, TIMEOUT_120S,
+                        f"Kserve CR {KSERVE_CR_NAME} not ready within {TIMEOUT_120S}s")
     cr = yaml.safe_dump(cr_dict or KSERVE_CR_TEMPLATE)
     run([kubectl_bin, "create", "-f", "-"], input_text=cr)
-    return _poll_cr(kubectl_bin, KSERVE_CR_NAME, is_cr_ready, 120,
-                    f"Kserve CR {KSERVE_CR_NAME} not ready within 120s")
+    return _poll_cr(kubectl_bin, KSERVE_CR_NAME, is_cr_ready, TIMEOUT_120S,
+                    f"Kserve CR {KSERVE_CR_NAME} not ready within {TIMEOUT_120S}s")
 
 
 # ---------------------------------------------------------------------------
@@ -122,38 +124,27 @@ def _poll_cr(kubectl_bin, name, predicate, timeout, msg):
     raise TimeoutError(msg)
 
 
-def wait_for_kserve_cleanup(kubectl_bin, name=KSERVE_CR_NAME, is_openshift=False, timeout=120):
+def wait_for_kserve_cleanup(kubectl_bin, name=KSERVE_CR_NAME, is_openshift=False, timeout=TIMEOUT_120S):
     """Wait until the Kserve CR is fully deleted."""
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        if not cr_exists(kubectl_bin, name):
-            break
-        time.sleep(5)
-    else:
-        raise TimeoutError(f"Kserve CR {name} not deleted within {timeout}s")
-    _wait_for_managed_deployments_gc(kubectl_bin, is_openshift, timeout=60)
+    result = run([kubectl_bin, "get", "kserve", name, "--ignore-not-found"])
+    if result.stdout.strip():
+        run([
+            kubectl_bin, "wait", "--for=delete", f"kserve/{name}",
+            f"--timeout={timeout}s",
+        ])
+    _wait_for_managed_deployments_gc(kubectl_bin, is_openshift, timeout=TIMEOUT_60S)
 
 
-def _wait_for_managed_deployments_gc(kubectl_bin, is_openshift, timeout=60):
+def _wait_for_managed_deployments_gc(kubectl_bin, is_openshift, timeout=TIMEOUT_60S):
     """Wait until managed deployments are cleaned up by garbage collection."""
     expected = operand_deployments(is_openshift)
-    deadline = time.time() + timeout
-    last_error = None
-    while time.time() < deadline:
-        result = run(
-            [kubectl_bin, "get", "deployments", "-n", NAMESPACE, "-o", "yaml"], check=False
-        )
-        if result.returncode != 0:
-            last_error = result.stderr.strip()
-            time.sleep(5)
-            continue
-        deployments = yaml.safe_load(result.stdout)
-        dep_names = [d["metadata"]["name"] for d in deployments.get("items", [])]
-        if all(op not in dep_names for op in expected):
-            return
-        time.sleep(5)
-    suffix = f" (last kubectl error: {last_error})" if last_error else ""
-    raise TimeoutError(f"Managed deployments not cleaned up within {timeout}s{suffix}")
+    for dep in expected:
+        result = run([kubectl_bin, "get", "deployment", dep, "-n", NAMESPACE, "--ignore-not-found"])
+        if result.stdout.strip():
+            run([
+                kubectl_bin, "wait", "--for=delete", f"deployment/{dep}",
+                "-n", NAMESPACE, f"--timeout={timeout}s",
+            ])
 
 
 # ---------------------------------------------------------------------------
@@ -174,12 +165,6 @@ def cluster_info():
 def kubectl(cluster_info):
     """Return the kubectl binary name for the cluster."""
     return cluster_info.kubectl
-
-
-@pytest.fixture
-def ensure_kserve_cr(kubectl):
-    """Ensure a Kserve CR exists; create if missing, leave in place after test."""
-    return create_kserve_cr(kubectl)
 
 
 @pytest.fixture

--- a/kserve-module/tests/e2e/conftest.py
+++ b/kserve-module/tests/e2e/conftest.py
@@ -40,7 +40,7 @@ class ClusterInfo:
 
 
 # ---------------------------------------------------------------------------
-# Helper functions — pure
+# Helper functions - pure
 # ---------------------------------------------------------------------------
 def operand_deployments(is_openshift):
     """Return the expected operand deployments for the detected platform."""
@@ -54,12 +54,12 @@ def is_cr_ready(cr):
 
 
 # ---------------------------------------------------------------------------
-# Helper functions — shell / kubectl
+# Helper functions - shell / kubectl
 # ---------------------------------------------------------------------------
-def run(cmd, check=True, timeout=60):
-    """Run a shell command and return the result."""
+def run(cmd, check=True, timeout=60, input_text=None):
+    """Run a command and return the result."""
     result = subprocess.run(
-        cmd, shell=True, capture_output=True, text=True, timeout=timeout
+        cmd, capture_output=True, text=True, timeout=timeout, input=input_text
     )
     if check and result.returncode != 0:
         raise RuntimeError(
@@ -70,7 +70,7 @@ def run(cmd, check=True, timeout=60):
 
 def get_cr(kubectl_bin, name=KSERVE_CR_NAME, check=True):
     """Fetch the Kserve CR and return parsed YAML. Returns None on failure when check=False."""
-    result = run(f"{kubectl_bin} get kserve {name} -o yaml", check=False)
+    result = run([kubectl_bin, "get", "kserve", name, "-o", "yaml"], check=False)
     if result.returncode != 0:
         if check:
             raise RuntimeError(
@@ -88,10 +88,10 @@ def cr_exists(kubectl_bin, name=KSERVE_CR_NAME):
 def trigger_reconcile(kubectl_bin, name=KSERVE_CR_NAME, trigger_id=None):
     """Trigger reconcile by patching an annotation."""
     trigger_id = trigger_id or f"e2e-{int(time.time())}"
-    run(
-        f"{kubectl_bin} annotate kserve {name} "
-        f"test-trigger={trigger_id} --overwrite"
-    )
+    run([
+        kubectl_bin, "annotate", "kserve", name,
+        f"test-trigger={trigger_id}", "--overwrite",
+    ])
 
 
 def create_kserve_cr(kubectl_bin, cr_dict=None):
@@ -99,14 +99,14 @@ def create_kserve_cr(kubectl_bin, cr_dict=None):
     if cr_exists(kubectl_bin):
         return _poll_cr(kubectl_bin, KSERVE_CR_NAME, is_cr_ready, 120,
                         f"Kserve CR {KSERVE_CR_NAME} not ready within 120s")
-    cr = yaml.dump(cr_dict or KSERVE_CR_TEMPLATE)
-    run(f"echo '{cr}' | {kubectl_bin} create -f -")
+    cr = yaml.safe_dump(cr_dict or KSERVE_CR_TEMPLATE)
+    run([kubectl_bin, "create", "-f", "-"], input_text=cr)
     return _poll_cr(kubectl_bin, KSERVE_CR_NAME, is_cr_ready, 120,
                     f"Kserve CR {KSERVE_CR_NAME} not ready within 120s")
 
 
 # ---------------------------------------------------------------------------
-# Helper functions — polling / wait
+# Helper functions - polling / wait
 # ---------------------------------------------------------------------------
 def _poll_cr(kubectl_bin, name, predicate, timeout, msg):
     """Poll the Kserve CR until predicate(cr) returns True."""
@@ -138,18 +138,22 @@ def _wait_for_managed_deployments_gc(kubectl_bin, is_openshift, timeout=60):
     """Wait until managed deployments are cleaned up by garbage collection."""
     expected = operand_deployments(is_openshift)
     deadline = time.time() + timeout
+    last_error = None
     while time.time() < deadline:
         result = run(
-            f"{kubectl_bin} get deployments -n {NAMESPACE} -o yaml", check=False
+            [kubectl_bin, "get", "deployments", "-n", NAMESPACE, "-o", "yaml"], check=False
         )
         if result.returncode != 0:
-            return
+            last_error = result.stderr.strip()
+            time.sleep(5)
+            continue
         deployments = yaml.safe_load(result.stdout)
         dep_names = [d["metadata"]["name"] for d in deployments.get("items", [])]
         if all(op not in dep_names for op in expected):
             return
         time.sleep(5)
-    raise TimeoutError(f"Operand deployments not cleaned up within {timeout}s")
+    suffix = f" (last kubectl error: {last_error})" if last_error else ""
+    raise TimeoutError(f"Managed deployments not cleaned up within {timeout}s{suffix}")
 
 
 # ---------------------------------------------------------------------------
@@ -185,5 +189,5 @@ def apply_kserve_cr(kubectl, cluster_info):
     cr = create_kserve_cr(kubectl)
     yield cr
     if created:
-        run(f"{kubectl} delete kserve {KSERVE_CR_NAME} --ignore-not-found", check=False)
+        run([kubectl, "delete", "kserve", KSERVE_CR_NAME, "--ignore-not-found"], check=False)
         wait_for_kserve_cleanup(kubectl, is_openshift=cluster_info.is_openshift)

--- a/kserve-module/tests/e2e/pytest.ini
+++ b/kserve-module/tests/e2e/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    sanity: core lifecycle tests that must pass on every cluster
+    status: status condition and error handling tests

--- a/kserve-module/tests/e2e/test_lifecycle.py
+++ b/kserve-module/tests/e2e/test_lifecycle.py
@@ -1,0 +1,203 @@
+"""E2E tests for Kserve CR lifecycle: create, update, delete, CEL validation."""
+
+import yaml
+import pytest
+
+from conftest import (
+    run,
+    get_cr,
+    create_kserve_cr,
+    is_cr_ready,
+    _poll_cr,
+    wait_for_kserve_cleanup,
+    operand_deployments,
+    KSERVE_CR_NAME,
+    NAMESPACE,
+    OPERATOR_DEPLOYMENT,
+)
+
+
+def _generation_matches(cr):
+    gen = cr.get("metadata", {}).get("generation", -1)
+    observed = cr.get("status", {}).get("observedGeneration", -2)
+    return gen == observed
+
+
+def _verify_deployments_available(kubectl, is_openshift):
+    expected = operand_deployments(is_openshift)
+    result = run(f"{kubectl} get deployments -n {NAMESPACE} -o yaml")
+    deployments = yaml.safe_load(result.stdout)
+    items = {d["metadata"]["name"]: d for d in deployments.get("items", [])}
+    for name in expected:
+        assert name in items, \
+            f"{name} not found. Deployments: {list(items.keys())}"
+        conditions = {c["type"]: c for c in items[name].get("status", {}).get("conditions", [])}
+        avail = conditions.get("Available", {})
+        assert avail.get("status") == "True", \
+            f"{name} not Available. Condition: {avail}"
+
+
+@pytest.mark.sanity
+class TestCreate:
+    """Verify CR creation triggers operand resource deployment."""
+
+    def test_create_deploys_operands(self, kubectl, cluster_info, apply_kserve_cr):
+        """Kserve CR creation deploys managed deployments with Available status.
+
+        apply_kserve_cr fixture creates the CR and waits for Ready=True.
+        This test verifies the actual cluster state matches.
+        """
+        _verify_deployments_available(kubectl, is_openshift=cluster_info.is_openshift)
+
+
+@pytest.mark.sanity
+class TestDelete:
+    """Verify CR deletion removes managed resources and preserves CRDs."""
+
+    def test_delete_cleans_up_managed_resources(self, kubectl, cluster_info, ensure_kserve_cr):
+        """Kserve CR deletion removes managed deployments but keeps the operator running.
+
+        Verifies GC cleans up operand deployments via ownerReference,
+        while the operator deployment itself remains.
+        """
+        run(f"{kubectl} delete kserve {KSERVE_CR_NAME}")
+        wait_for_kserve_cleanup(kubectl, is_openshift=cluster_info.is_openshift)
+
+        result = run(f"{kubectl} get kserve {KSERVE_CR_NAME}", check=False)
+        assert result.returncode != 0, "Kserve CR should be deleted"
+
+        expected = operand_deployments(cluster_info.is_openshift)
+        result = run(f"{kubectl} get deployments -n {NAMESPACE} -o yaml")
+        deployments = yaml.safe_load(result.stdout)
+        dep_names = [d["metadata"]["name"] for d in deployments.get("items", [])]
+
+        for operand in expected:
+            assert operand not in dep_names, \
+                f"{operand} should be deleted. Found: {dep_names}"
+
+        assert OPERATOR_DEPLOYMENT in dep_names, \
+            "Operator deployment should still be running"
+
+
+@pytest.mark.sanity
+class TestUpdate:
+    """Verify spec changes trigger reconcile and apply new config."""
+
+    def test_spec_change_triggers_reconcile(self, kubectl, ensure_kserve_cr):
+        """Patching spec.rawDeploymentServiceConfig triggers reconcile.
+
+        Verifies generation increments, observedGeneration catches up,
+        and the new spec value is persisted.
+        """
+        cr_before = get_cr(kubectl)
+        gen_before = cr_before["metadata"]["generation"]
+        current = cr_before.get("spec", {}).get("rawDeploymentServiceConfig", "Headless")
+        new_value = "Headed" if current == "Headless" else "Headless"
+
+        run(
+            f'{kubectl} patch kserve {KSERVE_CR_NAME} --type merge '
+            f"""-p '{{"spec":{{"rawDeploymentServiceConfig":"{new_value}"}}}}'"""
+        )
+
+        cr_after = _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, 120,
+                            "observedGeneration not matching within 120s")
+        gen_after = cr_after["metadata"]["generation"]
+
+        assert gen_after > gen_before, \
+            f"Generation should increment: {gen_before} -> {gen_after}"
+        assert cr_after["status"]["observedGeneration"] == gen_after, \
+            "observedGeneration should match generation after reconcile"
+        assert cr_after["spec"]["rawDeploymentServiceConfig"] == new_value, \
+            f"Spec should reflect update: expected {new_value}"
+
+
+@pytest.mark.sanity
+class TestCELValidation:
+    """Verify CEL validation rules on the Kserve CRD."""
+
+    def test_rejects_invalid_cr_name(self, kubectl):
+        """CRD-level CEL rule enforces singleton name 'default-kserve'.
+
+        Attempts to create a CR with name 'invalid-name' and verifies
+        the API server rejects it before it reaches the controller.
+        """
+        invalid_cr = (
+            "apiVersion: components.platform.opendatahub.io/v1alpha1\n"
+            "kind: Kserve\n"
+            "metadata:\n"
+            "  name: invalid-name\n"
+            "spec:\n"
+            "  managementState: Managed\n"
+        )
+
+        result = run(
+            f"echo '{invalid_cr}' | {kubectl} apply -f -", check=False
+        )
+
+        assert result.returncode != 0, \
+            "CR with invalid name should be rejected"
+        assert "default-kserve" in result.stderr or "invalid" in result.stderr.lower(), \
+            f"Error should reference name validation. stderr: {result.stderr}"
+
+        result = run(f"{kubectl} get kserve invalid-name", check=False)
+        assert result.returncode != 0, "Invalid CR should not exist"
+
+
+class TestManagementState:
+    """Verify managementState transitions update sub-component config."""
+
+    @pytest.mark.skip(reason="managementState: Removed not yet implemented")
+    def test_removed_updates_subcomponent_config(self, kubectl, apply_kserve_cr):
+        """Setting nim.managementState to Removed updates sub-component config.
+
+        Not yet implemented — skipped until managementState: Removed is supported.
+        """
+        run(
+            f"{kubectl} patch kserve {KSERVE_CR_NAME} --type merge "
+            f"""-p '{{"spec":{{"nim":{{"managementState":"Removed"}}}}}}'"""
+        )
+
+        cr = _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, 120,
+                      "observedGeneration not matching within 120s")
+
+        nim_state = cr.get("spec", {}).get("nim", {}).get("managementState")
+        assert nim_state == "Removed", f"Expected Removed, got {nim_state}"
+
+@pytest.mark.sanity
+class TestLifecycleE2E:
+    """End-to-end lifecycle tests covering create -> update -> delete."""
+
+    def _run_full_lifecycle(self, kubectl, is_openshift):
+        expected = operand_deployments(is_openshift)
+
+        cr = create_kserve_cr(kubectl)
+        assert is_cr_ready(cr), "CR should be Ready after creation"
+        _verify_deployments_available(kubectl, is_openshift)
+
+        current = cr.get("spec", {}).get("rawDeploymentServiceConfig", "Headless")
+        new_value = "Headed" if current == "Headless" else "Headless"
+        run(
+            f'{kubectl} patch kserve {KSERVE_CR_NAME} --type merge '
+            f"""-p '{{"spec":{{"rawDeploymentServiceConfig":"{new_value}"}}}}'"""
+        )
+        cr = _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, 120,
+                      "observedGeneration not matching within 120s")
+        assert cr["status"]["observedGeneration"] == cr["metadata"]["generation"]
+        assert cr["spec"]["rawDeploymentServiceConfig"] == new_value
+
+        run(f"{kubectl} delete kserve {KSERVE_CR_NAME}")
+        wait_for_kserve_cleanup(kubectl, is_openshift=is_openshift)
+
+        result = run(f"{kubectl} get deployments -n {NAMESPACE} -o yaml")
+        deployments = yaml.safe_load(result.stdout)
+        dep_names = [d["metadata"]["name"] for d in deployments.get("items", [])]
+        for operand in expected:
+            assert operand not in dep_names, f"{operand} should be deleted"
+
+    def test_full_lifecycle(self, kubectl, cluster_info):
+        """Full lifecycle in a single test: create -> verify -> update -> delete.
+
+        Runs without fixtures to test the complete flow sequentially,
+        ensuring no state leaks between phases.
+        """
+        self._run_full_lifecycle(kubectl, is_openshift=cluster_info.is_openshift)

--- a/kserve-module/tests/e2e/test_lifecycle.py
+++ b/kserve-module/tests/e2e/test_lifecycle.py
@@ -1,5 +1,6 @@
 """E2E tests for Kserve CR lifecycle: create, update, delete, CEL validation."""
 
+import json
 import yaml
 import pytest
 
@@ -25,7 +26,7 @@ def _generation_matches(cr):
 
 def _verify_deployments_available(kubectl, is_openshift):
     expected = operand_deployments(is_openshift)
-    result = run(f"{kubectl} get deployments -n {NAMESPACE} -o yaml")
+    result = run([kubectl, "get", "deployments", "-n", NAMESPACE, "-o", "yaml"])
     deployments = yaml.safe_load(result.stdout)
     items = {d["metadata"]["name"]: d for d in deployments.get("items", [])}
     for name in expected:
@@ -60,14 +61,14 @@ class TestDelete:
         Verifies GC cleans up operand deployments via ownerReference,
         while the operator deployment itself remains.
         """
-        run(f"{kubectl} delete kserve {KSERVE_CR_NAME}")
+        run([kubectl, "delete", "kserve", KSERVE_CR_NAME])
         wait_for_kserve_cleanup(kubectl, is_openshift=cluster_info.is_openshift)
 
-        result = run(f"{kubectl} get kserve {KSERVE_CR_NAME}", check=False)
+        result = run([kubectl, "get", "kserve", KSERVE_CR_NAME], check=False)
         assert result.returncode != 0, "Kserve CR should be deleted"
 
         expected = operand_deployments(cluster_info.is_openshift)
-        result = run(f"{kubectl} get deployments -n {NAMESPACE} -o yaml")
+        result = run([kubectl, "get", "deployments", "-n", NAMESPACE, "-o", "yaml"])
         deployments = yaml.safe_load(result.stdout)
         dep_names = [d["metadata"]["name"] for d in deployments.get("items", [])]
 
@@ -94,10 +95,8 @@ class TestUpdate:
         current = cr_before.get("spec", {}).get("rawDeploymentServiceConfig", "Headless")
         new_value = "Headed" if current == "Headless" else "Headless"
 
-        run(
-            f'{kubectl} patch kserve {KSERVE_CR_NAME} --type merge '
-            f"""-p '{{"spec":{{"rawDeploymentServiceConfig":"{new_value}"}}}}'"""
-        )
+        patch = json.dumps({"spec": {"rawDeploymentServiceConfig": new_value}})
+        run([kubectl, "patch", "kserve", KSERVE_CR_NAME, "--type", "merge", "-p", patch])
 
         cr_after = _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, 120,
                             "observedGeneration not matching within 120s")
@@ -109,6 +108,14 @@ class TestUpdate:
             "observedGeneration should match generation after reconcile"
         assert cr_after["spec"]["rawDeploymentServiceConfig"] == new_value, \
             f"Spec should reflect update: expected {new_value}"
+
+        expected_headless = "true" if new_value == "Headless" else "false"
+        result = run([
+            kubectl, "get", "configmap", "inferenceservice-config",
+            "-n", NAMESPACE, "-o", "jsonpath={.data.service}",
+        ])
+        assert f'"serviceClusterIPNone": {expected_headless}' in result.stdout, \
+            f"ConfigMap should reflect serviceClusterIPNone={expected_headless}"
 
 
 @pytest.mark.sanity
@@ -131,15 +138,15 @@ class TestCELValidation:
         )
 
         result = run(
-            f"echo '{invalid_cr}' | {kubectl} apply -f -", check=False
+            [kubectl, "apply", "-f", "-"], check=False, input_text=invalid_cr
         )
 
         assert result.returncode != 0, \
             "CR with invalid name should be rejected"
-        assert "default-kserve" in result.stderr or "invalid" in result.stderr.lower(), \
-            f"Error should reference name validation. stderr: {result.stderr}"
+        assert "Kserve name must be 'default-kserve'" in result.stderr, \
+            f"Error should reference CEL name validation. stderr: {result.stderr}"
 
-        result = run(f"{kubectl} get kserve invalid-name", check=False)
+        result = run([kubectl, "get", "kserve", "invalid-name"], check=False)
         assert result.returncode != 0, "Invalid CR should not exist"
 
 
@@ -150,12 +157,10 @@ class TestManagementState:
     def test_removed_updates_subcomponent_config(self, kubectl, apply_kserve_cr):
         """Setting nim.managementState to Removed updates sub-component config.
 
-        Not yet implemented — skipped until managementState: Removed is supported.
+        Not yet implemented - skipped until managementState: Removed is supported.
         """
-        run(
-            f"{kubectl} patch kserve {KSERVE_CR_NAME} --type merge "
-            f"""-p '{{"spec":{{"nim":{{"managementState":"Removed"}}}}}}'"""
-        )
+        patch = json.dumps({"spec": {"nim": {"managementState": "Removed"}}})
+        run([kubectl, "patch", "kserve", KSERVE_CR_NAME, "--type", "merge", "-p", patch])
 
         cr = _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, 120,
                       "observedGeneration not matching within 120s")
@@ -176,19 +181,25 @@ class TestLifecycleE2E:
 
         current = cr.get("spec", {}).get("rawDeploymentServiceConfig", "Headless")
         new_value = "Headed" if current == "Headless" else "Headless"
-        run(
-            f'{kubectl} patch kserve {KSERVE_CR_NAME} --type merge '
-            f"""-p '{{"spec":{{"rawDeploymentServiceConfig":"{new_value}"}}}}'"""
-        )
+        patch = json.dumps({"spec": {"rawDeploymentServiceConfig": new_value}})
+        run([kubectl, "patch", "kserve", KSERVE_CR_NAME, "--type", "merge", "-p", patch])
         cr = _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, 120,
                       "observedGeneration not matching within 120s")
         assert cr["status"]["observedGeneration"] == cr["metadata"]["generation"]
         assert cr["spec"]["rawDeploymentServiceConfig"] == new_value
 
-        run(f"{kubectl} delete kserve {KSERVE_CR_NAME}")
+        expected_headless = "true" if new_value == "Headless" else "false"
+        result = run([
+            kubectl, "get", "configmap", "inferenceservice-config",
+            "-n", NAMESPACE, "-o", "jsonpath={.data.service}",
+        ])
+        assert f'"serviceClusterIPNone": {expected_headless}' in result.stdout, \
+            f"ConfigMap should reflect serviceClusterIPNone={expected_headless}"
+
+        run([kubectl, "delete", "kserve", KSERVE_CR_NAME])
         wait_for_kserve_cleanup(kubectl, is_openshift=is_openshift)
 
-        result = run(f"{kubectl} get deployments -n {NAMESPACE} -o yaml")
+        result = run([kubectl, "get", "deployments", "-n", NAMESPACE, "-o", "yaml"])
         deployments = yaml.safe_load(result.stdout)
         dep_names = [d["metadata"]["name"] for d in deployments.get("items", [])]
         for operand in expected:

--- a/kserve-module/tests/e2e/test_lifecycle.py
+++ b/kserve-module/tests/e2e/test_lifecycle.py
@@ -6,15 +6,13 @@ import pytest
 
 from conftest import (
     run,
-    get_cr,
-    create_kserve_cr,
-    is_cr_ready,
     _poll_cr,
     wait_for_kserve_cleanup,
     operand_deployments,
     KSERVE_CR_NAME,
     NAMESPACE,
     OPERATOR_DEPLOYMENT,
+    TIMEOUT_120S,
 )
 
 
@@ -55,7 +53,7 @@ class TestCreate:
 class TestDelete:
     """Verify CR deletion removes managed resources and preserves CRDs."""
 
-    def test_delete_cleans_up_managed_resources(self, kubectl, cluster_info, ensure_kserve_cr):
+    def test_delete_cleans_up_managed_resources(self, kubectl, cluster_info, apply_kserve_cr):
         """Kserve CR deletion removes managed deployments but keeps the operator running.
 
         Verifies GC cleans up operand deployments via ownerReference,
@@ -84,32 +82,34 @@ class TestDelete:
 class TestUpdate:
     """Verify spec changes trigger reconcile and apply new config."""
 
-    def test_spec_change_triggers_reconcile(self, kubectl, ensure_kserve_cr):
+    def test_spec_change_triggers_reconcile(self, kubectl, apply_kserve_cr):
         """Patching spec.rawDeploymentServiceConfig triggers reconcile.
 
         Verifies generation increments, observedGeneration catches up,
         and the new spec value is persisted.
         """
-        cr_before = get_cr(kubectl)
-        gen_before = cr_before["metadata"]["generation"]
-        current = cr_before.get("spec", {}).get("rawDeploymentServiceConfig", "Headless")
-        new_value = "Headed" if current == "Headless" else "Headless"
+        gen_before = apply_kserve_cr["metadata"]["generation"]
 
-        patch = json.dumps({"spec": {"rawDeploymentServiceConfig": new_value}})
+        result = run([
+            kubectl, "get", "configmap", "inferenceservice-config",
+            "-n", NAMESPACE, "-o", "jsonpath={.data.service}",
+        ])
+        assert '"serviceClusterIPNone": true' in result.stdout, \
+            "ConfigMap should have serviceClusterIPNone=true before update"
+
+        patch = json.dumps({"spec": {"rawDeploymentServiceConfig": "Headed"}})
         run([kubectl, "patch", "kserve", KSERVE_CR_NAME, "--type", "merge", "-p", patch])
 
-        cr_after = _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, 120,
-                            "observedGeneration not matching within 120s")
+        cr_after = _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, TIMEOUT_120S,
+                            f"observedGeneration not matching within {TIMEOUT_120S}s")
         gen_after = cr_after["metadata"]["generation"]
 
         assert gen_after > gen_before, \
             f"Generation should increment: {gen_before} -> {gen_after}"
-        assert cr_after["status"]["observedGeneration"] == gen_after, \
-            "observedGeneration should match generation after reconcile"
-        assert cr_after["spec"]["rawDeploymentServiceConfig"] == new_value, \
-            f"Spec should reflect update: expected {new_value}"
+        assert cr_after["spec"]["rawDeploymentServiceConfig"] == "Headed", \
+            "Spec should reflect update: expected Headed"
 
-        expected_headless = "true" if new_value == "Headless" else "false"
+        expected_headless = "false"
         result = run([
             kubectl, "get", "configmap", "inferenceservice-config",
             "-n", NAMESPACE, "-o", "jsonpath={.data.service}",
@@ -162,53 +162,8 @@ class TestManagementState:
         patch = json.dumps({"spec": {"nim": {"managementState": "Removed"}}})
         run([kubectl, "patch", "kserve", KSERVE_CR_NAME, "--type", "merge", "-p", patch])
 
-        cr = _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, 120,
-                      "observedGeneration not matching within 120s")
+        cr = _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, TIMEOUT_120S,
+                      f"observedGeneration not matching within {TIMEOUT_120S}s")
 
         nim_state = cr.get("spec", {}).get("nim", {}).get("managementState")
         assert nim_state == "Removed", f"Expected Removed, got {nim_state}"
-
-@pytest.mark.sanity
-class TestLifecycleE2E:
-    """End-to-end lifecycle tests covering create -> update -> delete."""
-
-    def _run_full_lifecycle(self, kubectl, is_openshift):
-        expected = operand_deployments(is_openshift)
-
-        cr = create_kserve_cr(kubectl)
-        assert is_cr_ready(cr), "CR should be Ready after creation"
-        _verify_deployments_available(kubectl, is_openshift)
-
-        current = cr.get("spec", {}).get("rawDeploymentServiceConfig", "Headless")
-        new_value = "Headed" if current == "Headless" else "Headless"
-        patch = json.dumps({"spec": {"rawDeploymentServiceConfig": new_value}})
-        run([kubectl, "patch", "kserve", KSERVE_CR_NAME, "--type", "merge", "-p", patch])
-        cr = _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, 120,
-                      "observedGeneration not matching within 120s")
-        assert cr["status"]["observedGeneration"] == cr["metadata"]["generation"]
-        assert cr["spec"]["rawDeploymentServiceConfig"] == new_value
-
-        expected_headless = "true" if new_value == "Headless" else "false"
-        result = run([
-            kubectl, "get", "configmap", "inferenceservice-config",
-            "-n", NAMESPACE, "-o", "jsonpath={.data.service}",
-        ])
-        assert f'"serviceClusterIPNone": {expected_headless}' in result.stdout, \
-            f"ConfigMap should reflect serviceClusterIPNone={expected_headless}"
-
-        run([kubectl, "delete", "kserve", KSERVE_CR_NAME])
-        wait_for_kserve_cleanup(kubectl, is_openshift=is_openshift)
-
-        result = run([kubectl, "get", "deployments", "-n", NAMESPACE, "-o", "yaml"])
-        deployments = yaml.safe_load(result.stdout)
-        dep_names = [d["metadata"]["name"] for d in deployments.get("items", [])]
-        for operand in expected:
-            assert operand not in dep_names, f"{operand} should be deleted"
-
-    def test_full_lifecycle(self, kubectl, cluster_info):
-        """Full lifecycle in a single test: create -> verify -> update -> delete.
-
-        Runs without fixtures to test the complete flow sequentially,
-        ensuring no state leaks between phases.
-        """
-        self._run_full_lifecycle(kubectl, is_openshift=cluster_info.is_openshift)

--- a/kserve-module/tests/scripts/setup-cluster.sh
+++ b/kserve-module/tests/scripts/setup-cluster.sh
@@ -230,8 +230,8 @@ cleanup_ocp_subscription() {
       log_info "Waiting for cert-manager pods cleanup..."
       kubectl wait --for=delete pods --all -n cert-manager --timeout=120s 2>/dev/null || true
 
-      # Clean up remaining cert-manager resources
-      kubectl delete issuers,clusterissuers,certificates --all --all-namespaces --ignore-not-found 2>/dev/null || true
+      # Clean up cert-manager resources created by this script
+      kubectl delete -k "${PROJECT_ROOT}/config/overlays/odh-test/cert-manager" --ignore-not-found 2>/dev/null || true
       ;;
     rhcl-operator)
       log_info "Deleting RHCL operands..."


### PR DESCRIPTION
**What this PR does / why we need it**:
- E2E lifecycle tests (pytest): create, update, delete, CEL validation, full lifecycle
- cert-manager RBAC for controller (kubebuilder markers + generated role.yaml)
- Fix modelcontroller directory name in test fixture
- e2e-kserve-module make target
- E2E testing guide (kserve-module/docs/e2e-testing.md)
- Fix cert-manager cleanup to use `kubectl delete -k` instead of `--all-namespaces`

follow up
- https://github.com/opendatahub-io/kserve/pull/1562#discussion_r3344505200
- 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://redhat.atlassian.net/browse/RHOAIENG-61202

**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

* Xks
```
PLATFORM=xks
kind create cluster
make e2e-setup-kserve-module E2E_IMG=quay.io/jooholee/kserve-module-controller:latest
make e2e-kserve-module
```
* ocp
```
oc login XXXX
PLATFORM=ocp
make e2e-setup-kserve-module  PLATFORM=ocp E2E_IMG=quay.io/jooholee/kserve-module-controller:latest
make e2e-kserve-module
```
* Cleanup
```
make e2e-cleanup-kserve-module 
```

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runnable end-to-end test target to exercise the KServe CR lifecycle.

* **Tests**
  * New e2e test suite covering create, update, delete, and validation scenarios with pytest fixtures and markers.

* **Documentation**
  * Added an e2e testing guide with quick-start, platform notes, and test commands.

* **Chores**
  * Expanded RBAC for cert-manager resources and improved cluster cleanup steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->