### PR TITLE
test(e2e): add flow control smoke tests with auth pipeline hook

### DIFF
--- a/test/e2e/llmisvc/conftest.py
+++ b/test/e2e/llmisvc/conftest.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 # Fixture factory - not called explicitly, but must be imported for pytest to discover it.
 from .fixtures import test_case  # noqa: F401
 
@@ -73,3 +75,23 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "tracing: mark test as a distributed tracing test"
     )
+    config.addinivalue_line("markers", "flow_control: mark test as a flow control test")
+
+
+@pytest.fixture
+def flow_control_auth():
+    """Auth provider hook for downstream deployments.
+
+    Override this fixture in a downstream conftest.py to enable auth pipeline
+    testing. Return a dict with:
+
+        {
+            "annotations": dict,   # LLMISVC metadata annotations to enable auth
+            "setup": callable,     # (kserve_client, service_name) -> token_str
+            "cleanup": callable,   # (kserve_client, service_name) -> None
+        }
+
+    When this fixture returns None (upstream default), the auth verification
+    section is skipped.
+    """
+    return None

--- a/test/e2e/llmisvc/conftest.py
+++ b/test/e2e/llmisvc/conftest.py
@@ -17,8 +17,6 @@ import pytest
 # Fixture factory - not called explicitly, but must be imported for pytest to discover it.
 from .fixtures import test_case  # noqa: F401
 
