### PR TITLE
refactor(kserve-module): reuse path in fixtures

### DIFF
--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -29,21 +29,21 @@ type componentConfig struct {
 
 var components = []componentConfig{
 	{
-		name:          kserveComponentName,
-		sourcePath:    kserveManifestSourcePath,
-		sourcePathXKS: kserveManifestSourcePathXKS,
+		name:          KserveComponentName,
+		sourcePath:    KserveManifestSourcePath,
+		sourcePathXKS: KserveManifestSourcePathXKS,
 		imageMap:      kserveImageParamMap,
 		postRender:    kservePostRender,
 	},
 	{
-		name:        odhModelControllerComponentName,
-		sourcePath:  modelControllerSourcePath,
+		name:        OdhModelControllerComponentName,
+		sourcePath:  ModelControllerSourcePath,
 		imageMap:    modelControllerImageParamMap,
 		extraParams: modelControllerExtraParams,
 	},
 	{
-		name:       wvaComponentName,
-		sourcePath: wvaManifestSourcePathOCP,
+		name:       WVAComponentName,
+		sourcePath: WVAManifestSourcePathOCP,
 		imageMap:   wvaImageParamMap,
 		enabled:    isWVAEnabled,
 		postRender: wvaPostRender,

--- a/kserve-module/pkg/kservemodule/components_test.go
+++ b/kserve-module/pkg/kservemodule/components_test.go
@@ -60,7 +60,7 @@ func TestComponentsConfig_WVAHasEnabled(t *testing.T) {
 	g := NewWithT(t)
 	var wva *componentConfig
 	for i := range components {
-		if components[i].name == wvaComponentName {
+		if components[i].name == WVAComponentName {
 			wva = &components[i]
 			break
 		}

--- a/kserve-module/pkg/kservemodule/constants.go
+++ b/kserve-module/pkg/kservemodule/constants.go
@@ -2,15 +2,15 @@ package kservemodule
 
 const (
 	// Component names
-	kserveComponentName             = "kserve"
-	odhModelControllerComponentName = "modelcontroller"
-	wvaComponentName                = "wva"
+	KserveComponentName             = "kserve"
+	OdhModelControllerComponentName = "modelcontroller"
+	WVAComponentName                = "wva"
 
 	// Manifest source paths
-	kserveManifestSourcePath    = "overlays/odh"
-	kserveManifestSourcePathXKS = "overlays/odh-xks"
-	modelControllerSourcePath   = "base"
-	wvaManifestSourcePathOCP = "openshift"
+	KserveManifestSourcePath    = "overlays/odh"
+	KserveManifestSourcePathXKS = "overlays/odh-xks"
+	ModelControllerSourcePath   = "base"
+	WVAManifestSourcePathOCP    = "openshift"
 
 	// Deployment names
 	kserveControllerDeployment  = "kserve-controller-manager"

--- a/kserve-module/pkg/kservemodule/fixture/envtest.go
+++ b/kserve-module/pkg/kservemodule/fixture/envtest.go
@@ -135,10 +135,10 @@ spec:
       - name: manager
         image: ghcr.io/llm-d/llm-d-workload-variant-autoscaler:latest
 `
-	writeKustomizeDir(filepath.Join(workDir, "kserve", "overlays", "odh"), kserveManifest)
-	writeKustomizeDir(filepath.Join(workDir, "kserve", "overlays", "odh-xks"), kserveManifest)
-	writeKustomizeDir(filepath.Join(workDir, "modelcontroller", "base"), modelCtrlManifest)
-	writeKustomizeDir(filepath.Join(workDir, "wva", "openshift"), wvaManifest)
+	writeKustomizeDir(filepath.Join(workDir, kservemodule.KserveComponentName, kservemodule.KserveManifestSourcePath), kserveManifest)
+	writeKustomizeDir(filepath.Join(workDir, kservemodule.KserveComponentName, kservemodule.KserveManifestSourcePathXKS), kserveManifest)
+	writeKustomizeDir(filepath.Join(workDir, kservemodule.OdhModelControllerComponentName, kservemodule.ModelControllerSourcePath), modelCtrlManifest)
+	writeKustomizeDir(filepath.Join(workDir, kservemodule.WVAComponentName, kservemodule.WVAManifestSourcePathOCP), wvaManifest)
 }
 
 func writeKustomizeDir(dir, manifest string) {

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -241,7 +241,7 @@ func (r *KserveModuleReconciler) reconcileComponent(ctx context.Context,
 		}
 	}
 
-	commonPostRender(resources, kserveComponentName)
+	commonPostRender(resources, KserveComponentName)
 
 	log.Info("component rendering complete", "component", comp.name, "resources", len(resources))
 	return resources, nil

--- a/kserve-module/pkg/kservemodule/status.go
+++ b/kserve-module/pkg/kservemodule/status.go
@@ -153,7 +153,7 @@ func (r *KserveModuleReconciler) setReleaseStatus(kserve *platformv1alpha1.Kserv
 	}
 
 	releases, err := loadComponentReleases(r.ManifestsTemplatePath,
-		[]string{kserveComponentName, odhModelControllerComponentName})
+		[]string{KserveComponentName, OdhModelControllerComponentName})
 	if err != nil {
 		ctrl.Log.Error(err, "failed to load component releases")
 		return


### PR DESCRIPTION
**What this PR does / why we need it**:
Export component name and manifest path constants so integration test fixtures can reference them directly instead of hardcoding strings. Previously, changing a path in constants.go silently broke envtest fixtures (happened during WVA work).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
