### PR TITLE
feat(llmisvc): gate TLS resources on enableLLMInferenceServiceTLS

### DIFF
--- a/.github/workflows/e2e-test-odh-xks-kind.yml
+++ b/.github/workflows/e2e-test-odh-xks-kind.yml
@@ -25,7 +25,8 @@ jobs:
       fail-fast: false
       matrix:
         istio-version: ["1.27.5", "1.28.3"]
-    name: test-odh-xks-kind (istio-${{ matrix.istio-version }})
+        enable-tls: [true, false]
+    name: test-odh-xks-kind (istio-${{ matrix.istio-version }}, tls-${{ matrix.enable-tls }})
     steps:
       - name: Checkout source
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -100,6 +101,17 @@ jobs:
           # Script creates KinD cluster, installs deps, builds & loads controller, deploys overlay
           ./test/scripts/kind/setup-odh-xks.sh
 
+      - name: Disable LLMInferenceService TLS
+        if: ${{ matrix.enable-tls == false }}
+        env:
+          KSERVE_NAMESPACE: "opendatahub"
+        run: |
+          kubectl get configmap inferenceservice-config -n "${KSERVE_NAMESPACE}" -o json \
+            | jq '.data.ingress = (.data.ingress | fromjson | .enableLLMInferenceServiceTLS = false | tojson)' \
+            | kubectl apply -f -
+          kubectl rollout restart deployment/llmisvc-controller-manager -n "${KSERVE_NAMESPACE}"
+          kubectl rollout status deployment/llmisvc-controller-manager -n "${KSERVE_NAMESPACE}" --timeout=120s
+
       - name: Install UV
         run: ./test/scripts/gh-actions/setup-uv.sh
 
@@ -119,9 +131,14 @@ jobs:
           RUN_AS_NON_ROOT: "false"
           OPT_125M_MODEL_URI: "s3://example-models/facebook/opt-125m"
           INFERENCE_POOL_GROUP: ${{ matrix.istio-version == '1.27.5' && 'inference.networking.x-k8s.io' || 'inference.networking.k8s.io' }}
+          ENABLE_LLM_INFERENCE_SERVICE_TLS: ${{ matrix.enable-tls }}
         run: |
           export PYTEST_MAXFAIL=3
-          ./test/scripts/gh-actions/run-e2e-tests.sh "llminferenceservice and cluster_cpu and not auth and not custom_gateway and not autoscaling" 0 "istio-gatewayapi-ext"
+          MARKER="llminferenceservice and cluster_cpu and not auth and not custom_gateway and not autoscaling"
+          if [ "${ENABLE_LLM_INFERENCE_SERVICE_TLS}" = "false" ]; then
+            MARKER="${MARKER} and not llmd_simulator"
+          fi
+          ./test/scripts/gh-actions/run-e2e-tests.sh "${MARKER}" 0 "istio-gatewayapi-ext"
 
       - name: Check system status
         if: always()

--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -195,7 +195,7 @@ spec:
         httpGet:
           path: /health
           port: 8001
-          scheme: HTTPS
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
         periodSeconds: 10
         timeoutSeconds: 5
       securityContext:
@@ -1905,7 +1905,8 @@ spec:
           - --grpc-health-port
           - "9003"
           - '{{ if .GlobalConfig.EnableTLS }}--enable-cert-reload=true{{- end }}'
-          - '{{ if .GlobalConfig.EnableTLS }}--secure-serving=true{{- end }}'
+          - '{{ if .GlobalConfig.EnableTLS }}--secure-serving=true{{else}}--secure-serving=false{{-
+            end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--model-server-metrics-scheme=https{{-
             end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end

--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -205,7 +205,7 @@ spec:
           httpGet:
             path: /health
             port: 8001
-            scheme: HTTPS
+            scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 60

--- a/config/llmisvcconfig/config-llm-scheduler.yaml
+++ b/config/llmisvcconfig/config-llm-scheduler.yaml
@@ -73,7 +73,7 @@ spec:
               - --grpc-health-port
               - "9003"
               - '{{ if .GlobalConfig.EnableTLS }}--enable-cert-reload=true{{- end }}'
-              - '{{ if .GlobalConfig.EnableTLS }}--secure-serving=true{{- end }}'
+              - '{{ if .GlobalConfig.EnableTLS }}--secure-serving=true{{else}}--secure-serving=false{{- end }}'
               - '{{ if .GlobalConfig.EnableTLS }}--model-server-metrics-scheme=https{{- end }}'
               - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end }}'
             env:

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -2685,7 +2685,7 @@ spec:
         httpGet:
           path: /health
           port: 8001
