### PR TITLE
[RHOAIENG-62725] Add kserve-module dev deployment and ModelCache docs

### DIFF
--- a/kserve-module/docs/dev-deployment.md
+++ b/kserve-module/docs/dev-deployment.md
@@ -1,0 +1,211 @@
+# Deploying the kserve-module to a Dev Cluster
+
+This guide covers building, deploying, and configuring the kserve-module controller on CRC or any OpenShift cluster for development and testing.
+
+## Prerequisites
+
+- OpenShift cluster (CRC or ROSA) with `oc` logged in
+- Docker or Podman
+- A container registry you can push to (e.g. `quay.io/youruser`)
+- cert-manager installed (required for webhook certificates)
+
+## 1. Build and Push the kserve-module
+
+```bash
+export KO_DOCKER_REPO=quay.io/youruser
+export TAG=dev
+
+ENGINE=docker make -f Makefile.kserve-module.mk docker-push-kserve-module
+```
+
+## 2. Deploy the kserve-module
+
+### Full deploy (CRDs + RBAC + controller)
+
+This builds the kustomize overlay and applies everything via SSA -- CRDs, RBAC, and the controller Deployment:
+
+```bash
+ENGINE=docker make -f Makefile.kserve-module.mk deploy-kserve-module
+```
+
+### Update only the controller image (if already deployed)
+
+```bash
+oc set image deployment/kserve-module-controller-manager \
+  -n opendatahub \
+  manager=quay.io/youruser/kserve-module-controller:dev
+```
+
+### Apply CRDs or RBAC independently
+
+If you need to apply CRDs or RBAC separately (e.g. after adding new fields or RBAC markers without rebuilding the module image):
+
+```bash
+# CRD only
+kubectl apply --server-side -f kserve-module/config/crd/components.platform.opendatahub.io_kserves.yaml
+
+# RBAC only (after running make manifests-kserve-module)
+kubectl apply --server-side -f kserve-module/config/rbac/role.yaml
+```
+
+### Verify the controller is running
+
+```bash
+oc get pods -n opendatahub -l app.kubernetes.io/name=kserve-module-controller-manager
+oc logs -n opendatahub -l app.kubernetes.io/name=kserve-module-controller-manager -f
+```
+
+## 3. Override Component Images
+
+The kserve-module resolves component images from embedded `params.env` files at build time. For dev testing, you can override any image via environment variables on the kserve-module-controller-manager deployment.
+
+### Available image overrides
+
+| Component | Env Var | Default source |
+|-----------|---------|----------------|
+| kserve-controller | `RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE` | `config/overlays/odh/params.env` |
+| llmisvc-controller | `RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE` | `config/overlays/odh/params.env` |
+| kserve-agent | `RELATED_IMAGE_ODH_KSERVE_AGENT_IMAGE` | `config/overlays/odh/params.env` |
+| kserve-router | `RELATED_IMAGE_ODH_KSERVE_ROUTER_IMAGE` | `config/overlays/odh/params.env` |
+| storage-initializer | `RELATED_IMAGE_ODH_KSERVE_STORAGE_INITIALIZER_IMAGE` | `config/overlays/odh/params.env` |
+| localmodel-controller | `RELATED_IMAGE_ODH_KSERVE_LOCALMODEL_CONTROLLER_IMAGE` | `config/overlays/odh-modelcache/params.env` |
+| localmodelnode-agent | `RELATED_IMAGE_ODH_KSERVE_LOCALMODELNODE_AGENT_IMAGE` | `config/overlays/odh-modelcache/params.env` |
+| odh-model-controller | `RELATED_IMAGE_ODH_MODEL_CONTROLLER_IMAGE` | hardcoded |
+| wva-controller | `RELATED_IMAGE_ODH_WORKLOAD_VARIANT_AUTOSCALER_CONTROLLER_IMAGE` | `config/overlays/openshift/params.env` |
+
+### Setting an override
+
+```bash
+oc set env deployment/kserve-module-controller-manager -n opendatahub \
+  RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE=quay.io/youruser/kserve-controller:dev
+```
+
+The module controller will restart automatically and reconcile with the new image on its next cycle.
+
+### Removing an override (revert to default)
+
+```bash
+oc set env deployment/kserve-module-controller-manager -n opendatahub \
+  RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE-
+```
+
+Note the trailing `-` which removes the env var.
+
+### Changing default images at build time
+
+Edit the params.env files before building the kserve-module:
+
+- `config/overlays/odh/params.env` -- kserve, llmisvc, agent, router, storage-initializer
+- `config/overlays/odh-modelcache/params.env` -- localmodel-controller, localmodelnode-agent
+
+## 4. Create the Kserve CR
+
+The kserve-module is driven by a singleton `Kserve` custom resource named `default-kserve`.
+
+### Minimal CR
+
+```yaml
+apiVersion: components.platform.opendatahub.io/v1alpha1
+kind: Kserve
+metadata:
+  name: default-kserve
+spec:
+  managementState: Managed
+```
+
+### Full CR with all configurable features
+
+```yaml
+apiVersion: components.platform.opendatahub.io/v1alpha1
+kind: Kserve
+metadata:
+  name: default-kserve
+spec:
+  # Overall management state. Set to Removed to undeploy all components.
+  managementState: Managed
+
+  # Controls whether Services use ClusterIP: None (Headless) or ClusterIP (Headed).
+  # Headless is the default for RawDeployment mode.
+  # Options: Headless, Headed
+  rawDeploymentServiceConfig: Headless
+
+  # NIM (NVIDIA Inference Microservice) integration
+  nim:
+    # Managed (default): deploys NIM account resources
+    # Removed: skips NIM resources
+    managementState: Managed
+    # Set to true for air-gapped environments
+    airGapped: false
+
+  # WVA (Workload Variant Autoscaler)
+  wva:
+    # Removed (default): WVA not deployed
+    # Managed: deploys WVA controller and resources
+    managementState: Removed
+
+  # ModelCache (local model caching on worker nodes)
+  modelCache:
+    # Removed (default): ModelCache not deployed
+    # Managed: deploys localmodel controller, agent DaemonSet, PV/PVC, LMNG
+    managementState: Managed
+    # Required when Managed. Size of the host-path volume for cached models.
+    cacheSize: 50Gi
+    # Select nodes by name (mutually exclusive with nodeSelector)
+    nodeNames:
+      - worker-0
+      - worker-1
+    # OR select nodes by label (mutually exclusive with nodeNames)
+    # nodeSelector:
+    #   matchLabels:
+    #     node-role.kubernetes.io/gpu: ""
+```
+
+### Apply the CR
+
+```bash
+oc apply -f kserve-cr.yaml
+```
+
+### Verify readiness
+
+```bash
+oc get kserve default-kserve -o jsonpath='{.status.phase}'
+# Expected: Ready
+
+oc get kserve default-kserve -o jsonpath='{.status.conditions}' | jq .
+```
+
+## 5. Troubleshooting
+
+### CRD gets reverted after manual changes
+
+The kserve-module SSA-applies all resources (including CRDs) every reconcile. Manual CRD edits will be overwritten. To test with a modified CRD:
+1. Scale down the module: `oc scale deployment/kserve-module-controller-manager -n opendatahub --replicas=0`
+2. Apply your CRD: `kubectl apply --server-side --force-conflicts -f config/crd/full/serving.kserve.io_inferenceservices.yaml`
+3. Test, then scale back up when done
+
+### Image not updating after env var change
+
+The module sets the image on the target Deployment, but the pods may use a cached image if `imagePullPolicy: IfNotPresent`. Delete the pods to force a fresh pull:
+
+```bash
+oc delete pod -n opendatahub -l control-plane=kserve-controller-manager
+```
+
+### RBAC errors in controller logs
+
+After adding new RBAC markers, regenerate and apply:
+
+```bash
+make manifests-kserve-module
+kubectl apply --server-side -f kserve-module/config/rbac/role.yaml
+oc delete pod -n opendatahub -l app.kubernetes.io/name=kserve-module-controller-manager
+```
+
+### Controller reconcile not triggering
+
+Force a reconcile by annotating the Kserve CR:
+
+```bash
+kubectl annotate kserve default-kserve force-reconcile="$(date +%s)" --overwrite
+```

