### PR TITLE
feat(kserve-module): migrate HWP upgrade path from opendatahub-operator [RHOAIENG-63833]

### DIFF
--- a/kserve-module/config/rbac/role.yaml
+++ b/kserve-module/config/rbac/role.yaml
@@ -157,12 +157,6 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - dashboard.opendatahub.io
-  resources:
-  - acceleratorprofiles
-  verbs:
-  - list
-- apiGroups:
   - infrastructure.opendatahub.io
   resources:
   - hardwareprofiles
@@ -351,7 +345,6 @@ rules:
   verbs:
   - list
   - patch
-  - update
 - apiGroups:
   - serving.kserve.io
   resources:

--- a/kserve-module/config/rbac/role.yaml
+++ b/kserve-module/config/rbac/role.yaml
@@ -157,6 +157,19 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - dashboard.opendatahub.io
+  resources:
+  - acceleratorprofiles
+  verbs:
+  - list
+- apiGroups:
+  - infrastructure.opendatahub.io
+  resources:
+  - hardwareprofiles
+  verbs:
+  - get
+  - list
+- apiGroups:
   - monitoring.coreos.com
   resourceNames:
   - k8s
@@ -209,6 +222,12 @@ rules:
   verbs:
   - get
   - update
+- apiGroups:
+  - opendatahub.io
+  resources:
+  - odhdashboardconfigs
+  verbs:
+  - get
 - apiGroups:
   - operator.openshift.io
   resources:
@@ -325,6 +344,20 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - inferenceservices
+  verbs:
+  - list
+  - patch
+  - update
+- apiGroups:
+  - serving.kserve.io
+  resources:
+  - servingruntimes
+  verbs:
+  - get
 - apiGroups:
   - template.openshift.io
   resources:

--- a/kserve-module/config/rbac/role.yaml
+++ b/kserve-module/config/rbac/role.yaml
@@ -162,7 +162,6 @@ rules:
   - hardwareprofiles
   verbs:
   - get
