### PR TITLE
fix(ci): do not apply upstream manifests for llmisvc

### DIFF
--- a/test/scripts/openshift-ci/deploy.kserve-manual.sh
+++ b/test/scripts/openshift-ci/deploy.kserve-manual.sh
@@ -83,6 +83,9 @@ sed -i "s|kserve-agent=.*|kserve-agent=${KSERVE_AGENT_IMAGE}|" "${PARAMS_ENV}"
 sed -i "s|kserve-router=.*|kserve-router=${KSERVE_ROUTER_IMAGE}|" "${PARAMS_ENV}"
 sed -i "s|kserve-storage-initializer=.*|kserve-storage-initializer=${STORAGE_INITIALIZER_IMAGE}|" "${PARAMS_ENV}"
 
+echo "=== Final params.env"
+cat "${PARAMS_ENV}"
+
 ODH_MANIFESTS=$(kustomize build "${PROJECT_ROOT}/config/overlays/odh-test")
 
 # Apply CRDs first and wait for them to be established before applying the rest
@@ -102,15 +105,10 @@ echo "${ODH_MANIFESTS}" | oc apply --server-side=true --force-conflicts -f - || 
 echo "Waiting for llmisvc-controller-manager to be ready..."
 wait_for_pod_ready "${KSERVE_NAMESPACE}" "control-plane=llmisvc-controller-manager" 600s
 
-# Re-apply LLMInferenceServiceConfig resources now that webhook is ready
-echo "Re-applying LLMInferenceServiceConfig resources with webhook validation..."
-kustomize build "${PROJECT_ROOT}/config/llmisvcconfig" | oc apply --server-side=true --force-conflicts -f -
-
-if [[ "${1:-}" =~ "llm-d" ]]; then
-  echo "Restarting llmisvc-controller to apply configuration changes"
-  oc delete pod -n "${KSERVE_NAMESPACE}" -l control-plane=llmisvc-controller-manager
-  wait_for_pod_ready "${KSERVE_NAMESPACE}" "control-plane=llmisvc-controller-manager" 300s
-fi
+# We cannot apply individual overlays with `kustomize build "${PROJECT_ROOT}/config/llmisvcconfig"` because it will
+# override ODH images that are only injected for the odh overlay.
+echo "Re-Applying all resources..."
+echo "${ODH_MANIFESTS}" | oc apply --server-side=true --force-conflicts -f -
 
 echo "Applying DSC/DSCI resources..."
 oc apply -f "${PROJECT_ROOT}/config/overlays/odh-test/dsci.yaml"


### PR DESCRIPTION
I'm seeing this image in CI manifests, while CI should use midstream images (params.env)
```
    image: ghcr.io/llm-d/llm-d-router-endpoint-picker:v0.9.0-rc.2
```
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/opendatahub-io_kserve/1680/pull-ci-opendatahub-io-kserve-master-e2e-llm-inference-service/2071383782031626240/artifacts/e2e-llm-inference-service/kserve-must-gather/artifacts/gather-kserve/quay-io-modh-must-gather-sha256-413dd7e38522873c8c0839832d818bbcc384b80d559001d0fc4adfbf6cff2a2b/namespaces/kserve-ci-e2e-test/pods/scheduler-v06-pd-migration-test-kserve-router-scheduler-8cwtwzb/scheduler-v06-pd-migration-test-kserve-router-scheduler-8cwtwzb.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment flow by re-applying the full set of generated resources after CRD updates, which should make setup more reliable.
  * Added clearer output showing the final rendered configuration after image overrides are applied, making it easier to verify the applied values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->