### PR TITLE
fix(kserve-module): address module guide compliance findings

### DIFF
--- a/kserve-module/config/rbac/role.yaml
+++ b/kserve-module/config/rbac/role.yaml
@@ -144,18 +144,6 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - coordination.k8s.io
-  resources:
-  - leases
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - monitoring.coreos.com
   resourceNames:
   - k8s

--- a/kserve-module/config/rbac/service_account.yaml
+++ b/kserve-module/config/rbac/service_account.yaml
@@ -2,3 +2,5 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kserve-module-controller-manager
+  labels:
+    app.kubernetes.io/name: kserve-module-controller-manager

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -39,7 +39,6 @@ import (
 // +kubebuilder:rbac:groups="",resources=serviceaccounts/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;delete;get;list;patch;update;watch
-// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;get;list;patch;watch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings;clusterroles;clusterrolebindings,verbs=create;delete;get;list;patch;update;watch
 // escalate/bind scoped to the exact roles and clusterroles deployed by this controller

--- a/kserve-module/pkg/kservemodule/status.go
+++ b/kserve-module/pkg/kservemodule/status.go
@@ -155,10 +155,6 @@ func (r *KserveModuleReconciler) updateStatus(ctx context.Context, kserve *platf
 }
 
 func (r *KserveModuleReconciler) setReleaseStatus(kserve *platformv1alpha1.Kserve) {
-	if len(kserve.Status.Releases) > 0 {
-		return
-	}
-
 	releases, err := loadComponentReleases(r.ManifestsTemplatePath,
 		[]string{KserveComponentName, OdhModelControllerComponentName})
 	if err != nil {


### PR DESCRIPTION
Reviewed kserve-module against the ODH modularisation guide docs.

- Remove duplicate lease RBAC from ClusterRole (guide says namespace-scoped Role only)
- Remove write-once guard in setReleaseStatus so releases update on operator upgrade
- Add app.kubernetes.io/name label to ServiceAccount for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed release status not being properly updated by ensuring component information is consistently loaded and synchronized.

* **Refactor**
  * Removed unused Kubernetes permissions from controller configuration.
  * Enhanced controller service account labeling for improved resource identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->