### PR TITLE
ci: restore kserve group-test PipelineRun

### DIFF
--- a/.tekton/kserve-group-test.yaml
+++ b/.tekton/kserve-group-test.yaml
@@ -1,0 +1,66 @@
+---
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/opendatahub-io/kserve?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "group-test"
+    pipelinesascode.tekton.dev/on-comment: "^/group-test"
+  name: kserve-group-test
+  namespace: open-data-hub-tenant
+  labels:
+    appstudio.openshift.io/application: group-testing
+    appstudio.openshift.io/component: kserve-group
+    pipelines.appstudio.openshift.io/type: test
+spec:
+  params:
+  - name: group-components
+    value: '{ "kserve-agent-ci": "opendatahub/kserve-agent", "kserve-controller-ci": "opendatahub/kserve-controller", "kserve-router-ci": "opendatahub/kserve-router", "kserve-storage-initializer-ci": "opendatahub/kserve-storage-initializer", "odh-kserve-llmisvc-controller-ci": "opendatahub/odh-kserve-llmisvc-controller" }'
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  pipelineRef:
+    resolver: git
+    params:
+    - name: url
+      value: https://github.com/opendatahub-io/odh-konflux-central.git
+    - name: revision
+      value: main
+    - name: pathInRepo
+      value: integration-tests/kserve/pr-group-testing-pipeline.yaml
+  taskRunTemplate:
+    podTemplate:
+      nodeSelector:
+        konflux-ci.dev/workload: konflux-tenants
+      tolerations:
+      - effect: NoSchedule
+        key: konflux-ci.dev/workload
+        operator: Equal
+        value: konflux-tenants
+    serviceAccountName: konflux-integration-runner
+  timeouts:
+    pipeline: 4h0m0s
+    tasks: 3h
+  taskRunSpecs:
+    - pipelineTaskName: clone-repository
+      serviceAccountName: build-pipeline-kserve-group
+    - pipelineTaskName: build-sklearn-serving-runtime
+      serviceAccountName: build-pipeline-kserve-group
+    - pipelineTaskName: build-custom-transformer
+      serviceAccountName: build-pipeline-kserve-group
+    - pipelineTaskName: build-custom-model-grpc
+      serviceAccountName: build-pipeline-kserve-group
+    - pipelineTaskName: build-success-200-isvc
+      serviceAccountName: build-pipeline-kserve-group
+    - pipelineTaskName: build-error-404-isvc
+      serviceAccountName: build-pipeline-kserve-group
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'


### PR DESCRIPTION
## Summary
- The group-test PipelineRun was dropped during the `.tekton` pipeline centralization to odh-konflux-central (PR #1500)
- The Pipeline definition (`integration-tests/kserve/pr-group-testing-pipeline.yaml`) and `kserve-group` Component still exist in odh-konflux-central, but without this PipelineRun in `.tekton/` the `group-test` event has no trigger
- Mirrors `pipelineruns/kserve/kserve-group-test.yaml` added in opendatahub-io/odh-konflux-central#487

## Test plan
- [ ] Verify PaC picks up the new PipelineRun definition
- [ ] Trigger a `/group-test` comment on a test PR to confirm the pipeline runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new automated group test pipeline configuration for KServe pull requests.
  * Supports trigger-based runs with PR metadata, configurable component image mappings, and source revision inputs.
  * Includes dedicated runtime settings for execution timeouts, service account usage, node selection, tolerations, and git authentication access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->