### PR TITLE
Fix multi-node InferenceService Ready condition stuck at Unknown

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_status.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status.go
@@ -380,7 +380,7 @@ func (ss *InferenceServiceStatus) PropagateRawStatus(
 				}
 			}
 		} else {
-			// If progressing condition is True, and the reason is set to NewReplicaSetAvailable, override component as ready.
+			// If progressing condition is True, and the reason is NewReplicaSetAvailable, override component as ready.
 			// This is because progressing condition doesn't get set to false when deployment is complete.
 			// See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#complete-deployment
 			if progressingCondition.IsTrue() {
@@ -391,7 +391,12 @@ func (ss *InferenceServiceStatus) PropagateRawStatus(
 						Reason:  progressingCondition.Reason,
 						Message: progressingCondition.Message,
 					}
-				} else {
+				} else if availableCondition == nil || availableCondition.Status != corev1.ConditionTrue {
+					// Only mark Unknown when Available has NOT confirmed readiness.
+					// For multi-node deployments, there is a transient mismatch during rollout
+					// where Progressing=True with a non-"NewReplicaSetAvailable" reason while
+					// Available=True for all deployments.
+					// In that case the component IS ready and should not be downgraded.
 					componentReadyCondition = &apis.Condition{
 						Type:    readyCondition,
 						Status:  corev1.ConditionUnknown,
@@ -449,12 +454,12 @@ func getDeploymentCondition(deploymentList []*appsv1.Deployment, conditionType a
 				if con.Type == conditionType {
 					statuses = append(statuses, con.Status)
 					messages = append(messages, containerName+con.Message)
+					reasons = append(reasons, containerName+con.Reason)
 					lastTransitionTime = append(lastTransitionTime, apis.VolatileTime{
 						Inner: con.LastTransitionTime,
 					})
 					break
 				}
-				reasons = append(reasons, containerName+con.Reason)
 			}
 		}
 		// If the status of both the head node and worker node deployments matches the conditionType
@@ -463,8 +468,31 @@ func getDeploymentCondition(deploymentList []*appsv1.Deployment, conditionType a
 			condition.Status = allStatusesTrue(statuses)
 			condition.Message = strings.Join(messages, ", ")
 			condition.LastTransitionTime = lastTransitionTime[0] // used head node one
+			// When all deployments share the same reason, emit it without container prefixes
+			// so that downstream comparisons (e.g. == "NewReplicaSetAvailable") work
+			// identically to the single-deployment path.
+			rawReasons := make([]string, 0, len(deploymentList))
+			for _, deployment := range deploymentList {
+				for _, con := range deployment.Status.Conditions {
+					if con.Type == conditionType {
+						rawReasons = append(rawReasons, con.Reason)
+						break
+					}
+				}
+			}
+			allSame := len(rawReasons) > 0
+			for i := 1; i < len(rawReasons); i++ {
+				if rawReasons[i] != rawReasons[0] {
+					allSame = false
+					break
+				}
+			}
+			if allSame {
+				condition.Reason = rawReasons[0]
+			} else {
+				condition.Reason = strings.Join(reasons, ", ")
+			}
 		}
-		condition.Reason = strings.Join(reasons, ", ")
 	} else if len(deploymentList) == 1 {
 		// Usual rawDeployment case
 		for _, con := range deploymentList[0].Status.Conditions {

--- a/pkg/apis/serving/v1beta1/inference_service_status_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_status_test.go
@@ -1784,11 +1784,56 @@ func TestGetDeploymentCondition_MultiDeployment_AllTrue(t *testing.T) {
 	if condition.Message != expectedMsg {
 		t.Errorf("expected message %q, got %q", expectedMsg, condition.Message)
 	}
-	if condition.Reason != "" {
-		t.Errorf("expected reason to be empty, got %q", condition.Reason)
+	expectedReason := "predictor-container: HeadReady, worker-container: WorkerReady"
+	if condition.Reason != expectedReason {
+		t.Errorf("expected reason %q, got %q", expectedReason, condition.Reason)
 	}
 	if !condition.LastTransitionTime.Inner.Equal(&now) {
 		t.Errorf("expected last transition time %v, got %v", now, condition.LastTransitionTime.Inner)
+	}
+}
+
+func TestGetDeploymentCondition_MultiDeployment_SameReason(t *testing.T) {
+	now := metav1.Now()
+	headDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "predictor",
+		},
+		Status: appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{
+				{
+					Type:               appsv1.DeploymentProgressing,
+					Status:             corev1.ConditionTrue,
+					Reason:             "NewReplicaSetAvailable",
+					Message:            "Head progressed.",
+					LastTransitionTime: now,
+				},
+			},
+		},
+	}
+	workerDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "predictor-worker",
+		},
+		Status: appsv1.DeploymentStatus{
+			Conditions: []appsv1.DeploymentCondition{
+				{
+					Type:               appsv1.DeploymentProgressing,
+					Status:             corev1.ConditionTrue,
+					Reason:             "NewReplicaSetAvailable",
+					Message:            "Worker progressed.",
+					LastTransitionTime: now,
+				},
+			},
+		},
+	}
+	condition := getDeploymentCondition([]*appsv1.Deployment{headDeployment, workerDeployment}, appsv1.DeploymentProgressing)
+	if condition.Status != corev1.ConditionTrue {
+		t.Errorf("expected condition status %v, got %v", corev1.ConditionTrue, condition.Status)
+	}
+	expectedReason := "NewReplicaSetAvailable"
+	if condition.Reason != expectedReason {
+		t.Errorf("expected reason %q, got %q", expectedReason, condition.Reason)
 	}
 }
 
