### PR TITLE
kserve-module: Add WVA image param map validation unit test

### DIFF
--- a/kserve-module/pkg/kservemodule/images_test.go
+++ b/kserve-module/pkg/kservemodule/images_test.go
@@ -20,6 +20,13 @@ func TestModelControllerImageParamMap_AllValuesAreRelatedImage(t *testing.T) {
 	}
 }
 
+func TestWVAImageParamMap_AllValuesAreRelatedImage(t *testing.T) {
+	g := NewWithT(t)
+	for key, val := range wvaImageParamMap {
+		g.Expect(val).Should(HavePrefix("RELATED_IMAGE_"), "key %q has value %q without RELATED_IMAGE_ prefix", key, val)
+	}
+}
+
 func TestImageParamMaps_NoKeyOverlap(t *testing.T) {
 	g := NewWithT(t)
 	for key := range kserveImageParamMap {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds RELATED_IMAGE_ prefix check for wvaImageParamMap, matching the existing validation pattern for kserve and modelcontroller maps.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
