### PR TITLE
feat(kserve-module): add NIM ManagementState reconciliation and fix cleanup postRender

### DIFF
--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -91,9 +91,12 @@ func isWVAEnabled(kserve *platformv1alpha1.Kserve) bool {
 }
 
 func modelControllerExtraParams(kserve *platformv1alpha1.Kserve) map[string]string {
-	nimState := string(common.Managed)
-	if kserve.Spec.NIM.ManagementState == common.Removed {
-		nimState = string(common.Removed)
+	nimState := string(common.Removed)
+	if platformv1alpha1.GetManagementState(kserve) == common.Managed {
+		nimState = string(kserve.Spec.NIM.ManagementState)
+		if nimState == "" {
+			nimState = string(common.Managed)
+		}
 	}
 	return map[string]string{
 		"nim-state":    strings.ToLower(nimState),

--- a/kserve-module/pkg/kservemodule/components_test.go
+++ b/kserve-module/pkg/kservemodule/components_test.go
@@ -70,6 +70,57 @@ func TestComponentsConfig_WVAHasEnabled(t *testing.T) {
 	g.Expect(wva.sourcePathXKS).Should(BeEmpty(), "WVA is OCP-only, must not have XKS overlay")
 }
 
+func TestModelControllerExtraParams(t *testing.T) {
+	tests := []struct {
+		name           string
+		kserveState    common.ManagementState
+		nimState       common.ManagementState
+		expectedNIM    string
+		expectedKserve string
+	}{
+		{
+			name:           "Kserve Managed + NIM Managed",
+			kserveState:    common.Managed,
+			nimState:       common.Managed,
+			expectedNIM:    "managed",
+			expectedKserve: "managed",
+		},
+		{
+			name:           "Kserve Managed + NIM Removed",
+			kserveState:    common.Managed,
+			nimState:       common.Removed,
+			expectedNIM:    "removed",
+			expectedKserve: "managed",
+		},
+		{
+			name:           "Kserve Managed + NIM empty defaults to managed",
+			kserveState:    common.Managed,
+			nimState:       "",
+			expectedNIM:    "managed",
+			expectedKserve: "managed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			kserve := &platformv1alpha1.Kserve{
+				Spec: platformv1alpha1.KserveSpec{
+					ManagementSpec: common.ManagementSpec{
+						ManagementState: tt.kserveState,
+					},
+					NIM: platformv1alpha1.NIMSpec{
+						ManagementState: tt.nimState,
+					},
+				},
+			}
+			params := modelControllerExtraParams(kserve)
+			g.Expect(params["nim-state"]).To(Equal(tt.expectedNIM))
+			g.Expect(params["kserve-state"]).To(Equal(tt.expectedKserve))
+		})
+	}
+}
+
 func TestApplyManagedByLabel(t *testing.T) {
 	g := NewWithT(t)
 

--- a/kserve-module/pkg/kservemodule/images.go
+++ b/kserve-module/pkg/kservemodule/images.go
@@ -23,6 +23,17 @@ var kserveImageParamMap = map[string]string{
 
 var modelControllerImageParamMap = map[string]string{
 	"odh-model-controller": "RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE",
+	"odh-model-serving-api":   "RELATED_IMAGE_ODH_MODEL_SERVING_API_IMAGE",
+	"caikit-standalone-image": "RELATED_IMAGE_ODH_CAIKIT_NLP_IMAGE",
+	"ovms-image":              "RELATED_IMAGE_ODH_OPENVINO_MODEL_SERVER_IMAGE",
+	"mlserver-image":          "RELATED_IMAGE_ODH_MLSERVER_IMAGE",
+	"vllm-cuda-image":         "RELATED_IMAGE_RHAII_VLLM_CUDA_IMAGE",
+	"vllm-cpu-image":          "RELATED_IMAGE_ODH_VLLM_CPU_IMAGE",
+	"vllm-cpu-x86-image":      "RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE",
+	"vllm-gaudi-image":        "RELATED_IMAGE_RHAII_VLLM_GAUDI_IMAGE",
+	"vllm-rocm-image":         "RELATED_IMAGE_RHAII_VLLM_ROCM_IMAGE",
+	"vllm-spyre-image":        "RELATED_IMAGE_RHAII_VLLM_SPYRE_IMAGE",
+	"guardrails-detector-huggingface-runtime-image": "RELATED_IMAGE_ODH_GUARDRAILS_DETECTOR_HUGGINGFACE_RUNTIME_IMAGE",
 }
 
 var wvaImageParamMap = map[string]string{

--- a/kserve-module/pkg/kservemodule/resource_manager.go
+++ b/kserve-module/pkg/kservemodule/resource_manager.go
@@ -85,6 +85,13 @@ func (r *KserveModuleReconciler) defaultCleanup(ctx context.Context, comp compon
 		return fmt.Errorf("rendering %s manifests for cleanup: %w", comp.name, err)
 	}
 
+	if comp.postRender != nil {
+		resources, err = comp.postRender(ctx, r, nil, resources)
+		if err != nil {
+			return fmt.Errorf("post-render for cleanup %s: %w", comp.name, err)
+		}
+	}
+
 	var errs []string
 	for i := range resources {
 		res := &resources[i]

--- a/kserve-module/tests/e2e/conftest.py
+++ b/kserve-module/tests/e2e/conftest.py
@@ -28,6 +28,7 @@ OPERAND_DEPLOYMENTS_OCP = [
 ]
 
 WVA_DEPLOYMENT = "workload-variant-autoscaler-controller-manager"
+MODEL_CONTROLLER_DEPLOYMENT = "odh-model-controller"
 
 KSERVE_CR_TEMPLATE = {
     "apiVersion": "components.platform.opendatahub.io/v1alpha1",

--- a/kserve-module/tests/e2e/test_lifecycle.py
+++ b/kserve-module/tests/e2e/test_lifecycle.py
@@ -18,6 +18,7 @@ from conftest import (
     NAMESPACE,
     OPERATOR_DEPLOYMENT,
     WVA_DEPLOYMENT,
+    MODEL_CONTROLLER_DEPLOYMENT,
     TIMEOUT_120S,
     TIMEOUT_60S,
 )
@@ -157,6 +158,7 @@ class TestCELValidation:
         assert result.returncode != 0, "Invalid CR should not exist"
 
 
+@pytest.mark.sanity
 class TestManagementState:
     """Verify managementState transitions for sub-components (WVA, NIM)."""
 
@@ -210,6 +212,71 @@ class TestManagementState:
         wait_for_deployment_gone(kubectl, WVA_DEPLOYMENT)
 
         _verify_deployments_available(kubectl, is_openshift=True)
+
+    def test_nim_default_managed_env_var(self, kubectl, cluster_info, apply_kserve_cr):
+        """NIM defaults to Managed — odh-model-controller should have NIM_STATE=managed."""
+        if not cluster_info.is_openshift:
+            pytest.skip("odh-model-controller is OCP-only")
+
+        _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, TIMEOUT_120S,
+                 f"observedGeneration not matching within {TIMEOUT_120S}s")
+        wait_for_deployment(kubectl, MODEL_CONTROLLER_DEPLOYMENT)
+
+        result = run([
+            kubectl, "get", "deployment", MODEL_CONTROLLER_DEPLOYMENT,
+            "-n", NAMESPACE, "-o",
+            "jsonpath={.spec.template.spec.containers[?(@.name=='manager')].env[?(@.name=='NIM_STATE')].value}",
+        ])
+        assert result.stdout.strip() == "managed", \
+            f"NIM_STATE should be 'managed' by default, got '{result.stdout.strip()}'"
+
+    def test_nim_managed_to_removed_updates_env(self, kubectl, cluster_info, apply_kserve_cr):
+        """Switching NIM to Removed updates odh-model-controller NIM_STATE env var."""
+        if not cluster_info.is_openshift:
+            pytest.skip("odh-model-controller is OCP-only")
+
+        wait_for_deployment(kubectl, MODEL_CONTROLLER_DEPLOYMENT)
+
+        patch = json.dumps({"spec": {"nim": {"managementState": "Removed"}}})
+        run([kubectl, "patch", "kserve", KSERVE_CR_NAME, "--type", "merge", "-p", patch])
+
+        _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, TIMEOUT_120S,
+                 f"observedGeneration not matching within {TIMEOUT_120S}s")
+
+        wait_for_deployment(kubectl, MODEL_CONTROLLER_DEPLOYMENT)
+
+        result = run([
+            kubectl, "get", "deployment", MODEL_CONTROLLER_DEPLOYMENT,
+            "-n", NAMESPACE, "-o",
+            "jsonpath={.spec.template.spec.containers[?(@.name=='manager')].env[?(@.name=='NIM_STATE')].value}",
+        ])
+        assert result.stdout.strip() == "removed", \
+            f"NIM_STATE should be 'removed' after patch, got '{result.stdout.strip()}'"
+
+    def test_nim_removed_to_managed_updates_env(self, kubectl, cluster_info, apply_kserve_cr):
+        """Switching NIM back to Managed updates odh-model-controller NIM_STATE env var."""
+        if not cluster_info.is_openshift:
+            pytest.skip("odh-model-controller is OCP-only")
+
+        patch = json.dumps({"spec": {"nim": {"managementState": "Removed"}}})
+        run([kubectl, "patch", "kserve", KSERVE_CR_NAME, "--type", "merge", "-p", patch])
+        _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, TIMEOUT_120S,
+                 f"observedGeneration not matching within {TIMEOUT_120S}s")
+
+        patch = json.dumps({"spec": {"nim": {"managementState": "Managed"}}})
+        run([kubectl, "patch", "kserve", KSERVE_CR_NAME, "--type", "merge", "-p", patch])
+        _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, TIMEOUT_120S,
+                 f"observedGeneration not matching within {TIMEOUT_120S}s")
+
+        wait_for_deployment(kubectl, MODEL_CONTROLLER_DEPLOYMENT)
+
+        result = run([
+            kubectl, "get", "deployment", MODEL_CONTROLLER_DEPLOYMENT,
+            "-n", NAMESPACE, "-o",
+            "jsonpath={.spec.template.spec.containers[?(@.name=='manager')].env[?(@.name=='NIM_STATE')].value}",
+        ])
+        assert result.stdout.strip() == "managed", \
+            f"NIM_STATE should be 'managed' after reverting, got '{result.stdout.strip()}'"
 
 
 @pytest.mark.sanity


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. Re-running failed tests: comment `/rerun-all` to rerun all failed workflows.
-->

**What this PR does / why we need it**:
Add NIM sub-component ManagementState reconciliation and fix cleanup postRender gap from the WVA PR, plus missing RELATED_IMAGE for odh-model-controller

**Bug fixes**
- Apply postRender during cleanup so WVA Namespace resources are filtered out (fixes forbidden error on namespace deletion)
- Add missing modelcontroller image param mappings (vllm, ovms, mlserver, caikit, guardrails, model-serving-api)

**NIM**
- Align NIM state logic with odh-operator: default `Managed`, use NIM ManagementState only when Kserve is Managed, handle empty as Managed
- NIM state change triggers odh-model-controller pod restart via Kustomize replacements (params.env → NIM_STATE env var → Deployment spec change → SSA rollout)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #  https://redhat.atlassian.net/browse/RHOAIENG-67036

**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NIM (NVIDIA Inference Microservice) management state configuration with sensible defaults and automatic state transitions.
  * Extended support for additional model serving runtime images including VLLM, OVMS, MLServer, Caikit, and Guardrails components.

* **Tests**
  * Added comprehensive unit and E2E tests validating NIM state management, configuration derivation, and lifecycle transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->