-import pytest
-
 _HARDCODED_TLS_WORKLOADS = (
     "workload-llmd-simulator",
     "workload-simulated-dp-ep-cpu",
@@ -80,18 +78,28 @@ def pytest_configure(config):
 
 @pytest.fixture
 def flow_control_auth():
-    """Auth provider hook for downstream deployments.
+    """Midstream override: enables auth pipeline testing for flow control.
 
-    Override this fixture in a downstream conftest.py to enable auth pipeline
-    testing. Return a dict with:
-
-        {
-            "annotations": dict,   # LLMISVC metadata annotations to enable auth
-            "setup": callable,     # (kserve_client, service_name) -> token_str
-            "cleanup": callable,   # (kserve_client, service_name) -> None
-        }
-
-    When this fixture returns None (upstream default), the auth verification
-    section is skipped.
+    The upstream default returns None (auth skipped). This midstream version
+    enables auth on the LLMISVC and provides SA token setup/cleanup so the
+    test verifies: unauthenticated -> 401, authenticated -> 200.
     """
-    return None
+    from .test_llm_auth import (
+        create_service_account_with_inference_access,
+        cleanup_service_account,
+    )
+
+    def setup(kserve_client, service_name):
+        sa = f"{service_name}-fc-sa"
+        return create_service_account_with_inference_access(
+            kserve_client, sa, service_name
+        )
+
+    def cleanup(kserve_client, service_name):
+        cleanup_service_account(kserve_client, f"{service_name}-fc-sa")
+
+    return {
+        "annotations": {"security.opendatahub.io/enable-auth": "true"},
+        "setup": setup,
+        "cleanup": cleanup,
+    }

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -1388,6 +1388,99 @@ LLMINFERENCESERVICE_CONFIGS = {
             ]
         },
     },
+    # --- Flow Control configurations ---
+    "scheduler-flow-control-round-robin": {
+        "router": {
+            "scheduler": {
+                "config": {
+                    "inline": {
+                        "apiVersion": "inference.networking.x-k8s.io/v1alpha1",
+                        "kind": "EndpointPickerConfig",
+                        "featureGates": ["flowControl"],
+                        "plugins": [
+                            {"type": "queue-scorer"},
+                            {"type": "kv-cache-utilization-scorer"},
+                            {
+                                "type": "round-robin-fairness-policy",
+                                "name": "round-robin",
+                            },
+                            {
+                                "type": "edf-ordering-policy",
+                                "name": "edf",
+                            },
+                            {
+                                "type": "slo-deadline-ordering-policy",
+                                "name": "slo-deadline",
+                            },
+                        ],
+                        "flowControl": {
+                            "priorityBands": [
+                                {
+                                    "priority": 100,
+                                    "fairnessPolicyRef": "round-robin",
+                                    "orderingPolicyRef": "edf",
+                                },
+                                {
+                                    "priority": 0,
+                                    "fairnessPolicyRef": "round-robin",
+                                },
+                                {
+                                    "priority": -1,
+                                    "fairnessPolicyRef": "round-robin",
+                                    "orderingPolicyRef": "slo-deadline",
+                                },
+                            ],
+                        },
+                        "schedulingProfiles": [
+                            {
+                                "name": "default",
+                                "plugins": [
+                                    {"pluginRef": "queue-scorer", "weight": 2},
+                                    {
+                                        "pluginRef": "kv-cache-utilization-scorer",
+                                        "weight": 2,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    },
+    "scheduler-flow-control-concurrency-detector": {
+        "router": {
+            "scheduler": {
+                "config": {
+                    "inline": {
+                        "apiVersion": "inference.networking.x-k8s.io/v1alpha1",
+                        "kind": "EndpointPickerConfig",
+                        "featureGates": ["flowControl"],
+                        "plugins": [
+                            {"type": "queue-scorer"},
+                            {"type": "kv-cache-utilization-scorer"},
+                            {"type": "concurrency-detector"},
+                        ],
+                        "saturationDetector": {
+                            "pluginRef": "concurrency-detector",
+                        },
+                        "schedulingProfiles": [
+                            {
+                                "name": "default",
+                                "plugins": [
+                                    {"pluginRef": "queue-scorer", "weight": 2},
+                                    {
+                                        "pluginRef": "kv-cache-utilization-scorer",
+                                        "weight": 2,
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    },
     "tracing-enabled": {
         "tracing": {
             "exporterEndpoint": "http://jaeger.observability.svc.cluster.local:4317",
@@ -1711,6 +1804,82 @@ def delete_scheduler_configmap():
     except client.rest.ApiException as e:
         if e.status != 404:  # Ignore not found
             raise
+
+
+INFERENCE_OBJECTIVE_GROUP = "inference.networking.x-k8s.io"
+INFERENCE_OBJECTIVE_VERSION = "v1alpha2"
+INFERENCE_OBJECTIVE_PLURAL = "inferenceobjectives"
+
+
+def create_inference_objectives(pool_name, objectives):
+    """Create InferenceObjective resources for flow control priority testing.
+
+    Args:
+        pool_name: Name of the InferencePool to reference.
+        objectives: List of dicts with 'name' and 'priority' keys.
+    """
+    inject_k8s_proxy()
+    api = client.CustomObjectsApi()
+
+    for obj in objectives:
+        body = {
+            "apiVersion": f"{INFERENCE_OBJECTIVE_GROUP}/{INFERENCE_OBJECTIVE_VERSION}",
+            "kind": "InferenceObjective",
+            "metadata": {
+                "name": obj["name"],
+                "namespace": KSERVE_TEST_NAMESPACE,
+            },
+            "spec": {
+                "poolRef": {"name": pool_name},
+                "priority": obj["priority"],
+            },
+        }
+        try:
+            api.create_namespaced_custom_object(
+                INFERENCE_OBJECTIVE_GROUP,
+                INFERENCE_OBJECTIVE_VERSION,
+                KSERVE_TEST_NAMESPACE,
+                INFERENCE_OBJECTIVE_PLURAL,
+                body,
+            )
+            logger.info(
+                f"Created InferenceObjective {obj['name']} (priority={obj['priority']})"
+            )
+        except client.rest.ApiException as e:
+            if e.status == 409:
+                api.replace_namespaced_custom_object(
+                    INFERENCE_OBJECTIVE_GROUP,
+                    INFERENCE_OBJECTIVE_VERSION,
+                    KSERVE_TEST_NAMESPACE,
+                    INFERENCE_OBJECTIVE_PLURAL,
+                    obj["name"],
+                    body,
+                )
+                logger.info(
+                    f"Updated InferenceObjective {obj['name']} (priority={obj['priority']})"
+                )
+            else:
+                raise
+
+
+def delete_inference_objectives(names):
+    """Delete InferenceObjective resources."""
+    inject_k8s_proxy()
+    api = client.CustomObjectsApi()
+
+    for name in names:
+        try:
+            api.delete_namespaced_custom_object(
+                INFERENCE_OBJECTIVE_GROUP,
+                INFERENCE_OBJECTIVE_VERSION,
+                KSERVE_TEST_NAMESPACE,
+                INFERENCE_OBJECTIVE_PLURAL,
+                name,
+            )
+            logger.info(f"Deleted InferenceObjective {name}")
+        except client.rest.ApiException as e:
+            if e.status != 404:
+                raise
 
 
 def create_pvc(

--- a/test/e2e/llmisvc/test_flow_control.py
+++ b/test/e2e/llmisvc/test_flow_control.py
@@ -1,0 +1,221 @@
+# Copyright 2025 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import time
+
+import pytest
+import requests
+from kserve import KServeClient
+from kubernetes import client
+
+from .fixtures import (
+    create_inference_objectives,
+    delete_inference_objectives,
+    inject_k8s_proxy,
+)
+from .logging import logger
+from .test_llm_inference_service import (
+    TestCase,
+    completions_payload,
+    create_response_assertion,
+    create_llmisvc,
+    get_llm_service_url,
+    maybe_delete_llmisvc,
+    wait_for_llm_isvc_ready,
+    wait_for_model_response,
+)
+
+FC_OBJECTIVES = [
+    {"name": "fc-high-priority", "priority": 100},
+    {"name": "fc-low-priority", "priority": -1},
+]
+FC_OBJECTIVE_NAMES = [o["name"] for o in FC_OBJECTIVES]
+
+
+@pytest.mark.llminferenceservice
+@pytest.mark.asyncio(loop_scope="session")
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        pytest.param(
+            TestCase(
+                base_refs=[
+                    "router-managed",
+                    "scheduler-flow-control-round-robin",
+                    "workload-llmd-simulator",
+                ],
+                prompt="KServe is a",
+                service_name="fc-smoke-test",
+                payload_formatter=completions_payload,
+                response_assertion=create_response_assertion(with_field="choices"),
+            ),
+            marks=[
+                pytest.mark.cluster_cpu,
+                pytest.mark.cluster_single_node,
+                pytest.mark.llmd_simulator,
+                pytest.mark.flow_control,
+            ],
+            id="flow-control-utilization-detector",
+        ),
+        pytest.param(
+            TestCase(
+                base_refs=[
+                    "router-managed",
+                    "scheduler-flow-control-concurrency-detector",
+                    "workload-llmd-simulator",
+                ],
+                prompt="KServe is a",
+                service_name="fc-concurrency-test",
+                payload_formatter=completions_payload,
+                response_assertion=create_response_assertion(with_field="choices"),
+            ),
+            marks=[
+                pytest.mark.cluster_cpu,
+                pytest.mark.cluster_single_node,
+                pytest.mark.llmd_simulator,
+                pytest.mark.flow_control,
+            ],
+            id="flow-control-concurrency-detector",
+        ),
+    ],
+    indirect=True,
+)
+def test_flow_control_smoke(test_case: TestCase, flow_control_auth):
+    """Verify that the EPP boots and serves traffic with flow control enabled.
+
+    Sends requests with different fairness IDs, InferenceObjective headers, and
+    default headers. When a downstream auth provider is available (via the
+    flow_control_auth fixture), also verifies the auth -> flow control pipeline.
+    """
+    inject_k8s_proxy()
+    kserve_client = KServeClient(
+        config_file=os.environ.get("KUBECONFIG", "~/.kube/config"),
+        client_configuration=client.Configuration(),
+    )
+
+    service_name = test_case.llm_service.metadata.name
+    prefix = test_case.log_prefix
+    test_failed = False
+
+    if flow_control_auth:
+        if not test_case.llm_service.metadata.annotations:
+            test_case.llm_service.metadata.annotations = {}
+        test_case.llm_service.metadata.annotations.update(
+            flow_control_auth.get("annotations", {})
+        )
+
+    try:
+        print(f"{prefix} Creating LLMInferenceService {service_name}")
+        create_llmisvc(kserve_client, test_case.llm_service)
+        print(f"{prefix} Waiting for ready")
+        wait_for_llm_isvc_ready(
+            kserve_client, test_case.llm_service, test_case.wait_timeout
+        )
+        print(f"{prefix} Waiting for model response")
+        wait_for_model_response(kserve_client, test_case, test_case.wait_timeout)
+
+        url = get_llm_service_url(kserve_client, test_case.llm_service)
+        payload = test_case.payload_formatter(test_case)
+
+        for tenant in ["tenant-a", "tenant-b"]:
+            print(f"{prefix} Sending request with fairness_id={tenant}")
+            resp = requests.post(
+                f"{url}/v1/completions",
+                json=payload,
+                headers={"x-gateway-inference-fairness-id": tenant},
+                timeout=test_case.response_timeout,
+            )
+            assert resp.status_code == 200, (
+                f"fairness_id={tenant} failed: {resp.status_code} {resp.text}"
+            )
+
+        pool_name = f"{service_name}-inference-pool"
+        create_inference_objectives(pool_name, FC_OBJECTIVES)
+        time.sleep(5)
+
+        for obj in FC_OBJECTIVES:
+            print(
+                f"{prefix} Sending request with objective={obj['name']} "
+                f"(priority={obj['priority']})"
+            )
+            resp = requests.post(
+                f"{url}/v1/completions",
+                json=payload,
+                headers={"x-gateway-inference-objective": obj["name"]},
+                timeout=test_case.response_timeout,
+            )
+            assert resp.status_code == 200, (
+                f"objective={obj['name']} failed: {resp.status_code} {resp.text}"
+            )
+
+        if flow_control_auth:
+            _verify_auth_pipeline(
+                flow_control_auth, kserve_client, test_case, url, payload, prefix
+            )
+
+    except Exception as e:
+        test_failed = True
+        logger.error(f"{prefix} Failed: {e}")
+        raise
+    finally:
+        if flow_control_auth and "cleanup" in flow_control_auth:
+            flow_control_auth["cleanup"](kserve_client, service_name)
+        delete_inference_objectives(FC_OBJECTIVE_NAMES)
+        maybe_delete_llmisvc(kserve_client, test_case.llm_service, test_failed)
+
+
+def _verify_auth_pipeline(auth, kserve_client, test_case, url, payload, prefix):
+    service_name = test_case.llm_service.metadata.name
+    token = auth["setup"](kserve_client, service_name)
+    endpoint = f"{url}/v1/completions"
+
+    print(f"{prefix} Verifying unauthenticated request is rejected")
+    resp = requests.post(
+        endpoint,
+        json=payload,
+        headers={"Content-Type": "application/json"},
+        timeout=test_case.response_timeout,
+    )
+    assert resp.status_code in [401, 403], (
+        f"Expected 401/403 without token, got {resp.status_code}"
+    )
+    print(f"{prefix} Unauthenticated rejected: {resp.status_code}")
+
+    print(f"{prefix} Verifying authenticated request succeeds")
+    resp = None
+    for attempt in range(24):
+        resp = requests.post(
+            endpoint,
+            json=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {token}",
+            },
+            timeout=test_case.response_timeout,
+        )
+        if resp.status_code == 200:
+            break
+        if resp.status_code in [401, 403, 502, 503, 504]:
+            logger.info(
+                f"Attempt {attempt + 1}: got {resp.status_code}, "
+                "waiting for auth/routing propagation..."
+            )
+            time.sleep(5)
+        else:
+            break
+    assert resp.status_code == 200, (
+        f"Expected 200 with token, got {resp.status_code}: {resp.text}"
+    )
+    print(f"{prefix} Authenticated request succeeded through flow control")


### PR DESCRIPTION
## Summary

Cherry-pick upstream flow control smoke tests (kserve/kserve#5694) and activate the
`flow_control_auth` pytest fixture hook for midstream auth pipeline testing.

### How it works

Upstream defines a `flow_control_auth` fixture in conftest returning `None` (auth skipped).
Midstream overrides the fixture body to return an auth provider that enables auth on the
LLMISVC and creates SA tokens. The upstream test function conditionally runs the auth
verification when the fixture returns non-None.

### Request path exercised (midstream)

```
SA token → Gateway (Envoy) → Authorino (ext_authz) → injects headers → EPP flow control → 200
```

### Commits

1. Cherry-pick upstream smoke tests + fixtures + no-op `flow_control_auth` fixture
2. Override `flow_control_auth` in conftest to enable auth pipeline testing

### Test plan

- [ ] `pytest test/e2e/llmisvc/test_flow_control.py -m flow_control` passes
- [ ] Auth hook activates: unauthenticated → 401, authenticated → 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end smoke coverage for scheduler flow-control in LLM inference services, validating routing via fairness/concurrency signals and objective-based prioritization.
  * Introduced new flow-control configuration presets (including round-robin and concurrency-detector modes) to broaden scenario coverage.
  * Added support for authenticated test runs, including automatic creation/cleanup of required auth resources when provided.
  * Registered a dedicated test marker to organize flow-control E2E cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->