### PR TITLE
RHOAIENG-63016: feat: add operator-chaos L1 shift-left upgrade validation 

### DIFF
--- a/.github/workflows/chaos-validate.yml
+++ b/.github/workflows/chaos-validate.yml
@@ -29,8 +29,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          persist-credentials: false
+
+      - name: Merge target branch
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --unshallow origin
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
+          git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0

--- a/.github/workflows/chaos-validate.yml
+++ b/.github/workflows/chaos-validate.yml
@@ -1,0 +1,169 @@
+---
+name: Operator Chaos Validation
+
+"on":
+  pull_request:
+    paths:
+      - .github/workflows/chaos-validate.yml
+      - pkg/apis/**
+      - config/crd/**
+      - pkg/controller/**
+      - chaos/**
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: "Base ref to compare against for manual runs"
+        required: false
+        default: master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  operator-chaos:
+    name: operator-chaos shift-left validation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install operator-chaos
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/bin"
+          GOBIN="${RUNNER_TEMP}/bin" go install github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@latest
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+
+      - name: Checkout base branch assets
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || inputs.base_ref || github.event.repository.default_branch }}
+          path: base-branch
+          persist-credentials: false
+          sparse-checkout: |
+            chaos/knowledge
+            config/crd/full
+          sparse-checkout-cone-mode: true
+
+      - name: Validate knowledge model
+        shell: bash
+        run: |
+          set -euo pipefail
+          operator-chaos validate --knowledge chaos/knowledge/kserve.yaml
+
+      - name: Run local preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+          operator-chaos preflight --knowledge chaos/knowledge/kserve.yaml --local
+
+      - name: Validate experiments
+        shell: bash
+        run: |
+          set -euo pipefail
+          status=0
+          for f in chaos/experiments/*.yaml; do
+            echo "--- ${f} ---"
+            if ! operator-chaos validate "${f}"; then
+              status=1
+            fi
+          done
+          exit "${status}"
+
+      - name: Diff knowledge model
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_knowledge="base-branch/chaos/knowledge"
+          if [[ ! -d "${base_knowledge}" ]]; then
+            echo "No base knowledge model found; skipping knowledge diff for bootstrap PR."
+            exit 0
+          fi
+
+          output_dir="${RUNNER_TEMP}/operator-chaos"
+          mkdir -p "${output_dir}"
+          knowledge_diff_json="${output_dir}/knowledge-diff.json"
+
+          operator-chaos diff \
+            --source "${base_knowledge}" \
+            --target chaos/knowledge \
+            --breaking \
+            --format json > "${knowledge_diff_json}"
+          operator-chaos diff \
+            --source "${base_knowledge}" \
+            --target chaos/knowledge \
+            --breaking
+
+          knowledge_breaking=$(jq -r '.summary.breakingChanges // 0' "${knowledge_diff_json}")
+          if (( knowledge_breaking > 0 )); then
+            echo "operator-chaos detected ${knowledge_breaking} breaking knowledge change(s)."
+            exit 1
+          fi
+
+      - name: Diff CRD schemas
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_crd_dir="base-branch/config/crd/full"
+          target_crd_dir="config/crd/full"
+          if [[ ! -d "${source_crd_dir}" ]]; then
+            echo "No base CRD directory found; skipping CRD diff for bootstrap PR."
+            exit 0
+          fi
+
+          output_dir="${RUNNER_TEMP}/operator-chaos"
+          mkdir -p "${output_dir}"
+
+          # Collect all CRD YAML files (including subdirectories) into flat temp dirs
+          source_flat="${output_dir}/source-crds"
+          target_flat="${output_dir}/target-crds"
+          rm -rf "${source_flat}" "${target_flat}"
+          mkdir -p "${source_flat}" "${target_flat}"
+
+          find "${source_crd_dir}" -name '*.yaml' ! -name 'kustomization.yaml' ! -name '*_patch.yaml' -exec cp {} "${source_flat}/" \;
+          find "${target_crd_dir}" -name '*.yaml' ! -name 'kustomization.yaml' ! -name '*_patch.yaml' -exec cp {} "${target_flat}/" \;
+
+          crd_diff_json="${output_dir}/crd-diff.json"
+
+          operator-chaos diff-crds \
+            --source-crds "${source_flat}" \
+            --target-crds "${target_flat}" \
+            --format json > "${crd_diff_json}"
+          operator-chaos diff-crds \
+            --source-crds "${source_flat}" \
+            --target-crds "${target_flat}"
+
+          crd_breaking=$(jq -r '
+            reduce ((.crds // [])[]?.apiVersions[]?.schemaChanges[]?) as $change
+              (0; if ($change.severity | ascii_downcase) == "breaking" then . + 1 else . end)
+          ' "${crd_diff_json}")
+          if (( crd_breaking > 0 )); then
+            echo "operator-chaos detected ${crd_breaking} breaking CRD schema change(s)."
+            exit 1
+          fi
+
+      - name: Preview upgrade simulation
+        shell: bash
+        run: |
+          set -euo pipefail
+          base_knowledge="base-branch/chaos/knowledge"
+          if [[ ! -d "${base_knowledge}" ]]; then
+            echo "No base knowledge model found; skipping simulate-upgrade for bootstrap PR."
+            exit 0
+          fi
+
+          operator-chaos simulate-upgrade \
+            --source "${base_knowledge}" \
+            --target chaos/knowledge \
+            --dry-run

--- a/.github/workflows/chaos-validate.yml
+++ b/.github/workflows/chaos-validate.yml
@@ -29,15 +29,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - name: Merge target branch
-        if: github.event_name == 'pull_request'
-        run: |
-          git fetch --unshallow origin
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          git config user.email "ci@kserve.io"
-          git config user.name "CI Bot"
-          git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0

--- a/.github/workflows/chaos-validate.yml
+++ b/.github/workflows/chaos-validate.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "${RUNNER_TEMP}/bin"
-          GOBIN="${RUNNER_TEMP}/bin" go install github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@latest
+          GOBIN="${RUNNER_TEMP}/bin" go install github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@v0.0.0-20260616171738-edb1c045f677
           echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
 
       - name: Checkout base branch assets

--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -16,7 +16,7 @@ AGENT_IMG = kserve-agent
 ROUTER_IMG = kserve-router
 STORAGE_INIT_IMG = kserve-storage-initializer
 
-.PHONY: deploy-dev-llm-ocp deploy-ci uv-update-lockfiles
+.PHONY: deploy-dev-llm-ocp deploy-ci uv-update-lockfiles chaos-validate
 
 -include Makefile.ocp.mk
 
@@ -48,6 +48,27 @@ manifests-distro: controller-gen
 	@$(CONTROLLER_GEN) rbac:roleName=kserve-localmodelnode-distro-role \
 		paths=./pkg/controller/v1alpha1/localmodelnode/distro \
 		output:rbac:artifacts:config=config/overlays/odh-modelcache/rbac/localmodelnode
+
+## operator-chaos tooling
+OPERATOR_CHAOS = $(LOCALBIN)/operator-chaos
+OPERATOR_CHAOS_VERSION ?= latest
+
+.PHONY: operator-chaos
+operator-chaos: $(OPERATOR_CHAOS)
+$(OPERATOR_CHAOS): $(LOCALBIN)
+	test -s $(LOCALBIN)/operator-chaos || GOTOOLCHAIN=auto GOBIN=$(LOCALBIN) go install github.com/opendatahub-io/operator-chaos/cmd/operator-chaos@$(OPERATOR_CHAOS_VERSION)
+
+chaos-validate: operator-chaos ## Validate chaos knowledge model and experiments.
+	$(OPERATOR_CHAOS) validate --knowledge chaos/knowledge/kserve.yaml
+	$(OPERATOR_CHAOS) preflight --knowledge chaos/knowledge/kserve.yaml --local
+	@status=0; \
+	for f in chaos/experiments/*.yaml; do \
+		echo "--- $$f ---"; \
+		if ! $(OPERATOR_CHAOS) validate "$$f"; then \
+			status=1; \
+		fi; \
+	done; \
+	exit $$status
 
 -include Makefile.kserve-module.mk
 

--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -51,7 +51,7 @@ manifests-distro: controller-gen
 
 ## operator-chaos tooling
 OPERATOR_CHAOS = $(LOCALBIN)/operator-chaos
-OPERATOR_CHAOS_VERSION ?= latest
+OPERATOR_CHAOS_VERSION ?= v0.0.0-20260616171738-edb1c045f677
 
 .PHONY: operator-chaos
 operator-chaos: $(OPERATOR_CHAOS)

--- a/chaos/README.md
+++ b/chaos/README.md
@@ -1,0 +1,78 @@
+# Chaos Validation (operator-chaos)
+
+This directory integrates [operator-chaos](https://github.com/opendatahub-io/operator-chaos)
+for shift-left upgrade validation at **Level 1** maturity.
+
+A GitHub Actions workflow (`.github/workflows/chaos-validate.yml`) runs on PRs
+that touch API types, controllers, CRDs, or the knowledge model and:
+
+- Validates the knowledge model (`validate --knowledge`, `preflight --local`)
+- Validates all experiment YAML files
+- Diffs the knowledge model between base and PR branches (`diff --breaking`)
+- Diffs CRD schemas between base and PR branches (`diff-crds`)
+- Previews upgrade experiments (`simulate-upgrade --dry-run`)
+
+## Directory structure
+
+```
+chaos/
+  knowledge/
+    kserve.yaml          # Knowledge model describing operator topology
+  experiments/
+    main-controller-kill.yaml
+    llm-controller-isolation.yaml
+    isvc-config-corruption.yaml
+    isvc-validator-disrupt.yaml
+    crashloop-inject.yaml
+    dependency-odh-model-controller-kill.yaml
+    image-corrupt.yaml
+    ownerref-orphan.yaml
+    pdb-block.yaml
+    resource-deletion-service.yaml
+    route-host-collision.yaml
+    route-tls-mutation.yaml
+```
+
+## Knowledge model
+
+`knowledge/kserve.yaml` describes KServe's operator topology:
+
+| Component | Type | Webhooks | Finalizers | Dependencies |
+|-----------|------|----------|------------|--------------|
+| kserve-controller-manager | Deployment | 7 (2 mutating, 5 validating) | 2 | none |
+| llmisvc-controller-manager | Deployment | 4 (validating) | 1 | kserve-controller-manager |
+| kserve-localmodel-controller-manager | Deployment | 1 (validating) | 1 | kserve-controller-manager |
+| kserve-localmodelnode-agent | DaemonSet | none | none | kserve-localmodel-controller-manager |
+
+Each component lists its managed resources (Deployments, ServiceAccounts,
+Secrets, Leases, ConfigMaps) and steady-state checks for convergence
+verification.
+
+## Local validation
+
+```sh
+make chaos-validate
+```
+
+This downloads `operator-chaos` to `bin/` and validates the knowledge model
+and all experiments.
+
+## Maintenance
+
+When CRDs, webhooks, managed resources, or controller topology change,
+update `knowledge/kserve.yaml` in the same PR. The GHA workflow diffs the
+knowledge model against the base branch and flags breaking changes.
+
+## Maturity levels
+
+| Level | Status | Description |
+|-------|--------|-------------|
+| L1 | Implemented | GHA workflow, knowledge model, experiment validation |
+| L2 | Future | ChaosClient SDK integration into controller envtests |
+| L3 | Future | Live experiment execution on a KinD/OCP cluster |
+| L4 | Future | OLM channel-hop simulation with upgrade playbooks |
+
+## References
+
+- [operator-chaos documentation](https://opendatahub-io.github.io/operator-chaos/)
+- [operator-chaos repository](https://github.com/opendatahub-io/operator-chaos)

--- a/chaos/README.md
+++ b/chaos/README.md
@@ -14,7 +14,7 @@ that touch API types, controllers, CRDs, or the knowledge model and:
 
 ## Directory structure
 
-```
+```text
 chaos/
   knowledge/
     kserve.yaml          # Knowledge model describing operator topology

--- a/chaos/experiments/crashloop-inject.yaml
+++ b/chaos/experiments/crashloop-inject.yaml
@@ -1,0 +1,36 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: kserve-crashloop-inject
+spec:
+  tier: 3
+  target:
+    operator: kserve
+    component: kserve
+    resource: Deployment/kserve-controller-manager
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: kserve-controller-manager
+        namespace: redhat-ods-applications
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: CrashLoopInject
+    dangerLevel: high
+    parameters:
+      name: kserve-controller-manager
+    ttl: "300s"
+  hypothesis:
+    description: >-
+      Replacing the container command with a nonexistent binary causes
+      CrashLoopBackOff. Tests whether the operator detects the degraded
+      deployment and takes corrective action.
+    recoveryTimeout: 180s
+  blastRadius:
+    maxPodsAffected: 2
+    allowDangerous: true
+    allowedNamespaces:
+      - redhat-ods-applications

--- a/chaos/experiments/crashloop-inject.yaml
+++ b/chaos/experiments/crashloop-inject.yaml
@@ -16,7 +16,7 @@ spec:
         name: kserve-controller-manager
         namespace: redhat-ods-applications
         conditionType: Available
-    timeout: "30s"
+    timeout: "60s"
   injection:
     type: CrashLoopInject
     dangerLevel: high

--- a/chaos/experiments/crashloop-inject.yaml
+++ b/chaos/experiments/crashloop-inject.yaml
@@ -2,6 +2,7 @@ apiVersion: chaos.operatorchaos.io/v1alpha1
 kind: ChaosExperiment
 metadata:
   name: kserve-crashloop-inject
+  namespace: redhat-ods-applications
 spec:
   tier: 3
   target:

--- a/chaos/experiments/dependency-odh-model-controller-kill.yaml
+++ b/chaos/experiments/dependency-odh-model-controller-kill.yaml
@@ -2,6 +2,7 @@ apiVersion: chaos.operatorchaos.io/v1alpha1
 kind: ChaosExperiment
 metadata:
   name: kserve-dependency-odh-model-controller-kill
+  namespace: redhat-ods-applications
 spec:
   tier: 1
   target:

--- a/chaos/experiments/dependency-odh-model-controller-kill.yaml
+++ b/chaos/experiments/dependency-odh-model-controller-kill.yaml
@@ -1,0 +1,33 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: kserve-dependency-odh-model-controller-kill
+spec:
+  tier: 1
+  target:
+    operator: kserve
+    component: kserve-controller
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: kserve-controller-manager
+        namespace: opendatahub
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: PodKill
+    parameters:
+      labelSelector: "app=odh-model-controller"
+    ttl: "300s"
+  hypothesis:
+    description: >-
+      Killing odh-model-controller (which kserve depends on for model serving
+      routing) should not crash kserve. Kserve should continue operating in
+      degraded mode and recover when the dependency is restored.
+    recoveryTimeout: 120s
+  blastRadius:
+    maxPodsAffected: 1
+    allowedNamespaces:
+      - opendatahub

--- a/chaos/experiments/dependency-odh-model-controller-kill.yaml
+++ b/chaos/experiments/dependency-odh-model-controller-kill.yaml
@@ -13,9 +13,9 @@ spec:
         apiVersion: apps/v1
         kind: Deployment
         name: kserve-controller-manager
-        namespace: opendatahub
+        namespace: redhat-ods-applications
         conditionType: Available
-    timeout: "30s"
+    timeout: "60s"
   injection:
     type: PodKill
     parameters:
@@ -30,4 +30,4 @@ spec:
   blastRadius:
     maxPodsAffected: 1
     allowedNamespaces:
-      - opendatahub
+      - redhat-ods-applications

--- a/chaos/experiments/image-corrupt.yaml
+++ b/chaos/experiments/image-corrupt.yaml
@@ -1,0 +1,36 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: kserve-image-corrupt
+spec:
+  tier: 3
+  target:
+    operator: kserve
+    component: kserve
+    resource: Deployment/kserve-controller-manager
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: kserve-controller-manager
+        namespace: redhat-ods-applications
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: ImageCorrupt
+    dangerLevel: high
+    parameters:
+      name: kserve-controller-manager
+    ttl: "300s"
+  hypothesis:
+    description: >-
+      Patching the container image to an invalid registry causes
+      ImagePullBackOff. Tests whether the operator detects the stuck
+      rollout and takes corrective action.
+    recoveryTimeout: 180s
+  blastRadius:
+    maxPodsAffected: 2
+    allowDangerous: true
+    allowedNamespaces:
+      - redhat-ods-applications

--- a/chaos/experiments/image-corrupt.yaml
+++ b/chaos/experiments/image-corrupt.yaml
@@ -2,6 +2,7 @@ apiVersion: chaos.operatorchaos.io/v1alpha1
 kind: ChaosExperiment
 metadata:
   name: kserve-image-corrupt
+  namespace: redhat-ods-applications
 spec:
   tier: 3
   target:

--- a/chaos/experiments/image-corrupt.yaml
+++ b/chaos/experiments/image-corrupt.yaml
@@ -16,7 +16,7 @@ spec:
         name: kserve-controller-manager
         namespace: redhat-ods-applications
         conditionType: Available
-    timeout: "30s"
+    timeout: "60s"
   injection:
     type: ImageCorrupt
     dangerLevel: high

--- a/chaos/experiments/isvc-config-corruption.yaml
+++ b/chaos/experiments/isvc-config-corruption.yaml
@@ -1,0 +1,42 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: kserve-isvc-config-corruption
+  namespace: kserve
+spec:
+  tier: 2
+  target:
+    operator: kserve
+    component: kserve-controller-manager
+    resource: ConfigMap/inferenceservice-config
+  steadyState:
+    checks:
+      - type: resourceExists
+        apiVersion: v1
+        kind: ConfigMap
+        name: inferenceservice-config
+        namespace: kserve
+    timeout: "30s"
+  injection:
+    type: ConfigDrift
+    dangerLevel: high
+    parameters:
+      name: inferenceservice-config
+      key: deploy
+      value: "{}"
+      resourceType: ConfigMap
+    ttl: "300s"
+  hypothesis:
+    description: >-
+      When the deploy key in the inferenceservice-config ConfigMap is
+      overwritten with an empty JSON object, kserve should detect the
+      partial config corruption and recover within 120s. Existing
+      InferenceService resources should continue serving, and the
+      controller should either fall back to built-in defaults or
+      surface clear error conditions rather than silently failing.
+    recoveryTimeout: 120s
+  blastRadius:
+    maxPodsAffected: 1
+    allowedNamespaces:
+      - kserve
+    allowDangerous: true

--- a/chaos/experiments/isvc-config-corruption.yaml
+++ b/chaos/experiments/isvc-config-corruption.yaml
@@ -2,7 +2,7 @@ apiVersion: chaos.operatorchaos.io/v1alpha1
 kind: ChaosExperiment
 metadata:
   name: kserve-isvc-config-corruption
-  namespace: kserve
+  namespace: redhat-ods-applications
 spec:
   tier: 2
   target:
@@ -15,8 +15,8 @@ spec:
         apiVersion: v1
         kind: ConfigMap
         name: inferenceservice-config
-        namespace: kserve
-    timeout: "30s"
+        namespace: redhat-ods-applications
+    timeout: "60s"
   injection:
     type: ConfigDrift
     dangerLevel: high
@@ -38,5 +38,5 @@ spec:
   blastRadius:
     maxPodsAffected: 1
     allowedNamespaces:
-      - kserve
+      - redhat-ods-applications
     allowDangerous: true

--- a/chaos/experiments/isvc-validator-disrupt.yaml
+++ b/chaos/experiments/isvc-validator-disrupt.yaml
@@ -2,7 +2,7 @@ apiVersion: chaos.operatorchaos.io/v1alpha1
 kind: ChaosExperiment
 metadata:
   name: kserve-isvc-validator-disrupt
-  namespace: kserve
+  namespace: redhat-ods-applications
 spec:
   tier: 4
   target:
@@ -15,9 +15,9 @@ spec:
         apiVersion: apps/v1
         kind: Deployment
         name: kserve-controller-manager
-        namespace: kserve
+        namespace: redhat-ods-applications
         conditionType: Available
-    timeout: "30s"
+    timeout: "60s"
   injection:
     type: WebhookDisrupt
     dangerLevel: high

--- a/chaos/experiments/isvc-validator-disrupt.yaml
+++ b/chaos/experiments/isvc-validator-disrupt.yaml
@@ -1,0 +1,40 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: kserve-isvc-validator-disrupt
+  namespace: kserve
+spec:
+  tier: 4
+  target:
+    operator: kserve
+    component: kserve-controller-manager
+    resource: ValidatingWebhookConfiguration/inferenceservice.serving.kserve.io
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: kserve-controller-manager
+        namespace: kserve
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: WebhookDisrupt
+    dangerLevel: high
+    parameters:
+      webhookName: "inferenceservice.serving.kserve.io"
+      action: "setFailurePolicy"
+      value: "Ignore"
+    ttl: "60s"
+  hypothesis:
+    description: >-
+      When the ValidatingWebhookConfiguration for InferenceService has
+      its failurePolicy weakened from Fail to Ignore, invalid
+      InferenceService resources can bypass validation. This tests the
+      blast radius of a weakened admission policy. Recovery is provided
+      by the chaos framework's TTL-based cleanup after 60s, since kserve
+      does not self-heal webhook configuration drift.
+    recoveryTimeout: 120s
+  blastRadius:
+    maxPodsAffected: 1
+    allowDangerous: true

--- a/chaos/experiments/llm-controller-isolation.yaml
+++ b/chaos/experiments/llm-controller-isolation.yaml
@@ -2,7 +2,7 @@ apiVersion: chaos.operatorchaos.io/v1alpha1
 kind: ChaosExperiment
 metadata:
   name: kserve-llm-controller-isolation
-  namespace: kserve
+  namespace: redhat-ods-applications
 spec:
   tier: 2
   target:
@@ -15,9 +15,9 @@ spec:
         apiVersion: apps/v1
         kind: Deployment
         name: llmisvc-controller-manager
-        namespace: kserve
+        namespace: redhat-ods-applications
         conditionType: Available
-    timeout: "30s"
+    timeout: "60s"
   injection:
     type: NetworkPartition
     parameters:
@@ -34,4 +34,4 @@ spec:
   blastRadius:
     maxPodsAffected: 1
     allowedNamespaces:
-      - kserve
+      - redhat-ods-applications

--- a/chaos/experiments/llm-controller-isolation.yaml
+++ b/chaos/experiments/llm-controller-isolation.yaml
@@ -1,0 +1,37 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: kserve-llm-controller-isolation
+  namespace: kserve
+spec:
+  tier: 2
+  target:
+    operator: kserve
+    component: llmisvc-controller-manager
+    resource: Deployment/llmisvc-controller-manager
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: llmisvc-controller-manager
+        namespace: kserve
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: NetworkPartition
+    parameters:
+      labelSelector: control-plane=llmisvc-controller-manager
+    ttl: "60s"
+  hypothesis:
+    description: >-
+      When the llmisvc-controller-manager is network-partitioned from the
+      API server, it should lose its leader lease and stop reconciling LLM
+      resources. The main kserve-controller-manager must remain unaffected.
+      Once the partition is lifted after 60s, the LLM controller should
+      re-acquire its lease and resume normal operation within 120s.
+    recoveryTimeout: 120s
+  blastRadius:
+    maxPodsAffected: 1
+    allowedNamespaces:
+      - kserve

--- a/chaos/experiments/main-controller-kill.yaml
+++ b/chaos/experiments/main-controller-kill.yaml
@@ -2,7 +2,7 @@ apiVersion: chaos.operatorchaos.io/v1alpha1
 kind: ChaosExperiment
 metadata:
   name: kserve-main-controller-kill
-  namespace: kserve
+  namespace: redhat-ods-applications
 spec:
   tier: 1
   target:
@@ -15,9 +15,9 @@ spec:
         apiVersion: apps/v1
         kind: Deployment
         name: kserve-controller-manager
-        namespace: kserve
+        namespace: redhat-ods-applications
         conditionType: Available
-    timeout: "30s"
+    timeout: "60s"
   injection:
     type: PodKill
     parameters:
@@ -34,4 +34,4 @@ spec:
   blastRadius:
     maxPodsAffected: 1
     allowedNamespaces:
-      - kserve
+      - redhat-ods-applications

--- a/chaos/experiments/main-controller-kill.yaml
+++ b/chaos/experiments/main-controller-kill.yaml
@@ -1,0 +1,37 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: kserve-main-controller-kill
+  namespace: kserve
+spec:
+  tier: 1
+  target:
+    operator: kserve
+    component: kserve-controller-manager
+    resource: Deployment/kserve-controller-manager
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: kserve-controller-manager
+        namespace: kserve
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: PodKill
+    parameters:
+      labelSelector: control-plane=kserve-controller-manager
+    count: 1
+    ttl: "300s"
+  hypothesis:
+    description: >-
+      When the kserve-controller-manager pod is killed, the Deployment
+      controller recreates it and leader election completes recovery.
+      InferenceService reconciliation should resume within 60s without
+      data loss or duplicate work.
+    recoveryTimeout: 60s
+  blastRadius:
+    maxPodsAffected: 1
+    allowedNamespaces:
+      - kserve

--- a/chaos/experiments/ownerref-orphan.yaml
+++ b/chaos/experiments/ownerref-orphan.yaml
@@ -2,6 +2,7 @@ apiVersion: chaos.operatorchaos.io/v1alpha1
 kind: ChaosExperiment
 metadata:
   name: kserve-ownerref-orphan
+  namespace: redhat-ods-applications
 spec:
   tier: 3
   target:

--- a/chaos/experiments/ownerref-orphan.yaml
+++ b/chaos/experiments/ownerref-orphan.yaml
@@ -1,0 +1,34 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: kserve-ownerref-orphan
+spec:
+  tier: 3
+  target:
+    operator: kserve
+    component: kserve-controller
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: kserve-controller-manager
+        namespace: opendatahub
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: OwnerRefOrphan
+    parameters:
+      apiVersion: "apps/v1"
+      kind: "Deployment"
+      name: "kserve-controller-manager"
+    ttl: "120s"
+  hypothesis:
+    description: >-
+      Removing ownerReferences from the kserve-controller-manager Deployment
+      should trigger the operator to re-adopt it within the recovery timeout.
+    recoveryTimeout: 60s
+  blastRadius:
+    maxPodsAffected: 1
+    allowedNamespaces:
+      - opendatahub

--- a/chaos/experiments/ownerref-orphan.yaml
+++ b/chaos/experiments/ownerref-orphan.yaml
@@ -13,7 +13,7 @@ spec:
         apiVersion: apps/v1
         kind: Deployment
         name: kserve-controller-manager
-        namespace: opendatahub
+        namespace: redhat-ods-applications
         conditionType: Available
     timeout: "30s"
   injection:
@@ -31,4 +31,4 @@ spec:
   blastRadius:
     maxPodsAffected: 1
     allowedNamespaces:
-      - opendatahub
+      - redhat-ods-applications

--- a/chaos/experiments/pdb-block.yaml
+++ b/chaos/experiments/pdb-block.yaml
@@ -2,6 +2,7 @@ apiVersion: chaos.operatorchaos.io/v1alpha1
 kind: ChaosExperiment
 metadata:
   name: kserve-pdb-block
+  namespace: redhat-ods-applications
 spec:
   tier: 2
   target:

--- a/chaos/experiments/pdb-block.yaml
+++ b/chaos/experiments/pdb-block.yaml
@@ -1,0 +1,36 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: kserve-pdb-block
+spec:
+  tier: 2
+  target:
+    operator: kserve
+    component: kserve
+    resource: Deployment/kserve-controller-manager
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: kserve-controller-manager
+        namespace: redhat-ods-applications
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: PDBBlock
+    dangerLevel: high
+    parameters:
+      labelSelector: control-plane=kserve-controller-manager
+    ttl: "10s"
+  hypothesis:
+    description: >-
+      Creating a PDB with maxUnavailable=0 blocks all voluntary
+      evictions. Tests whether the operator's pods can be drained
+      for node maintenance or cluster upgrades.
+    recoveryTimeout: 120s
+  blastRadius:
+    maxPodsAffected: 2
+    allowDangerous: true
+    allowedNamespaces:
+      - redhat-ods-applications

--- a/chaos/experiments/pdb-block.yaml
+++ b/chaos/experiments/pdb-block.yaml
@@ -16,7 +16,7 @@ spec:
         name: kserve-controller-manager
         namespace: redhat-ods-applications
         conditionType: Available
-    timeout: "30s"
+    timeout: "60s"
   injection:
     type: PDBBlock
     dangerLevel: high

--- a/chaos/experiments/resource-deletion-service.yaml
+++ b/chaos/experiments/resource-deletion-service.yaml
@@ -1,0 +1,38 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: kserve-resource-deletion-service
+spec:
+  tier: 3
+  target:
+    operator: kserve
+    component: kserve
+    resource: Deployment/kserve-controller-manager
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: kserve-controller-manager
+        namespace: redhat-ods-applications
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: ResourceDeletion
+    dangerLevel: high
+    parameters:
+      apiVersion: v1
+      kind: Service
+      name: kserve-controller-manager-metrics-service
+    ttl: "300s"
+  hypothesis:
+    description: >-
+      Deleting the metrics/webhook Service tests whether the operator
+      recreates it during reconciliation. Without the Service,
+      metrics scraping and webhook calls fail.
+    recoveryTimeout: 180s
+  blastRadius:
+    maxPodsAffected: 2
+    allowDangerous: true
+    allowedNamespaces:
+      - redhat-ods-applications

--- a/chaos/experiments/resource-deletion-service.yaml
+++ b/chaos/experiments/resource-deletion-service.yaml
@@ -16,7 +16,7 @@ spec:
         name: kserve-controller-manager
         namespace: redhat-ods-applications
         conditionType: Available
-    timeout: "30s"
+    timeout: "60s"
   injection:
     type: ResourceDeletion
     dangerLevel: high
@@ -27,9 +27,9 @@ spec:
     ttl: "300s"
   hypothesis:
     description: >-
-      Deleting the metrics/webhook Service tests whether the operator
+      Deleting the metrics Service tests whether the operator
       recreates it during reconciliation. Without the Service,
-      metrics scraping and webhook calls fail.
+      metrics scraping fails.
     recoveryTimeout: 180s
   blastRadius:
     maxPodsAffected: 2

--- a/chaos/experiments/resource-deletion-service.yaml
+++ b/chaos/experiments/resource-deletion-service.yaml
@@ -2,6 +2,7 @@ apiVersion: chaos.operatorchaos.io/v1alpha1
 kind: ChaosExperiment
 metadata:
   name: kserve-resource-deletion-service
+  namespace: redhat-ods-applications
 spec:
   tier: 3
   target:

--- a/chaos/experiments/route-host-collision.yaml
+++ b/chaos/experiments/route-host-collision.yaml
@@ -14,9 +14,9 @@ spec:
         apiVersion: apps/v1
         kind: Deployment
         name: kserve-controller-manager
-        namespace: kserve
+        namespace: redhat-ods-applications
         conditionType: Available
-    timeout: "30s"
+    timeout: "60s"
   injection:
     type: CRDMutation
     dangerLevel: high
@@ -43,5 +43,5 @@ spec:
   blastRadius:
     maxPodsAffected: 1
     allowedNamespaces:
-      - kserve
+      - redhat-ods-applications
     allowDangerous: true

--- a/chaos/experiments/route-host-collision.yaml
+++ b/chaos/experiments/route-host-collision.yaml
@@ -2,6 +2,7 @@ apiVersion: chaos.operatorchaos.io/v1alpha1
 kind: ChaosExperiment
 metadata:
   name: kserve-route-host-collision
+  namespace: redhat-ods-applications
 spec:
   tier: 3
   target:

--- a/chaos/experiments/route-host-collision.yaml
+++ b/chaos/experiments/route-host-collision.yaml
@@ -1,0 +1,47 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: kserve-route-host-collision
+spec:
+  tier: 3
+  target:
+    operator: kserve
+    component: kserve-controller-manager
+    resource: Route/kserve-isvc-route
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: kserve-controller-manager
+        namespace: kserve
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: CRDMutation
+    dangerLevel: high
+    # NOTE: Replace "kserve-isvc-route" with the actual Route name for
+    # your InferenceService. KServe creates Routes per InferenceService
+    # with names like "<isvc-name>-predictor" in the model namespace.
+    parameters:
+      apiVersion: "route.openshift.io/v1"
+      kind: "Route"
+      name: "kserve-isvc-route"
+      path: "spec.host"
+      value: "chaos-collision.apps.cluster.invalid"
+    ttl: "300s"
+  hypothesis:
+    description: >-
+      Mutating a KServe InferenceService Route host simulates a DNS
+      misconfiguration that makes the model endpoint unreachable. KServe
+      or the RHOAI operator should detect the Route drift and reconcile
+      the host. NOTE: KServe creates Routes per InferenceService; the
+      Route name in parameters must be customized for each deployment.
+      Expected verdict: Resilient if the Route is restored, Vulnerable
+      if the model endpoint remains unreachable.
+    recoveryTimeout: 120s
+  blastRadius:
+    maxPodsAffected: 1
+    allowedNamespaces:
+      - kserve
+    allowDangerous: true

--- a/chaos/experiments/route-tls-mutation.yaml
+++ b/chaos/experiments/route-tls-mutation.yaml
@@ -1,0 +1,46 @@
+apiVersion: chaos.operatorchaos.io/v1alpha1
+kind: ChaosExperiment
+metadata:
+  name: kserve-route-tls-mutation
+spec:
+  tier: 3
+  target:
+    operator: kserve
+    component: kserve-controller-manager
+    resource: Route/kserve-isvc-route
+  steadyState:
+    checks:
+      - type: conditionTrue
+        apiVersion: apps/v1
+        kind: Deployment
+        name: kserve-controller-manager
+        namespace: kserve
+        conditionType: Available
+    timeout: "30s"
+  injection:
+    type: CRDMutation
+    dangerLevel: high
+    # NOTE: Replace "kserve-isvc-route" with the actual Route name for
+    # your InferenceService.
+    parameters:
+      apiVersion: "route.openshift.io/v1"
+      kind: "Route"
+      name: "kserve-isvc-route"
+      path: "spec.tls.termination"
+      value: "passthrough"
+    ttl: "300s"
+  hypothesis:
+    description: >-
+      Changing TLS termination on a KServe InferenceService Route from
+      edge/reencrypt to passthrough breaks HTTPS inference endpoints.
+      The KServe controller or RHOAI operator should detect the TLS
+      drift and restore the correct termination mode. NOTE: The Route
+      name must be customized for each InferenceService deployment.
+      Expected verdict: Resilient if restored, Vulnerable if inference
+      endpoints stay broken.
+    recoveryTimeout: 120s
+  blastRadius:
+    maxPodsAffected: 1
+    allowedNamespaces:
+      - kserve
+    allowDangerous: true

--- a/chaos/experiments/route-tls-mutation.yaml
+++ b/chaos/experiments/route-tls-mutation.yaml
@@ -14,9 +14,9 @@ spec:
         apiVersion: apps/v1
         kind: Deployment
         name: kserve-controller-manager
-        namespace: kserve
+        namespace: redhat-ods-applications
         conditionType: Available
-    timeout: "30s"
+    timeout: "60s"
   injection:
     type: CRDMutation
     dangerLevel: high
@@ -42,5 +42,5 @@ spec:
   blastRadius:
     maxPodsAffected: 1
     allowedNamespaces:
-      - kserve
+      - redhat-ods-applications
     allowDangerous: true

--- a/chaos/experiments/route-tls-mutation.yaml
+++ b/chaos/experiments/route-tls-mutation.yaml
@@ -2,6 +2,7 @@ apiVersion: chaos.operatorchaos.io/v1alpha1
 kind: ChaosExperiment
 metadata:
   name: kserve-route-tls-mutation
+  namespace: redhat-ods-applications
 spec:
   tier: 3
   target:

--- a/chaos/knowledge/kserve.yaml
+++ b/chaos/knowledge/kserve.yaml
@@ -1,0 +1,199 @@
+operator:
+  name: kserve
+  namespace: redhat-ods-applications
+  repository: https://github.com/kserve/kserve
+
+components:
+  - name: kserve-controller-manager
+    controller: KServe
+    managedResources:
+      - apiVersion: apps/v1
+        kind: Deployment
+        name: kserve-controller-manager
+        namespace: redhat-ods-applications
+        labels:
+          control-plane: kserve-controller-manager
+          app.kubernetes.io/name: kserve-controller-manager
+          controller-tools.k8s.io: "1.0"
+        expectedSpec:
+          replicas: 1
+      - apiVersion: v1
+        kind: ConfigMap
+        name: inferenceservice-config
+        namespace: redhat-ods-applications
+      - apiVersion: v1
+        kind: ServiceAccount
+        name: kserve-controller-manager
+        namespace: redhat-ods-applications
+      - apiVersion: v1
+        kind: Secret
+        name: kserve-webhook-server-cert
+        namespace: redhat-ods-applications
+      - apiVersion: coordination.k8s.io/v1
+        kind: Lease
+        name: kserve-controller-manager-leader-lock
+        namespace: redhat-ods-applications
+    webhooks:
+      - name: inferenceservice.kserve-webhook-server.defaulter
+        type: mutating
+        path: /mutate-serving-kserve-io-v1beta1-inferenceservice
+      - name: inferenceservice.kserve-webhook-server.pod-mutator
+        type: mutating
+        path: /mutate-pods
+      - name: inferenceservice.kserve-webhook-server.validator
+        type: validating
+        path: /validate-serving-kserve-io-v1beta1-inferenceservice
+      - name: trainedmodel.kserve-webhook-server.validator
+        type: validating
+        path: /validate-serving-kserve-io-v1alpha1-trainedmodel
+      - name: inferencegraph.kserve-webhook-server.validator
+        type: validating
+        path: /validate-serving-kserve-io-v1alpha1-inferencegraph
+      - name: clusterservingruntime.kserve-webhook-server.validator
+        type: validating
+        path: /validate-serving-kserve-io-v1alpha1-clusterservingruntime
+      - name: servingruntime.kserve-webhook-server.validator
+        type: validating
+        path: /validate-serving-kserve-io-v1alpha1-servingruntime
+    finalizers:
+      - inferenceservice.finalizers
+      - trainedmodel.finalizer
+    steadyState:
+      checks:
+        - type: conditionTrue
+          apiVersion: apps/v1
+          kind: Deployment
+          name: kserve-controller-manager
+          namespace: redhat-ods-applications
+          conditionType: Available
+      timeout: "60s"
+
+  - name: llmisvc-controller-manager
+    controller: KServe
+    managedResources:
+      - apiVersion: apps/v1
+        kind: Deployment
+        name: llmisvc-controller-manager
+        namespace: redhat-ods-applications
+        labels:
+          control-plane: llmisvc-controller-manager
+          app.kubernetes.io/name: llmisvc-controller-manager
+          app.kubernetes.io/component: controller
+          controller-tools.k8s.io: "1.0"
+        expectedSpec:
+          replicas: 1
+      - apiVersion: v1
+        kind: ServiceAccount
+        name: llmisvc-controller-manager
+        namespace: redhat-ods-applications
+      - apiVersion: v1
+        kind: Secret
+        name: llmisvc-webhook-server-cert
+        namespace: redhat-ods-applications
+      - apiVersion: coordination.k8s.io/v1
+        kind: Lease
+        name: llminferenceservice-kserve-controller-manager
+        namespace: redhat-ods-applications
+    webhooks:
+      - name: llminferenceservice.kserve-webhook-server.v1alpha1.validator
+        type: validating
+        path: /validate-serving-kserve-io-v1alpha1-llminferenceservice
+      - name: llminferenceservice.kserve-webhook-server.v1alpha2.validator
+        type: validating
+        path: /validate-serving-kserve-io-v1alpha2-llminferenceservice
+      - name: llminferenceserviceconfig.kserve-webhook-server.v1alpha1.validator
+        type: validating
+        path: /validate-serving-kserve-io-v1alpha1-llminferenceserviceconfig
+      - name: llminferenceserviceconfig.kserve-webhook-server.v1alpha2.validator
+        type: validating
+        path: /validate-serving-kserve-io-v1alpha2-llminferenceserviceconfig
+    finalizers:
+      - serving.kserve.io/llmisvc-finalizer
+    dependencies:
+      - kserve-controller-manager
+    steadyState:
+      checks:
+        - type: conditionTrue
+          apiVersion: apps/v1
+          kind: Deployment
+          name: llmisvc-controller-manager
+          namespace: redhat-ods-applications
+          conditionType: Available
+      timeout: "60s"
+
+  - name: kserve-localmodel-controller-manager
+    controller: KServe
+    managedResources:
+      - apiVersion: apps/v1
+        kind: Deployment
+        name: kserve-localmodel-controller-manager
+        namespace: redhat-ods-applications
+        labels:
+          control-plane: kserve-localmodel-controller-manager
+          app.kubernetes.io/name: kserve-localmodel-controller-manager
+          controller-tools.k8s.io: "1.0"
+        expectedSpec:
+          replicas: 1
+      - apiVersion: v1
+        kind: ServiceAccount
+        name: kserve-localmodel-controller-manager
+        namespace: redhat-ods-applications
+      - apiVersion: v1
+        kind: Secret
+        name: localmodel-webhook-server-cert
+        namespace: redhat-ods-applications
+      - apiVersion: coordination.k8s.io/v1
+        kind: Lease
+        name: kserve-local-model-manager-leader-lock
+        namespace: redhat-ods-applications
+    webhooks:
+      - name: localmodelcache.kserve-webhook-server.validator
+        type: validating
+        path: /validate-serving-kserve-io-v1alpha1-localmodelcache
+    finalizers:
+      - localmodel.kserve.io/finalizer
+    dependencies:
+      - kserve-controller-manager
+    steadyState:
+      checks:
+        - type: conditionTrue
+          apiVersion: apps/v1
+          kind: Deployment
+          name: kserve-localmodel-controller-manager
+          namespace: redhat-ods-applications
+          conditionType: Available
+      timeout: "60s"
+
+  - name: kserve-localmodelnode-agent
+    controller: KServe
+    managedResources:
+      - apiVersion: apps/v1
+        kind: DaemonSet
+        name: kserve-localmodelnode-agent
+        namespace: redhat-ods-applications
+        labels:
+          control-plane: kserve-localmodelnode-agent
+          app.kubernetes.io/name: kserve-localmodelnode-agent
+          controller-tools.k8s.io: "1.0"
+      - apiVersion: v1
+        kind: ServiceAccount
+        name: kserve-localmodelnode-agent
+        namespace: redhat-ods-applications
+      - apiVersion: coordination.k8s.io/v1
+        kind: Lease
+        name: kserve-local-model-node-manager-leader-lock
+        namespace: redhat-ods-applications
+    dependencies:
+      - kserve-localmodel-controller-manager
+    steadyState:
+      checks:
+        - type: resourceExists
+          apiVersion: apps/v1
+          kind: DaemonSet
+          name: kserve-localmodelnode-agent
+          namespace: redhat-ods-applications
+      timeout: "60s"
+
+recovery:
+  reconcileTimeout: "300s"
+  maxReconcileCycles: 10


### PR DESCRIPTION
Add operator-chaos integration for detecting breaking CRD and API
changes at PR time. This includes a knowledge model describing KServe's
4 controllers, 16 managed resources, 12 webhooks, and 4 finalizers,
along with 12 pre-built chaos experiments and a GitHub Actions workflow
that validates the knowledge model, diffs for breaking changes, diffs
CRD schemas, and previews upgrade simulation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new chaos validation workflow for pull requests and manual runs to verify upgrade resilience before merge.
  * Expanded chaos coverage with a new knowledge model and multiple additional chaos experiments for KServe components, controllers, and related routes.
* **Documentation**
  * Added a comprehensive “Chaos Validation (operator-chaos)” README with local run guidance and directory structure overview.
* **Bug Fixes**
  * Enhanced validation to fail early on breaking changes in knowledge and CRD schema, and to include a dry-run upgrade simulation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->