-  - list
 - apiGroups:
   - monitoring.coreos.com
   resourceNames:

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -98,7 +98,7 @@ import (
 // --- Upgrade path: HardwareProfile migration ---
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices,verbs=list;patch
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=servingruntimes,verbs=get
-// +kubebuilder:rbac:groups=infrastructure.opendatahub.io,resources=hardwareprofiles,verbs=get;list
+// +kubebuilder:rbac:groups=infrastructure.opendatahub.io,resources=hardwareprofiles,verbs=get
 // +kubebuilder:rbac:groups=opendatahub.io,resources=odhdashboardconfigs,verbs=get
 
 type ResourceDeployer interface {

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -96,10 +96,9 @@ import (
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 
 // --- Upgrade path: HardwareProfile migration ---
-// +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices,verbs=list;update;patch
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices,verbs=list;patch
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=servingruntimes,verbs=get
 // +kubebuilder:rbac:groups=infrastructure.opendatahub.io,resources=hardwareprofiles,verbs=get;list
-// +kubebuilder:rbac:groups=dashboard.opendatahub.io,resources=acceleratorprofiles,verbs=list
 // +kubebuilder:rbac:groups=opendatahub.io,resources=odhdashboardconfigs,verbs=get
 
 type ResourceDeployer interface {

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -95,6 +95,13 @@ import (
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=localmodelnodegroups,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=get;list;watch;create;update;patch;delete
 
+// --- Upgrade path: HardwareProfile migration ---
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=inferenceservices,verbs=list;update;patch
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=servingruntimes,verbs=get
+// +kubebuilder:rbac:groups=infrastructure.opendatahub.io,resources=hardwareprofiles,verbs=get;list
+// +kubebuilder:rbac:groups=dashboard.opendatahub.io,resources=acceleratorprofiles,verbs=list
+// +kubebuilder:rbac:groups=opendatahub.io,resources=odhdashboardconfigs,verbs=get
+
 type ResourceDeployer interface {
 	Deploy(ctx context.Context, input deploy.DeployInput) error
 }

--- a/kserve-module/pkg/kservemodule/setup.go
+++ b/kserve-module/pkg/kservemodule/setup.go
@@ -159,6 +159,13 @@ func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	r.controller = c
 
+	if err := mgr.Add(&upgradeRunnable{
+		client:        mgr.GetClient(),
+		applicationNS: r.getApplicationsNamespace(),
+	}); err != nil {
+		return fmt.Errorf("error registering upgrade runnable: %w", err)
+	}
+
 	return nil
 }
 

--- a/kserve-module/pkg/kservemodule/upgrade.go
+++ b/kserve-module/pkg/kservemodule/upgrade.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -21,6 +22,7 @@ import (
 )
 
 const (
+	odhDashboardConfigName         = "odh-dashboard-config"
 	hwpNameAnnotation              = "opendatahub.io/hardware-profile-name"
 	hwpNamespaceAnnotation         = "opendatahub.io/hardware-profile-namespace"
 	acceleratorNameAnnotation      = "opendatahub.io/accelerator-name"
@@ -113,7 +115,7 @@ func getOdhDashboardConfig(ctx context.Context, cli client.Client, applicationNS
 	odhConfig := &unstructured.Unstructured{}
 	odhConfig.SetGroupVersionKind(odhDashboardConfigGVK)
 
-	err := cli.Get(ctx, client.ObjectKey{Name: "odh-dashboard-config", Namespace: applicationNS}, odhConfig)
+	err := cli.Get(ctx, client.ObjectKey{Name: odhDashboardConfigName, Namespace: applicationNS}, odhConfig)
 	if err == nil {
 		return odhConfig, true, nil
 	}
@@ -185,13 +187,21 @@ func attachHardwareProfileToInferenceServices(ctx context.Context, cli client.Cl
 
 		// Prefer AcceleratorProfile annotation from the associated ServingRuntime.
 		servingRuntime, srErr := getSRFromISVC(ctx, cli, isvc)
-		if srErr == nil {
+		if srErr != nil {
+			log.V(1).Info("Could not get ServingRuntime for InferenceService; falling back to container-size matching",
+				"isvc", isvc.GetName(), "namespace", isvc.GetNamespace(), "error", srErr)
+		} else {
 			runtimeAnnotations := servingRuntime.GetAnnotations()
 			if runtimeAnnotations == nil {
 				runtimeAnnotations = map[string]string{}
 			}
 			if apName := runtimeAnnotations[acceleratorNameAnnotation]; apName != "" {
 				hwpName := fmt.Sprintf("%s-serving", strings.ReplaceAll(strings.ToLower(apName), " ", "-"))
+				if errsMsg := validation.IsDNS1123Label(hwpName); len(errsMsg) > 0 {
+					log.Info("Skipping HardwareProfile migration: derived HWP name is not a valid DNS label",
+						"isvc", isvc.GetName(), "hwpName", hwpName, "reasons", errsMsg)
+					continue
+				}
 				hwpNS := runtimeAnnotations[acceleratorProfileNSAnnotation]
 				if annotErr := setHWPAnnotation(ctx, cli, isvc, hwpName, hwpNS, applicationNS); annotErr != nil {
 					if !handleISVCSetHWPAnnotationError(ctx, cli, isvc, annotErr) {

--- a/kserve-module/pkg/kservemodule/upgrade.go
+++ b/kserve-module/pkg/kservemodule/upgrade.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -141,7 +142,7 @@ func attachHardwareProfileToInferenceServices(ctx context.Context, cli client.Cl
 		return nil
 	}
 
-	containerSizes, err := getContainerSizes(odhConfig, "modelServerSizes")
+	containerSizes, err := getContainerSizes(ctx, odhConfig, "modelServerSizes")
 	if err != nil {
 		return fmt.Errorf("failed to get modelServerSizes from OdhDashboardConfig: %w", err)
 	}
@@ -314,6 +315,9 @@ func getInferenceServiceResources(isvc *unstructured.Unstructured) (map[string]a
 
 // findContainerSizeByResources matches the given resource map against the known container sizes
 // and returns the name of the first match, or an empty string when no size matches.
+//
+// Comparison uses resource.Quantity semantics so that equivalent values like "1" and "1000m"
+// are treated as equal, matching Kubernetes resource handling.
 func findContainerSizeByResources(sizes []containerSize, resources map[string]any) string {
 	if resources == nil {
 		return ""
@@ -325,16 +329,39 @@ func findContainerSizeByResources(sizes []containerSize, resources map[string]an
 		return ""
 	}
 
-	for _, size := range sizes {
-		reqCpu, _ := requests["cpu"].(string)
-		reqMem, _ := requests["memory"].(string)
-		limCpu, _ := limits["cpu"].(string)
-		limMem, _ := limits["memory"].(string)
+	parseQ := func(m map[string]any, key string) (resource.Quantity, bool) {
+		s, ok := m[key].(string)
+		if !ok || s == "" {
+			return resource.Quantity{}, false
+		}
+		q, err := resource.ParseQuantity(s)
+		return q, err == nil
+	}
 
-		if reqCpu == size.Resources.Requests.Cpu &&
-			reqMem == size.Resources.Requests.Memory &&
-			limCpu == size.Resources.Limits.Cpu &&
-			limMem == size.Resources.Limits.Memory {
+	isvcReqCPU, ok1 := parseQ(requests, "cpu")
+	isvcReqMem, ok2 := parseQ(requests, "memory")
+	isvcLimCPU, ok3 := parseQ(limits, "cpu")
+	isvcLimMem, ok4 := parseQ(limits, "memory")
+	if !ok1 || !ok2 || !ok3 || !ok4 {
+		// ISVC resource values are admission-validated by Kubernetes using the same parser, so
+		// parse failures are impossible in practice. custom-serving is the safe fallback either way.
+		return ""
+	}
+
+	for _, size := range sizes {
+		szReqCPU, e1 := resource.ParseQuantity(size.Resources.Requests.Cpu)
+		szReqMem, e2 := resource.ParseQuantity(size.Resources.Requests.Memory)
+		szLimCPU, e3 := resource.ParseQuantity(size.Resources.Limits.Cpu)
+		szLimMem, e4 := resource.ParseQuantity(size.Resources.Limits.Memory)
+		if e1 != nil || e2 != nil || e3 != nil || e4 != nil {
+			// Sizes are pre-validated by getContainerSizes; ParseQuantity will not fail in practice.
+			continue
+		}
+
+		if isvcReqCPU.Cmp(szReqCPU) == 0 &&
+			isvcReqMem.Cmp(szReqMem) == 0 &&
+			isvcLimCPU.Cmp(szLimCPU) == 0 &&
+			isvcLimMem.Cmp(szLimMem) == 0 {
 			return size.Name
 		}
 	}
@@ -368,8 +395,12 @@ func isNamespaceManagedByKueue(ctx context.Context, cli client.Client, namespace
 // getContainerSizes extracts the container size entries from spec.<sizeType> in OdhDashboardConfig
 // and maps each entry to a containerSize struct.
 //
-// Returns an empty slice (not an error) when the sizeType key is absent from the spec.
-func getContainerSizes(odhConfig *unstructured.Unstructured, sizeType string) ([]containerSize, error) {
+// Entries with missing or unparseable resource quantity strings are skipped with a warning log,
+// since a silently-skipped size would cause ISVCs to fall through to the custom-serving fallback
+// with no indication of why. Returns an empty slice (not an error) when the sizeType key is absent.
+func getContainerSizes(ctx context.Context, odhConfig *unstructured.Unstructured, sizeType string) ([]containerSize, error) {
+	log := ctrl.LoggerFrom(ctx)
+
 	sizes, found, err := unstructured.NestedSlice(odhConfig.Object, "spec", sizeType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read spec.%s from OdhDashboardConfig: %w", sizeType, err)
@@ -409,9 +440,35 @@ func getContainerSizes(odhConfig *unstructured.Unstructured, sizeType string) ([
 			}
 		}
 
+		if err := validateContainerSizeQuantities(cs); err != nil {
+			log.Info("Skipping OdhDashboardConfig container size entry: invalid resource quantity",
+				"size", cs.Name, "sizeType", sizeType, "error", err)
+			continue
+		}
+
 		result = append(result, cs)
 	}
 	return result, nil
+}
+
+// validateContainerSizeQuantities checks that all four resource quantity strings in a containerSize
+// are parseable as Kubernetes resource.Quantity values.
+func validateContainerSizeQuantities(cs containerSize) error {
+	fields := []struct {
+		label string
+		value string
+	}{
+		{"requests.cpu", cs.Resources.Requests.Cpu},
+		{"requests.memory", cs.Resources.Requests.Memory},
+		{"limits.cpu", cs.Resources.Limits.Cpu},
+		{"limits.memory", cs.Resources.Limits.Memory},
+	}
+	for _, f := range fields {
+		if _, err := resource.ParseQuantity(f.value); err != nil {
+			return fmt.Errorf("invalid %s %q: %w", f.label, f.value, err)
+		}
+	}
+	return nil
 }
 
 // setHWPAnnotation locates the HardwareProfile named hwpName by searching namespaces in
@@ -423,6 +480,10 @@ func getContainerSizes(odhConfig *unstructured.Unstructured, sizeType string) ([
 // is set and a warning Kubernetes Event is emitted.
 func setHWPAnnotation(ctx context.Context, cli client.Client, isvc *unstructured.Unstructured, hwpName, apNamespace, applicationNS string) error {
 	log := ctrl.LoggerFrom(ctx)
+
+	// Capture the base before any mutation so Patch sends only the annotation diff,
+	// avoiding lost-update conflicts from concurrent writes to other ISVC fields.
+	base := isvc.DeepCopy()
 
 	annotations := isvc.GetAnnotations()
 	if annotations == nil {
@@ -466,7 +527,7 @@ func setHWPAnnotation(ctx context.Context, cli client.Client, isvc *unstructured
 	}
 
 	isvc.SetAnnotations(annotations)
-	return cli.Update(ctx, isvc)
+	return cli.Patch(ctx, isvc, client.MergeFrom(base))
 }
 
 // getHardwareProfile fetches the HardwareProfile with the given name from the given namespace

--- a/kserve-module/pkg/kservemodule/upgrade.go
+++ b/kserve-module/pkg/kservemodule/upgrade.go
@@ -1,0 +1,507 @@
+package kservemodule
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
+)
+
+const (
+	hwpNameAnnotation              = "opendatahub.io/hardware-profile-name"
+	hwpNamespaceAnnotation         = "opendatahub.io/hardware-profile-namespace"
+	acceleratorNameAnnotation      = "opendatahub.io/accelerator-name"
+	acceleratorProfileNSAnnotation = "opendatahub.io/accelerator-profile-namespace"
+	kserveDeploymentModeAnnotation = "serving.kserve.io/deploymentMode"
+	kserveDeploymentModeServerless = "Serverless"
+	containerSizeHWPPrefix         = "containersize-"
+	customServingHWP               = "custom-serving"
+	kueueQueueNameLabel            = "kueue.x-k8s.io/queue-name"
+	kueueManagedLabel              = "kueue.openshift.io/managed"
+	kueueLegacyManagedLabel        = "kueue-managed"
+)
+
+//nolint:gochecknoglobals // Immutable GVK constants used only within this file.
+var (
+	inferenceServiceGVK   = schema.GroupVersionKind{Group: "serving.kserve.io", Version: "v1beta1", Kind: "InferenceService"}
+	servingRuntimeGVK     = schema.GroupVersionKind{Group: "serving.kserve.io", Version: "v1alpha1", Kind: "ServingRuntime"}
+	hardwareProfileGVK    = schema.GroupVersionKind{Group: "infrastructure.opendatahub.io", Version: "v1", Kind: "HardwareProfile"}
+	acceleratorProfileGVK = schema.GroupVersionKind{Group: "dashboard.opendatahub.io", Version: "v1", Kind: "AcceleratorProfile"}
+	odhDashboardConfigGVK = schema.GroupVersionKind{Group: "opendatahub.io", Version: "v1alpha", Kind: "OdhDashboardConfig"}
+)
+
+// containerSize mirrors the ContainerSize struct from opendatahub-operator's upgrade_utils.go
+// and represents a model-server container size entry from OdhDashboardConfig.
+type containerSize struct {
+	Name      string
+	Resources struct {
+		Requests struct{ Cpu, Memory string }
+		Limits   struct{ Cpu, Memory string }
+	}
+}
+
+// upgradeRunnable executes one-time upgrade tasks after the controller-manager wins leader election.
+// It implements manager.Runnable so that the manager calls Start exactly once on startup.
+type upgradeRunnable struct {
+	client        client.Client
+	applicationNS string
+}
+
+// Start runs the upgrade tasks once. Errors are logged but never returned so that
+// upgrade failures never block manager startup.
+func (u *upgradeRunnable) Start(ctx context.Context) error {
+	if err := runUpgradeTasks(ctx, u.client, u.applicationNS); err != nil {
+		ctrl.LoggerFrom(ctx).Error(err, "upgrade tasks encountered errors (non-fatal)")
+	}
+	return nil
+}
+
+// NeedLeaderElection reports that upgrade tasks must run under leader election,
+// matching the pattern used by opendatahub-operator's LeaderElectionRunnableFunc.
+func (u *upgradeRunnable) NeedLeaderElection() bool { return true }
+
+// runUpgradeTasks checks whether both the HardwareProfile and AcceleratorProfile CRDs are present,
+// fetches OdhDashboardConfig, and delegates to attachHardwareProfileToInferenceServices.
+//
+// Returns nil (with an informational log) when either CRD is absent or when OdhDashboardConfig
+// is not found, since those conditions are expected on clusters that haven't deployed the relevant features.
+func runUpgradeTasks(ctx context.Context, cli client.Client, applicationNS string) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	hwpGK := schema.GroupKind{Group: hardwareProfileGVK.Group, Kind: hardwareProfileGVK.Kind}
+	if err := cluster.CustomResourceDefinitionExists(ctx, cli, hwpGK); err != nil {
+		log.Info("Skipping HWP migration: HardwareProfile CRD not found", "group", hwpGK.Group)
+		return nil
+	}
+
+	apGK := schema.GroupKind{Group: acceleratorProfileGVK.Group, Kind: acceleratorProfileGVK.Kind}
+	if err := cluster.CustomResourceDefinitionExists(ctx, cli, apGK); err != nil {
+		log.Info("Skipping HWP migration: AcceleratorProfile CRD not found", "group", apGK.Group)
+		return nil
+	}
+
+	odhConfig, found, err := getOdhDashboardConfig(ctx, cli, applicationNS)
+	if err != nil {
+		return fmt.Errorf("error fetching OdhDashboardConfig: %w", err)
+	}
+	if !found {
+		log.Info("Skipping HWP migration: OdhDashboardConfig not found", "namespace", applicationNS)
+		return nil
+	}
+
+	return attachHardwareProfileToInferenceServices(ctx, cli, applicationNS, odhConfig)
+}
+
+// getOdhDashboardConfig retrieves the OdhDashboardConfig singleton from the given namespace.
+//
+// Returns (obj, true, nil) when found, (nil, false, nil) when not present, and
+// (nil, false, err) on API errors.
+func getOdhDashboardConfig(ctx context.Context, cli client.Client, applicationNS string) (*unstructured.Unstructured, bool, error) {
+	odhConfig := &unstructured.Unstructured{}
+	odhConfig.SetGroupVersionKind(odhDashboardConfigGVK)
+
+	err := cli.Get(ctx, client.ObjectKey{Name: "odh-dashboard-config", Namespace: applicationNS}, odhConfig)
+	if err == nil {
+		return odhConfig, true, nil
+	}
+	if k8serr.IsNotFound(err) || meta.IsNoMatchError(err) {
+		return nil, false, nil
+	}
+	return nil, false, fmt.Errorf("unable to get OdhDashboardConfig: %w", err)
+}
+
+// attachHardwareProfileToInferenceServices iterates over all cluster-wide InferenceServices and
+// sets the opendatahub.io/hardware-profile-name annotation where it is absent, deriving the
+// HardwareProfile name from the ServingRuntime's AcceleratorProfile annotation, a matching
+// container size, or the "custom-serving" fallback.
+//
+// Serverless ISVCs and ISVCs in Kueue-managed namespaces without the queue label are skipped.
+// Per-ISVC errors are accumulated and returned together; processing continues for remaining ISVCs.
+func attachHardwareProfileToInferenceServices(ctx context.Context, cli client.Client, applicationNS string, odhConfig *unstructured.Unstructured) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	isvcs, err := getInferenceServices(ctx, cli)
+	if err != nil {
+		return fmt.Errorf("failed to list InferenceServices: %w", err)
+	}
+	if len(isvcs) == 0 {
+		log.Info("No InferenceServices found, skipping HWP annotation migration")
+		return nil
+	}
+
+	containerSizes, err := getContainerSizes(odhConfig, "modelServerSizes")
+	if err != nil {
+		return fmt.Errorf("failed to get modelServerSizes from OdhDashboardConfig: %w", err)
+	}
+
+	var errs []error
+	for _, isvc := range isvcs {
+		annotations := isvc.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+
+		if annotations[hwpNameAnnotation] != "" {
+			continue
+		}
+
+		if isISVCServerless(isvc) {
+			log.Info("Skipping Serverless InferenceService during HWP migration",
+				"isvc", isvc.GetName(), "namespace", isvc.GetNamespace())
+			msg := fmt.Sprintf("Skipping HardwareProfile migration for Serverless InferenceService %s", isvc.GetName())
+			if eventErr := recordWarningEvent(ctx, cli, isvc, "ServerlessMigrationSkipped", msg); eventErr != nil {
+				log.Error(eventErr, "Failed to record warning event", "isvc", isvc.GetName())
+			}
+			continue
+		}
+
+		kueueManaged, nsErr := isNamespaceManagedByKueue(ctx, cli, isvc.GetNamespace())
+		if nsErr != nil {
+			log.Error(nsErr, "Failed to check Kueue namespace management; proceeding with HardwareProfile annotation",
+				"namespace", isvc.GetNamespace())
+		} else if kueueManaged && isvc.GetLabels()[kueueQueueNameLabel] == "" {
+			msg := fmt.Sprintf("Skipping HardwareProfile migration for InferenceService %s: namespace is Kueue-managed but missing required label %q",
+				isvc.GetName(), kueueQueueNameLabel)
+			log.Info("Skipping HardwareProfile migration: namespace is Kueue-managed but missing required label",
+				"isvc", isvc.GetName(), "namespace", isvc.GetNamespace(), "label", kueueQueueNameLabel)
+			if eventErr := recordWarningEvent(ctx, cli, isvc, "HardwareProfileMigrationSkipped", msg); eventErr != nil {
+				log.Error(eventErr, "Failed to record warning event", "isvc", isvc.GetName())
+			}
+			continue
+		}
+
+		// Prefer AcceleratorProfile annotation from the associated ServingRuntime.
+		servingRuntime, srErr := getSRFromISVC(ctx, cli, isvc)
+		if srErr == nil {
+			runtimeAnnotations := servingRuntime.GetAnnotations()
+			if runtimeAnnotations == nil {
+				runtimeAnnotations = map[string]string{}
+			}
+			if apName := runtimeAnnotations[acceleratorNameAnnotation]; apName != "" {
+				hwpName := fmt.Sprintf("%s-serving", strings.ReplaceAll(strings.ToLower(apName), " ", "-"))
+				hwpNS := runtimeAnnotations[acceleratorProfileNSAnnotation]
+				if annotErr := setHWPAnnotation(ctx, cli, isvc, hwpName, hwpNS, applicationNS); annotErr != nil {
+					if !handleISVCSetHWPAnnotationError(ctx, cli, isvc, annotErr) {
+						errs = append(errs, fmt.Errorf("failed to set HWP annotation on InferenceService %s/%s: %w", isvc.GetNamespace(), isvc.GetName(), annotErr))
+					}
+				} else {
+					log.Info("Migrated ServingRuntime AcceleratorProfile annotation to HardwareProfile annotation for InferenceService",
+						"isvc", isvc.GetName(), "runtime", servingRuntime.GetName(), "hwp", hwpName)
+				}
+				continue
+			}
+		}
+
+		// Fall back to container-size matching, then to custom-serving.
+		hwpName := customServingHWP
+		var matchedSize string
+		resources, resErr := getInferenceServiceResources(isvc)
+		if resErr == nil {
+			matchedSize = findContainerSizeByResources(containerSizes, resources)
+			if matchedSize != "" {
+				hwpName = fmt.Sprintf("%s%s-serving", containerSizeHWPPrefix, strings.ReplaceAll(strings.ToLower(matchedSize), " ", "-"))
+			}
+		}
+
+		if annotErr := setHWPAnnotation(ctx, cli, isvc, hwpName, "", applicationNS); annotErr != nil {
+			if !handleISVCSetHWPAnnotationError(ctx, cli, isvc, annotErr) {
+				errs = append(errs, fmt.Errorf("failed to set HWP annotation on InferenceService %s/%s: %w", isvc.GetNamespace(), isvc.GetName(), annotErr))
+			}
+		} else if matchedSize != "" {
+			log.Info("Set HardwareProfile annotation for InferenceService based on container size match",
+				"isvc", isvc.GetName(), "size", matchedSize, "hardwareProfile", hwpName)
+		} else {
+			log.Info("Set HardwareProfile annotation for InferenceService with custom-serving HardwareProfile",
+				"isvc", isvc.GetName(), "hardwareProfile", hwpName)
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// handleISVCSetHWPAnnotationError inspects annotation update errors for known webhook rejections
+// (Serverless mode incompatibility and Kueue label validation). When recognised, it logs the
+// situation, emits a warning Event, and returns true so the caller can skip to the next ISVC
+// rather than treating it as a hard failure. Returns false for any other error.
+//
+// This is a precautionary check: Serverless and Kueue ISVCs are already filtered out before
+// calling setHWPAnnotation, but the webhook may still reject the update in edge cases.
+func handleISVCSetHWPAnnotationError(ctx context.Context, cli client.Client, isvc *unstructured.Unstructured, err error) bool {
+	log := ctrl.LoggerFrom(ctx)
+	errStr := err.Error()
+
+	if strings.Contains(errStr, "deploymentMode cannot be changed") || strings.Contains(errStr, "Serverless") {
+		log.Info("Skipping HardwareProfile migration: Serverless webhook rejection",
+			"isvc", isvc.GetName(), "namespace", isvc.GetNamespace(), "error", errStr)
+		msg := fmt.Sprintf("Skipping HardwareProfile migration due to Serverless mode incompatibility: %s", errStr)
+		if eventErr := recordWarningEvent(ctx, cli, isvc, "ServerlessMigrationSkipped", msg); eventErr != nil {
+			log.Error(eventErr, "Failed to record warning event", "isvc", isvc.GetName())
+		}
+		return true
+	}
+
+	if strings.Contains(errStr, "Kueue label validation failed") ||
+		(strings.Contains(errStr, "missing required label") && strings.Contains(errStr, "kueue")) {
+		log.Info("Skipping HardwareProfile migration: Kueue webhook rejection (RHOAIENG-50667)",
+			"isvc", isvc.GetName(), "namespace", isvc.GetNamespace(), "error", errStr)
+		msg := fmt.Sprintf("Skipping HardwareProfile migration for InferenceService %s: namespace is Kueue-managed but missing required label %q on the InferenceService",
+			isvc.GetName(), kueueQueueNameLabel)
+		if eventErr := recordWarningEvent(ctx, cli, isvc, "HardwareProfileMigrationSkipped", msg); eventErr != nil {
+			log.Error(eventErr, "Failed to record warning event", "isvc", isvc.GetName())
+		}
+		return true
+	}
+
+	return false
+}
+
+// getInferenceServices lists all InferenceService resources cluster-wide.
+//
+// Returns a nil slice (not an error) when the InferenceService GVK is not registered
+// in the cluster's API server (meta.IsNoMatchError).
+func getInferenceServices(ctx context.Context, cli client.Client) ([]*unstructured.Unstructured, error) {
+	isvcList := &unstructured.UnstructuredList{}
+	isvcList.SetGroupVersionKind(inferenceServiceGVK)
+
+	if err := cli.List(ctx, isvcList); err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	isvcs := make([]*unstructured.Unstructured, len(isvcList.Items))
+	for i := range isvcList.Items {
+		isvcs[i] = &isvcList.Items[i]
+	}
+	return isvcs, nil
+}
+
+// getSRFromISVC looks up the ServingRuntime referenced by an InferenceService's
+// spec.predictor.model.runtime field within the same namespace.
+func getSRFromISVC(ctx context.Context, cli client.Client, isvc *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	runtimeName, found, err := unstructured.NestedString(isvc.Object, "spec", "predictor", "model", "runtime")
+	if err != nil || !found {
+		return nil, errors.New("runtime not found in InferenceService spec")
+	}
+
+	sr := &unstructured.Unstructured{}
+	sr.SetGroupVersionKind(servingRuntimeGVK)
+	err = cli.Get(ctx, client.ObjectKey{Name: runtimeName, Namespace: isvc.GetNamespace()}, sr)
+	return sr, err
+}
+
+// getInferenceServiceResources extracts spec.predictor.model.resources from an InferenceService.
+func getInferenceServiceResources(isvc *unstructured.Unstructured) (map[string]any, error) {
+	resources, found, err := unstructured.NestedMap(isvc.Object, "spec", "predictor", "model", "resources")
+	if err != nil || !found {
+		return nil, errors.New("resources not found in InferenceService spec")
+	}
+	return resources, nil
+}
+
+// findContainerSizeByResources matches the given resource map against the known container sizes
+// and returns the name of the first match, or an empty string when no size matches.
+func findContainerSizeByResources(sizes []containerSize, resources map[string]any) string {
+	if resources == nil {
+		return ""
+	}
+
+	requests, reqOk := resources["requests"].(map[string]any)
+	limits, limOk := resources["limits"].(map[string]any)
+	if !reqOk || !limOk {
+		return ""
+	}
+
+	for _, size := range sizes {
+		reqCpu, _ := requests["cpu"].(string)
+		reqMem, _ := requests["memory"].(string)
+		limCpu, _ := limits["cpu"].(string)
+		limMem, _ := limits["memory"].(string)
+
+		if reqCpu == size.Resources.Requests.Cpu &&
+			reqMem == size.Resources.Requests.Memory &&
+			limCpu == size.Resources.Limits.Cpu &&
+			limMem == size.Resources.Limits.Memory {
+			return size.Name
+		}
+	}
+	return ""
+}
+
+// isISVCServerless reports whether an InferenceService is in Serverless deployment mode,
+// checking both the serving.kserve.io/deploymentMode annotation and the status.deploymentMode field.
+func isISVCServerless(isvc *unstructured.Unstructured) bool {
+	annotations := isvc.GetAnnotations()
+	if annotations != nil && annotations[kserveDeploymentModeAnnotation] == kserveDeploymentModeServerless {
+		return true
+	}
+	status, found, _ := unstructured.NestedString(isvc.Object, "status", "deploymentMode")
+	return found && status == kserveDeploymentModeServerless
+}
+
+// isNamespaceManagedByKueue returns true when the namespace carries either the
+// kueue.openshift.io/managed or the legacy kueue-managed label set to "true".
+func isNamespaceManagedByKueue(ctx context.Context, cli client.Client, namespaceName string) (bool, error) {
+	if namespaceName == "" {
+		return false, nil
+	}
+	ns := &corev1.Namespace{}
+	if err := cli.Get(ctx, client.ObjectKey{Name: namespaceName}, ns); err != nil {
+		return false, err
+	}
+	return ns.Labels[kueueManagedLabel] == "true" || ns.Labels[kueueLegacyManagedLabel] == "true", nil
+}
+
+// getContainerSizes extracts the container size entries from spec.<sizeType> in OdhDashboardConfig
+// and maps each entry to a containerSize struct.
+//
+// Returns an empty slice (not an error) when the sizeType key is absent from the spec.
+func getContainerSizes(odhConfig *unstructured.Unstructured, sizeType string) ([]containerSize, error) {
+	sizes, found, err := unstructured.NestedSlice(odhConfig.Object, "spec", sizeType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read spec.%s from OdhDashboardConfig: %w", sizeType, err)
+	}
+	if !found {
+		return []containerSize{}, nil
+	}
+
+	result := make([]containerSize, 0, len(sizes))
+	for _, item := range sizes {
+		sizeMap, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		cs := containerSize{}
+		if name, ok := sizeMap["name"].(string); ok {
+			cs.Name = name
+		}
+
+		if resources, ok := sizeMap["resources"].(map[string]any); ok {
+			if requests, ok := resources["requests"].(map[string]any); ok {
+				if cpu, ok := requests["cpu"].(string); ok {
+					cs.Resources.Requests.Cpu = cpu
+				}
+				if memory, ok := requests["memory"].(string); ok {
+					cs.Resources.Requests.Memory = memory
+				}
+			}
+			if limits, ok := resources["limits"].(map[string]any); ok {
+				if cpu, ok := limits["cpu"].(string); ok {
+					cs.Resources.Limits.Cpu = cpu
+				}
+				if memory, ok := limits["memory"].(string); ok {
+					cs.Resources.Limits.Memory = memory
+				}
+			}
+		}
+
+		result = append(result, cs)
+	}
+	return result, nil
+}
+
+// setHWPAnnotation locates the HardwareProfile named hwpName by searching namespaces in
+// priority order (apNamespace → isvc.Namespace → applicationNS), sets
+// opendatahub.io/hardware-profile-name and opendatahub.io/hardware-profile-namespace
+// annotations on the ISVC, then calls cli.Update.
+//
+// When the HardwareProfile is not found in any candidate namespace, only the name annotation
+// is set and a warning Kubernetes Event is emitted.
+func setHWPAnnotation(ctx context.Context, cli client.Client, isvc *unstructured.Unstructured, hwpName, apNamespace, applicationNS string) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	annotations := isvc.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[hwpNameAnnotation] = hwpName
+
+	isvcNS := isvc.GetNamespace()
+	var namespacesToCheck []string
+	if apNamespace != "" {
+		namespacesToCheck = append(namespacesToCheck, apNamespace)
+	}
+	if isvcNS != "" && isvcNS != apNamespace {
+		namespacesToCheck = append(namespacesToCheck, isvcNS)
+	}
+	if applicationNS != apNamespace && applicationNS != isvcNS {
+		namespacesToCheck = append(namespacesToCheck, applicationNS)
+	}
+
+	hwpFound := false
+	for _, ns := range namespacesToCheck {
+		_, err := getHardwareProfile(ctx, cli, hwpName, ns)
+		if err == nil {
+			annotations[hwpNamespaceAnnotation] = ns
+			hwpFound = true
+			log.Info("Found HardwareProfile for migration",
+				"hwpName", hwpName, "hwpNamespace", ns, "isvc", isvc.GetName(), "isvcNamespace", isvc.GetNamespace())
+			break
+		} else if !k8serr.IsNotFound(err) {
+			return fmt.Errorf("failed to check HardwareProfile %q in namespace %s: %w", hwpName, ns, err)
+		}
+	}
+
+	if !hwpFound {
+		log.Info("HardwareProfile not found in any candidate namespace; setting name annotation only",
+			"hwpName", hwpName, "isvc", isvc.GetName(), "searched", namespacesToCheck)
+		msg := fmt.Sprintf("Skipping HardwareProfile namespace annotation: %q not found in namespaces %v", hwpName, namespacesToCheck)
+		if eventErr := recordWarningEvent(ctx, cli, isvc, "HardwareProfileMigrationSkipped", msg); eventErr != nil {
+			log.Error(eventErr, "Failed to record warning event", "isvc", isvc.GetName())
+		}
+	}
+
+	isvc.SetAnnotations(annotations)
+	return cli.Update(ctx, isvc)
+}
+
+// getHardwareProfile fetches the HardwareProfile with the given name from the given namespace
+// using an unstructured client, avoiding a typed dependency on the HardwareProfile API package.
+func getHardwareProfile(ctx context.Context, cli client.Client, name, namespace string) (*unstructured.Unstructured, error) {
+	hwp := &unstructured.Unstructured{}
+	hwp.SetGroupVersionKind(hardwareProfileGVK)
+	err := cli.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, hwp)
+	return hwp, err
+}
+
+// recordWarningEvent creates a Kubernetes Warning Event for the given unstructured object.
+func recordWarningEvent(ctx context.Context, cli client.Client, obj *unstructured.Unstructured, reason, message string) error {
+	now := metav1.NewTime(time.Now())
+	event := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: obj.GetName() + "-",
+			Namespace:    obj.GetNamespace(),
+		},
+		InvolvedObject: corev1.ObjectReference{
+			APIVersion: obj.GetAPIVersion(),
+			Kind:       obj.GetKind(),
+			Name:       obj.GetName(),
+			Namespace:  obj.GetNamespace(),
+			UID:        obj.GetUID(),
+		},
+		Reason:              reason,
+		Message:             message,
+		Type:                corev1.EventTypeWarning,
+		FirstTimestamp:      now,
+		LastTimestamp:       now,
+		Count:               1,
+		Source:              corev1.EventSource{Component: "kserve-module"},
+		ReportingController: "kserve-module",
+		ReportingInstance:   "kserve-module",
+	}
+	return cli.Create(ctx, event)
+}

--- a/kserve-module/pkg/kservemodule/upgrade_test.go
+++ b/kserve-module/pkg/kservemodule/upgrade_test.go
@@ -759,23 +759,27 @@ func TestHandleISVCSetHWPAnnotationError(t *testing.T) {
 			handled := handleISVCSetHWPAnnotationError(ctx, cli, isvc, errors.New(tc.errStr))
 			g.Expect(handled).To(Equal(tc.wantHandled))
 
+			var events corev1.EventList
+			g.Expect(cli.List(ctx, &events)).To(Succeed())
 			if tc.wantHandled {
-				var events corev1.EventList
-				g.Expect(cli.List(ctx, &events)).To(Succeed())
 				g.Expect(events.Items).To(HaveLen(1))
 				g.Expect(events.Items[0].Type).To(Equal(corev1.EventTypeWarning))
 				g.Expect(events.Items[0].Reason).To(Equal(tc.wantReason))
+			} else {
+				g.Expect(events.Items).To(BeEmpty())
 			}
 		})
 	}
 }
 
 func TestGetContainerSizes(t *testing.T) {
+	ctx := context.Background()
+
 	t.Run("Normal", func(t *testing.T) {
 		g := NewWithT(t)
 
 		odhConfig := makeTestOdhDashboardConfig("test-namespace")
-		sizes, err := getContainerSizes(odhConfig, "modelServerSizes")
+		sizes, err := getContainerSizes(ctx, odhConfig, "modelServerSizes")
 
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(sizes).To(HaveLen(2))
@@ -802,7 +806,7 @@ func TestGetContainerSizes(t *testing.T) {
 		cfg.SetNamespace("test-namespace")
 		_ = unstructured.SetNestedMap(cfg.Object, map[string]any{}, "spec")
 
-		sizes, err := getContainerSizes(cfg, "modelServerSizes")
+		sizes, err := getContainerSizes(ctx, cfg, "modelServerSizes")
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(sizes).To(BeEmpty())
 	})
@@ -815,7 +819,8 @@ func TestGetContainerSizes(t *testing.T) {
 		cfg.SetName("odh-dashboard-config")
 		cfg.SetNamespace("test-namespace")
 		_ = unstructured.SetNestedSlice(cfg.Object, []any{
-			// Malformed: resources is a string, not a map. Entry is included with empty resource fields.
+			// Malformed: resources is a string, not a map — quantity fields end up empty and fail
+			// validation, so the entry is skipped entirely.
 			map[string]any{"name": "Malformed", "resources": "invalid"},
 			map[string]any{
 				"name": "Valid",
@@ -826,13 +831,42 @@ func TestGetContainerSizes(t *testing.T) {
 			},
 		}, "spec", "modelServerSizes")
 
-		sizes, err := getContainerSizes(cfg, "modelServerSizes")
+		sizes, err := getContainerSizes(ctx, cfg, "modelServerSizes")
 		g.Expect(err).NotTo(HaveOccurred())
-		g.Expect(sizes).To(HaveLen(2))
-		g.Expect(sizes[0].Name).To(Equal("Malformed"))
-		g.Expect(sizes[0].Resources.Requests.Cpu).To(BeEmpty())
-		g.Expect(sizes[1].Name).To(Equal("Valid"))
-		g.Expect(sizes[1].Resources.Requests.Cpu).To(Equal("1"))
+		g.Expect(sizes).To(HaveLen(1))
+		g.Expect(sizes[0].Name).To(Equal("Valid"))
+		g.Expect(sizes[0].Resources.Requests.Cpu).To(Equal("1"))
+	})
+
+	t.Run("InvalidQuantityEntry", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cfg := &unstructured.Unstructured{}
+		cfg.SetGroupVersionKind(odhDashboardConfigGVK)
+		cfg.SetName("odh-dashboard-config")
+		cfg.SetNamespace("test-namespace")
+		_ = unstructured.SetNestedSlice(cfg.Object, []any{
+			// Invalid quantity string in a structurally valid entry — skipped with a warning log.
+			map[string]any{
+				"name": "BadQuantity",
+				"resources": map[string]any{
+					"requests": map[string]any{"cpu": "not-a-quantity", "memory": "4Gi"},
+					"limits":   map[string]any{"cpu": "2", "memory": "8Gi"},
+				},
+			},
+			map[string]any{
+				"name": "Valid",
+				"resources": map[string]any{
+					"requests": map[string]any{"cpu": "1", "memory": "4Gi"},
+					"limits":   map[string]any{"cpu": "2", "memory": "8Gi"},
+				},
+			},
+		}, "spec", "modelServerSizes")
+
+		sizes, err := getContainerSizes(ctx, cfg, "modelServerSizes")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(sizes).To(HaveLen(1))
+		g.Expect(sizes[0].Name).To(Equal("Valid"))
 	})
 }
 
@@ -860,6 +894,13 @@ func TestFindContainerSizeByResources(t *testing.T) {
 	t.Run("ExactMatch", func(t *testing.T) {
 		g := NewWithT(t)
 		g.Expect(findContainerSizeByResources(sizes, makeResources("1", "4Gi", "2", "8Gi"))).To(Equal("Small"))
+	})
+
+	t.Run("SemanticEquivalentMatch", func(t *testing.T) {
+		g := NewWithT(t)
+		// "1000m" CPU and "4096Mi" memory are semantically equal to "1" and "4Gi" respectively;
+		// string comparison would miss this, Quantity comparison must not.
+		g.Expect(findContainerSizeByResources(sizes, makeResources("1000m", "4096Mi", "2000m", "8192Mi"))).To(Equal("Small"))
 	})
 
 	t.Run("PartialMatchCPUOnly", func(t *testing.T) {
@@ -979,11 +1020,11 @@ func TestAttachHardwareProfileToInferenceServices_ErrorAggregation(t *testing.T)
 		hwp := makeTestHardwareProfile(namespace, "custom-serving")
 
 		funcs := interceptor.Funcs{
-			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
 				if obj.GetName() == "isvc-2" {
-					return k8serr.NewInternalError(errors.New("update failed for isvc-2"))
+					return k8serr.NewInternalError(errors.New("patch failed for isvc-2"))
 				}
-				return c.Update(ctx, obj, opts...)
+				return c.Patch(ctx, obj, patch, opts...)
 			},
 		}
 		cli := fake.NewClientBuilder().
@@ -996,6 +1037,7 @@ func TestAttachHardwareProfileToInferenceServices_ErrorAggregation(t *testing.T)
 		err := attachHardwareProfileToInferenceServices(ctx, cli, namespace, odhConfig)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("isvc-2"))
+		g.Expect(err.Error()).To(ContainSubstring("patch failed for isvc-2"))
 
 		// isvc-1 and isvc-3 must be annotated despite isvc-2 failure.
 		for _, name := range []string{"isvc-1", "isvc-3"} {

--- a/kserve-module/pkg/kservemodule/upgrade_test.go
+++ b/kserve-module/pkg/kservemodule/upgrade_test.go
@@ -1,0 +1,1009 @@
+package kservemodule
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+// ─── REST mapper helpers ──────────────────────────────────────────────────────
+
+// testRESTScope implements apimeta.RESTScope for test REST mapper configuration.
+type testRESTScope struct{ name apimeta.RESTScopeName }
+
+func (s testRESTScope) Name() apimeta.RESTScopeName { return s.name }
+
+var (
+	testNamespaceScope = testRESTScope{name: apimeta.RESTScopeNameNamespace}
+	testClusterScope   = testRESTScope{name: apimeta.RESTScopeNameRoot}
+)
+
+// makeUpgradeTestScheme returns a scheme with corev1 and apiextensionsv1 registered.
+func makeUpgradeTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	_ = apiextensionsv1.AddToScheme(s)
+	return s
+}
+
+// makeUpgradeTestRESTMapper returns a REST mapper covering all GVKs used in upgrade tests.
+func makeUpgradeTestRESTMapper() apimeta.RESTMapper {
+	rm := apimeta.NewDefaultRESTMapper(nil)
+
+	// Typed resources (corev1 and apiextensions)
+	rm.Add(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}, testClusterScope)
+	rm.Add(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Event"}, testNamespaceScope)
+	rm.Add(schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"}, testClusterScope)
+
+	// Unstructured GVKs from upgrade.go
+	rm.Add(inferenceServiceGVK, testNamespaceScope)
+	rm.Add(servingRuntimeGVK, testNamespaceScope)
+	rm.Add(hardwareProfileGVK, testNamespaceScope)
+	rm.Add(odhDashboardConfigGVK, testNamespaceScope)
+
+	return rm
+}
+
+// ─── Object-builder helpers ───────────────────────────────────────────────────
+
+// makeTestOdhDashboardConfig returns an OdhDashboardConfig with Small and Large modelServerSizes.
+// Small: requests cpu=1,memory=4Gi limits cpu=2,memory=8Gi
+// Large: requests cpu=6,memory=16Gi limits cpu=10,memory=20Gi
+func makeTestOdhDashboardConfig(namespace string) *unstructured.Unstructured {
+	cfg := &unstructured.Unstructured{}
+	cfg.SetGroupVersionKind(odhDashboardConfigGVK)
+	cfg.SetName("odh-dashboard-config")
+	cfg.SetNamespace(namespace)
+
+	_ = unstructured.SetNestedSlice(cfg.Object, []any{
+		map[string]any{
+			"name": "Small",
+			"resources": map[string]any{
+				"requests": map[string]any{"cpu": "1", "memory": "4Gi"},
+				"limits":   map[string]any{"cpu": "2", "memory": "8Gi"},
+			},
+		},
+		map[string]any{
+			"name": "Large",
+			"resources": map[string]any{
+				"requests": map[string]any{"cpu": "6", "memory": "16Gi"},
+				"limits":   map[string]any{"cpu": "10", "memory": "20Gi"},
+			},
+		},
+	}, "spec", "modelServerSizes")
+
+	return cfg
+}
+
+// makeTestInferenceService returns an unstructured InferenceService.
+// runtimeName may be empty (no spec.predictor.model.runtime set).
+func makeTestInferenceService(namespace, name, runtimeName string) *unstructured.Unstructured {
+	isvc := &unstructured.Unstructured{}
+	isvc.SetGroupVersionKind(inferenceServiceGVK)
+	isvc.SetName(name)
+	isvc.SetNamespace(namespace)
+
+	if runtimeName != "" {
+		_ = unstructured.SetNestedField(isvc.Object, runtimeName, "spec", "predictor", "model", "runtime")
+	}
+
+	return isvc
+}
+
+// makeTestInferenceServiceWithResources returns an ISVC with
+// spec.predictor.model.resources set to the given cpu/memory values.
+func makeTestInferenceServiceWithResources(namespace, name, reqCPU, reqMem, limCPU, limMem string) *unstructured.Unstructured {
+	isvc := &unstructured.Unstructured{}
+	isvc.SetGroupVersionKind(inferenceServiceGVK)
+	isvc.SetName(name)
+	isvc.SetNamespace(namespace)
+
+	_ = unstructured.SetNestedMap(isvc.Object, map[string]any{
+		"requests": map[string]any{"cpu": reqCPU, "memory": reqMem},
+		"limits":   map[string]any{"cpu": limCPU, "memory": limMem},
+	}, "spec", "predictor", "model", "resources")
+
+	return isvc
+}
+
+// makeTestServingRuntime returns an unstructured ServingRuntime.
+func makeTestServingRuntime(namespace, name string) *unstructured.Unstructured {
+	sr := &unstructured.Unstructured{}
+	sr.SetGroupVersionKind(servingRuntimeGVK)
+	sr.SetName(name)
+	sr.SetNamespace(namespace)
+	return sr
+}
+
+// makeTestHardwareProfile returns an unstructured HardwareProfile.
+func makeTestHardwareProfile(namespace, name string) *unstructured.Unstructured {
+	hwp := &unstructured.Unstructured{}
+	hwp.SetGroupVersionKind(hardwareProfileGVK)
+	hwp.SetName(name)
+	hwp.SetNamespace(namespace)
+	return hwp
+}
+
+// makeTestNamespace returns a corev1.Namespace with the given labels.
+func makeTestNamespace(name string, labels map[string]string) *corev1.Namespace {
+	return &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels}}
+}
+
+// makeCRD returns an Established CustomResourceDefinition object for use in the fake client.
+func makeCRD(name string) *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status: apiextensionsv1.CustomResourceDefinitionStatus{
+			Conditions: []apiextensionsv1.CustomResourceDefinitionCondition{{
+				Type:   apiextensionsv1.Established,
+				Status: apiextensionsv1.ConditionTrue,
+			}},
+		},
+	}
+}
+
+// makeISVCFakeClient returns a fake client preloaded with the given objects
+// and a scheme with corev1 + apiextensionsv1.
+func makeISVCFakeClient(objects ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(makeUpgradeTestScheme()).
+		WithRESTMapper(makeUpgradeTestRESTMapper()).
+		WithObjects(objects...).
+		Build()
+}
+
+// shortCtx returns a context that expires quickly to bound retries in
+// cluster.CustomResourceDefinitionExists when the CRD is absent.
+func shortCtx() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 50*time.Millisecond)
+}
+
+// CRD names derived from GVKs via the formula used in cluster.CustomResourceDefinitionExists.
+const (
+	hwpCRDName = "hardwareprofiles.infrastructure.opendatahub.io"
+	apCRDName  = "acceleratorprofiles.dashboard.opendatahub.io"
+)
+
+// ─── Section A — Migrated Tests ───────────────────────────────────────────────
+
+func TestAttachHardwareProfileToInferenceServices(t *testing.T) {
+	ctx := context.Background()
+	namespace := "test-namespace"
+
+	t.Run("NoISVCs", func(t *testing.T) {
+		g := NewWithT(t)
+
+		odhConfig := makeTestOdhDashboardConfig(namespace)
+		cli := makeISVCFakeClient(odhConfig)
+
+		err := attachHardwareProfileToInferenceServices(ctx, cli, namespace, odhConfig)
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+
+	t.Run("AlreadyHasHWPAnnotation", func(t *testing.T) {
+		g := NewWithT(t)
+
+		odhConfig := makeTestOdhDashboardConfig(namespace)
+		isvc := makeTestInferenceService(namespace, "isvc-with-hwp", "")
+		isvc.SetAnnotations(map[string]string{hwpNameAnnotation: "existing-hwp"})
+
+		cli := makeISVCFakeClient(odhConfig, isvc)
+
+		err := attachHardwareProfileToInferenceServices(ctx, cli, namespace, odhConfig)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		updated := &unstructured.Unstructured{}
+		updated.SetGroupVersionKind(inferenceServiceGVK)
+		g.Expect(cli.Get(ctx, client.ObjectKey{Name: "isvc-with-hwp", Namespace: namespace}, updated)).To(Succeed())
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNameAnnotation, "existing-hwp"))
+	})
+
+	t.Run("ServingRuntimeAPAnnotation", func(t *testing.T) {
+		g := NewWithT(t)
+
+		odhConfig := makeTestOdhDashboardConfig(namespace)
+		sr := makeTestServingRuntime(namespace, "test-runtime")
+		sr.SetAnnotations(map[string]string{acceleratorNameAnnotation: "nvidia Gpu"})
+		isvc := makeTestInferenceService(namespace, "isvc-with-runtime", "test-runtime")
+		hwp := makeTestHardwareProfile(namespace, "nvidia-gpu-serving")
+
+		cli := makeISVCFakeClient(odhConfig, sr, isvc, hwp)
+
+		err := attachHardwareProfileToInferenceServices(ctx, cli, namespace, odhConfig)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		updated := &unstructured.Unstructured{}
+		updated.SetGroupVersionKind(inferenceServiceGVK)
+		g.Expect(cli.Get(ctx, client.ObjectKey{Name: "isvc-with-runtime", Namespace: namespace}, updated)).To(Succeed())
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNameAnnotation, "nvidia-gpu-serving"))
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNamespaceAnnotation, namespace))
+	})
+
+	t.Run("ContainerSizeMatch", func(t *testing.T) {
+		g := NewWithT(t)
+
+		odhConfig := makeTestOdhDashboardConfig(namespace)
+		isvc := makeTestInferenceServiceWithResources(namespace, "isvc-with-resources", "1", "4Gi", "2", "8Gi")
+		hwp := makeTestHardwareProfile(namespace, "containersize-small-serving")
+
+		cli := makeISVCFakeClient(odhConfig, isvc, hwp)
+
+		err := attachHardwareProfileToInferenceServices(ctx, cli, namespace, odhConfig)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		updated := &unstructured.Unstructured{}
+		updated.SetGroupVersionKind(inferenceServiceGVK)
+		g.Expect(cli.Get(ctx, client.ObjectKey{Name: "isvc-with-resources", Namespace: namespace}, updated)).To(Succeed())
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNameAnnotation, "containersize-small-serving"))
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNamespaceAnnotation, namespace))
+	})
+
+	t.Run("NonMatchingResources", func(t *testing.T) {
+		g := NewWithT(t)
+
+		odhConfig := makeTestOdhDashboardConfig(namespace)
+		isvc := makeTestInferenceServiceWithResources(namespace, "isvc-custom", "3", "10Gi", "5", "20Gi")
+		hwp := makeTestHardwareProfile(namespace, "custom-serving")
+
+		cli := makeISVCFakeClient(odhConfig, isvc, hwp)
+
+		err := attachHardwareProfileToInferenceServices(ctx, cli, namespace, odhConfig)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		updated := &unstructured.Unstructured{}
+		updated.SetGroupVersionKind(inferenceServiceGVK)
+		g.Expect(cli.Get(ctx, client.ObjectKey{Name: "isvc-custom", Namespace: namespace}, updated)).To(Succeed())
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNameAnnotation, "custom-serving"))
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNamespaceAnnotation, namespace))
+	})
+
+	t.Run("NoResourcesAtAll", func(t *testing.T) {
+		g := NewWithT(t)
+
+		odhConfig := makeTestOdhDashboardConfig(namespace)
+		isvc := makeTestInferenceService(namespace, "isvc-no-resources", "")
+		hwp := makeTestHardwareProfile(namespace, "custom-serving")
+
+		cli := makeISVCFakeClient(odhConfig, isvc, hwp)
+
+		err := attachHardwareProfileToInferenceServices(ctx, cli, namespace, odhConfig)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		updated := &unstructured.Unstructured{}
+		updated.SetGroupVersionKind(inferenceServiceGVK)
+		g.Expect(cli.Get(ctx, client.ObjectKey{Name: "isvc-no-resources", Namespace: namespace}, updated)).To(Succeed())
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNameAnnotation, "custom-serving"))
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNamespaceAnnotation, namespace))
+	})
+
+	t.Run("ServerlessAnnotation", func(t *testing.T) {
+		g := NewWithT(t)
+
+		odhConfig := makeTestOdhDashboardConfig(namespace)
+		isvc := makeTestInferenceService(namespace, "isvc-serverless-annotation", "")
+		isvc.SetAnnotations(map[string]string{kserveDeploymentModeAnnotation: "Serverless"})
+
+		cli := makeISVCFakeClient(odhConfig, isvc)
+
+		err := attachHardwareProfileToInferenceServices(ctx, cli, namespace, odhConfig)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		updated := &unstructured.Unstructured{}
+		updated.SetGroupVersionKind(inferenceServiceGVK)
+		g.Expect(cli.Get(ctx, client.ObjectKey{Name: "isvc-serverless-annotation", Namespace: namespace}, updated)).To(Succeed())
+		g.Expect(updated.GetAnnotations()).NotTo(HaveKey(hwpNameAnnotation))
+	})
+
+	t.Run("ServerlessStatus", func(t *testing.T) {
+		g := NewWithT(t)
+
+		odhConfig := makeTestOdhDashboardConfig(namespace)
+		isvc := makeTestInferenceService(namespace, "isvc-serverless-status", "")
+		isvc.Object["status"] = map[string]any{"deploymentMode": "Serverless"}
+
+		cli := makeISVCFakeClient(odhConfig, isvc)
+
+		err := attachHardwareProfileToInferenceServices(ctx, cli, namespace, odhConfig)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		updated := &unstructured.Unstructured{}
+		updated.SetGroupVersionKind(inferenceServiceGVK)
+		g.Expect(cli.Get(ctx, client.ObjectKey{Name: "isvc-serverless-status", Namespace: namespace}, updated)).To(Succeed())
+		g.Expect(updated.GetAnnotations()).NotTo(HaveKey(hwpNameAnnotation))
+	})
+
+	t.Run("KueueManagedNamespaceNoQueueLabel", func(t *testing.T) {
+		g := NewWithT(t)
+
+		odhConfig := makeTestOdhDashboardConfig(namespace)
+		ns := makeTestNamespace(namespace, map[string]string{kueueManagedLabel: "true"})
+		isvc := makeTestInferenceService(namespace, "isvc-kueue-ns-no-label", "")
+		hwp := makeTestHardwareProfile(namespace, "custom-serving")
+
+		cli := makeISVCFakeClient(ns, odhConfig, isvc, hwp)
+
+		err := attachHardwareProfileToInferenceServices(ctx, cli, namespace, odhConfig)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		updated := &unstructured.Unstructured{}
+		updated.SetGroupVersionKind(inferenceServiceGVK)
+		g.Expect(cli.Get(ctx, client.ObjectKey{Name: "isvc-kueue-ns-no-label", Namespace: namespace}, updated)).To(Succeed())
+		g.Expect(updated.GetAnnotations()).NotTo(HaveKey(hwpNameAnnotation))
+
+		var events corev1.EventList
+		g.Expect(cli.List(ctx, &events)).To(Succeed())
+		g.Expect(events.Items).To(HaveLen(1))
+		g.Expect(events.Items[0].Type).To(Equal(corev1.EventTypeWarning))
+		g.Expect(events.Items[0].Reason).To(Equal("HardwareProfileMigrationSkipped"))
+	})
+
+	t.Run("KueueLegacyManagedNamespaceNoQueueLabel", func(t *testing.T) {
+		g := NewWithT(t)
+
+		odhConfig := makeTestOdhDashboardConfig(namespace)
+		ns := makeTestNamespace(namespace, map[string]string{kueueLegacyManagedLabel: "true"})
+		isvc := makeTestInferenceService(namespace, "isvc-legacy-kueue-ns", "")
+		hwp := makeTestHardwareProfile(namespace, "custom-serving")
+
+		cli := makeISVCFakeClient(ns, odhConfig, isvc, hwp)
+
+		err := attachHardwareProfileToInferenceServices(ctx, cli, namespace, odhConfig)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		updated := &unstructured.Unstructured{}
+		updated.SetGroupVersionKind(inferenceServiceGVK)
+		g.Expect(cli.Get(ctx, client.ObjectKey{Name: "isvc-legacy-kueue-ns", Namespace: namespace}, updated)).To(Succeed())
+		g.Expect(updated.GetAnnotations()).NotTo(HaveKey(hwpNameAnnotation))
+
+		var events corev1.EventList
+		g.Expect(cli.List(ctx, &events)).To(Succeed())
+		g.Expect(events.Items).To(HaveLen(1))
+		g.Expect(events.Items[0].Type).To(Equal(corev1.EventTypeWarning))
+		g.Expect(events.Items[0].Reason).To(Equal("HardwareProfileMigrationSkipped"))
+	})
+
+	t.Run("KueueManagedNamespaceWithQueueLabel", func(t *testing.T) {
+		g := NewWithT(t)
+
+		odhConfig := makeTestOdhDashboardConfig(namespace)
+		ns := makeTestNamespace(namespace, map[string]string{kueueManagedLabel: "true"})
+		isvc := makeTestInferenceService(namespace, "isvc-kueue-ns-with-label", "")
+		isvc.SetLabels(map[string]string{kueueQueueNameLabel: "my-queue"})
+		hwp := makeTestHardwareProfile(namespace, "custom-serving")
+
+		cli := makeISVCFakeClient(ns, odhConfig, isvc, hwp)
+
+		err := attachHardwareProfileToInferenceServices(ctx, cli, namespace, odhConfig)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		updated := &unstructured.Unstructured{}
+		updated.SetGroupVersionKind(inferenceServiceGVK)
+		g.Expect(cli.Get(ctx, client.ObjectKey{Name: "isvc-kueue-ns-with-label", Namespace: namespace}, updated)).To(Succeed())
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNameAnnotation, "custom-serving"))
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNamespaceAnnotation, namespace))
+	})
+}
+
+func TestGetOdhDashboardConfig(t *testing.T) {
+	ctx := context.Background()
+	namespace := "test-namespace"
+
+	t.Run("Found", func(t *testing.T) {
+		g := NewWithT(t)
+
+		odhConfig := makeTestOdhDashboardConfig(namespace)
+		cli := makeISVCFakeClient(odhConfig)
+
+		result, found, err := getOdhDashboardConfig(ctx, cli, namespace)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(found).To(BeTrue())
+		g.Expect(result).NotTo(BeNil())
+		g.Expect(result.GetName()).To(Equal("odh-dashboard-config"))
+		g.Expect(result.GetNamespace()).To(Equal(namespace))
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cli := makeISVCFakeClient()
+
+		result, found, err := getOdhDashboardConfig(ctx, cli, namespace)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(found).To(BeFalse())
+		g.Expect(result).To(BeNil())
+	})
+
+	t.Run("NoMatchError", func(t *testing.T) {
+		g := NewWithT(t)
+
+		funcs := interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "OdhDashboardConfig" {
+					return &apimeta.NoKindMatchError{
+						GroupKind:        schema.GroupKind{Group: "opendatahub.io", Kind: "OdhDashboardConfig"},
+						SearchedVersions: []string{"v1alpha"},
+					}
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}
+		cli := fake.NewClientBuilder().
+			WithScheme(makeUpgradeTestScheme()).
+			WithRESTMapper(makeUpgradeTestRESTMapper()).
+			WithInterceptorFuncs(funcs).
+			Build()
+
+		result, found, err := getOdhDashboardConfig(ctx, cli, namespace)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(found).To(BeFalse())
+		g.Expect(result).To(BeNil())
+	})
+
+	t.Run("OtherAPIError", func(t *testing.T) {
+		g := NewWithT(t)
+
+		funcs := interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "OdhDashboardConfig" {
+					return k8serr.NewInternalError(errors.New("internal server error"))
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}
+		cli := fake.NewClientBuilder().
+			WithScheme(makeUpgradeTestScheme()).
+			WithRESTMapper(makeUpgradeTestRESTMapper()).
+			WithInterceptorFuncs(funcs).
+			Build()
+
+		result, found, err := getOdhDashboardConfig(ctx, cli, namespace)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("internal server error"))
+		g.Expect(found).To(BeFalse())
+		g.Expect(result).To(BeNil())
+	})
+}
+
+// ─── Section B — New Tests ────────────────────────────────────────────────────
+
+func TestRunUpgradeTasks(t *testing.T) {
+	const namespace = "test-namespace"
+
+	t.Run("NeitherCRDExists", func(t *testing.T) {
+		g := NewWithT(t)
+		cli := makeISVCFakeClient()
+		ctx, cancel := shortCtx()
+		defer cancel()
+		g.Expect(runUpgradeTasks(ctx, cli, namespace)).To(Succeed())
+	})
+
+	t.Run("HWPCRDMissingOnly", func(t *testing.T) {
+		g := NewWithT(t)
+		cli := makeISVCFakeClient(makeCRD(apCRDName))
+		ctx, cancel := shortCtx()
+		defer cancel()
+		g.Expect(runUpgradeTasks(ctx, cli, namespace)).To(Succeed())
+	})
+
+	t.Run("AcceleratorCRDMissingOnly", func(t *testing.T) {
+		g := NewWithT(t)
+		cli := makeISVCFakeClient(makeCRD(hwpCRDName))
+		ctx, cancel := shortCtx()
+		defer cancel()
+		g.Expect(runUpgradeTasks(ctx, cli, namespace)).To(Succeed())
+	})
+
+	t.Run("BothCRDsPresentOdhConfigNotFound", func(t *testing.T) {
+		g := NewWithT(t)
+		cli := makeISVCFakeClient(makeCRD(hwpCRDName), makeCRD(apCRDName))
+		g.Expect(runUpgradeTasks(context.Background(), cli, namespace)).To(Succeed())
+	})
+
+	t.Run("BothCRDsPresentOdhConfigError", func(t *testing.T) {
+		g := NewWithT(t)
+
+		funcs := interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "OdhDashboardConfig" {
+					return k8serr.NewInternalError(errors.New("internal server error"))
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}
+		cli := fake.NewClientBuilder().
+			WithScheme(makeUpgradeTestScheme()).
+			WithRESTMapper(makeUpgradeTestRESTMapper()).
+			WithObjects(makeCRD(hwpCRDName), makeCRD(apCRDName)).
+			WithInterceptorFuncs(funcs).
+			Build()
+
+		err := runUpgradeTasks(context.Background(), cli, namespace)
+		g.Expect(err).To(HaveOccurred())
+	})
+
+	t.Run("BothCRDsPresentHappyPath", func(t *testing.T) {
+		g := NewWithT(t)
+
+		odhConfig := makeTestOdhDashboardConfig(namespace)
+		isvc := makeTestInferenceService(namespace, "isvc-one", "")
+		hwp := makeTestHardwareProfile(namespace, "custom-serving")
+
+		cli := makeISVCFakeClient(makeCRD(hwpCRDName), makeCRD(apCRDName), odhConfig, isvc, hwp)
+
+		g.Expect(runUpgradeTasks(context.Background(), cli, namespace)).To(Succeed())
+
+		updated := &unstructured.Unstructured{}
+		updated.SetGroupVersionKind(inferenceServiceGVK)
+		g.Expect(cli.Get(context.Background(), client.ObjectKey{Name: "isvc-one", Namespace: namespace}, updated)).To(Succeed())
+		g.Expect(updated.GetAnnotations()).To(HaveKey(hwpNameAnnotation))
+	})
+}
+
+func TestUpgradeRunnableStart(t *testing.T) {
+	const namespace = "test-namespace"
+
+	t.Run("StartReturnsNilOnSuccess", func(t *testing.T) {
+		g := NewWithT(t)
+
+		odhConfig := makeTestOdhDashboardConfig(namespace)
+		isvc := makeTestInferenceService(namespace, "isvc-one", "")
+		hwp := makeTestHardwareProfile(namespace, "custom-serving")
+
+		cli := makeISVCFakeClient(makeCRD(hwpCRDName), makeCRD(apCRDName), odhConfig, isvc, hwp)
+		r := &upgradeRunnable{client: cli, applicationNS: namespace}
+
+		g.Expect(r.Start(context.Background())).To(Succeed())
+	})
+
+	t.Run("StartReturnsNilOnError", func(t *testing.T) {
+		g := NewWithT(t)
+
+		funcs := interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if obj.GetObjectKind().GroupVersionKind().Kind == "OdhDashboardConfig" {
+					return k8serr.NewInternalError(errors.New("internal server error"))
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}
+		cli := fake.NewClientBuilder().
+			WithScheme(makeUpgradeTestScheme()).
+			WithRESTMapper(makeUpgradeTestRESTMapper()).
+			WithObjects(makeCRD(hwpCRDName), makeCRD(apCRDName)).
+			WithInterceptorFuncs(funcs).
+			Build()
+
+		r := &upgradeRunnable{client: cli, applicationNS: namespace}
+		// Start absorbs all errors so manager startup is never blocked.
+		g.Expect(r.Start(context.Background())).To(Succeed())
+	})
+}
+
+func TestUpgradeRunnableNeedLeaderElection(t *testing.T) {
+	t.Run("NeedLeaderElectionIsTrue", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect((&upgradeRunnable{}).NeedLeaderElection()).To(BeTrue())
+	})
+}
+
+func TestSetHWPAnnotation(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		hwpTestName  = "test-hwp"
+		apNS         = "ap-ns"
+		isvcNS       = "isvc-ns"
+		appNS        = "app-ns"
+		isvcTestName = "test-isvc"
+	)
+
+	t.Run("FoundInAPNamespace", func(t *testing.T) {
+		g := NewWithT(t)
+
+		isvc := makeTestInferenceService(isvcNS, isvcTestName, "")
+		hwp := makeTestHardwareProfile(apNS, hwpTestName)
+
+		cli := makeISVCFakeClient(isvc, hwp)
+
+		err := setHWPAnnotation(ctx, cli, isvc, hwpTestName, apNS, appNS)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		updated := &unstructured.Unstructured{}
+		updated.SetGroupVersionKind(inferenceServiceGVK)
+		g.Expect(cli.Get(ctx, client.ObjectKey{Name: isvcTestName, Namespace: isvcNS}, updated)).To(Succeed())
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNameAnnotation, hwpTestName))
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNamespaceAnnotation, apNS))
+	})
+
+	t.Run("FoundInISVCNamespace", func(t *testing.T) {
+		g := NewWithT(t)
+
+		isvc := makeTestInferenceService(isvcNS, isvcTestName, "")
+		hwp := makeTestHardwareProfile(isvcNS, hwpTestName)
+
+		cli := makeISVCFakeClient(isvc, hwp)
+
+		// apNS has no HWP; ISVC namespace does.
+		err := setHWPAnnotation(ctx, cli, isvc, hwpTestName, apNS, appNS)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		updated := &unstructured.Unstructured{}
+		updated.SetGroupVersionKind(inferenceServiceGVK)
+		g.Expect(cli.Get(ctx, client.ObjectKey{Name: isvcTestName, Namespace: isvcNS}, updated)).To(Succeed())
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNameAnnotation, hwpTestName))
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNamespaceAnnotation, isvcNS))
+	})
+
+	t.Run("FoundInApplicationNamespace", func(t *testing.T) {
+		g := NewWithT(t)
+
+		isvc := makeTestInferenceService(isvcNS, isvcTestName, "")
+		hwp := makeTestHardwareProfile(appNS, hwpTestName)
+
+		cli := makeISVCFakeClient(isvc, hwp)
+
+		err := setHWPAnnotation(ctx, cli, isvc, hwpTestName, apNS, appNS)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		updated := &unstructured.Unstructured{}
+		updated.SetGroupVersionKind(inferenceServiceGVK)
+		g.Expect(cli.Get(ctx, client.ObjectKey{Name: isvcTestName, Namespace: isvcNS}, updated)).To(Succeed())
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNameAnnotation, hwpTestName))
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNamespaceAnnotation, appNS))
+	})
+
+	t.Run("NotFoundInAnyNamespace", func(t *testing.T) {
+		g := NewWithT(t)
+
+		isvc := makeTestInferenceService(isvcNS, isvcTestName, "")
+		cli := makeISVCFakeClient(isvc)
+
+		err := setHWPAnnotation(ctx, cli, isvc, hwpTestName, apNS, appNS)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		updated := &unstructured.Unstructured{}
+		updated.SetGroupVersionKind(inferenceServiceGVK)
+		g.Expect(cli.Get(ctx, client.ObjectKey{Name: isvcTestName, Namespace: isvcNS}, updated)).To(Succeed())
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNameAnnotation, hwpTestName))
+		g.Expect(updated.GetAnnotations()).NotTo(HaveKey(hwpNamespaceAnnotation))
+
+		var events corev1.EventList
+		g.Expect(cli.List(ctx, &events)).To(Succeed())
+		g.Expect(events.Items).To(HaveLen(1))
+		g.Expect(events.Items[0].Type).To(Equal(corev1.EventTypeWarning))
+		g.Expect(events.Items[0].Reason).To(Equal("HardwareProfileMigrationSkipped"))
+	})
+
+	t.Run("EmptyAPNamespaceSkipped", func(t *testing.T) {
+		g := NewWithT(t)
+
+		isvc := makeTestInferenceService(isvcNS, isvcTestName, "")
+		hwp := makeTestHardwareProfile(isvcNS, hwpTestName)
+
+		cli := makeISVCFakeClient(isvc, hwp)
+
+		// apNamespace="" means ap-ns is not searched; HWP is found in isvcNS.
+		err := setHWPAnnotation(ctx, cli, isvc, hwpTestName, "", appNS)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		updated := &unstructured.Unstructured{}
+		updated.SetGroupVersionKind(inferenceServiceGVK)
+		g.Expect(cli.Get(ctx, client.ObjectKey{Name: isvcTestName, Namespace: isvcNS}, updated)).To(Succeed())
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNameAnnotation, hwpTestName))
+		g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(hwpNamespaceAnnotation, isvcNS))
+	})
+}
+
+func TestHandleISVCSetHWPAnnotationError(t *testing.T) {
+	ctx := context.Background()
+	const namespace = "test-namespace"
+
+	cases := []struct {
+		name        string
+		errStr      string
+		wantHandled bool
+		wantReason  string
+	}{
+		{
+			name:        "ServerlessDeploymentModeWebhook",
+			errStr:      "deploymentMode cannot be changed",
+			wantHandled: true,
+			wantReason:  "ServerlessMigrationSkipped",
+		},
+		{
+			name:        "ServerlessKeywordWebhook",
+			errStr:      "Serverless mode incompatibility",
+			wantHandled: true,
+			wantReason:  "ServerlessMigrationSkipped",
+		},
+		{
+			name:        "KueueLabelValidationFailed",
+			errStr:      "Kueue label validation failed",
+			wantHandled: true,
+			wantReason:  "HardwareProfileMigrationSkipped",
+		},
+		{
+			name:        "KueueMissingRequiredLabel",
+			errStr:      "missing required label kueue something",
+			wantHandled: true,
+			wantReason:  "HardwareProfileMigrationSkipped",
+		},
+		{
+			name:        "UnrecognisedError",
+			errStr:      "something completely different",
+			wantHandled: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			isvc := makeTestInferenceService(namespace, "test-isvc", "")
+			cli := makeISVCFakeClient(isvc)
+
+			handled := handleISVCSetHWPAnnotationError(ctx, cli, isvc, errors.New(tc.errStr))
+			g.Expect(handled).To(Equal(tc.wantHandled))
+
+			if tc.wantHandled {
+				var events corev1.EventList
+				g.Expect(cli.List(ctx, &events)).To(Succeed())
+				g.Expect(events.Items).To(HaveLen(1))
+				g.Expect(events.Items[0].Type).To(Equal(corev1.EventTypeWarning))
+				g.Expect(events.Items[0].Reason).To(Equal(tc.wantReason))
+			}
+		})
+	}
+}
+
+func TestGetContainerSizes(t *testing.T) {
+	t.Run("Normal", func(t *testing.T) {
+		g := NewWithT(t)
+
+		odhConfig := makeTestOdhDashboardConfig("test-namespace")
+		sizes, err := getContainerSizes(odhConfig, "modelServerSizes")
+
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(sizes).To(HaveLen(2))
+
+		g.Expect(sizes[0].Name).To(Equal("Small"))
+		g.Expect(sizes[0].Resources.Requests.Cpu).To(Equal("1"))
+		g.Expect(sizes[0].Resources.Requests.Memory).To(Equal("4Gi"))
+		g.Expect(sizes[0].Resources.Limits.Cpu).To(Equal("2"))
+		g.Expect(sizes[0].Resources.Limits.Memory).To(Equal("8Gi"))
+
+		g.Expect(sizes[1].Name).To(Equal("Large"))
+		g.Expect(sizes[1].Resources.Requests.Cpu).To(Equal("6"))
+		g.Expect(sizes[1].Resources.Requests.Memory).To(Equal("16Gi"))
+		g.Expect(sizes[1].Resources.Limits.Cpu).To(Equal("10"))
+		g.Expect(sizes[1].Resources.Limits.Memory).To(Equal("20Gi"))
+	})
+
+	t.Run("KeyAbsent", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cfg := &unstructured.Unstructured{}
+		cfg.SetGroupVersionKind(odhDashboardConfigGVK)
+		cfg.SetName("odh-dashboard-config")
+		cfg.SetNamespace("test-namespace")
+		_ = unstructured.SetNestedMap(cfg.Object, map[string]any{}, "spec")
+
+		sizes, err := getContainerSizes(cfg, "modelServerSizes")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(sizes).To(BeEmpty())
+	})
+
+	t.Run("MalformedEntry", func(t *testing.T) {
+		g := NewWithT(t)
+
+		cfg := &unstructured.Unstructured{}
+		cfg.SetGroupVersionKind(odhDashboardConfigGVK)
+		cfg.SetName("odh-dashboard-config")
+		cfg.SetNamespace("test-namespace")
+		_ = unstructured.SetNestedSlice(cfg.Object, []any{
+			// Malformed: resources is a string, not a map. Entry is included with empty resource fields.
+			map[string]any{"name": "Malformed", "resources": "invalid"},
+			map[string]any{
+				"name": "Valid",
+				"resources": map[string]any{
+					"requests": map[string]any{"cpu": "1", "memory": "4Gi"},
+					"limits":   map[string]any{"cpu": "2", "memory": "8Gi"},
+				},
+			},
+		}, "spec", "modelServerSizes")
+
+		sizes, err := getContainerSizes(cfg, "modelServerSizes")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(sizes).To(HaveLen(2))
+		g.Expect(sizes[0].Name).To(Equal("Malformed"))
+		g.Expect(sizes[0].Resources.Requests.Cpu).To(BeEmpty())
+		g.Expect(sizes[1].Name).To(Equal("Valid"))
+		g.Expect(sizes[1].Resources.Requests.Cpu).To(Equal("1"))
+	})
+}
+
+func TestFindContainerSizeByResources(t *testing.T) {
+	sizes := []containerSize{
+		{
+			Name: "Small",
+			Resources: struct {
+				Requests struct{ Cpu, Memory string }
+				Limits   struct{ Cpu, Memory string }
+			}{
+				Requests: struct{ Cpu, Memory string }{Cpu: "1", Memory: "4Gi"},
+				Limits:   struct{ Cpu, Memory string }{Cpu: "2", Memory: "8Gi"},
+			},
+		},
+	}
+
+	makeResources := func(reqCPU, reqMem, limCPU, limMem string) map[string]any {
+		return map[string]any{
+			"requests": map[string]any{"cpu": reqCPU, "memory": reqMem},
+			"limits":   map[string]any{"cpu": limCPU, "memory": limMem},
+		}
+	}
+
+	t.Run("ExactMatch", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(findContainerSizeByResources(sizes, makeResources("1", "4Gi", "2", "8Gi"))).To(Equal("Small"))
+	})
+
+	t.Run("PartialMatchCPUOnly", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(findContainerSizeByResources(sizes, makeResources("1", "99Gi", "2", "8Gi"))).To(BeEmpty())
+	})
+
+	t.Run("NoMatch", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(findContainerSizeByResources(sizes, makeResources("99", "99Gi", "99", "99Gi"))).To(BeEmpty())
+	})
+
+	t.Run("NilResources", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(findContainerSizeByResources(sizes, nil)).To(BeEmpty())
+	})
+
+	t.Run("MissingRequestsMap", func(t *testing.T) {
+		g := NewWithT(t)
+		resources := map[string]any{
+			"limits": map[string]any{"cpu": "2", "memory": "8Gi"},
+		}
+		g.Expect(findContainerSizeByResources(sizes, resources)).To(BeEmpty())
+	})
+
+	t.Run("EmptySizeList", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(findContainerSizeByResources([]containerSize{}, makeResources("1", "4Gi", "2", "8Gi"))).To(BeEmpty())
+	})
+}
+
+func TestIsISVCServerless(t *testing.T) {
+	t.Run("AnnotationServerless", func(t *testing.T) {
+		g := NewWithT(t)
+		isvc := makeTestInferenceService("ns", "isvc", "")
+		isvc.SetAnnotations(map[string]string{kserveDeploymentModeAnnotation: "Serverless"})
+		g.Expect(isISVCServerless(isvc)).To(BeTrue())
+	})
+
+	t.Run("StatusServerless", func(t *testing.T) {
+		g := NewWithT(t)
+		isvc := makeTestInferenceService("ns", "isvc", "")
+		isvc.Object["status"] = map[string]any{"deploymentMode": "Serverless"}
+		g.Expect(isISVCServerless(isvc)).To(BeTrue())
+	})
+
+	t.Run("AnnotationOtherValue", func(t *testing.T) {
+		g := NewWithT(t)
+		isvc := makeTestInferenceService("ns", "isvc", "")
+		isvc.SetAnnotations(map[string]string{kserveDeploymentModeAnnotation: "RawDeployment"})
+		g.Expect(isISVCServerless(isvc)).To(BeFalse())
+	})
+
+	t.Run("NeitherSet", func(t *testing.T) {
+		g := NewWithT(t)
+		isvc := makeTestInferenceService("ns", "isvc", "")
+		g.Expect(isISVCServerless(isvc)).To(BeFalse())
+	})
+}
+
+func TestIsNamespaceManagedByKueue(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("KueueManagedLabel", func(t *testing.T) {
+		g := NewWithT(t)
+		ns := makeTestNamespace("my-ns", map[string]string{kueueManagedLabel: "true"})
+		cli := makeISVCFakeClient(ns)
+		managed, err := isNamespaceManagedByKueue(ctx, cli, "my-ns")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(managed).To(BeTrue())
+	})
+
+	t.Run("KueueLegacyManagedLabel", func(t *testing.T) {
+		g := NewWithT(t)
+		ns := makeTestNamespace("my-ns", map[string]string{kueueLegacyManagedLabel: "true"})
+		cli := makeISVCFakeClient(ns)
+		managed, err := isNamespaceManagedByKueue(ctx, cli, "my-ns")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(managed).To(BeTrue())
+	})
+
+	t.Run("NoKueueLabel", func(t *testing.T) {
+		g := NewWithT(t)
+		ns := makeTestNamespace("my-ns", map[string]string{"unrelated": "label"})
+		cli := makeISVCFakeClient(ns)
+		managed, err := isNamespaceManagedByKueue(ctx, cli, "my-ns")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(managed).To(BeFalse())
+	})
+
+	t.Run("EmptyNamespaceName", func(t *testing.T) {
+		g := NewWithT(t)
+		cli := makeISVCFakeClient()
+		managed, err := isNamespaceManagedByKueue(ctx, cli, "")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(managed).To(BeFalse())
+	})
+
+	t.Run("NamespaceNotFound", func(t *testing.T) {
+		g := NewWithT(t)
+		cli := makeISVCFakeClient()
+		_, err := isNamespaceManagedByKueue(ctx, cli, "nonexistent")
+		g.Expect(err).To(HaveOccurred())
+	})
+}
+
+func TestAttachHardwareProfileToInferenceServices_ErrorAggregation(t *testing.T) {
+	t.Run("MultipleISVCsOneFailsOthersContinue", func(t *testing.T) {
+		g := NewWithT(t)
+		ctx := context.Background()
+		namespace := "test-namespace"
+
+		odhConfig := makeTestOdhDashboardConfig(namespace)
+		isvc1 := makeTestInferenceService(namespace, "isvc-1", "")
+		isvc2 := makeTestInferenceService(namespace, "isvc-2", "")
+		isvc3 := makeTestInferenceService(namespace, "isvc-3", "")
+		hwp := makeTestHardwareProfile(namespace, "custom-serving")
+
+		funcs := interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				if obj.GetName() == "isvc-2" {
+					return k8serr.NewInternalError(errors.New("update failed for isvc-2"))
+				}
+				return c.Update(ctx, obj, opts...)
+			},
+		}
+		cli := fake.NewClientBuilder().
+			WithScheme(makeUpgradeTestScheme()).
+			WithRESTMapper(makeUpgradeTestRESTMapper()).
+			WithObjects(odhConfig, isvc1, isvc2, isvc3, hwp).
+			WithInterceptorFuncs(funcs).
+			Build()
+
+		err := attachHardwareProfileToInferenceServices(ctx, cli, namespace, odhConfig)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("isvc-2"))
+
+		// isvc-1 and isvc-3 must be annotated despite isvc-2 failure.
+		for _, name := range []string{"isvc-1", "isvc-3"} {
+			updated := &unstructured.Unstructured{}
+			updated.SetGroupVersionKind(inferenceServiceGVK)
+			g.Expect(cli.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, updated)).To(Succeed())
+			g.Expect(updated.GetAnnotations()).To(HaveKey(hwpNameAnnotation),
+				"expected %s to have HWP annotation", name)
+		}
+	})
+}

