### PR TITLE
[RHOAIENG-63844] CVE-2026-44432: urllib3 DoS due to excessive HTTP response decompression

### DIFF
--- a/python/aiffairness/poetry.lock
+++ b/python/aiffairness/poetry.lock
@@ -1342,7 +1342,7 @@ six = "^1.16.0"
 starlette = ">=1.0.1"
 tabulate = "^0.9.0"
 timing-asgi = "^0.3.0"
-urllib3 = ">=2.6.0"
+urllib3 = ">=2.7.0,<3.0.0"
 uvicorn = {version = "^0.30.6", extras = ["standard"]}
 
 [package.extras]
@@ -2894,13 +2894,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.2"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd"},
-    {file = "urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]

--- a/python/artexplainer/poetry.lock
+++ b/python/artexplainer/poetry.lock
@@ -1128,7 +1128,7 @@ six = "^1.16.0"
 starlette = ">=1.0.1"
 tabulate = "^0.9.0"
 timing-asgi = "^0.3.0"
-urllib3 = ">=2.6.0"
+urllib3 = ">=2.7.0,<3.0.0"
 uvicorn = {version = "^0.30.6", extras = ["standard"]}
 
 [package.extras]
@@ -2856,13 +2856,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.2"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd"},
-    {file = "urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]

--- a/python/custom_model/poetry.lock
+++ b/python/custom_model/poetry.lock
@@ -1086,7 +1086,7 @@ six = "^1.16.0"
 starlette = ">=1.0.1"
 tabulate = "^0.9.0"
 timing-asgi = "^0.3.0"
-urllib3 = ">=2.6.0"
+urllib3 = ">=2.7.0,<3.0.0"
 uvicorn = {version = "^0.30.6", extras = ["standard"]}
 
 [package.extras]
@@ -2867,13 +2867,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.2"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd"},
-    {file = "urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]

--- a/python/custom_tokenizer/poetry.lock
+++ b/python/custom_tokenizer/poetry.lock
@@ -927,7 +927,7 @@ six = "^1.16.0"
 starlette = ">=1.0.1"
 tabulate = "^0.9.0"
 timing-asgi = "^0.3.0"
-urllib3 = ">=2.6.0"
+urllib3 = ">=2.7.0,<3.0.0"
 uvicorn = {version = "^0.30.6", extras = ["standard"]}
 
 [package.extras]
@@ -2166,13 +2166,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.2"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd"},
-    {file = "urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]

--- a/python/custom_transformer/poetry.lock
+++ b/python/custom_transformer/poetry.lock
@@ -999,7 +999,7 @@ six = "^1.16.0"
 starlette = ">=1.0.1"
 tabulate = "^0.9.0"
 timing-asgi = "^0.3.0"
-urllib3 = ">=2.6.0"
+urllib3 = ">=2.7.0,<3.0.0"
 uvicorn = {version = "^0.30.6", extras = ["standard"]}
 
 [package.extras]
@@ -2554,13 +2554,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.2"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd"},
-    {file = "urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]

--- a/python/huggingfaceserver/poetry.lock
+++ b/python/huggingfaceserver/poetry.lock
@@ -2444,7 +2444,7 @@ six = "^1.16.0"
 starlette = ">=1.0.1"
 tabulate = "^0.9.0"
 timing-asgi = "^0.3.0"
-urllib3 = ">=2.6.0"
+urllib3 = ">=2.7.0,<3.0.0"
 uvicorn = {version = "^0.30.6", extras = ["standard"]}
 vllm = {version = "0.8.5", optional = true}
 
@@ -6108,13 +6108,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.2"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd"},
-    {file = "urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]

--- a/python/kserve/poetry.lock
+++ b/python/kserve/poetry.lock
@@ -6223,13 +6223,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.2"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd"},
-    {file = "urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]
@@ -6887,4 +6887,4 @@ storage = ["azure-identity", "azure-storage-blob", "azure-storage-file-share", "
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "dc241ff9c62429a0d338831d67cd0c9c2a73481b710659fd39edc54a682776f2"
+content-hash = "129e1981e31d45952600d447f8367f5b1e9cc3d7451374fbfb552bf9ac6218ec"

--- a/python/kserve/pyproject.toml
+++ b/python/kserve/pyproject.toml
@@ -60,7 +60,8 @@ pandas =  ">=2.2.0,<2.3.0"
 pydantic = "^2.5.0"
 pyyaml = "^6.0.0"
 # CVE-2025-66418 urllib3: Unbounded decompression chain leads to resource exhaustion
-urllib3 = ">=2.6.0"
+# CVE-2026-44432 urllib3: Denial of Service due to excessive HTTP response decompression
+urllib3 = ">=2.7.0,<3.0.0"
 # CVE-2025-69223 AIOHTTP's HTTP Parser auto_decompress feature is vulnerable to zip bomb
 aiohttp = ">=3.13.3"
 # CVE-2026-32597 PyJWT accepts unknown `crit` header extensions (RFC 7515 §4.1.11 MUST violation)

--- a/python/lgbserver/poetry.lock
+++ b/python/lgbserver/poetry.lock
@@ -1620,7 +1620,7 @@ six = "^1.16.0"
 starlette = ">=1.0.1"
 tabulate = "^0.9.0"
 timing-asgi = "^0.3.0"
-urllib3 = ">=2.6.0"
+urllib3 = ">=2.7.0,<3.0.0"
 uvicorn = {version = "^0.30.6", extras = ["standard"]}
 
 [package.extras]
@@ -3131,13 +3131,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.2"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd"},
-    {file = "urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]

--- a/python/paddleserver/poetry.lock
+++ b/python/paddleserver/poetry.lock
@@ -1631,7 +1631,7 @@ six = "^1.16.0"
 starlette = ">=1.0.1"
 tabulate = "^0.9.0"
 timing-asgi = "^0.3.0"
-urllib3 = ">=2.6.0"
+urllib3 = ">=2.7.0,<3.0.0"
 uvicorn = {version = "^0.30.6", extras = ["standard"]}
 
 [package.extras]
@@ -3190,13 +3190,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.2"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd"},
-    {file = "urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]

--- a/python/pmmlserver/poetry.lock
+++ b/python/pmmlserver/poetry.lock
@@ -1675,7 +1675,7 @@ six = "^1.16.0"
 starlette = ">=1.0.1"
 tabulate = "^0.9.0"
 timing-asgi = "^0.3.0"
-urllib3 = ">=2.6.0"
+urllib3 = ">=2.7.0,<3.0.0"
 uvicorn = {version = "^0.30.6", extras = ["standard"]}
 
 [package.extras]
@@ -3144,13 +3144,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.2"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd"},
-    {file = "urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]

--- a/python/sklearnserver/poetry.lock
+++ b/python/sklearnserver/poetry.lock
@@ -1620,7 +1620,7 @@ six = "^1.16.0"
 starlette = ">=1.0.1"
 tabulate = "^0.9.0"
 timing-asgi = "^0.3.0"
-urllib3 = ">=2.6.0"
+urllib3 = ">=2.7.0,<3.0.0"
 uvicorn = {version = "^0.30.6", extras = ["standard"]}
 
 [package.extras]
@@ -3101,13 +3101,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.2"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd"},
-    {file = "urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]

--- a/python/test_resources/graph/error_404_isvc/poetry.lock
+++ b/python/test_resources/graph/error_404_isvc/poetry.lock
@@ -916,7 +916,7 @@ six = "^1.16.0"
 starlette = ">=1.0.1"
 tabulate = "^0.9.0"
 timing-asgi = "^0.3.0"
-urllib3 = ">=2.6.0"
+urllib3 = ">=2.7.0,<3.0.0"
 uvicorn = {version = "^0.30.6", extras = ["standard"]}
 
 [package.extras]
@@ -2068,13 +2068,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.2"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd"},
-    {file = "urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]

--- a/python/test_resources/graph/success_200_isvc/poetry.lock
+++ b/python/test_resources/graph/success_200_isvc/poetry.lock
@@ -916,7 +916,7 @@ six = "^1.16.0"
 starlette = ">=1.0.1"
 tabulate = "^0.9.0"
 timing-asgi = "^0.3.0"
-urllib3 = ">=2.6.0"
+urllib3 = ">=2.7.0,<3.0.0"
 uvicorn = {version = "^0.30.6", extras = ["standard"]}
 
 [package.extras]
@@ -2068,13 +2068,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.2"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd"},
-    {file = "urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]

--- a/python/xgbserver/poetry.lock
+++ b/python/xgbserver/poetry.lock
@@ -1620,7 +1620,7 @@ six = "^1.16.0"
 starlette = ">=1.0.1"
 tabulate = "^0.9.0"
 timing-asgi = "^0.3.0"
-urllib3 = ">=2.6.0"
+urllib3 = ">=2.7.0,<3.0.0"
 uvicorn = {version = "^0.30.6", extras = ["standard"]}
 
 [package.extras]
@@ -3112,13 +3112,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.2"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd"},
-    {file = "urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]


### PR DESCRIPTION
## Summary
- Bump `urllib3` from `>=2.6.0` to `>=2.7.0,<3.0.0` in `python/kserve/pyproject.toml`
- Regenerate `python/kserve/poetry.lock` (urllib3 2.6.2 → 2.7.0)
- Fixes CVE-2026-44432 for the `odh-kserve-storage-initializer-rhel9` image [rhoai-2.25]

## Test plan
- [x] Storage-initializer container build succeeds
- [x] Runtime image confirms urllib3 2.7.0


Made with [Cursor](https://cursor.com)