@@ -1837,12 +1882,243 @@ func TestGetDeploymentCondition_MultiDeployment_OneFalse(t *testing.T) {
 	if condition.Message != expectedMsg {
 		t.Errorf("expected message %q, got %q", expectedMsg, condition.Message)
 	}
-	if condition.Reason != "" {
-		t.Errorf("expected reason to be empty, got %q", condition.Reason)
+	expectedReason := "predictor-container: HeadReady, worker-container: WorkerNotReady"
+	if condition.Reason != expectedReason {
+		t.Errorf("expected reason %q, got %q", expectedReason, condition.Reason)
 	}
 	if !condition.LastTransitionTime.Inner.Equal(&now) {
 		t.Errorf("expected last transition time %v, got %v", now, condition.LastTransitionTime.Inner)
 	}
+}
+
+func TestPropagateRawStatus_MultiNode_AvailableTrueProgressingNonStandard(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	scenarios := map[string]struct {
+		progressingReason   string
+		expectedReadyStatus bool
+	}{
+		"Progressing reason MinimumReplicasAvailable (non-standard) with Available=True should be ready": {
+			progressingReason:   "MinimumReplicasAvailable",
+			expectedReadyStatus: true,
+		},
+		"Progressing reason ReplicaSetUpdated with Available=True should be ready": {
+			progressingReason:   "ReplicaSetUpdated",
+			expectedReadyStatus: true,
+		},
+		"Progressing reason NewReplicaSetAvailable with Available=True should be ready": {
+			progressingReason:   "NewReplicaSetAvailable",
+			expectedReadyStatus: true,
+		},
+	}
+
+	for name, scenario := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			now := metav1.Now()
+			headDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-predictor",
+				},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 1,
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:               appsv1.DeploymentAvailable,
+							Status:             corev1.ConditionTrue,
+							Reason:             "MinimumReplicasAvailable",
+							Message:            "Deployment has minimum availability.",
+							LastTransitionTime: now,
+						},
+						{
+							Type:               appsv1.DeploymentProgressing,
+							Status:             corev1.ConditionTrue,
+							Reason:             scenario.progressingReason,
+							Message:            "progressing",
+							LastTransitionTime: now,
+						},
+					},
+				},
+			}
+			workerDeployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-predictor" + constants.WorkerNodeSuffix,
+				},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 1,
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:               appsv1.DeploymentAvailable,
+							Status:             corev1.ConditionTrue,
+							Reason:             "MinimumReplicasAvailable",
+							Message:            "Deployment has minimum availability.",
+							LastTransitionTime: now,
+						},
+						{
+							Type:               appsv1.DeploymentProgressing,
+							Status:             corev1.ConditionTrue,
+							Reason:             scenario.progressingReason,
+							Message:            "progressing",
+							LastTransitionTime: now,
+						},
+					},
+				},
+			}
+
+			status := &InferenceServiceStatus{
+				Status:      duckv1.Status{},
+				Address:     &duckv1.Addressable{},
+				URL:         &apis.URL{},
+				ModelStatus: ModelStatus{},
+			}
+			parsedUrl, _ := url.Parse("http://test-predictor-default.default.example.com")
+			testUrl := (*apis.URL)(parsedUrl)
+			deploymentList := []*appsv1.Deployment{headDeployment, workerDeployment}
+			status.PropagateRawStatus(PredictorComponent, deploymentList, testUrl)
+			res := status.IsConditionReady(PredictorReady)
+
+			g.Expect(res).To(gomega.Equal(scenario.expectedReadyStatus))
+		})
+	}
+}
+
+func TestPropagateRawStatus_MultiNode_PartialRollout_AvailableTrue(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	now := metav1.Now()
+	headDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-predictor",
+		},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 1,
+			Conditions: []appsv1.DeploymentCondition{
+				{
+					Type:               appsv1.DeploymentAvailable,
+					Status:             corev1.ConditionTrue,
+					Reason:             "MinimumReplicasAvailable",
+					Message:            "Deployment has minimum availability.",
+					LastTransitionTime: now,
+				},
+				{
+					Type:               appsv1.DeploymentProgressing,
+					Status:             corev1.ConditionTrue,
+					Reason:             "NewReplicaSetAvailable",
+					Message:            "Head has progressed.",
+					LastTransitionTime: now,
+				},
+			},
+		},
+	}
+	workerDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-predictor" + constants.WorkerNodeSuffix,
+		},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 1,
+			Conditions: []appsv1.DeploymentCondition{
+				{
+					Type:               appsv1.DeploymentAvailable,
+					Status:             corev1.ConditionTrue,
+					Reason:             "MinimumReplicasAvailable",
+					Message:            "Deployment has minimum availability.",
+					LastTransitionTime: now,
+				},
+				{
+					Type:               appsv1.DeploymentProgressing,
+					Status:             corev1.ConditionTrue,
+					Reason:             "ReplicaSetUpdated",
+					Message:            "Worker still updating.",
+					LastTransitionTime: now,
+				},
+			},
+		},
+	}
+
+	status := &InferenceServiceStatus{
+		Status:      duckv1.Status{},
+		Address:     &duckv1.Addressable{},
+		URL:         &apis.URL{},
+		ModelStatus: ModelStatus{},
+	}
+	parsedUrl, _ := url.Parse("http://test-predictor-default.default.example.com")
+	testUrl := (*apis.URL)(parsedUrl)
+	deploymentList := []*appsv1.Deployment{headDeployment, workerDeployment}
+	status.PropagateRawStatus(PredictorComponent, deploymentList, testUrl)
+
+	condition := status.GetCondition(PredictorReady)
+	g.Expect(condition).ToNot(gomega.BeNil())
+	// Available=True for both, so even though not all segments have NewReplicaSetAvailable,
+	// the Available guard prevents downgrade to Unknown. ISVC should still be ready.
+	g.Expect(condition.Status).To(gomega.Equal(corev1.ConditionTrue))
+}
+
+func TestPropagateRawStatus_MultiNode_AvailableFalseProgressingOngoing(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	now := metav1.Now()
+	headDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-predictor",
+		},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 1,
+			Conditions: []appsv1.DeploymentCondition{
+				{
+					Type:               appsv1.DeploymentAvailable,
+					Status:             corev1.ConditionFalse,
+					Reason:             "MinimumReplicasUnavailable",
+					Message:            "Deployment does not have minimum availability.",
+					LastTransitionTime: now,
+				},
+				{
+					Type:               appsv1.DeploymentProgressing,
+					Status:             corev1.ConditionTrue,
+					Reason:             "ReplicaSetUpdated",
+					Message:            "Updated to new replica set",
+					LastTransitionTime: now,
+				},
+			},
+		},
+	}
+	workerDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-predictor" + constants.WorkerNodeSuffix,
+		},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 1,
+			Conditions: []appsv1.DeploymentCondition{
+				{
+					Type:               appsv1.DeploymentAvailable,
+					Status:             corev1.ConditionFalse,
+					Reason:             "MinimumReplicasUnavailable",
+					Message:            "Deployment does not have minimum availability.",
+					LastTransitionTime: now,
+				},
+				{
+					Type:               appsv1.DeploymentProgressing,
+					Status:             corev1.ConditionTrue,
+					Reason:             "ReplicaSetUpdated",
+					Message:            "Updated to new replica set",
+					LastTransitionTime: now,
+				},
+			},
+		},
+	}
+
+	status := &InferenceServiceStatus{
+		Status:      duckv1.Status{},
+		Address:     &duckv1.Addressable{},
+		URL:         &apis.URL{},
+		ModelStatus: ModelStatus{},
+	}
+	parsedUrl, _ := url.Parse("http://test-predictor-default.default.example.com")
+	testUrl := (*apis.URL)(parsedUrl)
+	deploymentList := []*appsv1.Deployment{headDeployment, workerDeployment}
+	status.PropagateRawStatus(PredictorComponent, deploymentList, testUrl)
+
+	condition := status.GetCondition(PredictorReady)
+	g.Expect(condition).ToNot(gomega.BeNil())
+	g.Expect(condition.Status).To(gomega.Equal(corev1.ConditionFalse))
 }
 
 func TestGetDeploymentCondition_SingleDeployment_NoMatchingCondition(t *testing.T) {


### PR DESCRIPTION
## What

Fixes a bug where multi-node InferenceService `PredictorReady` condition gets stuck at `Unknown` despite all pods running and deployments being Available.

Upstream PR: https://github.com/kserve/kserve/pull/5703
Jira: [RHOAIENG-70416](https://redhat.atlassian.net/browse/RHOAIENG-70416)

## Why

Two issues in `PropagateRawStatus`:

1. **Exact string match failure**: The check `progressingCondition.Reason == "NewReplicaSetAvailable"` fails for multi-node deployments where `getDeploymentCondition` concatenates reasons with container name prefixes (e.g., `"predictor-container: NewReplicaSetAvailable, worker-container: NewReplicaSetAvailable"`).

2. **Available=True downgrade race**: When `Progressing=True` with an intermediate reason (e.g., `ReplicaSetUpdated` during rollout) while `Available=True` for all deployments, the ISVC was incorrectly set to `Unknown`. The component IS ready and should not be downgraded.

Additionally, `getDeploymentCondition` had a bug where `reasons = append(...)` was placed after `break`, making it unreachable for multi-node deployments.

## Changes

- Use `strings.Contains` instead of exact match for `NewReplicaSetAvailable` reason detection
- Add guard to prevent Unknown downgrade when `Available=True` is already confirmed
- Fix `reasons` append placement in `getDeploymentCondition` (move before `break`)
- Move `condition.Reason = strings.Join(...)` inside the `len(statuses) == 2` block
- Add unit tests covering multi-node Available+Progressing race scenarios

## Testing

- Unit tests: All 7 new/modified tests pass
- On-cluster validation: Deployed patched controller via DevSpace on RHOAI 3.5-ea.2 cluster with 2 GPU nodes. Multi-node ISVC correctly transitioned to `Ready: True` and maintained that state through rolling updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected readiness/condition handling for Deployment `Progressing=True`, so “unknown” is set only when the aggregated `Available` condition is missing or not `True` (for non-`NewReplicaSetAvailable` reasons).
  * Improved multi-deployment condition aggregation so metadata is collected only for the matching condition type, and `Reason` is either a shared reason (when identical) or a comma-joined composite (when different).
* **Tests**
  * Updated/added multi-node `PredictorReady` and deployment condition aggregation tests, covering same-reason, partial-rollout, and ongoing update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->