### PR TITLE
feat: set NextProtos on logger HTTP client TLS config

### DIFF
--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -82,7 +82,6 @@ type Options struct {
 	enableLeaderElection  bool
 	probeAddr             string
 	metricsSecure         bool
-	enableHTTP2           bool
 	migrationTimeout      time.Duration
 	migrationPollInterval time.Duration
 	zapOpts               zap.Options
@@ -95,7 +94,6 @@ func DefaultOptions() Options {
 		enableLeaderElection:  false,
 		probeAddr:             ":8081",
 		metricsSecure:         true,
-		enableHTTP2:           false,
 		migrationTimeout:      1 * time.Hour,
 		migrationPollInterval: 30 * time.Second,
 		zapOpts:               zap.Options{},
@@ -112,7 +110,6 @@ func GetOptions() Options {
 			"Enabling this will ensure there is only one active kserve controller manager.")
 	flag.StringVar(&opts.probeAddr, "health-probe-addr", opts.probeAddr, "The address the probe endpoint binds to.")
 	flag.BoolVar(&opts.metricsSecure, "metrics-secure", opts.metricsSecure, "Whether to serve metric via HTTPS.")
-	flag.BoolVar(&opts.enableHTTP2, "enable-http2", false, "If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.DurationVar(&opts.migrationTimeout, "storage-migration-timeout", opts.migrationTimeout, "Total retry budget for storage version migration.")
 	flag.DurationVar(&opts.migrationPollInterval, "storage-migration-poll-interval", opts.migrationPollInterval, "Polling interval for storage version migration retries after initial backoff.")
 	opts.zapOpts.BindFlags(flag.CommandLine)
@@ -152,19 +149,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	// http/2 should be disabled due to its vulnerabilities. More specifically, disabling http/2 will
-	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and
-	// Rapid Reset CVEs. For more information see:
-	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
-	// - https://github.com/advisories/GHSA-4374-p667-p6c8
-	disableHTTP2 := func(c *tls.Config) {
-		setupLog.Info("disabling http/2")
-		c.NextProtos = []string{"http/1.1"}
-	}
-
-	var tlsOpts []func(*tls.Config)
-	if !options.enableHTTP2 {
-		tlsOpts = append(tlsOpts, disableHTTP2)
+	tlsOpts := []func(*tls.Config){
+		func(c *tls.Config) {
+			c.NextProtos = []string{"h2", "http/1.1"}
+		},
 	}
 	// Metrics endpoint is enabled in 'config/default/kustomization.yaml'. The Metrics options configure the server.
 	// More info:

--- a/pkg/logger/worker.go
+++ b/pkg/logger/worker.go
@@ -107,6 +107,7 @@ func (w *Worker) sendHttpCloudEvent(logReq LogRequest) error {
 					RootCAs:            clientCertPool,
 					MinVersion:         tls.VersionTLS12,
 					InsecureSkipVerify: logReq.TlsSkipVerify, // #nosec G402
+					NextProtos:         []string{"h2", "http/1.1"},
 				},
 			}
 			t.Client.Transport = tlsTransport


### PR DESCRIPTION
## Summary

- Adds ALPN negotiation (`h2`, `http/1.1`) to the TLS client config used by the inference logger worker
- Without explicit `NextProtos`, Go's TLS client does not advertise protocol preferences during the TLS handshake, which can cause protocol mismatches with servers that require ALPN
- Removes the vestigial `enableHTTP2` flag from llmisvc. CVE-2023-44487 (HTTP/2 Rapid Reset) is fixed in Go's net/http since Go 1.21.3, and kserve uses Go 1.25.8. The flag was a no-op risk: when disabled, it set `NextProtos: ["http/1.1"]` which blocks HTTP/2 unnecessarily. Now always sets `NextProtos: ["h2", "http/1.1"]` for proper ALPN compliance.

## Changes

- `pkg/logger/worker.go`: Set `NextProtos: ["h2", "http/1.1"]` on logger HTTP client TLS config
- `cmd/llmisvc/main.go`: Remove `--enable-http2` CLI flag and `disableHTTP2` function, always enable HTTP/2 via ALPN

## Testing

- `go build ./...` passes
- Verified NextProtos is set on all TLS endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS protocol negotiation for HTTPS CloudEvents delivery to reliably support both HTTP/2 and HTTP/1.1.
  * Updated TLS handling for the metrics and webhook servers to use consistent HTTP/2/HTTP/1.1 negotiation.

* **Breaking Change**
  * Removed the option/flag for manually enabling HTTP/2; HTTP/2 negotiation is now applied automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->