### PR TITLE
RHOAIENG-60424: Add sast-shell-check taskRunSpecs to all push pipelines

### DIFF
--- a/.tekton/kserve-agent-push.yaml
+++ b/.tekton/kserve-agent-push.yaml
@@ -43,6 +43,15 @@ spec:
       value: main
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
+  taskRunSpecs:
+    - pipelineTaskName: sast-shell-check
+      computeResources:
+        requests:
+          cpu: '2'
+          memory: 16Gi
+        limits:
+          cpu: '2'
+          memory: 16Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-kserve-agent
   workspaces:

--- a/.tekton/kserve-controller-push.yaml
+++ b/.tekton/kserve-controller-push.yaml
@@ -43,6 +43,15 @@ spec:
       value: main
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
+  taskRunSpecs:
+    - pipelineTaskName: sast-shell-check
+      computeResources:
+        requests:
+          cpu: '2'
+          memory: 16Gi
+        limits:
+          cpu: '2'
+          memory: 16Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-kserve-controller
   workspaces:

--- a/.tekton/kserve-router-push.yaml
+++ b/.tekton/kserve-router-push.yaml
@@ -43,6 +43,15 @@ spec:
       value: main
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
+  taskRunSpecs:
+    - pipelineTaskName: sast-shell-check
+      computeResources:
+        requests:
+          cpu: '2'
+          memory: 16Gi
+        limits:
+          cpu: '2'
+          memory: 16Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-kserve-router
   workspaces:

--- a/.tekton/kserve-storage-initializer-push.yaml
+++ b/.tekton/kserve-storage-initializer-push.yaml
@@ -40,6 +40,15 @@ spec:
       value: main
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
+  taskRunSpecs:
+    - pipelineTaskName: sast-shell-check
+      computeResources:
+        requests:
+          cpu: '2'
+          memory: 16Gi
+        limits:
+          cpu: '2'
+          memory: 16Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-kserve-storage-initializer
   workspaces:

--- a/.tekton/odh-kserve-llmisvc-controller-push.yaml
+++ b/.tekton/odh-kserve-llmisvc-controller-push.yaml
@@ -43,6 +43,15 @@ spec:
       value: main
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
+  taskRunSpecs:
+    - pipelineTaskName: sast-shell-check
+      computeResources:
+        requests:
+          cpu: '2'
+          memory: 16Gi
+        limits:
+          cpu: '2'
+          memory: 16Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-kserve-llmisvc-controller-ci
   workspaces:

--- a/.tekton/odh-kserve-localmodel-controller-push.yaml
+++ b/.tekton/odh-kserve-localmodel-controller-push.yaml
@@ -44,6 +44,15 @@ spec:
       value: main
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
+  taskRunSpecs:
+    - pipelineTaskName: sast-shell-check
+      computeResources:
+        requests:
+          cpu: '2'
+          memory: 16Gi
+        limits:
+          cpu: '2'
+          memory: 16Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-kserve-localmodel-controller-ci
   workspaces:

--- a/.tekton/odh-kserve-localmodelnode-agent-push.yaml
+++ b/.tekton/odh-kserve-localmodelnode-agent-push.yaml
@@ -44,6 +44,15 @@ spec:
       value: main
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
+  taskRunSpecs:
+    - pipelineTaskName: sast-shell-check
+      computeResources:
+        requests:
+          cpu: '2'
+          memory: 16Gi
+        limits:
+          cpu: '2'
+          memory: 16Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-kserve-localmodelnode-agent-ci
   workspaces:

--- a/.tekton/odh-kserve-module-operator-push.yaml
+++ b/.tekton/odh-kserve-module-operator-push.yaml
@@ -38,6 +38,15 @@ spec:
       value: main
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
+  taskRunSpecs:
+    - pipelineTaskName: sast-shell-check
+      computeResources:
+        requests:
+          cpu: '2'
+          memory: 16Gi
+        limits:
+          cpu: '2'
+          memory: 16Gi
   taskRunTemplate:
     serviceAccountName: build-pipeline-odh-kserve-module-operator-ci
   workspaces:


### PR DESCRIPTION
## Summary
- Adds `taskRunSpecs` with compute resource overrides (2 CPU, 16Gi memory) for the `sast-shell-check` task across all 8 Tekton push pipelines
- Prevents OOM failures during SAST shell checks in Konflux CI push builds
- Push pipeline counterpart to #1587 which addressed pull pipelines

## Files changed
- `.tekton/kserve-agent-push.yaml`
- `.tekton/kserve-controller-push.yaml`
- `.tekton/kserve-router-push.yaml`
- `.tekton/kserve-storage-initializer-push.yaml`
- `.tekton/odh-kserve-llmisvc-controller-push.yaml`
- `.tekton/odh-kserve-localmodel-controller-push.yaml`
- `.tekton/odh-kserve-localmodelnode-agent-push.yaml`
- `.tekton/odh-kserve-module-operator-push.yaml`

## Test plan
- [ ] Verify Konflux push pipelines pass with the new resource limits
- [ ] Confirm sast-shell-check task no longer hits OOM on push builds