### PR TITLE
fix(kserve-module): use explicit CRD names for irregular plural handling

### DIFF
--- a/kserve-module/pkg/kservemodule/dependencies.go
+++ b/kserve-module/pkg/kservemodule/dependencies.go
@@ -212,7 +212,10 @@ func (r *KserveModuleReconciler) checkCRD(ctx context.Context, dep dependencyChe
 		Kind:    "CustomResourceDefinition",
 	})
 	if err := r.Client.Get(ctx, client.ObjectKey{Name: dep.crdName}, crd); err != nil {
-		return []string{fmt.Sprintf("%s CRD not found (%s): %v", dep.name, dep.crdName, err)}
+		if k8serr.IsNotFound(err) {
+			return []string{fmt.Sprintf("%s CRD not found (%s)", dep.name, dep.crdName)}
+		}
+		return []string{fmt.Sprintf("%s CRD lookup failed (%s): %v", dep.name, dep.crdName, err)}
 	}
 	return nil
 }

--- a/kserve-module/pkg/kservemodule/dependencies.go
+++ b/kserve-module/pkg/kservemodule/dependencies.go
@@ -12,7 +12,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster/olm"
 )
 
@@ -40,7 +39,7 @@ type conditionFilterFunc func(conditionType string, status string) bool
 type dependencyCheck struct {
 	name             string
 	checkType        checkType
-	groupKind        schema.GroupKind        // CRD check
+	crdName          string                  // Full CRD name (e.g. "authorizationpolicies.security.istio.io")
 	subscriptionName string                  // Subscription check
 	operatorGVK      schema.GroupVersionKind // Operator CR GVK
 	operatorCRName   string                  // Operator CR name (empty = list first)
@@ -56,11 +55,11 @@ type dependencyResult struct {
 	groupReasons    map[string][]string
 }
 
-func crdDep(name, group, kind, platform string, critical bool) dependencyCheck {
+func crdDep(name, crdName, platform string, critical bool) dependencyCheck {
 	return dependencyCheck{
 		name:      name,
 		checkType: checkCRD,
-		groupKind: schema.GroupKind{Group: group, Kind: kind},
+		crdName:   crdName,
 		platform:  platform,
 		critical:  critical,
 	}
@@ -93,28 +92,28 @@ func operatorDep(name string, gvk schema.GroupVersionKind, crName, condGroup, pl
 var kserveDependencies = []dependencyCheck{
 	// xks only checks
 	// Istio CRDs
-	crdDep("istio-destinationrule", "networking.istio.io", "DestinationRule", "xks", false),
-	crdDep("istio-envoyfilter", "networking.istio.io", "EnvoyFilter", "xks", false),
-	crdDep("istio-gateway", "networking.istio.io", "Gateway", "xks", false),
-	crdDep("istio-proxyconfig", "networking.istio.io", "ProxyConfig", "xks", false),
-	crdDep("istio-serviceentry", "networking.istio.io", "ServiceEntry", "xks", false),
-	crdDep("istio-sidecar", "networking.istio.io", "Sidecar", "xks", false),
-	crdDep("istio-workloadentry", "networking.istio.io", "WorkloadEntry", "xks", false),
-	crdDep("istio-workloadgroup", "networking.istio.io", "WorkloadGroup", "xks", false),
-	crdDep("istio-authorizationpolicy", "security.istio.io", "AuthorizationPolicy", "xks", false),
-	crdDep("istio-peerauthentication", "security.istio.io", "PeerAuthentication", "xks", false),
-	crdDep("istio-requestauthentication", "security.istio.io", "RequestAuthentication", "xks", false),
-	crdDep("istio-telemetry", "telemetry.istio.io", "Telemetry", "xks", false),
-	crdDep("istio-wasmplugin", "extensions.istio.io", "WasmPlugin", "xks", false),
+	crdDep("istio-destinationrule", "destinationrules.networking.istio.io", "xks", false),
+	crdDep("istio-envoyfilter", "envoyfilters.networking.istio.io", "xks", false),
+	crdDep("istio-gateway", "gateways.networking.istio.io", "xks", false),
+	crdDep("istio-proxyconfig", "proxyconfigs.networking.istio.io", "xks", false),
+	crdDep("istio-serviceentry", "serviceentries.networking.istio.io", "xks", false),
+	crdDep("istio-sidecar", "sidecars.networking.istio.io", "xks", false),
+	crdDep("istio-workloadentry", "workloadentries.networking.istio.io", "xks", false),
+	crdDep("istio-workloadgroup", "workloadgroups.networking.istio.io", "xks", false),
+	crdDep("istio-authorizationpolicy", "authorizationpolicies.security.istio.io", "xks", false),
+	crdDep("istio-peerauthentication", "peerauthentications.security.istio.io", "xks", false),
+	crdDep("istio-requestauthentication", "requestauthentications.security.istio.io", "xks", false),
+	crdDep("istio-telemetry", "telemetries.telemetry.istio.io", "xks", false),
+	crdDep("istio-wasmplugin", "wasmplugins.extensions.istio.io", "xks", false),
 
 	// cert-manager CRDs
-	crdDep("cert-manager-certificate", "cert-manager.io", "Certificate", "xks", true),
-	crdDep("cert-manager-certificaterequest", "cert-manager.io", "CertificateRequest", "xks", true),
-	crdDep("cert-manager-issuer", "cert-manager.io", "Issuer", "xks", true),
-	crdDep("cert-manager-clusterissuer", "cert-manager.io", "ClusterIssuer", "xks", true),
+	crdDep("cert-manager-certificate", "certificates.cert-manager.io", "xks", true),
+	crdDep("cert-manager-certificaterequest", "certificaterequests.cert-manager.io", "xks", true),
+	crdDep("cert-manager-issuer", "issuers.cert-manager.io", "xks", true),
+	crdDep("cert-manager-clusterissuer", "clusterissuers.cert-manager.io", "xks", true),
 
 	// LeaderWorkerSet CRD
-	crdDep("leaderworkerset", "leaderworkerset.x-k8s.io", "LeaderWorkerSet", "xks", false),
+	crdDep("leaderworkersets", "leaderworkersets.leaderworkerset.x-k8s.io", "xks", false),
 
 	// OCP Subscription checks
 	subscriptionDep("Red Hat Connectivity Link", rhclSubscription, conditionLLMISVCDeps, "ocp", false),
@@ -202,12 +201,18 @@ func (r *KserveModuleReconciler) checkDependencies(ctx context.Context) dependen
 }
 
 func (r *KserveModuleReconciler) checkCRD(ctx context.Context, dep dependencyCheck) []string {
-  	// Skip checks when context is cancelled to avoid false-positive dependency errors.
+	// Skip checks when context is cancelled to avoid false-positive dependency errors.
 	if ctx.Err() != nil {
 		return nil
 	}
-	if err := cluster.CustomResourceDefinitionExists(ctx, r.Client, dep.groupKind); err != nil {
-		return []string{fmt.Sprintf("%s CRD check failed (%s): %v", dep.name, dep.groupKind, err)}
+	crd := &unstructured.Unstructured{}
+	crd.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apiextensions.k8s.io",
+		Version: "v1",
+		Kind:    "CustomResourceDefinition",
+	})
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: dep.crdName}, crd); err != nil {
+		return []string{fmt.Sprintf("%s CRD not found (%s): %v", dep.name, dep.crdName, err)}
 	}
 	return nil
 }

--- a/kserve-module/pkg/kservemodule/dependencies_export_test.go
+++ b/kserve-module/pkg/kservemodule/dependencies_export_test.go
@@ -1,22 +1,42 @@
 package kservemodule
 
-import "k8s.io/apimachinery/pkg/runtime/schema"
+type CRDInfo struct {
+	Name     string // Full CRD name (e.g. "certificates.cert-manager.io")
+	Group    string // Extracted group (e.g. "cert-manager.io")
+	Resource string // Extracted plural resource (e.g. "certificates")
+}
 
-func XKSCRDDependenciesForTest() []schema.GroupKind {
-	var result []schema.GroupKind
+func parseCRDName(crdName string) CRDInfo {
+	// CRD names follow <plural>.<group> convention.
+	idx := 0
+	for i, c := range crdName {
+		if c == '.' {
+			idx = i
+			break
+		}
+	}
+	return CRDInfo{
+		Name:     crdName,
+		Group:    crdName[idx+1:],
+		Resource: crdName[:idx],
+	}
+}
+
+func XKSCRDDependenciesForTest() []CRDInfo {
+	var result []CRDInfo
 	for _, dep := range allDependencies {
 		if dep.checkType == checkCRD && dep.platform == "xks" {
-			result = append(result, dep.groupKind)
+			result = append(result, parseCRDName(dep.crdName))
 		}
 	}
 	return result
 }
 
-func CriticalCRDDependenciesForTest() []schema.GroupKind {
-	var result []schema.GroupKind
+func CriticalCRDDependenciesForTest() []CRDInfo {
+	var result []CRDInfo
 	for _, dep := range allDependencies {
 		if dep.checkType == checkCRD && dep.critical {
-			result = append(result, dep.groupKind)
+			result = append(result, parseCRDName(dep.crdName))
 		}
 	}
 	return result

--- a/kserve-module/pkg/kservemodule/dependencies_export_test.go
+++ b/kserve-module/pkg/kservemodule/dependencies_export_test.go
@@ -1,5 +1,10 @@
 package kservemodule
 
+import (
+	"fmt"
+	"strings"
+)
+
 type CRDInfo struct {
 	Name     string // Full CRD name (e.g. "certificates.cert-manager.io")
 	Group    string // Extracted group (e.g. "cert-manager.io")
@@ -7,18 +12,14 @@ type CRDInfo struct {
 }
 
 func parseCRDName(crdName string) CRDInfo {
-	// CRD names follow <plural>.<group> convention.
-	idx := 0
-	for i, c := range crdName {
-		if c == '.' {
-			idx = i
-			break
-		}
+	parts := strings.SplitN(crdName, ".", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		panic(fmt.Sprintf("invalid CRD name format (expected <plural>.<group>): %q", crdName))
 	}
 	return CRDInfo{
 		Name:     crdName,
-		Group:    crdName[idx+1:],
-		Resource: crdName[:idx],
+		Group:    parts[1],
+		Resource: parts[0],
 	}
 }
 

--- a/kserve-module/pkg/kservemodule/dependencies_test.go
+++ b/kserve-module/pkg/kservemodule/dependencies_test.go
@@ -34,10 +34,8 @@ func assertDependencyValid(g Gomega, dep dependencyCheck) {
 
 	switch dep.checkType {
 	case checkCRD:
-		g.Expect(dep.groupKind.Group).ShouldNot(BeEmpty(),
-			"CRD dependency %s must have groupKind.Group", dep.name)
-		g.Expect(dep.groupKind.Kind).ShouldNot(BeEmpty(),
-			"CRD dependency %s must have groupKind.Kind", dep.name)
+		g.Expect(dep.crdName).ShouldNot(BeEmpty(),
+			"CRD dependency %s must have crdName", dep.name)
 	case checkSubscription:
 		g.Expect(dep.subscriptionName).ShouldNot(BeEmpty(),
 			"subscription dependency %s must have subscriptionName", dep.name)

--- a/kserve-module/pkg/kservemodule/dependency_int_test.go
+++ b/kserve-module/pkg/kservemodule/dependency_int_test.go
@@ -103,8 +103,8 @@ var _ = Describe("Dependency Integration", Ordered, func() {
 	})
 
 	It("sets Degraded=True with Info severity when critical CRDs exist but some optional CRDs are missing", func(ctx SpecContext) {
-		for _, gk := range criticalCRDs {
-			crd := fixture.CreateCRD(ctx, testEnv.Client, gk.Group, "v1", gk.Kind, apiextensionsv1.NamespaceScoped)
+		for _, info := range criticalCRDs {
+			crd := fixture.CreateCRDByName(ctx, testEnv.Client, info.Name, info.Group, "v1", apiextensionsv1.NamespaceScoped)
 			testCRDs[crd.Name] = crd
 		}
 
@@ -126,8 +126,8 @@ var _ = Describe("Dependency Integration", Ordered, func() {
 	})
 
 	It("clears Degraded when all CRDs are present", func(ctx SpecContext) {
-		for _, gk := range kservemodule.XKSCRDDependenciesForTest() {
-			crd := fixture.CreateCRD(ctx, testEnv.Client, gk.Group, "v1", gk.Kind, apiextensionsv1.NamespaceScoped)
+		for _, info := range kservemodule.XKSCRDDependenciesForTest() {
+			crd := fixture.CreateCRDByName(ctx, testEnv.Client, info.Name, info.Group, "v1", apiextensionsv1.NamespaceScoped)
 			testCRDs[crd.Name] = crd
 		}
 

--- a/kserve-module/pkg/kservemodule/fixture/helpers.go
+++ b/kserve-module/pkg/kservemodule/fixture/helpers.go
@@ -61,12 +61,15 @@ func CreateCRD(ctx context.Context, cli client.Client, group, version, kind stri
 	return createCRDInternal(ctx, cli, fmt.Sprintf("%s.%s", plural, group), group, version, plural, strings.ToLower(kind), kind, scope)
 }
 
+// CreateCRDByName creates a CRD from its full name (e.g. "authorizationpolicies.security.istio.io").
+// The naive singular derivation (strip trailing "s") is incorrect for irregular plurals
+// but harmless — dependency checks look up CRDs by full name, not by singular/kind.
 func CreateCRDByName(ctx context.Context, cli client.Client, crdName, group, version string, scope apiextensionsv1.ResourceScope) *apiextensionsv1.CustomResourceDefinition {
-	plural := crdName[:strings.Index(crdName, ".")]
-	singular := plural
-	if len(singular) > 0 && singular[len(singular)-1] == 's' {
-		singular = singular[:len(singular)-1]
-	}
+	parts := strings.SplitN(crdName, ".", 2)
+	gomega.ExpectWithOffset(1, len(parts) == 2 && parts[0] != "" && parts[1] != "").To(gomega.BeTrue(),
+		"invalid CRD name %q; expected <plural>.<group>", crdName)
+	plural := parts[0]
+	singular, _ := strings.CutSuffix(plural, "s")
 	return createCRDInternal(ctx, cli, crdName, group, version, plural, singular, singular, scope)
 }
 

--- a/kserve-module/pkg/kservemodule/fixture/helpers.go
+++ b/kserve-module/pkg/kservemodule/fixture/helpers.go
@@ -57,12 +57,22 @@ func FindCondition(cr *platformv1alpha1.Kserve, condType string) *common.Conditi
 }
 
 func CreateCRD(ctx context.Context, cli client.Client, group, version, kind string, scope apiextensionsv1.ResourceScope) *apiextensionsv1.CustomResourceDefinition {
-	// Simplified plural — sufficient for test CRDs; not handling irregular plurals.
 	plural := strings.ToLower(kind) + "s"
+	return createCRDInternal(ctx, cli, fmt.Sprintf("%s.%s", plural, group), group, version, plural, strings.ToLower(kind), kind, scope)
+}
+
+func CreateCRDByName(ctx context.Context, cli client.Client, crdName, group, version string, scope apiextensionsv1.ResourceScope) *apiextensionsv1.CustomResourceDefinition {
+	plural := crdName[:strings.Index(crdName, ".")]
+	singular := plural
+	if len(singular) > 0 && singular[len(singular)-1] == 's' {
+		singular = singular[:len(singular)-1]
+	}
+	return createCRDInternal(ctx, cli, crdName, group, version, plural, singular, singular, scope)
+}
+
+func createCRDInternal(ctx context.Context, cli client.Client, name, group, version, plural, singular, kind string, scope apiextensionsv1.ResourceScope) *apiextensionsv1.CustomResourceDefinition {
 	crd := &apiextensionsv1.CustomResourceDefinition{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("%s.%s", plural, group),
-		},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 			Group: group,
 			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
@@ -71,10 +81,7 @@ func CreateCRD(ctx context.Context, cli client.Client, group, version, kind stri
 					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
 						Type: "object",
 						Properties: map[string]apiextensionsv1.JSONSchemaProps{
-							"status": {
-								Type:                   "object",
-								XPreserveUnknownFields: ptr.To(true),
-							},
+							"status": {Type: "object", XPreserveUnknownFields: ptr.To(true)},
 						},
 					},
 				},
@@ -85,13 +92,13 @@ func CreateCRD(ctx context.Context, cli client.Client, group, version, kind stri
 			Scope: scope,
 			Names: apiextensionsv1.CustomResourceDefinitionNames{
 				Plural:   plural,
-				Singular: strings.ToLower(kind),
+				Singular: singular,
 				Kind:     kind,
 			},
 		},
 	}
 
-	gomega.ExpectWithOffset(1, client.IgnoreAlreadyExists(cli.Create(ctx, crd))).To(gomega.Succeed())
+	gomega.ExpectWithOffset(2, client.IgnoreAlreadyExists(cli.Create(ctx, crd))).To(gomega.Succeed())
 
 	gomega.Eventually(func(g gomega.Gomega) {
 		var updated apiextensionsv1.CustomResourceDefinition


### PR DESCRIPTION
**What this PR does / why we need it**:
- cluster.CustomResourceDefinitionExists derives CRD names by appending "s" to the Kind, which fails for irregular plurals (Policy→policys, Entry→entrys,  Telemetry→telemetrys)
- Switched dependency checks to use explicit CRD names instead, bypassing the shared lib's pluralization logic
- Affected CRDs: AuthorizationPolicy, ServiceEntry, WorkloadEntry, Telemetry
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * CRD dependency checks now use full CRD names and return clearer "CRD not found" vs "lookup failed" messages for more precise diagnostics.

* **Tests**
  * Dependency and integration tests updated to use parsed CRD info.
  * Test fixture helpers improved for more robust CRD creation in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->