### PR TITLE
fix(kserve-module): fix flaky WVA e2e test with polling

### DIFF
--- a/kserve-module/tests/e2e/test_lifecycle.py
+++ b/kserve-module/tests/e2e/test_lifecycle.py
@@ -32,16 +32,8 @@ def _generation_matches(cr):
 
 def _verify_deployments_available(kubectl, is_openshift):
     expected = operand_deployments(is_openshift)
-    result = run([kubectl, "get", "deployments", "-n", NAMESPACE, "-o", "yaml"])
-    deployments = yaml.safe_load(result.stdout)
-    items = {d["metadata"]["name"]: d for d in deployments.get("items", [])}
     for name in expected:
-        assert name in items, \
-            f"{name} not found. Deployments: {list(items.keys())}"
-        conditions = {c["type"]: c for c in items[name].get("status", {}).get("conditions", [])}
-        avail = conditions.get("Available", {})
-        assert avail.get("status") == "True", \
-            f"{name} not Available. Condition: {avail}"
+        wait_for_deployment(kubectl, name)
 
 
 @pytest.mark.sanity


### PR DESCRIPTION
Replace one-shot deployment availability check with wait_for_deployment
polling. Fixes intermittent failures when deployments are temporarily
unavailable during reconcile (e.g. WVA state transitions).

Affects three call sites in test_lifecycle.py: TestCreate, test_wva_managed,
test_wva_managed_to_removed.