### PR TITLE
Fixing lora flaky test failures in prow

### DIFF
--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -124,6 +124,7 @@ func main() {
 	ctx := signals.SetupSignalHandler()
 	options := GetOptions()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&options.zapOpts)))
+	setupLog.Info("starting llmisvc-controller")
 
 	defaults := DefaultOptions()
 	if options.migrationTimeout <= 0 {

--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -124,7 +124,6 @@ func main() {
 	ctx := signals.SetupSignalHandler()
 	options := GetOptions()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&options.zapOpts)))
-	setupLog.Info("starting llmisvc-controller")
 
 	defaults := DefaultOptions()
 	if options.migrationTimeout <= 0 {

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -1036,7 +1036,7 @@ def get_llmisvc(
     kserve_client: KServeClient,
     name,
     namespace,
-    version=constants.KSERVE_V1ALPHA2_VERSION,
+    version=constants.KSERVE_V1ALPHA1_VERSION,
 ):
     try:
         return kserve_client.api_instance.get_namespaced_custom_object(

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -207,7 +207,7 @@ class TestCase:
     payload_formatter: Optional[Callable[["TestCase"], Dict[str, Any]]] = None
     response_assertion: Callable[[requests.Response], None] = assert_200
     wait_timeout: int = 900
-    response_timeout: int = 60
+    response_timeout: int = 120
     extra_headers: Optional[Dict[str, str]] = None
     url_getter: Optional[Callable] = None
     expected_gateway: Optional[Dict[str, Any]] = None

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -146,7 +146,6 @@ def get_model_routing_url(
             kserve_client,
             llm_isvc.metadata.name,
             llm_isvc.metadata.namespace,
-            llm_isvc.api_version.split("/")[1],
         )
 
         status = llm_isvc_status.get("status", {})
@@ -1037,7 +1036,7 @@ def get_llmisvc(
     kserve_client: KServeClient,
     name,
     namespace,
-    version=constants.KSERVE_V1ALPHA1_VERSION,
+    version=constants.KSERVE_V1ALPHA2_VERSION,
 ):
     try:
         return kserve_client.api_instance.get_namespaced_custom_object(
@@ -1132,7 +1131,6 @@ def get_llm_service_url(
             kserve_client,
             llm_isvc.metadata.name,
             llm_isvc.metadata.namespace,
-            llm_isvc.api_version.split("/")[1],
         )
 
         if "status" not in llm_isvc:
@@ -1175,7 +1173,6 @@ def wait_for_llm_isvc_ready(
             kserve_client,
             given.metadata.name,
             given.metadata.namespace,
-            given.api_version.split("/")[1],
         )
 
         if "status" not in out:

--- a/test/e2e/llmisvc/test_llm_lora_adapters.py
+++ b/test/e2e/llmisvc/test_llm_lora_adapters.py
@@ -60,7 +60,7 @@ class LoRATestCase:
     endpoint: str = "/v1/completions"
     max_tokens: int = 100
     wait_timeout: int = 900
-    response_timeout: int = 60
+    response_timeout: int = 120
 
 
 def build_llm_service_from_refs(

--- a/test/scripts/openshift-ci/run-e2e-tests.sh
+++ b/test/scripts/openshift-ci/run-e2e-tests.sh
@@ -47,7 +47,7 @@ export KUBE_CLI=${KUBE_CLI_COMMAND:-oc}
 export GITHUB_SHA=stable # Need to use stable as this is what the CI tags the images to for success-200 and error-404
 export BUILD_GRAPH_IMAGES="${BUILD_GRAPH_IMAGES:-true}"
 export RUNNING_LOCAL="${RUNNING_LOCAL:-false}"
-export SKIP_DELETION_ON_FAILURE="${SKIP_DELETION_ON_FAILURE:=true}"
+export SKIP_DELETION_ON_FAILURE="${SKIP_DELETION_ON_FAILURE:=false}"
 
 # Export the controller namespace so that E2E tests
 # (e.g. storage version migration) can find the controller.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated end-to-end service routing and readiness checks to use the default API version, improving compatibility.
  * Increased HTTP response timeouts for LLM inference and LoRA adapter E2E tests to reduce flakiness.
* **Chores**
  * Changed end-to-end test failure behavior so cleanup/deletion runs by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->