### PR TITLE
feat(kserve-module): add Konflux build support with manifest prefetch

### DIFF
--- a/build/manifests-config.yaml
+++ b/build/manifests-config.yaml
@@ -1,0 +1,18 @@
+map:
+  kserve:
+    src: config
+    dest: kserve
+    git.url: https://github.com/opendatahub-io/kserve
+    ref_type: branch
+    branch: release-v0.17
+  odh-model-controller:
+    src: config
+    dest: modelcontroller
+    git.url: https://github.com/opendatahub-io/odh-model-controller
+    ref_type: branch
+    branch: incubating
+  workload-variant-autoscaler:
+    src: config
+    dest: wva
+    git.url: https://github.com/opendatahub-io/workload-variant-autoscaler
+    git.commit: "0641ee03e8430cce5821797137b1b53bf70b98a2"

--- a/kserve-module-controller.Dockerfile
+++ b/kserve-module-controller.Dockerfile
@@ -18,7 +18,12 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # Collect kserve + odh-model-controller manifests
 COPY kserve-module/hack/  hack/
 COPY config/               ../config/
-RUN bash hack/get_kserve_manifests.sh
+RUN if [ -d /cachi2/prefetched-manifests ]; then \
+      mkdir -p opt/manifests && \
+      cp -r /cachi2/prefetched-manifests/* opt/manifests/; \
+    else \
+      bash hack/get_kserve_manifests.sh; \
+    fi
 
 # Runtime
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest


### PR DESCRIPTION
Add build/manifests-config.yaml and update Dockerfile for Konflux CI builds.

manifests-config.yaml defines the 3 operand manifest sources (kserve, odh-model-controller, workload-variant-autoscaler) used by the prefetch-manifests-oci-ta Tekton task during Konflux pipeline execution.

Dockerfile change: when /cachi2/prefetched-manifests exists (Konflux build), use pre-fetched manifests instead of running get_kserve_manifests.sh. Local/CI builds without CACHI2 fall back to the existing script.

Depends on: red-hat-data-services/rhoai-konflux-tasks#272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced centralized manifest configuration system for streamlined management of multiple component repositories with defined deployment destinations and version control references
  * Optimized build process with intelligent manifest acquisition that leverages prefetched artifacts to accelerate builds when available, while maintaining backward compatibility through automatic fallback mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->