### PR TITLE
fix: status update conflicts and suppress NotFound errors

### DIFF
--- a/kserve-module/pkg/kservemodule/status.go
+++ b/kserve-module/pkg/kservemodule/status.go
@@ -6,6 +6,9 @@ import (
 	"slices"
 	"strings"
 
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/opendatahub-io/odh-platform-utilities/api/common"
@@ -127,12 +130,8 @@ func (r *KserveModuleReconciler) updateComponentReadiness(ctx context.Context, k
 }
 
 func (r *KserveModuleReconciler) updateStatus(ctx context.Context, kserve *platformv1alpha1.Kserve, condMgr *conditions.Manager) error {
-	log := ctrl.LoggerFrom(ctx)
-
 	r.setReleaseStatus(kserve)
-
 	condMgr.Sort()
-	kserve.Status.ObservedGeneration = kserve.Generation
 
 	if condMgr.IsHappy() {
 		kserve.Status.Phase = common.PhaseReady
@@ -140,11 +139,19 @@ func (r *KserveModuleReconciler) updateStatus(ctx context.Context, kserve *platf
 		kserve.Status.Phase = common.PhaseNotReady
 	}
 
-	if err := r.Status().Update(ctx, kserve); err != nil {
-		log.Error(err, "failed to update status")
-		return err
-	}
-	return nil
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &platformv1alpha1.Kserve{}
+		if err := r.Get(ctx, types.NamespacedName{Name: kserve.Name}, latest); err != nil {
+			if k8serr.IsNotFound(err) {
+				ctrl.LoggerFrom(ctx).Info("CR deleted, skipping status update")
+				return nil
+			}
+			return err
+		}
+		latest.Status = kserve.Status
+		latest.Status.ObservedGeneration = kserve.Generation
+		return r.Status().Update(ctx, latest)
+	})
 }
 
 func (r *KserveModuleReconciler) setReleaseStatus(kserve *platformv1alpha1.Kserve) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Use retry.RetryOnConflict to handle resourceVersion conflicts in updateStatus. Skip status update when CR is already deleted. Use the reconcile-start generation for observedGeneration to avoid marking unprocessed spec changes as reconciled.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of status updates in the KServe module by implementing retry logic for concurrent update scenarios.
  * Enhanced handling of edge cases where resources are deleted during status synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->