### PR TITLE
fix(kserve-module): move drift test to lifecycle and replace sleep

### DIFF
--- a/kserve-module/tests/e2e/conftest.py
+++ b/kserve-module/tests/e2e/conftest.py
@@ -55,6 +55,12 @@ def is_cr_ready(cr):
     return any(c.get("type") == "Ready" and c.get("status") == "True" for c in conditions)
 
 
+def get_conditions(kubectl_bin, name=KSERVE_CR_NAME):
+    """Fetch conditions as a dict keyed by condition type."""
+    cr = get_cr(kubectl_bin, name)
+    return {c["type"]: c for c in cr.get("status", {}).get("conditions", [])}
+
+
 # ---------------------------------------------------------------------------
 # Helper functions - shell / kubectl
 # ---------------------------------------------------------------------------
@@ -110,6 +116,23 @@ def create_kserve_cr(kubectl_bin, cr_dict=None):
 # ---------------------------------------------------------------------------
 # Helper functions - polling / wait
 # ---------------------------------------------------------------------------
+def wait_for(assertion_fn, timeout=60.0, interval=5.0):
+    """Poll until assertion_fn() succeeds or timeout expires."""
+    deadline = time.time() + timeout
+    last_error = None
+    while True:
+        try:
+            return assertion_fn()
+        except (AssertionError, Exception) as e:
+            last_error = e
+            if time.time() >= deadline:
+                raise AssertionError(
+                    f"Timed out after {timeout}s waiting for assertion. "
+                    f"Last error: {last_error}"
+                ) from e
+            time.sleep(interval)
+
+
 def _poll_cr(kubectl_bin, name, predicate, timeout, msg):
     """Poll the Kserve CR until predicate(cr) returns True."""
     deadline = time.time() + timeout

--- a/kserve-module/tests/e2e/test_lifecycle.py
+++ b/kserve-module/tests/e2e/test_lifecycle.py
@@ -7,12 +7,16 @@ import pytest
 from conftest import (
     run,
     _poll_cr,
+    get_conditions,
+    wait_for,
     wait_for_kserve_cleanup,
+    trigger_reconcile,
     operand_deployments,
     KSERVE_CR_NAME,
     NAMESPACE,
     OPERATOR_DEPLOYMENT,
     TIMEOUT_120S,
+    TIMEOUT_60S,
 )
 
 
@@ -167,3 +171,41 @@ class TestManagementState:
 
         nim_state = cr.get("spec", {}).get("nim", {}).get("managementState")
         assert nim_state == "Removed", f"Expected Removed, got {nim_state}"
+
+
+@pytest.mark.sanity
+class TestDriftCorrection:
+    """SSA drift correction — manual edits reverted on reconcile."""
+
+    def test_configmap_edit_reverted(self, kubectl, apply_kserve_cr):
+        """Manual ConfigMap edit is reverted by SSA on next reconcile."""
+        cm_name = "inferenceservice-config"
+
+        run([
+            kubectl, "patch", "configmap", cm_name, "-n", NAMESPACE,
+            "--type", "merge",
+            "-p", '{"data":{"ingress":"{\\"ingressClassName\\":\\"TAMPERED\\"}"}}',
+        ])
+
+        result = run([
+            kubectl, "get", "configmap", cm_name, "-n", NAMESPACE,
+            "-o", "jsonpath={.data.ingress}",
+        ])
+        assert "TAMPERED" in result.stdout
+
+        trigger_reconcile(kubectl, trigger_id="drift-001")
+
+        def assert_tampered_reverted():
+            result = run([
+                kubectl, "get", "configmap", cm_name, "-n", NAMESPACE,
+                "-o", "jsonpath={.data.ingress}",
+            ])
+            assert "TAMPERED" not in result.stdout
+
+        wait_for(assert_tampered_reverted, timeout=TIMEOUT_60S, interval=5)
+
+        def assert_provisioning_succeeded():
+            conditions = get_conditions(kubectl)
+            assert conditions["ProvisioningSucceeded"]["status"] == "True"
+
+        wait_for(assert_provisioning_succeeded, timeout=TIMEOUT_60S, interval=5)

--- a/kserve-module/tests/e2e/test_status.py
+++ b/kserve-module/tests/e2e/test_status.py
@@ -1,4 +1,4 @@
-"""E2E tests for status conditions and drift correction.
+"""E2E tests for status conditions.
 
 Deployment unavailability, error isolation, and dependency handling are covered
 by integration tests (reconciler_int_test.go, dependency_int_test.go) because
@@ -6,22 +6,12 @@ SSA re-applies desired state before the readiness check runs, making it
 impossible to simulate in E2E.
 """
 
-import time
-
 import pytest
 
 from conftest import (
-    run,
     get_cr,
-    trigger_reconcile,
-    NAMESPACE,
+    get_conditions,
 )
-
-
-def _get_conditions(kubectl):
-    """Fetch conditions as a dict keyed by condition type."""
-    cr = get_cr(kubectl)
-    return {c["type"]: c for c in cr.get("status", {}).get("conditions", [])}
 
 
 @pytest.mark.sanity
@@ -30,7 +20,7 @@ class TestStatusConditions:
 
     def test_happy_path_all_conditions(self, kubectl, cluster_info, apply_kserve_cr):
         """All conditions report correctly after successful reconcile."""
-        conditions = _get_conditions(kubectl)
+        conditions = get_conditions(kubectl)
 
         assert conditions["Ready"]["status"] == "True"
         assert conditions["ProvisioningSucceeded"]["status"] == "True"
@@ -50,34 +40,3 @@ class TestStatusConditions:
         assert cr["status"]["observedGeneration"] == cr["metadata"]["generation"]
 
 
-@pytest.mark.sanity
-class TestDriftCorrection:
-    """SSA drift correction — manual edits reverted on reconcile."""
-
-    def test_configmap_edit_reverted(self, kubectl, apply_kserve_cr):
-        """Manual ConfigMap edit is reverted by SSA on next reconcile."""
-        cm_name = "inferenceservice-config"
-
-        run([
-            kubectl, "patch", "configmap", cm_name, "-n", NAMESPACE,
-            "--type", "merge",
-            "-p", '{"data":{"ingress":"{\\"ingressClassName\\":\\"TAMPERED\\"}"}}',
-        ])
-
-        result = run([
-            kubectl, "get", "configmap", cm_name, "-n", NAMESPACE,
-            "-o", "jsonpath={.data.ingress}",
-        ])
-        assert "TAMPERED" in result.stdout
-
-        trigger_reconcile(kubectl, trigger_id="drift-001")
-        time.sleep(15)
-
-        result = run([
-            kubectl, "get", "configmap", cm_name, "-n", NAMESPACE,
-            "-o", "jsonpath={.data.ingress}",
-        ])
-        assert "TAMPERED" not in result.stdout
-
-        conditions = _get_conditions(kubectl)
-        assert conditions["ProvisioningSucceeded"]["status"] == "True"


### PR DESCRIPTION
**What this PR does / why we need it**:
Moved TestDriftCorrection from test_status.py to test_lifecycle.py — drift correction is reconciler resource management behavior, not status reporting. Replaced time.sleep(15) with wait_for() polling helper to avoid flaky failures on slower clusters where reconcile takes longer than a fixed sleep window.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved E2E test infrastructure with reusable utilities for enhanced test reliability and consistency across test suites.
  * Added drift correction testing to verify system behavior under configuration changes.
  * Refactored test utilities to reduce code duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->