### PR TITLE
docs: add agent docs for ODH midstream KServe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,62 @@
+# KServe (ODH Midstream)
+
+ODH midstream fork of [kserve/kserve](https://github.com/kserve/kserve). Go controllers via controller-runtime. See [docs/architecture.md](docs/architecture.md) for reconciliation flows and the distro build-tag pattern.
+
+## Constraints
+
+- **Generated files are read-only** — overwritten by `make precommit`: `charts/*/`, quick-install scripts, Helm helpers synced from `charts/_common/`
+- **Makefile is source of truth** — read `Makefile` / `Makefile.tools.mk` before changing build steps; midstream overrides go in `Makefile.overrides.mk` only
+- **ODH logic in companion files** — never inline in upstream-owned files; see below and [architecture.md](docs/architecture.md#distro-build-tag-pattern)
+- **Run `make precommit` before committing**
+
+## ODH-specific changes
+
+| Change | Location |
+|--------|----------|
+| ODH/OpenShift behavior | `*_odh.go` (`//go:build distro`) |
+| Upstream no-op fallback | `*_default.go` (`//go:build !distro`) |
+| ODH-only RBAC | `distro/controller_rbac_odh.go` (generated via `make manifests-distro`) |
+| Makefile / image names | `Makefile.overrides.mk` |
+| Scheme registration | `pkg/scheme/register_odh.go`, `cmd/manager/main_schemes_odh.go` |
+
+**Hook pairs** — upstream calls a hook; `_default.go` no-ops, `_odh.go` implements. Example: `controller_setup_{default,odh}.go` in llmisvc. Only acceptable upstream edit is adding the hook call; use reconciler receiver methods when the hook needs client access.
+
+**Additive-only** — new ODH symbols in `*_odh.go` with no `_default.go` when upstream never calls them.
+
+`Makefile.overrides.mk` sets `GOTAGS=distro`. Propagate through Dockerfiles/build targets — see `.rules/{build-tags,distro-builds,makefile-split}.md`.
+
+## Layout
+
+- APIs: `pkg/apis/serving/{v1alpha1,v1alpha2,v1beta1}`
+- Controllers: `pkg/controller/{v1alpha1,v1alpha2,v1beta1}`
+- Webhooks: `pkg/webhook/admission/`
+- Binaries: `cmd/manager/` (ISVC, InferenceGraph), `cmd/llmisvc/`, `cmd/localmodel/` (ModelCache)
+
+## Commands
+
+```
+make test          # full Go test suite
+make precommit     # format, lint, codegen, manifest sync
+```
+
+Focused test after `make setup-envtest`:
+
+```
+KUBEBUILDER_ASSETS="$(./bin/setup-envtest use $(go list -m -f '{{ .Version }}' k8s.io/api | awk -F'[v.]' '{printf "1.%d", $3}') -p path)" \
+  go test ./pkg/controller/v1beta1/... -run TestName -v
+```
+
+## Testing
+
+- Tests colocated with code; unit tests use `fake.NewClientBuilder`, controllers use envtest
+- Use `pkgtest.NewEnvTest()` from `pkg/testing/` (not raw `envtest.Environment{}`); llmisvc has `fixture/` builders
+- envtest has no built-in controllers or GC — simulate external status updates yourself
+- Per-test namespace, `defer` cleanup, `Eventually`/`Consistently` (never `time.Sleep`), `retry.RetryOnConflict` for contested updates
+- Match the test package style of the controller you're editing (llmisvc uses external `_test` packages)
+
+## Controller conventions (this repo)
+
+- Reconcile idempotently; `NotFound` → success; guard status writes with deep-equal to avoid loops
+- `spec` vs `status` in separate API calls; use `Mark*` helpers from `*_lifecycle.go` (see LLMISVC as reference), not raw condition slice edits
+- Include `observedGeneration` in conditions; composite `Ready` should surface first failing sub-condition
+- ODH networking/permissions changes → companion `*_odh.go` files listed in [architecture.md](docs/architecture.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,90 @@
+# Architecture (Agent Reference)
+
+Controller reconciliation flows and the distro build-tag pattern for the ODH midstream fork.
+
+**Shared config:** `inferenceservice-config` ConfigMap in the `kserve` namespace drives deployment modes, ingress, local model settings, router image, and feature flags.
+
+## Binaries
+
+| Binary | Entry | Controllers |
+|--------|-------|-------------|
+| KServe manager | `cmd/manager/` | InferenceService, InferenceGraph, TrainedModel |
+| LLMISVC | `cmd/llmisvc/` | LLMInferenceService |
+| Local model | `cmd/localmodel/` | LocalModelCache, LocalModelNamespaceCache, LocalModelNode |
+
+APIs: `pkg/apis/serving/`. Controllers: `pkg/controller/{v1alpha1,v1alpha2,v1beta1}/`.
+
+## Distro build tag pattern
+
+Upstream-owned files must stay ODH-free. Platform code compiles only with `-tags distro`:
+
+| File | Tag | Role |
+|------|-----|------|
+| `*_odh.go` | `distro` | ODH/OpenShift implementation |
+| `*_default.go` | `!distro` | No-op stub for upstream builds |
+| `distro/controller_rbac_odh.go` | none | ODH RBAC markers for `make manifests-distro` |
+
+Hook pattern: upstream calls e.g. `extendControllerSetup()` → `controller_setup_{default,odh}.go` in llmisvc. Additive-only files (`constants_odh.go`, `register_odh.go`) need no `_default.go` if upstream never calls them.
+
+`Makefile.overrides.mk` sets `GOTAGS=distro`. Tag must propagate Makefile → Docker `GOTAGS` build-arg → `go build -tags` (missing tag silently drops ODH code). CI: `.github/workflows/distro-build-check.yml`.
+
+## InferenceService (ISVC)
+
+`pkg/controller/v1beta1/inferenceservice/` · `InferenceServiceReconciler.Reconcile()`
+
+1. Load `inferenceservice-config` → resolve deployment mode (Standard / Knative / ModelMesh)
+2. Finalizer on create; cleanup + remove on delete
+3. ModelMesh without transformer → skip predictor reconcile, update status only
+4. Reconcile components: Predictor (skipped in ModelMesh), Transformer, Explainer — each creates Deployment or Knative Service
+5. Ingress via `reconcilers.NewReconcilerFactory()` (Istio VS, Ingress, HTTPRoute, OpenShift Route)
+6. `modelconfig` ConfigMap reconcile → status update
+
+**ODH:** `reconcilers/service/service_reconciler_odh.go`, `reconcilers/ingress/annotation_filter_odh.go`, `components/annotation_filter_odh.go`, `pkg/apis/serving/v1beta1/configmap_odh.go`
+
+## LLMInferenceService (LLMISVC)
+
+`pkg/controller/v1alpha2/llmisvc/` · `LLMISVCReconciler.Reconcile()`
+
+1. Finalizer; `finalize()` cleans scheduler SA and monitoring on delete
+2. CA bundle ConfigMap reconcile
+3. `reconcileBaseRefs()` — merge `LLMInferenceServiceConfig` refs into effective spec (failure sets condition, short-circuits)
+4. `reconcileWorkload()` — TLS certs, platform permissions, then all topology types every pass (single Deployment, LeaderWorkerSet multi-node, prefill/decode disaggregated, HPA/KEDA/VariantAutoscaling)
+5. `reconcileRouter()` — HTTPRoutes, InferencePool (v1/v1alpha2), scheduler; `ensureGatewayPreconditions()` marks status without requeue on missing CRDs
+6. Monitoring resources → `observeWorkloadStatus()` → status (composite `Ready` from workload + router sub-conditions)
+
+**ODH:** `controller_setup_odh.go`, `workload_{tls_cert,permissions}_odh.go`, `router_{preconditions,platform_networking,discovery_additional}_odh.go`, `distro/controller_rbac_odh.go`
+
+## InferenceGraph
+
+`pkg/controller/v1alpha1/inferencegraph/` · `InferenceGraphReconciler.Reconcile()`
+
+1. Finalizer; auth SA cleanup on delete
+2. Resolve each step's `ServiceURL` from referenced ISVC via `GetPredictorEndpoint()` (not-ready → requeue)
+3. **Standard:** auth resources if enabled → router Deployment/Service/HPA → OpenShift Route if CRD present → `PropagateRawStatus`
+4. **Knative:** router Knative Service → propagate ksvc conditions/URL to graph status
+5. Force-stop annotation handling → status update
+
+Router image/resources from `router` key in `inferenceservice-config`.
+
+## ModelCache (LocalModel)
+
+Pre-downloads models to node-local storage for ISVCs/LLMISVCs labeled `serving.kserve.io/local-model: <modelName>`.
+
+| Controller | Package | Role |
+|------------|---------|------|
+| LocalModelCache | `localmodel/reconcilers/` | Cluster-scoped; orchestrates nodes + PV/PVC |
+| LocalModelNamespaceCache | same | Namespace-scoped variant |
+| LocalModelNode | `localmodelnode/` | DaemonSet agent per node |
+
+**LocalModelCache reconcile** (`localmodelcache_reconciler.go`):
+
+1. Deleting → `DeleteModelFromNodes()`; else add finalizer
+2. `ReconcileLocalModelNode()` — add model to node group `LocalModelNode` specs
+3. Per node group: download PV/PVC in job namespace
+4. `ReconcileForIsvcs()` — consumer PV/PVC per labeled ISVC/LLMISVC
+
+**LocalModelNode** (DaemonSet, `NODE_NAME` env): for each model — check hash-based folder under `models/`; if missing launch/monitor storage-initializer Job; update `Status.ModelStatus`; prune orphaned folders/jobs on spec change.
+
+**Watches re-enqueue cache CRs on:** ISVC/LLMISVC local-model label change, matching Node ready, LocalModelNode status change, owned PVC change.
+
+**ODH:** `localmodelnode/{platform,file_utils}_odh.go`, `localmodel/distro/controller_rbac_odh.go`, `localmodelnode/distro/controller_rbac_odh.go`


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `AGENTS.md` and `docs/architecture.md` to guide autonomous coding agents working in this ODH midstream fork. The docs cover distro build-tag conventions for keeping ODH changes out of upstream-owned files, controller reconciliation flows (ISVC, LLMISVC, InferenceGraph, ModelCache), and repo-specific testing and layout guidance — without duplicating generic controller-runtime knowledge.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:

Documentation-only change; no functional code changes.

- [x] Reviewed `AGENTS.md` and `docs/architecture.md` for accuracy against current controller code and distro file conventions
- [x] N/A — no runtime or unit tests required

- Logs

**Special notes for your reviewer**:

- `AGENTS.md` focuses on constraints and where to put ODH-specific code; `docs/architecture.md` covers reconciliation order and ODH touchpoint file paths.
- Content was intentionally kept compact to avoid polluting agent context windows.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [x] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architecture documentation describing reconciliation flows, deployment configuration, and component management for inference services.
  * Added contribution guidelines covering repository structure, testing conventions, and build patterns for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->