--- a/kserve-module/docs/feature-modelcache.md
+++ b/kserve-module/docs/feature-modelcache.md
@@ -1,0 +1,175 @@
+# Feature: ModelCache
+
+ModelCache pre-downloads models to node-local storage so InferenceServices can start without pulling from remote storage. It is managed as a sub-component of the kserve-module via the `Kserve` CR.
+
+## Enable ModelCache
+
+```bash
+WORKER_NODE=$(oc get nodes -l node-role.kubernetes.io/worker -o jsonpath='{.items[0].metadata.name}')
+
+oc patch kserve default-kserve --type merge -p "{
+  \"spec\": {
+    \"modelCache\": {
+      \"managementState\": \"Managed\",
+      \"cacheSize\": \"5Gi\",
+      \"nodeNames\": [\"$WORKER_NODE\"]
+    }
+  }
+}"
+```
+
+### Using nodeSelector instead of nodeNames
+
+```bash
+oc patch kserve default-kserve --type merge -p '{
+  "spec": {
+    "modelCache": {
+      "managementState": "Managed",
+      "cacheSize": "50Gi",
+      "nodeSelector": {
+        "matchLabels": {
+          "node-role.kubernetes.io/gpu": ""
+        }
+      }
+    }
+  }
+}'
+```
+
+`nodeNames` and `nodeSelector` are mutually exclusive.
+
+## Verify ModelCache Resources
+
+When ModelCache is enabled, the kserve-module creates and manages the following resources:
+
+```bash
+# PersistentVolume -- hostPath volume on labeled nodes
+oc get pv kserve-localmodelnode-pv
+
+# PersistentVolumeClaim -- bound to the PV in the applications namespace
+oc get pvc kserve-localmodelnode-pvc -n opendatahub
+
+# LocalModelNodeGroup -- tells the localmodel controller which nodes to use
+oc get localmodelnodegroups.serving.kserve.io workers
+
+# Node label -- applied to each selected node
+oc get node $WORKER_NODE -o jsonpath='{.metadata.labels.kserve/localmodel}'
+# Expected: worker
+
+# Namespace PSA -- elevated to privileged for the agent DaemonSet
+oc get ns opendatahub -o jsonpath='{.metadata.labels.pod-security\.kubernetes\.io/enforce}'
+# Expected: privileged
+
+# ConfigMap -- localModel section enabled
+oc get cm inferenceservice-config -n opendatahub -o jsonpath='{.data.localModel}' | jq .enabled
+# Expected: true
+```
+
+## Disable ModelCache
+
+```bash
+oc patch kserve default-kserve --type merge -p '{"spec":{"modelCache":{"managementState":"Removed"}}}'
+```
+
+All ModelCache resources are cleaned up automatically:
+- PV, PVC, and LocalModelNodeGroup are deleted
+- Node labels (`kserve/localmodel`) are removed
+- Namespace PSA is reverted to `baseline`
+- ConfigMap `localModel.enabled` is set to `false`
+
+## How It Works
+
+### Architecture
+
+The ModelCache feature deploys two controllers and a DaemonSet:
+
+| Component | Role |
+|-----------|------|
+| `kserve-localmodel-controller-manager` | Orchestrates model downloads across node groups |
+| `kserve-localmodelnode-agent` (DaemonSet) | Runs on labeled nodes, manages local model storage |
+| `fix-permissions` (Job) | One-shot job to fix hostPath volume permissions on OpenShift |
+
+### Storage
+
+The PV uses a `hostPath` volume at `/var/lib/kserve/models` with `storageClassName: local-storage`. The `local-storage` StorageClass does not need to exist as a Kubernetes object -- it is only used as a string label for static PV/PVC binding.
+
+### SELinux (OpenShift)
+
+On OpenShift, the DaemonSet agent pods are patched with the namespace's MCS level (`openshift.io/sa.scc.mcs` annotation) so their SELinux context matches the download jobs and fix-permissions jobs that share the same PVC. This is handled automatically during the kserve-module's post-render phase.
+
+### Status Conditions
+
+The `ModelCacheReady` condition on the Kserve CR reports:
+- `Disabled` -- ModelCache is not enabled
+- `ResourcesReady` -- all resources (PV, PVC, LMNG) exist and DaemonSet MCS matches
+- `ResourcesNotReady` -- one or more resources are missing
+- `NamespaceMCSMissing` -- the applications namespace is missing the `openshift.io/sa.scc.mcs` annotation
+- `SELinuxMCSMismatch` -- the DaemonSet MCS level doesn't match the namespace annotation
+
+## Creating a LocalModelCache
+
+Once ModelCache is enabled, create a `LocalModelCache` resource to pre-download a model:
+
+```yaml
+apiVersion: serving.kserve.io/v1alpha1
+kind: LocalModelCache
+metadata:
+  name: qwen2-0.5b-instruct
+spec:
+  modelSize: 10Gi
+  nodeGroups:
+    - workers
+  sourceModelUri: hf://Qwen/Qwen2-0.5B-Instruct
+```
+
+The localmodel controller will create download jobs on each node in the `workers` node group. Progress is reported in the `LocalModelCache` status:
+
+```bash
+oc get localmodelcache qwen2-0.5b-instruct -o jsonpath='{.status.nodeStatus}'
+```
+
+## Creating a LocalModelNamespaceCache
+
+`LocalModelNamespaceCache` is the namespace-scoped variant of `LocalModelCache`. It pre-downloads a model for use by InferenceServices in a specific namespace, rather than cluster-wide.
+
+```yaml
+apiVersion: serving.kserve.io/v1alpha1
+kind: LocalModelNamespaceCache
+metadata:
+  name: opt-125m
+  namespace: modelcache-test
+spec:
+  modelSize: 2Gi
+  nodeGroups:
+    - workers
+  sourceModelUri: hf://facebook/opt-125m
+```
+
+Check download status:
+
+```bash
+oc get localmodelnamespacecache opt-125m -n modelcache-test -o jsonpath='{.status}'  | jq .
+```
+
+Example output when download is complete:
+
+```json
+{
+  "copies": {
+    "available": 1,
+    "total": 1
+  },
+  "nodeStatus": {
+    "crc": "NodeDownloaded"
+  }
+}
+```
+
+### Difference from LocalModelCache
+
+| | LocalModelCache | LocalModelNamespaceCache |
+|---|---|---|
+| Scope | Cluster-wide | Single namespace |
+| Created by | Cluster admin | Namespace user |
+| PV/PVC | Shared across namespaces | Scoped to the namespace |
+| Use case | Shared models across teams | Team-specific models |


### PR DESCRIPTION
## Summary
- Add `kserve-module/docs/dev-deployment.md` -- building, deploying, image overrides, full Kserve CR example, troubleshooting
- Add `kserve-module/docs/feature-modelcache.md` -- ModelCache enable/disable lifecycle, resource verification, architecture, SELinux MCS, LocalModelCache and LocalModelNamespaceCache examples

Documentation-only change; no functional code changes.