--- a/kserve-module/pkg/kservemodule/upgrade_test.go
+++ b/kserve-module/pkg/kservemodule/upgrade_test.go
@@ -66,7 +66,7 @@ func makeUpgradeTestRESTMapper() apimeta.RESTMapper {
 func makeTestOdhDashboardConfig(namespace string) *unstructured.Unstructured {
 	cfg := &unstructured.Unstructured{}
 	cfg.SetGroupVersionKind(odhDashboardConfigGVK)
-	cfg.SetName("odh-dashboard-config")
+	cfg.SetName(odhDashboardConfigName)
 	cfg.SetNamespace(namespace)
 
 	_ = unstructured.SetNestedSlice(cfg.Object, []any{
@@ -169,7 +169,7 @@ func makeISVCFakeClient(objects ...client.Object) client.Client {
 // shortCtx returns a context that expires quickly to bound retries in
 // cluster.CustomResourceDefinitionExists when the CRD is absent.
 func shortCtx() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), 50*time.Millisecond)
+	return context.WithTimeout(context.Background(), 500*time.Millisecond)
 }
 
 // CRD names derived from GVKs via the formula used in cluster.CustomResourceDefinitionExists.
@@ -412,7 +412,7 @@ func TestGetOdhDashboardConfig(t *testing.T) {
 		g.Expect(err).NotTo(HaveOccurred())
 		g.Expect(found).To(BeTrue())
 		g.Expect(result).NotTo(BeNil())
-		g.Expect(result.GetName()).To(Equal("odh-dashboard-config"))
+		g.Expect(result.GetName()).To(Equal(odhDashboardConfigName))
 		g.Expect(result.GetNamespace()).To(Equal(namespace))
 	})
 
@@ -802,7 +802,7 @@ func TestGetContainerSizes(t *testing.T) {
 
 		cfg := &unstructured.Unstructured{}
 		cfg.SetGroupVersionKind(odhDashboardConfigGVK)
-		cfg.SetName("odh-dashboard-config")
+		cfg.SetName(odhDashboardConfigName)
 		cfg.SetNamespace("test-namespace")
 		_ = unstructured.SetNestedMap(cfg.Object, map[string]any{}, "spec")
 
@@ -816,7 +816,7 @@ func TestGetContainerSizes(t *testing.T) {
 
 		cfg := &unstructured.Unstructured{}
 		cfg.SetGroupVersionKind(odhDashboardConfigGVK)
-		cfg.SetName("odh-dashboard-config")
+		cfg.SetName(odhDashboardConfigName)
 		cfg.SetNamespace("test-namespace")
 		_ = unstructured.SetNestedSlice(cfg.Object, []any{
 			// Malformed: resources is a string, not a map — quantity fields end up empty and fail
@@ -843,7 +843,7 @@ func TestGetContainerSizes(t *testing.T) {
 
 		cfg := &unstructured.Unstructured{}
 		cfg.SetGroupVersionKind(odhDashboardConfigGVK)
-		cfg.SetName("odh-dashboard-config")
+		cfg.SetName(odhDashboardConfigName)
 		cfg.SetNamespace("test-namespace")
 		_ = unstructured.SetNestedSlice(cfg.Object, []any{
 			// Invalid quantity string in a structurally valid entry — skipped with a warning log.


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves the HardwareProfile annotation migration for InferenceServices from
opendatahub-operator into kserve-module so the module owns its own upgrade
lifecycle.

The migration runs once on leader startup. Errors are accumulated and logged
without blocking the remaining ISVCs or manager startup.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

https://redhat.atlassian.net/browse/RHOAIENG-63833


**Feature/Issue validation/testing**:

TODO


**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a startup, leader-election migration that assigns InferenceService hardware-profile annotations using ServingRuntime accelerator profile and dashboard resource-size matching.
  * Skips unsupported updates for serverless and Kueue-managed namespaces and emits warning events when assignment is skipped or can’t be completed.
* **Bug Fixes**
  * Continues migrating other InferenceServices even if individual annotation/patch operations fail, aggregating errors.
* **Chores**
  * Extended RBAC permissions and registered the migration runnable at startup.
* **Tests**
  * Added a comprehensive migration test suite covering CRD/preflight behavior, sizing logic, skip rules, and event emission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->