### PR TITLE
fix(ocp/rbac): unset llminferenceservice SCC priority

### DIFF
--- a/config/overlays/odh/rbac/llmisvc/llm-svc-scc.yaml
+++ b/config/overlays/odh/rbac/llmisvc/llm-svc-scc.yaml
@@ -2,7 +2,14 @@ kind: SecurityContextConstraints
 apiVersion: security.openshift.io/v1
 metadata:
   name: openshift-ai-llminferenceservice-scc
-priority: 10
+# priority is intentionally null. OCP SCC admission evaluates the union of the
+# pod's ServiceAccount and the identity that submits the pod create, then selects
+# the highest-priority SCC available to either. A positive priority makes this SCC
+# auto-win over restricted-v2 for any pod created by a broadly-privileged requestor
+# (e.g. a GitOps controller), hijacking unrelated workloads. With null priority
+# this SCC is only selected when a pod actually requires the extra capabilities it
+# grants; otherwise OCP falls back to a more restrictive SCC.
+priority: null
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Unsets the `priority` field on the `openshift-ai-llminferenceservice-scc` SecurityContextConstraints (previously `priority: 10`).

OCP SCC admission evaluates the union of the pod's ServiceAccount and the identity that submits the pod create, then selects the highest-priority SCC available to either. With a positive priority, this SCC auto-wins over `restricted-v2` for any pod created by a broadly-privileged requestor (e.g. a GitOps controller such as Flux running with cluster-admin-equivalent RBAC), so unrelated workloads get assigned the RHOAI SCC. Unsetting the priority means this SCC is only selected when a pod actually requires the capabilities it grants; pods that do not request them fall back to a more restrictive SCC.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

(Jira: [RHOAIENG-54150](https://redhat.atlassian.net/browse/RHOAIENG-54150))

**Feature/Issue validation/testing**:

Reproduced and verified on a ROSA 4.18 cluster (a supported OCP version for RHOAI 2.25):

- [x] Test A: with priority set, an unrelated pod created by a broadly-privileged requestor is assigned `openshift-ai-llminferenceservice-scc`; with priority unset, it is no longer auto-selected and falls back to a more restrictive SCC.
- [x] Test B: no regression - a pod that declares `IPC_LOCK` (as the llmisvc data-parallel worker presets do) still selects this SCC at null priority, since `restricted-v2` cannot admit added capabilities.

- Logs

```
# same pod / same restricted pod-SA, only the submitter and priority differ
priority 10, submitted by broad-RBAC requestor    -> openshift-ai-llminferenceservice-scc
priority unset, submitted by broad-RBAC requestor -> falls back (restricted / anyuid)
priority unset, pod requests IPC_LOCK             -> openshift-ai-llminferenceservice-scc (no regression)
```

**Special notes for your reviewer**:

No image version changes. This is a hardening / defense-in-depth change. Note that fully achieving `restricted-v2` for unrelated GitOps-submitted workloads also requires scoping down the submitting controllers' RBAC (customer-side), since SCC admission counts the submitter's access by design. See [RHOAIENG-54150](https://redhat.atlassian.net/browse/RHOAIENG-54150) for the full investigation.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works? (Validated on-cluster; the existing SCC controller test asserts RoleBinding behavior and is unaffected. SCC priority is a static manifest value not covered by unit tests.)
- [x] Has code been commented, particularly in hard-to-understand areas? (Added a comment in the manifest explaining why priority is intentionally unset.)
- [ ] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:

```release-note
Unset the priority on the openshift-ai-llminferenceservice SCC so it is no longer auto-selected over restricted-v2 for unrelated workloads created by broadly-privileged requestors.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated security context constraint selection so the inference service no longer automatically prefers an option solely based on a fixed priority.
  * By setting priority to unset, this SCC will only be chosen when the pod actually requires its additional capabilities, improving alignment with real runtime permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->