### PR TITLE
fix(localmodelnode): trigger permission-fix job on subdirectory permission issues

### DIFF
--- a/pkg/controller/v1alpha1/localmodelnode/platform_odh.go
+++ b/pkg/controller/v1alpha1/localmodelnode/platform_odh.go
@@ -78,21 +78,44 @@ func (c *LocalModelNodeReconciler) enhanceDownloadJob(ctx context.Context, job *
 func (c *LocalModelNodeReconciler) ensureModelRootFolderExistsAndIsWritable(ctx context.Context,
 	localModelConfig *v1beta1.LocalModelConfig,
 ) (*ensureModelRootFolderResult, error) {
+	needsPermFix := false
+
 	// Create model root folder — tolerate permission errors
 	if err := fsHelper.ensureModelRootFolderExists(); err != nil {
 		if os.IsPermission(err) {
-			c.Log.Info("Model root folder not writable, will launch permission fix job", "path", modelsRootFolder, "error", err)
+			c.Log.Info("Model root folder not writable, need permission fix", "path", modelsRootFolder, "error", err)
+			needsPermFix = true
 		} else {
 			return nil, fmt.Errorf("failed to ensure model root folder: %w", err)
 		}
 	}
 
-	// If already writable, nothing to do
-	if isModelRootWritable() {
-		return &ensureModelRootFolderResult{Continue: true}, nil
+	// Check existing subdirectories for permission issues — a download job or prior
+	// agent run may have created subdirectories with different ownership (e.g.
+	// root:root), leaving them inaccessible to the current agent UID.
+	if !needsPermFix && isModelRootWritable() {
+		entries, readErr := os.ReadDir(modelsRootFolder)
+		if readErr != nil && os.IsPermission(readErr) {
+			needsPermFix = true
+		} else if readErr == nil {
+			for _, entry := range entries {
+				if !entry.IsDir() {
+					continue
+				}
+				subdir := filepath.Join(modelsRootFolder, entry.Name())
+				if _, err := os.ReadDir(subdir); err != nil && os.IsPermission(err) {
+					c.Log.Info("Subdirectory has permission issues", "path", subdir, "error", err)
+					needsPermFix = true
+					break
+				}
+			}
+		}
+		if !needsPermFix {
+			return &ensureModelRootFolderResult{Continue: true}, nil
+		}
 	}
 
-	c.Log.Info("Model root directory is not writable, launching permission fix job", "path", modelsRootFolder)
+	c.Log.Info("Launching permission fix job", "path", modelsRootFolder)
 
 	// Load OpenShift config for permission fix image
 	openshiftConfig, err := v1beta1.NewOpenShiftConfig(c.IsvcConfigMap)

--- a/pkg/controller/v1alpha1/localmodelnode/platform_odh_test.go
+++ b/pkg/controller/v1alpha1/localmodelnode/platform_odh_test.go
@@ -400,6 +400,75 @@ var _ = Describe("LocalModelNode OCP platform hooks", func() {
 			Expect(fixJobs.Items).To(BeEmpty(), "No permission fix jobs should exist when filesystem is writable")
 		})
 
+		It("Should launch permission fix job when subdirectories have permission issues", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+
+			fsMock = &mockFileSystem{
+				subDirs: []os.DirEntry{},
+			}
+			fsHelper = fsMock
+			isModelRootWritable = func() bool { return true }
+
+			// Point modelsRootFolder to a real temp dir with a broken subdirectory
+			tmpDir, err := os.MkdirTemp("", "modelcache-subdir-perm-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(tmpDir)
+			brokenSubdir := filepath.Join(tmpDir, "model-broken")
+			Expect(os.Mkdir(brokenSubdir, 0o000)).To(Succeed())
+			defer os.Chmod(brokenSubdir, 0o755) //nolint
+			savedModelsRoot := modelsRootFolder
+			modelsRootFolder = tmpDir
+			defer func() { modelsRootFolder = savedModelsRoot }()
+
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: configs,
+			}
+			Expect(k8sClient.Create(ctx, configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, configMap)
+
+			nodeName = "worker-subdir-perm"
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   nodeName,
+					Labels: map[string]string{"node.kubernetes.io/instance-type": "gpu"},
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, node)).Should(Succeed())
+			defer k8sClient.Delete(ctx, node)
+
+			localModelNode := &v1alpha1.LocalModelNode{
+				ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+				Spec: v1alpha1.LocalModelNodeSpec{
+					LocalModels: []v1alpha1.LocalModelInfo{},
+				},
+			}
+			Expect(k8sClient.Create(ctx, localModelNode)).Should(Succeed())
+			defer k8sClient.Delete(ctx, localModelNode)
+
+			jobs := &batchv1.JobList{}
+			fixLabels := map[string]string{
+				"fix-permissions": "true",
+				"node":            nodeName,
+			}
+			Eventually(func() bool {
+				err := k8sClient.List(ctx, jobs, client.InNamespace(modelCacheNamespace), client.MatchingLabels(fixLabels))
+				return err == nil && len(jobs.Items) == 1
+			}, timeout, interval).Should(BeTrue(),
+				"Permission fix job should be created when subdirectories have permission issues despite root being writable")
+
+			isModelRootWritable = func() bool { return true }
+		})
+
 		It("Should fall back to process UID when FSGroup is not configured", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			DeferCleanup(cancel)


### PR DESCRIPTION
## Summary

- Fixes the agent's `ensureModelRootFolderExistsAndIsWritable` to detect and act on subdirectory permission issues, not just root folder failures
- When download jobs run as root they can create model subdirectories with `root:root` ownership, leaving them inaccessible to the agent UID — the root folder `MkdirAll` succeeds so the permission-fix job was never launched

## What Changed

### `pkg/controller/v1alpha1/localmodelnode/platform_odh.go`
- After confirming the model root folder exists and is writable, scans subdirectories with `os.ReadDir` for permission errors
- If any subdirectory returns `os.IsPermission`, sets `needsPermFix = true` and launches the permission-fix job to correct ownership and SELinux labels
- Refactored flow to use a single `needsPermFix` flag for both root-level and subdirectory-level permission failures

### `pkg/controller/v1alpha1/localmodelnode/platform_odh_test.go`
- Added test case `Should launch permission fix job when subdirectories have permission issues` that creates a real temp directory with a `0o000`-mode subdirectory and asserts the permission-fix Job is created

### `pkg/controller/v1alpha1/localmodelnode/controller_test.go`
- Removed stale comment in mock struct

## Test plan

- [x] Unit test: permission-fix job launched when subdirectory has `0o000` permissions despite root being writable
- [x] Existing permission-fix tests continue to pass
- [ ] Verify on RHOAI cluster: agent detects root-owned model subdirectories and launches permission-fix job