### PR TITLE
fix: add NetworkPolicy for WVA controller to allow Prometheus metrics scraping

### DIFF
--- a/config/overlays/odh/network-policies.yaml
+++ b/config/overlays/odh/network-policies.yaml
@@ -9,3 +9,15 @@ spec:
       control-plane: kserve-controller-manager
   ingress:
     - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: workload-variant-autoscaler-controller-manager
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: workload-variant-autoscaler
+  ingress:
+    - {}


### PR DESCRIPTION
## Problem

The WVA (Workload Variant Autoscaler) controller is deployed into `redhat-ods-applications` by the kserve-module. This namespace has a restrictive default-deny NetworkPolicy that blocks all ingress traffic unless explicitly allowed.

Previously, the WVA controller ran in its own namespace (`workload-variant-autoscaler-system`) which had no such restriction. With the consolidation into `redhat-ods-applications` recently, Prometheus in `openshift-user-workload-monitoring` can no longer reach the WVA metrics endpoint (port 8443), causing metrics like `wva_desired_ratio` to be unavailable.

The existing `network-policies.yaml` in the ODH overlay only covers `kserve-controller-manager` but not the WVA controller pods.

## Root Cause

The kserve ODH overlay has had a NetworkPolicy for `kserve-controller-manager` since 2023 (commit 644786502), but when WVA was moved into the same namespace, no equivalent policy was added for its controller pods.

## Fix

Add a NetworkPolicy for the WVA controller to `config/overlays/odh/network-policies.yaml`, following the same allow-all-ingress pattern used for `kserve-controller-manager`. The policy targets pods with labels `control-plane: controller-manager` and `app.kubernetes.io/name: workload-variant-autoscaler`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network policy configuration targeting workload autoscaler controller-manager pods to ensure proper network access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->