### PR TITLE
feat(kserve-module): add E2E status condition and drift correction tests

### DIFF
--- a/kserve-module/tests/e2e/test_status.py
+++ b/kserve-module/tests/e2e/test_status.py
@@ -1,0 +1,83 @@
+"""E2E tests for status conditions and drift correction.
+
+Deployment unavailability, error isolation, and dependency handling are covered
+by integration tests (reconciler_int_test.go, dependency_int_test.go) because
+SSA re-applies desired state before the readiness check runs, making it
+impossible to simulate in E2E.
+"""
+
+import time
+
+import pytest
+
+from conftest import (
+    run,
+    get_cr,
+    trigger_reconcile,
+    NAMESPACE,
+)
+
+
+def _get_conditions(kubectl):
+    """Fetch conditions as a dict keyed by condition type."""
+    cr = get_cr(kubectl)
+    return {c["type"]: c for c in cr.get("status", {}).get("conditions", [])}
+
+
+@pytest.mark.sanity
+class TestStatusConditions:
+    """Status condition reporting on a shared CR."""
+
+    def test_happy_path_all_conditions(self, kubectl, cluster_info, apply_kserve_cr):
+        """All conditions report correctly after successful reconcile."""
+        conditions = _get_conditions(kubectl)
+
+        assert conditions["Ready"]["status"] == "True"
+        assert conditions["ProvisioningSucceeded"]["status"] == "True"
+        assert conditions["ProvisioningSucceeded"]["reason"] == "AllResourcesApplied"
+        assert conditions["KServeReady"]["status"] == "True"
+        assert conditions["KServeReady"]["reason"] == "AllDeploymentsAvailable"
+        assert conditions["DependenciesAvailable"]["status"] == "True"
+        assert conditions["Degraded"]["status"] == "False"
+        assert conditions["Degraded"]["reason"] == "NoDegradation"
+
+        if cluster_info.is_openshift:
+            assert conditions["ModelControllerReady"]["status"] == "True"
+            assert conditions["ModelControllerReady"]["reason"] == "AllDeploymentsAvailable"
+
+        cr = get_cr(kubectl)
+        assert cr["status"]["phase"] == "Ready"
+        assert cr["status"]["observedGeneration"] == cr["metadata"]["generation"]
+
+
+@pytest.mark.sanity
+class TestDriftCorrection:
+    """SSA drift correction — manual edits reverted on reconcile."""
+
+    def test_configmap_edit_reverted(self, kubectl, apply_kserve_cr):
+        """Manual ConfigMap edit is reverted by SSA on next reconcile."""
+        cm_name = "inferenceservice-config"
+
+        run(
+            f"{kubectl} patch configmap {cm_name} -n {NAMESPACE} "
+            f"--type merge "
+            f"""-p '{{"data":{{"ingress":"{{\\"ingressClassName\\":\\"TAMPERED\\"}}"}}}}' """
+        )
+
+        result = run(
+            f"{kubectl} get configmap {cm_name} -n {NAMESPACE} "
+            f"-o jsonpath='{{.data.ingress}}'"
+        )
+        assert "TAMPERED" in result.stdout
+
+        trigger_reconcile(kubectl, trigger_id="drift-001")
+        time.sleep(15)
+
+        result = run(
+            f"{kubectl} get configmap {cm_name} -n {NAMESPACE} "
+            f"-o jsonpath='{{.data.ingress}}'"
+        )
+        assert "TAMPERED" not in result.stdout
+
+        conditions = _get_conditions(kubectl)
+        assert conditions["ProvisioningSucceeded"]["status"] == "True"

--- a/kserve-module/tests/e2e/test_status.py
+++ b/kserve-module/tests/e2e/test_status.py
@@ -58,25 +58,25 @@ class TestDriftCorrection:
         """Manual ConfigMap edit is reverted by SSA on next reconcile."""
         cm_name = "inferenceservice-config"
 
-        run(
-            f"{kubectl} patch configmap {cm_name} -n {NAMESPACE} "
-            f"--type merge "
-            f"""-p '{{"data":{{"ingress":"{{\\"ingressClassName\\":\\"TAMPERED\\"}}"}}}}' """
-        )
+        run([
+            kubectl, "patch", "configmap", cm_name, "-n", NAMESPACE,
+            "--type", "merge",
+            "-p", '{"data":{"ingress":"{\\"ingressClassName\\":\\"TAMPERED\\"}"}}',
+        ])
 
-        result = run(
-            f"{kubectl} get configmap {cm_name} -n {NAMESPACE} "
-            f"-o jsonpath='{{.data.ingress}}'"
-        )
+        result = run([
+            kubectl, "get", "configmap", cm_name, "-n", NAMESPACE,
+            "-o", "jsonpath={.data.ingress}",
+        ])
         assert "TAMPERED" in result.stdout
 
         trigger_reconcile(kubectl, trigger_id="drift-001")
         time.sleep(15)
 
-        result = run(
-            f"{kubectl} get configmap {cm_name} -n {NAMESPACE} "
-            f"-o jsonpath='{{.data.ingress}}'"
-        )
+        result = run([
+            kubectl, "get", "configmap", cm_name, "-n", NAMESPACE,
+            "-o", "jsonpath={.data.ingress}",
+        ])
         assert "TAMPERED" not in result.stdout
 
         conditions = _get_conditions(kubectl)


### PR DESCRIPTION
**What this PR does / why we need it**:
- E2E tests for status condition reporting and SSA drift correction

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://redhat.atlassian.net/browse/RHOAIENG-61203


**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

Run pytest kserve-module/tests/e2e/test_status.py -m sanity on OCP cluster with kserve-module deployed.

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