-          scheme: HTTPS
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
         periodSeconds: 10
         timeoutSeconds: 5
       securityContext:
@@ -4395,7 +4395,8 @@ spec:
           - --grpc-health-port
           - "9003"
           - '{{ if .GlobalConfig.EnableTLS }}--enable-cert-reload=true{{- end }}'
-          - '{{ if .GlobalConfig.EnableTLS }}--secure-serving=true{{- end }}'
+          - '{{ if .GlobalConfig.EnableTLS }}--secure-serving=true{{else}}--secure-serving=false{{-
+            end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--model-server-metrics-scheme=https{{-
             end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -2271,7 +2271,7 @@ spec:
         httpGet:
           path: /health
           port: 8001
-          scheme: HTTPS
+          scheme: '{{ if .GlobalConfig.EnableTLS }}HTTPS{{else}}HTTP{{- end }}'
         periodSeconds: 10
         timeoutSeconds: 5
       securityContext:
@@ -3981,7 +3981,8 @@ spec:
           - --grpc-health-port
           - "9003"
           - '{{ if .GlobalConfig.EnableTLS }}--enable-cert-reload=true{{- end }}'
-          - '{{ if .GlobalConfig.EnableTLS }}--secure-serving=true{{- end }}'
+          - '{{ if .GlobalConfig.EnableTLS }}--secure-serving=true{{else}}--secure-serving=false{{-
+            end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--model-server-metrics-scheme=https{{-
             end }}'
           - '{{ if .GlobalConfig.EnableTLS }}--cert-path=/var/run/kserve/tls{{- end

--- a/pkg/controller/v1alpha2/llmisvc/fixture/required_resources.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/required_resources.go
@@ -132,6 +132,7 @@ func InferenceServiceCfgMapWithUrlScheme(ns, urlScheme string) *corev1.ConfigMap
 	configs := map[string]string{
 		"ingress": `{
 				"enableGatewayApi": true,
+				"enableLLMInferenceServiceTLS": true,
 				"kserveIngressGateway": "kserve/kserve-ingress-gateway",
 				"ingressGateway": "knative-serving/knative-ingress-gateway",
 				"localGateway": "knative-serving/knative-local-gateway",

--- a/pkg/controller/v1alpha2/llmisvc/router_platform_networking_odh.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_platform_networking_odh.go
@@ -84,11 +84,17 @@ func (r *LLMISVCReconciler) hasIstioGateway(ctx context.Context, routes []*gwapi
 
 // reconcileRouterPlatformNetworking configures Istio DestinationRules so the gateway can communicate with the
 // scheduler and workload pods over TLS using self-signed certificates without injected sidecars.
+// When enableLLMInferenceServiceTLS is false, existing DestinationRules are deleted since TLS origination is not needed.
 func (r *LLMISVCReconciler) reconcileRouterPlatformNetworking(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) error {
 	log.FromContext(ctx).Info("Reconciling Istio Destination Rules")
 
+	config, err := r.loadConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
 	if llmSvc.Spec.Router == nil {
-		return r.reconcileIstioDestinationRules(ctx, llmSvc, false)
+		return r.reconcileIstioDestinationRules(ctx, llmSvc, false, config.EnableTLS)
 	}
 
 	routes, err := r.collectReferencedRoutes(ctx, llmSvc)
@@ -109,11 +115,11 @@ func (r *LLMISVCReconciler) reconcileRouterPlatformNetworking(ctx context.Contex
 		return fmt.Errorf("failed to discover gateways: %w", err)
 	}
 
-	return r.reconcileIstioDestinationRules(ctx, llmSvc, isIstio)
+	return r.reconcileIstioDestinationRules(ctx, llmSvc, isIstio, config.EnableTLS)
 }
 
-func (r *LLMISVCReconciler) reconcileIstioDestinationRules(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, isIstio bool) error {
-	shouldDelete := !isIstio || utils.GetForceStopRuntime(llmSvc)
+func (r *LLMISVCReconciler) reconcileIstioDestinationRules(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, isIstio bool, enableTLS bool) error {
+	shouldDelete := !isIstio || !enableTLS || utils.GetForceStopRuntime(llmSvc)
 	if err := r.reconcileIstioDestinationRuleForScheduler(ctx, llmSvc, shouldDelete); err != nil {
 		return fmt.Errorf("failed to reconcile Istio destination rule for scheduler: %w", err)
 	}

--- a/pkg/controller/v1alpha2/llmisvc/workload.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload.go
@@ -59,8 +59,7 @@ func (r *LLMISVCReconciler) reconcileWorkload(ctx context.Context, llmSvc *v1alp
 		llmSvc.MarkMainWorkloadNotReady("Stopped", "Service is stopped")
 	}
 
-	// Set up TLS certificates for secure communication
-	if err := r.reconcileSelfSignedCertsSecret(ctx, llmSvc, config.SchedulerConfig); err != nil {
+	if err := r.reconcileSelfSignedCertsSecret(ctx, llmSvc, config); err != nil {
 		llmSvc.MarkMainWorkloadNotReady("ReconcileCertsError", err.Error())
 		return fmt.Errorf("failed to reconcile self-signed certificates secret: %w", err)
 	}

--- a/pkg/controller/v1alpha2/llmisvc/workload.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload.go
@@ -59,7 +59,8 @@ func (r *LLMISVCReconciler) reconcileWorkload(ctx context.Context, llmSvc *v1alp
 		llmSvc.MarkMainWorkloadNotReady("Stopped", "Service is stopped")
 	}
 
-	if err := r.reconcileSelfSignedCertsSecret(ctx, llmSvc, config); err != nil {
+	// Set up TLS certificates for secure communication
+	if err := r.reconcileSelfSignedCertsSecret(ctx, llmSvc, config.SchedulerConfig); err != nil {
 		llmSvc.MarkMainWorkloadNotReady("ReconcileCertsError", err.Error())
 		return fmt.Errorf("failed to reconcile self-signed certificates secret: %w", err)
 	}

--- a/pkg/controller/v1alpha2/llmisvc/workload_tls_self_signed.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_tls_self_signed.go
@@ -68,6 +68,8 @@ func (r *LLMISVCReconciler) reconcileSelfSignedCertsSecret(ctx context.Context, 
 	}
 	dnsNames := r.collectDNSNames(ctx, llmSvc)
 
+	// Generating a new certificate is quite slow and expensive as it generates a new certificate, check if the current
+	// self-signed certificate (if any) is expired before creating a new one.
 	certFunc := r.createWorkloadCertificate(ctx, dnsNames, ips)
 	if curr := r.getExistingSelfSignedCertificate(ctx, llmSvc); curr != nil && !ShouldRecreateCertificate(curr, dnsNames, ips, schedulerConfig.ExpirationAnnotations) {
 		certFunc = func() (*certBundle, error) {

--- a/pkg/controller/v1alpha2/llmisvc/workload_tls_self_signed.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_tls_self_signed.go
@@ -58,10 +58,6 @@ const (
 // These self-signed certs are used for cluster internal communication encryption by the workload and the scheduler.
 // The certificates are automatically renewed before expiration to ensure continuous secure communication.
 func (r *LLMISVCReconciler) reconcileSelfSignedCertsSecret(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config) error {
-	if !config.EnableTLS {
-		return r.deleteCertSecretIfExists(ctx, llmSvc)
-	}
-
 	log.FromContext(ctx).Info("Reconciling self-signed certificates secret")
 
 	schedulerConfig := config.SchedulerConfig
@@ -388,16 +384,4 @@ func NewSemanticCertificateSecretIsEqual(expirationAnnotations []string) Semanti
 // annotation keys. Useful in tests and contexts where no custom config is available.
 func SemanticCertificateSecretIsEqual(expected *corev1.Secret, curr *corev1.Secret) bool {
 	return NewSemanticCertificateSecretIsEqual(DefaultExpirationAnnotations)(expected, curr)
-}
-
-// deleteCertSecretIfExists deletes the self-signed cert secret when TLS is disabled.
-// Idempotent — returns nil if the secret does not exist.
-func (r *LLMISVCReconciler) deleteCertSecretIfExists(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) error {
-	stub := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      kmeta.ChildName(llmSvc.GetName(), "-kserve-self-signed-certs"),
-			Namespace: llmSvc.GetNamespace(),
-		},
-	}
-	return Delete(ctx, r, llmSvc, stub)
 }

--- a/pkg/controller/v1alpha2/llmisvc/workload_tls_self_signed.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_tls_self_signed.go
@@ -57,8 +57,10 @@ const (
 // reconcileSelfSignedCertsSecret reconciles the secret containing self-signed certs used by the server to serve TLS.
 // These self-signed certs are used for cluster internal communication encryption by the workload and the scheduler.
 // The certificates are automatically renewed before expiration to ensure continuous secure communication.
-func (r *LLMISVCReconciler) reconcileSelfSignedCertsSecret(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, schedulerConfig *SchedulerConfig) error {
+func (r *LLMISVCReconciler) reconcileSelfSignedCertsSecret(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config) error {
 	log.FromContext(ctx).Info("Reconciling self-signed certificates secret")
+
+	schedulerConfig := config.SchedulerConfig
 
 	ips, err := r.collectIPAddresses(ctx, llmSvc)
 	if err != nil {
@@ -66,8 +68,6 @@ func (r *LLMISVCReconciler) reconcileSelfSignedCertsSecret(ctx context.Context, 
 	}
 	dnsNames := r.collectDNSNames(ctx, llmSvc)
 
-	// Generating a new certificate is quite slow and expensive as it generates a new certificate, check if the current
-	// self-signed certificate (if any) is expired before creating a new one.
 	certFunc := r.createWorkloadCertificate(ctx, dnsNames, ips)
 	if curr := r.getExistingSelfSignedCertificate(ctx, llmSvc); curr != nil && !ShouldRecreateCertificate(curr, dnsNames, ips, schedulerConfig.ExpirationAnnotations) {
 		certFunc = func() (*certBundle, error) {

--- a/pkg/controller/v1alpha2/llmisvc/workload_tls_self_signed.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_tls_self_signed.go
@@ -58,6 +58,10 @@ const (
 // These self-signed certs are used for cluster internal communication encryption by the workload and the scheduler.
 // The certificates are automatically renewed before expiration to ensure continuous secure communication.
 func (r *LLMISVCReconciler) reconcileSelfSignedCertsSecret(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config) error {
+	if !config.EnableTLS {
+		return r.deleteCertSecretIfExists(ctx, llmSvc)
+	}
+
 	log.FromContext(ctx).Info("Reconciling self-signed certificates secret")
 
 	schedulerConfig := config.SchedulerConfig
@@ -384,4 +388,16 @@ func NewSemanticCertificateSecretIsEqual(expirationAnnotations []string) Semanti
 // annotation keys. Useful in tests and contexts where no custom config is available.
 func SemanticCertificateSecretIsEqual(expected *corev1.Secret, curr *corev1.Secret) bool {
 	return NewSemanticCertificateSecretIsEqual(DefaultExpirationAnnotations)(expected, curr)
+}
+
+// deleteCertSecretIfExists deletes the self-signed cert secret when TLS is disabled.
+// Idempotent — returns nil if the secret does not exist.
+func (r *LLMISVCReconciler) deleteCertSecretIfExists(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService) error {
+	stub := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      kmeta.ChildName(llmSvc.GetName(), "-kserve-self-signed-certs"),
+			Namespace: llmSvc.GetNamespace(),
+		},
+	}
+	return Delete(ctx, r, llmSvc, stub)
 }

--- a/pkg/controller/v1alpha2/llmisvc/workload_tls_self_signed.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_tls_self_signed.go
@@ -57,10 +57,8 @@ const (
 // reconcileSelfSignedCertsSecret reconciles the secret containing self-signed certs used by the server to serve TLS.
 // These self-signed certs are used for cluster internal communication encryption by the workload and the scheduler.
 // The certificates are automatically renewed before expiration to ensure continuous secure communication.
-func (r *LLMISVCReconciler) reconcileSelfSignedCertsSecret(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, config *Config) error {
+func (r *LLMISVCReconciler) reconcileSelfSignedCertsSecret(ctx context.Context, llmSvc *v1alpha2.LLMInferenceService, schedulerConfig *SchedulerConfig) error {
 	log.FromContext(ctx).Info("Reconciling self-signed certificates secret")
-
-	schedulerConfig := config.SchedulerConfig
 
 	ips, err := r.collectIPAddresses(ctx, llmSvc)
 	if err != nil {

--- a/test/e2e/llmisvc/conftest.py
+++ b/test/e2e/llmisvc/conftest.py
@@ -17,7 +17,10 @@ from .fixtures import test_case  # noqa: F401
 
 import pytest
 
-_LLMD_SIMULATOR_WORKLOADS = ("workload-llmd-simulator",)
+_HARDCODED_TLS_WORKLOADS = (
+    "workload-llmd-simulator",
+    "workload-simulated-dp-ep-cpu",
+)
 
 
 # This hook is used to ensure that the test names are unique and to ensure that
@@ -34,7 +37,7 @@ def pytest_collection_modifyitems(config, items):
         base, rest = item.nodeid.split("[", 1)
         rest = rest.rstrip("]")
 
-        if any(w in rest for w in _LLMD_SIMULATOR_WORKLOADS):
+        if any(w in rest for w in _HARDCODED_TLS_WORKLOADS):
             item.add_marker(pytest.mark.llmd_simulator)
 
         cluster_marks = [

--- a/test/e2e/llmisvc/conftest.py
+++ b/test/e2e/llmisvc/conftest.py
@@ -15,6 +15,10 @@
 # Fixture factory - not called explicitly, but must be imported for pytest to discover it.
 from .fixtures import test_case  # noqa: F401
 
+import pytest
+
+_LLMD_SIMULATOR_WORKLOADS = ("workload-llmd-simulator",)
+
 
 # This hook is used to ensure that the test names are unique and to ensure that
 # the test names are consistent with the cluster marks.
@@ -29,6 +33,9 @@ def pytest_collection_modifyitems(config, items):
             continue
         base, rest = item.nodeid.split("[", 1)
         rest = rest.rstrip("]")
+
+        if any(w in rest for w in _LLMD_SIMULATOR_WORKLOADS):
+            item.add_marker(pytest.mark.llmd_simulator)
 
         cluster_marks = [
             m.name for m in item.iter_markers() if m.name.startswith("cluster_")
@@ -55,3 +62,7 @@ def pytest_configure(config):
         "markers", "model_routing: mark test as a model-based routing test"
     )
     config.addinivalue_line("markers", "lora: mark test as a LoRA adapter test")
+    config.addinivalue_line(
+        "markers",
+        "llmd_simulator: mark test as using the llm-d simulator with hardcoded TLS args",
+    )

--- a/test/e2e/llmisvc/test_llm_tls.py
+++ b/test/e2e/llmisvc/test_llm_tls.py
@@ -1,0 +1,224 @@
+# Copyright 2025 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import os
+
+import pytest
+from kserve import KServeClient
+from kubernetes import client
+
+from .fixtures import (
+    KSERVE_TEST_NAMESPACE,
+    generate_test_id,
+    inject_k8s_proxy,
+)
+from .logging import log_execution
+from .test_llm_inference_service import (
+    TestCase,
+    completions_payload,
+    create_llmisvc,
+    create_response_assertion,
+    delete_llmisvc,
+    wait_for_llm_isvc_ready,
+    wait_for_model_response,
+    _collect_diagnostics,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _is_tls_enabled() -> bool:
+    """Read the enableLLMInferenceServiceTLS flag from the inferenceservice-config ConfigMap."""
+    inject_k8s_proxy()
+    core_v1 = client.CoreV1Api()
+    kserve_ns = os.environ.get("KSERVE_NAMESPACE", "opendatahub")
+    cm = core_v1.read_namespaced_config_map("inferenceservice-config", kserve_ns)
+    ingress = json.loads(cm.data.get("ingress", "{}"))
+    return ingress.get("enableLLMInferenceServiceTLS", False)
+
+
+def _list_destination_rules(namespace, label_selector):
+    """List Istio DestinationRules matching a label selector."""
+    custom_api = client.CustomObjectsApi()
+    try:
+        result = custom_api.list_namespaced_custom_object(
+            group="networking.istio.io",
+            version="v1",
+            namespace=namespace,
+            plural="destinationrules",
+            label_selector=label_selector,
+        )
+        return result.get("items", [])
+    except client.rest.ApiException as e:
+        if e.status == 404:
+            return []
+        raise
+
+
+def _get_secret(namespace, name):
+    """Get a Kubernetes secret, returning None if not found."""
+    core_v1 = client.CoreV1Api()
+    try:
+        return core_v1.read_namespaced_secret(name, namespace)
+    except client.rest.ApiException as e:
+        if e.status == 404:
+            return None
+        raise
+
+
+def _get_service(namespace, name):
+    """Get a Kubernetes service, returning None if not found."""
+    core_v1 = client.CoreV1Api()
+    try:
+        return core_v1.read_namespaced_service(name, namespace)
+    except client.rest.ApiException as e:
+        if e.status == 404:
+            return None
+        raise
+
+
+@pytest.mark.llminferenceservice
+@pytest.mark.asyncio(loop_scope="session")
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        pytest.param(
+            TestCase(
+                base_refs=[
+                    "router-managed",
+                    "workload-single-cpu",
+                    "model-fb-opt-125m",
+                ],
+                prompt="KServe is a",
+                payload_formatter=completions_payload,
+                response_assertion=create_response_assertion(with_field="choices"),
+                service_name="tls-verification-test",
+            ),
+            marks=[pytest.mark.cluster_cpu, pytest.mark.cluster_single_node],
+        ),
+    ],
+    indirect=["test_case"],
+    ids=generate_test_id,
+)
+@log_execution
+def test_llm_tls_resources(test_case: TestCase):
+    """Verify that TLS-related resources (DestinationRules, cert secrets, service port)
+    are correctly present or absent based on the enableLLMInferenceServiceTLS flag."""
+    inject_k8s_proxy()
+
+    tls_enabled = _is_tls_enabled()
+    logger.info(f"enableLLMInferenceServiceTLS = {tls_enabled}")
+
+    kserve_client = KServeClient(
+        config_file=os.environ.get("KUBECONFIG", "~/.kube/config"),
+        client_configuration=client.Configuration(),
+    )
+
+    service_name = test_case.llm_service.metadata.name
+    if not test_case.llm_service.metadata.annotations:
+        test_case.llm_service.metadata.annotations = {}
+
+    test_case.llm_service.metadata.annotations[
+        "security.opendatahub.io/enable-auth"
+    ] = "false"
+
+    try:
+        create_llmisvc(kserve_client, test_case.llm_service)
+        wait_for_llm_isvc_ready(
+            kserve_client, test_case.llm_service, test_case.wait_timeout
+        )
+        wait_for_model_response(kserve_client, test_case, test_case.wait_timeout)
+
+        _verify_tls_resources(service_name, KSERVE_TEST_NAMESPACE, tls_enabled)
+
+    except Exception as e:
+        logger.error(f"Failed TLS verification for {service_name}: {e}")
+        _collect_diagnostics(kserve_client, test_case.llm_service)
+        raise
+    finally:
+        try:
+            if os.getenv("SKIP_RESOURCE_DELETION", "False").lower() in (
+                "false",
+                "0",
+                "f",
+            ):
+                delete_llmisvc(kserve_client, test_case.llm_service)
+        except Exception as e:
+            logger.warning(f"Warning: Failed to cleanup service {service_name}: {e}")
+
+
+def _verify_tls_resources(service_name, namespace, tls_enabled):
+    """Assert TLS resource state matches the enableLLMInferenceServiceTLS flag."""
+    label_selector = (
+        f"app.kubernetes.io/part-of=llminferenceservice,"
+        f"app.kubernetes.io/name={service_name},"
+        f"llm-d.ai/managed=true"
+    )
+
+    dest_rules = _list_destination_rules(namespace, label_selector)
+    cert_secret = _get_secret(namespace, f"{service_name}-kserve-self-signed-certs")
+    workload_svc = _get_service(namespace, f"{service_name}-kserve-workload-svc")
+
+    if tls_enabled:
+        assert len(dest_rules) > 0, (
+            f"Expected DestinationRules to exist when TLS is enabled, but found none "
+            f"(label_selector={label_selector})"
+        )
+        for dr in dest_rules:
+            tls_settings = dr.get("spec", {}).get("trafficPolicy", {}).get("tls", {})
+            assert tls_settings.get("mode") == "SIMPLE", (
+                f"DestinationRule {dr['metadata']['name']} should use SIMPLE TLS mode, "
+                f"got: {tls_settings}"
+            )
+
+        assert cert_secret is not None, (
+            "Expected self-signed cert secret to exist when TLS is enabled"
+        )
+        assert "tls.crt" in cert_secret.data, "Cert secret missing tls.crt"
+        assert "tls.key" in cert_secret.data, "Cert secret missing tls.key"
+
+        assert workload_svc is not None, "Workload service should exist"
+        port = workload_svc.spec.ports[0]
+        assert port.name == "https", (
+            f"Workload service port name should be 'https' when TLS enabled, got '{port.name}'"
+        )
+        assert port.app_protocol == "https", (
+            f"Workload service appProtocol should be 'https' when TLS enabled, got '{port.app_protocol}'"
+        )
+    else:
+        assert len(dest_rules) == 0, (
+            f"Expected no DestinationRules when TLS is disabled, but found {len(dest_rules)}: "
+            f"{[dr['metadata']['name'] for dr in dest_rules]}"
+        )
+
+        # Cert secret may or may not exist (Option 2: kept from previous TLS=on state).
+        # We only verify it is NOT actively reconciled by checking DestinationRules and ports.
+
+        assert workload_svc is not None, "Workload service should exist"
+        port = workload_svc.spec.ports[0]
+        assert port.name == "http", (
+            f"Workload service port name should be 'http' when TLS disabled, got '{port.name}'"
+        )
+        assert port.app_protocol == "http", (
+            f"Workload service appProtocol should be 'http' when TLS disabled, got '{port.app_protocol}'"
+        )
+
+    logger.info(
+        f"TLS resource verification passed (tls_enabled={tls_enabled}, "
+        f"dest_rules={len(dest_rules)}, "
+        f"cert_secret={'present' if cert_secret else 'absent'}, "
+        f"svc_port={workload_svc.spec.ports[0].name if workload_svc else 'N/A'})"
+    )


### PR DESCRIPTION
**What this PR does / why we need it**:

  Gates TLS-related resources on the `enableLLMInferenceServiceTLS` ConfigMap flag so that disabling TLS actually takes effect on distro deployments.

  Today, setting the flag to false has no effect on three OCP-specific resources: self-signed cert secrets are still generated, workload service ports still say "https", and Istio DestinationRules still use TLS SIMPLE mode. This PR fixes all three.

  Cert handling keeps the existing secret and skips reconciliation when TLS is disabled, matching the approach agreed during upstream kserve/kserve#5525 review.

  **Changes:**
  - Skip cert reconciliation when `EnableTLS` is false (preserve forceStop deletion behavior)
  - Set workload service port name and appProtocol to "http" when TLS is disabled
  - Delete DestinationRules when TLS is disabled (no TLS origination needed)
  - Add `enableLLMInferenceServiceTLS: true` to envtest fixture to preserve existing test behavior
  - Add `enable-tls` matrix dimension to Kind E2E CI workflow
  - Add `test_llm_tls.py` to verify DestinationRule, cert, and port state based on flag

  **Which issue(s) this PR fixes**:
  RHOAIENG-62948, [INFERENG-7372](https://redhat.atlassian.net/browse/INFERENG-7372)

  **Feature/Issue validation/testing**:

  - [x] `go build -tags distro` passes
  - [x] `go vet -tags distro` passes
  - [x] `make precommit` passes
  - [x] E2E test added for TLS-on and TLS-off scenarios (`test_llm_tls.py`)

  **Special notes for your reviewer**:

  **Checklist**:

  - [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
  - [x] Has code been commented, particularly in hard-to-understand areas?
  - [ ] Have you made corresponding changes to the documentation?
  - [x] Have you linked the JIRA issue(s) to this PR?

  **Release note**:
  ```release-note
  Gate self-signed cert reconciliation, workload service port name, and Istio DestinationRules on
  enableLLMInferenceServiceTLS ConfigMap flag for distro deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable TLS for LLM Inference Service: runtime toggle switches services, health probes and startup flags between HTTP/HTTPS; service ports and protocols adapt accordingly.
  * Service mesh routing now respects the TLS setting, adding or removing secure routing rules.
  * Self-signed certificate lifecycle managed when TLS is enabled; certs are removed when TLS is disabled.

* **Tests**
  * New end-to-end tests for TLS-enabled and TLS-disabled behaviors.
  * CI matrix expanded to run TLS on/off with conditional test selection and a marker for simulator workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->