### PR TITLE
fix(e2e): use parametersRef ConfigMap for gateway 2Gi memory

### DIFF
--- a/test/e2e/common/gateway_proxy.py
+++ b/test/e2e/common/gateway_proxy.py
@@ -1,0 +1,124 @@
+# Copyright 2025 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Gateway proxy resource tuning for e2e tests.
+
+When GATEWAY_PROXY_MEMORY is set, creates a gateway-implementation-specific
+resource and injects parametersRef into Gateway specs so the proxy gets
+the requested memory limits.
+
+Default backend: Envoy Gateway (EnvoyProxy CR).
+Alternative backends can be swapped in via set_backend() from a
+pytest plugin's pytest_configure hook.
+"""
+
+import logging
+import os
+
+from kubernetes import client
+
+logger = logging.getLogger(__name__)
+
+GATEWAY_PROXY_MEMORY = os.environ.get("GATEWAY_PROXY_MEMORY")
+
+_RESOURCE_NAME = "gateway-proxy-config"
+
+_ENVOY_PROXY_GROUP = "gateway.envoyproxy.io"
+_ENVOY_PROXY_VERSION = "v1alpha1"
+_ENVOY_PROXY_PLURAL = "envoyproxies"
+
+
+class _EnvoyGatewayBackend:
+
+    def ensure(self, namespace, api_client):
+        custom_api = client.CustomObjectsApi(api_client)
+        body = {
+            "apiVersion": f"{_ENVOY_PROXY_GROUP}/{_ENVOY_PROXY_VERSION}",
+            "kind": "EnvoyProxy",
+            "metadata": {"name": _RESOURCE_NAME, "namespace": namespace},
+            "spec": {
+                "provider": {
+                    "type": "Kubernetes",
+                    "kubernetes": {
+                        "envoyDeployment": {
+                            "container": {
+                                "resources": {
+                                    "limits": {
+                                        "memory": GATEWAY_PROXY_MEMORY,
+                                    },
+                                    "requests": {"memory": "256Mi"},
+                                }
+                            }
+                        }
+                    },
+                }
+            },
+        }
+        try:
+            custom_api.get_namespaced_custom_object(
+                _ENVOY_PROXY_GROUP,
+                _ENVOY_PROXY_VERSION,
+                namespace,
+                _ENVOY_PROXY_PLURAL,
+                _RESOURCE_NAME,
+            )
+            custom_api.replace_namespaced_custom_object(
+                _ENVOY_PROXY_GROUP,
+                _ENVOY_PROXY_VERSION,
+                namespace,
+                _ENVOY_PROXY_PLURAL,
+                _RESOURCE_NAME,
+                body,
+            )
+            logger.info("Updated EnvoyProxy %s", _RESOURCE_NAME)
+        except client.rest.ApiException as e:
+            if e.status == 404:
+                custom_api.create_namespaced_custom_object(
+                    _ENVOY_PROXY_GROUP,
+                    _ENVOY_PROXY_VERSION,
+                    namespace,
+                    _ENVOY_PROXY_PLURAL,
+                    body,
+                )
+                logger.info("Created EnvoyProxy %s", _RESOURCE_NAME)
+            else:
+                raise
+
+    def parameters_ref(self):
+        return {
+            "group": _ENVOY_PROXY_GROUP,
+            "kind": "EnvoyProxy",
+            "name": _RESOURCE_NAME,
+        }
+
+
+_backend = _EnvoyGatewayBackend()
+
+
+def set_backend(backend):
+    """Replace the default backend. Call from pytest_configure in a plugin."""
+    global _backend
+    _backend = backend
+
+
+def ensure_proxy_resource(namespace, api_client):
+    """Create or update the proxy resource for the active backend."""
+    _backend.ensure(namespace, api_client)
+
+
+def inject_proxy_params(gateway):
+    """Inject parametersRef into a gateway spec for proxy memory override."""
+    gateway.setdefault("spec", {}).setdefault("infrastructure", {})[
+        "parametersRef"
+    ] = _backend.parameters_ref()

--- a/test/e2e/common/gateway_proxy_istio.py
+++ b/test/e2e/common/gateway_proxy_istio.py
@@ -1,0 +1,94 @@
+# Copyright 2025 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Istio backend for gateway proxy resource tuning.
+
+Pytest plugin -- activate via ``-p common.gateway_proxy_istio``.
+Creates a ConfigMap with an Istio deployment strategic merge patch
+and points parametersRef at it.
+"""
+
+import logging
+
+import yaml
+from kubernetes import client
+
+from .gateway_proxy import (
+    GATEWAY_PROXY_MEMORY,
+    _RESOURCE_NAME,
+    set_backend,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class _IstioBackend:
+
+    def ensure(self, namespace, api_client):
+        core_api = client.CoreV1Api(api_client)
+        patch = {
+            "spec": {
+                "template": {
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "istio-proxy",
+                                "resources": {
+                                    "limits": {
+                                        "memory": GATEWAY_PROXY_MEMORY,
+                                    },
+                                    "requests": {"memory": "256Mi"},
+                                },
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        data = {
+            "deployment": yaml.dump(patch, default_flow_style=False),
+        }
+        try:
+            existing = core_api.read_namespaced_config_map(
+                _RESOURCE_NAME, namespace
+            )
+            existing.data = data
+            core_api.replace_namespaced_config_map(
+                _RESOURCE_NAME, namespace, existing
+            )
+            logger.info("Updated ConfigMap %s", _RESOURCE_NAME)
+        except client.rest.ApiException as e:
+            if e.status == 404:
+                body = client.V1ConfigMap(
+                    metadata=client.V1ObjectMeta(
+                        name=_RESOURCE_NAME,
+                        namespace=namespace,
+                    ),
+                    data=data,
+                )
+                core_api.create_namespaced_config_map(namespace, body)
+                logger.info("Created ConfigMap %s", _RESOURCE_NAME)
+            else:
+                raise
+
+    def parameters_ref(self):
+        return {
+            "group": "",
+            "kind": "ConfigMap",
+            "name": _RESOURCE_NAME,
+        }
+
+
+def pytest_configure(config):
+    set_backend(_IstioBackend())

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -1571,9 +1571,13 @@ def _ensure_gateway_proxy_configmap(namespace):
     }
     data = {"deployment": yaml.dump(patch, default_flow_style=False)}
     try:
-        existing = core_api.read_namespaced_config_map(_GATEWAY_PROXY_CONFIG_NAME, namespace)
+        existing = core_api.read_namespaced_config_map(
+            _GATEWAY_PROXY_CONFIG_NAME, namespace
+        )
         existing.data = data
-        core_api.replace_namespaced_config_map(_GATEWAY_PROXY_CONFIG_NAME, namespace, existing)
+        core_api.replace_namespaced_config_map(
+            _GATEWAY_PROXY_CONFIG_NAME, namespace, existing
+        )
         logger.info(f"✓ Updated ConfigMap {_GATEWAY_PROXY_CONFIG_NAME}")
     except client.rest.ApiException as e:
         if e.status == 404:

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -1549,9 +1549,9 @@ GATEWAY_PROXY_MEMORY = os.environ.get("GATEWAY_PROXY_MEMORY")
 _GATEWAY_PROXY_CONFIG_NAME = "gateway-proxy-config"
 
 
-def _ensure_gateway_proxy_configmap(namespace):
+def _ensure_gateway_proxy_configmap(namespace, kserve_client):
     """Create or update the gateway proxy ConfigMap for parametersRef."""
-    core_api = client.CoreV1Api(client.ApiClient())
+    core_api = client.CoreV1Api(kserve_client.api_instance.api_client)
     patch = {
         "spec": {
             "template": {
@@ -1616,7 +1616,7 @@ def create_router_resources(gateways, routes=None, kserve_client=None):
 
     if GATEWAY_PROXY_MEMORY:
         ns = gateways[0]["metadata"]["namespace"] if gateways else KSERVE_TEST_NAMESPACE
-        _ensure_gateway_proxy_configmap(ns)
+        _ensure_gateway_proxy_configmap(ns, kserve_client)
         for gw in gateways:
             _inject_gateway_proxy_params(gw)
 

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -17,6 +17,8 @@ import os
 import re
 import time
 
+import yaml
+
 import pytest
 from ..common.gw_api import (
     create_or_update_gateway,
@@ -1542,29 +1544,59 @@ def generate_test_id(test_case) -> str:
     return "-".join(test_case.base_refs)
 
 
-def _ensure_configmap(kserve_client, cm):
-    """Create or update a ConfigMap."""
+GATEWAY_PROXY_MEMORY = os.environ.get("GATEWAY_PROXY_MEMORY")
+
+_GATEWAY_PROXY_CONFIG_NAME = "gateway-proxy-config"
+
+
+def _ensure_gateway_proxy_configmap(namespace):
+    """Create or update the gateway proxy ConfigMap for parametersRef."""
     core_api = client.CoreV1Api(client.ApiClient())
-    name = cm["metadata"]["name"]
-    ns = cm["metadata"]["namespace"]
+    patch = {
+        "spec": {
+            "template": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "istio-proxy",
+                            "resources": {
+                                "limits": {"memory": GATEWAY_PROXY_MEMORY},
+                                "requests": {"memory": "256Mi"},
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    data = {"deployment": yaml.dump(patch, default_flow_style=False)}
     try:
-        existing = core_api.read_namespaced_config_map(name, ns)
-        existing.data = cm.get("data", {})
-        core_api.replace_namespaced_config_map(name, ns, existing)
-        logger.info(f"✓ Updated ConfigMap {name}")
+        existing = core_api.read_namespaced_config_map(_GATEWAY_PROXY_CONFIG_NAME, namespace)
+        existing.data = data
+        core_api.replace_namespaced_config_map(_GATEWAY_PROXY_CONFIG_NAME, namespace, existing)
+        logger.info(f"✓ Updated ConfigMap {_GATEWAY_PROXY_CONFIG_NAME}")
     except client.rest.ApiException as e:
         if e.status == 404:
             body = client.V1ConfigMap(
                 metadata=client.V1ObjectMeta(
-                    name=name,
-                    namespace=ns,
+                    name=_GATEWAY_PROXY_CONFIG_NAME,
+                    namespace=namespace,
                 ),
-                data=cm.get("data", {}),
+                data=data,
             )
-            core_api.create_namespaced_config_map(ns, body)
-            logger.info(f"✓ Created ConfigMap {name}")
+            core_api.create_namespaced_config_map(namespace, body)
+            logger.info(f"✓ Created ConfigMap {_GATEWAY_PROXY_CONFIG_NAME}")
         else:
             raise
+
+
+def _inject_gateway_proxy_params(gateway):
+    """Inject parametersRef into a gateway spec for proxy memory override."""
+    gateway.setdefault("spec", {}).setdefault("infrastructure", {})["parametersRef"] = {
+        "group": "",
+        "kind": "ConfigMap",
+        "name": _GATEWAY_PROXY_CONFIG_NAME,
+    }
 
 
 def create_router_resources(gateways, routes=None, kserve_client=None):
@@ -1573,14 +1605,16 @@ def create_router_resources(gateways, routes=None, kserve_client=None):
     The create_or_update functions are idempotent, so multiple tests creating the same
     resource will not cause errors.
     """
-    from .test_resources import GATEWAY_PROXY_CONFIG
-
     if not kserve_client:
         kserve_client = KServeClient(
             config_file=os.environ.get("KUBECONFIG", "~/.kube/config")
         )
 
-    _ensure_configmap(kserve_client, GATEWAY_PROXY_CONFIG)
+    if GATEWAY_PROXY_MEMORY:
+        ns = gateways[0]["metadata"]["namespace"] if gateways else KSERVE_TEST_NAMESPACE
+        _ensure_gateway_proxy_configmap(ns)
+        for gw in gateways:
+            _inject_gateway_proxy_params(gw)
 
     for gateway in gateways:
         gateway_name = gateway.get("metadata", {}).get("name", "unknown")

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -17,9 +17,12 @@ import os
 import re
 import time
 
-import yaml
-
 import pytest
+from ..common.gateway_proxy import (
+    GATEWAY_PROXY_MEMORY,
+    ensure_proxy_resource,
+    inject_proxy_params,
+)
 from ..common.gw_api import (
     create_or_update_gateway,
     create_or_update_route,
@@ -1544,65 +1547,6 @@ def generate_test_id(test_case) -> str:
     return "-".join(test_case.base_refs)
 
 
-GATEWAY_PROXY_MEMORY = os.environ.get("GATEWAY_PROXY_MEMORY")
-
-_GATEWAY_PROXY_CONFIG_NAME = "gateway-proxy-config"
-
-
-def _ensure_gateway_proxy_configmap(namespace, kserve_client):
-    """Create or update the gateway proxy ConfigMap for parametersRef."""
-    core_api = client.CoreV1Api(kserve_client.api_instance.api_client)
-    patch = {
-        "spec": {
-            "template": {
-                "spec": {
-                    "containers": [
-                        {
-                            "name": "istio-proxy",
-                            "resources": {
-                                "limits": {"memory": GATEWAY_PROXY_MEMORY},
-                                "requests": {"memory": "256Mi"},
-                            },
-                        }
-                    ]
-                }
-            }
-        }
-    }
-    data = {"deployment": yaml.dump(patch, default_flow_style=False)}
-    try:
-        existing = core_api.read_namespaced_config_map(
-            _GATEWAY_PROXY_CONFIG_NAME, namespace
-        )
-        existing.data = data
-        core_api.replace_namespaced_config_map(
-            _GATEWAY_PROXY_CONFIG_NAME, namespace, existing
-        )
-        logger.info(f"✓ Updated ConfigMap {_GATEWAY_PROXY_CONFIG_NAME}")
-    except client.rest.ApiException as e:
-        if e.status == 404:
-            body = client.V1ConfigMap(
-                metadata=client.V1ObjectMeta(
-                    name=_GATEWAY_PROXY_CONFIG_NAME,
-                    namespace=namespace,
-                ),
-                data=data,
-            )
-            core_api.create_namespaced_config_map(namespace, body)
-            logger.info(f"✓ Created ConfigMap {_GATEWAY_PROXY_CONFIG_NAME}")
-        else:
-            raise
-
-
-def _inject_gateway_proxy_params(gateway):
-    """Inject parametersRef into a gateway spec for proxy memory override."""
-    gateway.setdefault("spec", {}).setdefault("infrastructure", {})["parametersRef"] = {
-        "group": "",
-        "kind": "ConfigMap",
-        "name": _GATEWAY_PROXY_CONFIG_NAME,
-    }
-
-
 def create_router_resources(gateways, routes=None, kserve_client=None):
     """Create router resources (gateways and routes). These resources are shared and not deleted.
 
@@ -1616,9 +1560,9 @@ def create_router_resources(gateways, routes=None, kserve_client=None):
 
     if GATEWAY_PROXY_MEMORY:
         ns = gateways[0]["metadata"]["namespace"] if gateways else KSERVE_TEST_NAMESPACE
-        _ensure_gateway_proxy_configmap(ns, kserve_client)
+        ensure_proxy_resource(ns, kserve_client.api_instance.api_client)
         for gw in gateways:
-            _inject_gateway_proxy_params(gw)
+            inject_proxy_params(gw)
 
     for gateway in gateways:
         gateway_name = gateway.get("metadata", {}).get("name", "unknown")

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -1542,16 +1542,45 @@ def generate_test_id(test_case) -> str:
     return "-".join(test_case.base_refs)
 
 
+def _ensure_configmap(kserve_client, cm):
+    """Create or update a ConfigMap."""
+    core_api = client.CoreV1Api(client.ApiClient())
+    name = cm["metadata"]["name"]
+    ns = cm["metadata"]["namespace"]
+    try:
+        existing = core_api.read_namespaced_config_map(name, ns)
+        existing.data = cm.get("data", {})
+        core_api.replace_namespaced_config_map(name, ns, existing)
+        logger.info(f"✓ Updated ConfigMap {name}")
+    except client.rest.ApiException as e:
+        if e.status == 404:
+            body = client.V1ConfigMap(
+                metadata=client.V1ObjectMeta(
+                    name=name,
+                    namespace=ns,
+                ),
+                data=cm.get("data", {}),
+            )
+            core_api.create_namespaced_config_map(ns, body)
+            logger.info(f"✓ Created ConfigMap {name}")
+        else:
+            raise
+
+
 def create_router_resources(gateways, routes=None, kserve_client=None):
     """Create router resources (gateways and routes). These resources are shared and not deleted.
 
     The create_or_update functions are idempotent, so multiple tests creating the same
     resource will not cause errors.
     """
+    from .test_resources import GATEWAY_PROXY_CONFIG
+
     if not kserve_client:
         kserve_client = KServeClient(
             config_file=os.environ.get("KUBECONFIG", "~/.kube/config")
         )
+
+    _ensure_configmap(kserve_client, GATEWAY_PROXY_CONFIG)
 
     for gateway in gateways:
         gateway_name = gateway.get("metadata", {}).get("name", "unknown")

--- a/test/e2e/llmisvc/test_resources.py
+++ b/test/e2e/llmisvc/test_resources.py
@@ -19,6 +19,39 @@ from .fixtures import KSERVE_TEST_NAMESPACE, INFERENCE_POOL_GROUP
 # GatewayClass name - can be overridden via GATEWAY_CLASS_NAME env var (e.g., "istio")
 GATEWAY_CLASS_NAME = os.environ.get("GATEWAY_CLASS_NAME", "envoy")
 
+GATEWAY_PROXY_CONFIG_NAME = "gateway-proxy-config"
+
+GATEWAY_PROXY_CONFIG = {
+    "apiVersion": "v1",
+    "kind": "ConfigMap",
+    "metadata": {
+        "name": GATEWAY_PROXY_CONFIG_NAME,
+        "namespace": KSERVE_TEST_NAMESPACE,
+    },
+    "data": {
+        "deployment": (
+            "spec:\n"
+            "  template:\n"
+            "    spec:\n"
+            "      containers:\n"
+            "      - name: istio-proxy\n"
+            "        resources:\n"
+            "          limits:\n"
+            "            memory: 2Gi\n"
+            "          requests:\n"
+            "            memory: 256Mi\n"
+        ),
+    },
+}
+
+_GATEWAY_PARAMS_REF = {
+    "parametersRef": {
+        "group": "",
+        "kind": "ConfigMap",
+        "name": GATEWAY_PROXY_CONFIG_NAME,
+    },
+}
+
 ROUTER_GATEWAYS = [
     {
         "apiVersion": "gateway.networking.k8s.io/v1",
@@ -29,6 +62,7 @@ ROUTER_GATEWAYS = [
         },
         "spec": {
             "gatewayClassName": GATEWAY_CLASS_NAME,
+            "infrastructure": _GATEWAY_PARAMS_REF,
             "listeners": [
                 {
                     "name": "http",
@@ -52,6 +86,7 @@ ROUTER_GATEWAYS = [
         },
         "spec": {
             "gatewayClassName": GATEWAY_CLASS_NAME,
+            "infrastructure": _GATEWAY_PARAMS_REF,
             "listeners": [
                 {
                     "name": "http",

--- a/test/e2e/llmisvc/test_resources.py
+++ b/test/e2e/llmisvc/test_resources.py
@@ -19,39 +19,6 @@ from .fixtures import KSERVE_TEST_NAMESPACE, INFERENCE_POOL_GROUP
 # GatewayClass name - can be overridden via GATEWAY_CLASS_NAME env var (e.g., "istio")
 GATEWAY_CLASS_NAME = os.environ.get("GATEWAY_CLASS_NAME", "envoy")
 
-GATEWAY_PROXY_CONFIG_NAME = "gateway-proxy-config"
-
-GATEWAY_PROXY_CONFIG = {
-    "apiVersion": "v1",
-    "kind": "ConfigMap",
-    "metadata": {
-        "name": GATEWAY_PROXY_CONFIG_NAME,
-        "namespace": KSERVE_TEST_NAMESPACE,
-    },
-    "data": {
-        "deployment": (
-            "spec:\n"
-            "  template:\n"
-            "    spec:\n"
-            "      containers:\n"
-            "      - name: istio-proxy\n"
-            "        resources:\n"
-            "          limits:\n"
-            "            memory: 2Gi\n"
-            "          requests:\n"
-            "            memory: 256Mi\n"
-        ),
-    },
-}
-
-_GATEWAY_PARAMS_REF = {
-    "parametersRef": {
-        "group": "",
-        "kind": "ConfigMap",
-        "name": GATEWAY_PROXY_CONFIG_NAME,
-    },
-}
-
 ROUTER_GATEWAYS = [
     {
         "apiVersion": "gateway.networking.k8s.io/v1",
@@ -62,7 +29,6 @@ ROUTER_GATEWAYS = [
         },
         "spec": {
             "gatewayClassName": GATEWAY_CLASS_NAME,
-            "infrastructure": _GATEWAY_PARAMS_REF,
             "listeners": [
                 {
                     "name": "http",
@@ -86,7 +52,6 @@ ROUTER_GATEWAYS = [
         },
         "spec": {
             "gatewayClassName": GATEWAY_CLASS_NAME,
-            "infrastructure": _GATEWAY_PARAMS_REF,
             "listeners": [
                 {
                     "name": "http",

--- a/test/scripts/openshift-ci/infra/deploy.gateway.ingress.sh
+++ b/test/scripts/openshift-ci/infra/deploy.gateway.ingress.sh
@@ -31,6 +31,27 @@ echo "⏳ Creating a Gateway"
 INGRESS_NS=openshift-ingress
 oc create namespace ${INGRESS_NS} || true
 
+echo "⏳ Creating gateway memory ConfigMap for parametersRef"
+oc apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gateway-proxy-config
+  namespace: ${INGRESS_NS}
+data:
+  deployment: |
+    spec:
+      template:
+        spec:
+          containers:
+          - name: istio-proxy
+            resources:
+              limits:
+                memory: 2Gi
+              requests:
+                memory: 256Mi
+EOF
+
 oc apply -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -47,6 +68,10 @@ spec:
        namespaces:
          from: All
   infrastructure:
+    parametersRef:
+      group: ""
+      kind: ConfigMap
+      name: gateway-proxy-config
     labels:
       serving.kserve.io/gateway: kserve-ingress-gateway
 EOF

--- a/test/scripts/openshift-ci/infra/deploy.gateway.ingress.sh
+++ b/test/scripts/openshift-ci/infra/deploy.gateway.ingress.sh
@@ -31,8 +31,9 @@ echo "⏳ Creating a Gateway"
 INGRESS_NS=openshift-ingress
 oc create namespace ${INGRESS_NS} || true
 
-echo "⏳ Creating gateway memory ConfigMap for parametersRef"
-oc apply -f - <<EOF
+if [[ -n "${GATEWAY_PROXY_MEMORY:-}" ]]; then
+  echo "⏳ Creating gateway memory ConfigMap for parametersRef (${GATEWAY_PROXY_MEMORY})"
+  oc apply -f - <<EOF
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -47,10 +48,11 @@ data:
           - name: istio-proxy
             resources:
               limits:
-                memory: 2Gi
+                memory: ${GATEWAY_PROXY_MEMORY}
               requests:
                 memory: 256Mi
 EOF
+fi
 
 oc apply -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
@@ -67,6 +69,7 @@ spec:
      allowedRoutes:
        namespaces:
          from: All
+$(if [[ -n "${GATEWAY_PROXY_MEMORY:-}" ]]; then cat <<INFRA
   infrastructure:
     parametersRef:
       group: ""
@@ -74,6 +77,13 @@ spec:
       name: gateway-proxy-config
     labels:
       serving.kserve.io/gateway: kserve-ingress-gateway
+INFRA
+else cat <<INFRA
+  infrastructure:
+    labels:
+      serving.kserve.io/gateway: kserve-ingress-gateway
+INFRA
+fi)
 EOF
 
 wait_for_pod_ready "openshift-ingress" "serving.kserve.io/gateway=kserve-ingress-gateway"

--- a/test/scripts/openshift-ci/run-e2e-tests.sh
+++ b/test/scripts/openshift-ci/run-e2e-tests.sh
@@ -42,6 +42,7 @@ esac
 export GATEWAY_CLASS_NAME=${GATEWAY_CLASS_NAME:-"openshift-default"}
 export GATEWAY_PROXY_MEMORY="${GATEWAY_PROXY_MEMORY:-2Gi}"
 export INFERENCE_POOL_GROUP="${INFERENCE_POOL_GROUP:-inference.networking.k8s.io}"
+export PYTEST_ARGS="${PYTEST_ARGS:-} -p common.gateway_proxy_istio"
 export RUN_AS_NON_ROOT="${RUN_AS_NON_ROOT:-true}"
 export KUBE_CLI=${KUBE_CLI_COMMAND:-oc}
 

--- a/test/scripts/openshift-ci/run-e2e-tests.sh
+++ b/test/scripts/openshift-ci/run-e2e-tests.sh
@@ -40,6 +40,7 @@ case "${DEPLOYMENT_PROFILE}" in
 esac
 
 export GATEWAY_CLASS_NAME=${GATEWAY_CLASS_NAME:-"openshift-default"}
+export GATEWAY_PROXY_MEMORY="${GATEWAY_PROXY_MEMORY:-2Gi}"
 export INFERENCE_POOL_GROUP="${INFERENCE_POOL_GROUP:-inference.networking.k8s.io}"
 export RUN_AS_NON_ROOT="${RUN_AS_NON_ROOT:-true}"
 export KUBE_CLI=${KUBE_CLI_COMMAND:-oc}


### PR DESCRIPTION
## Summary
- Gateway proxy (istio-proxy) enters CrashLoopBackOff during e2e-llmisvc runs without increased memory limits
- Use Istio 1.26's Gateway API `parametersRef` to set proxy memory to 2Gi via a ConfigMap with strategic merge patch
- This is the controller-native mechanism -- the gateway controller reads `parametersRef` during its own reconciliation, so resource limits survive controller reconciliation (unlike direct Deployment patches or sidecar annotations)
- Applied to all 3 gateways: `openshift-ai-inference`, `router-gateway-1`, `router-gateway-2`

## Evidence
Verified via revert experiment on PR #1680:
- **With fix**: inference-gw had 2 early restarts, stable for entire run. 40/42 tests passed.
- **Without fix (reverted)**: inference-gw hit **16 restarts**, CrashLoopBackOff for 75+ minutes, never recovered. 34/42 passed (6 failed + 1 error from gateway unavailability).

Gateway diagnostics captured by the Envoy memory monitor in `conftest.py`.

## Test plan
- [ ] Konflux `kserve-group-test` passes without gateway CrashLoopBackOff
- [ ] Gateway memory stays under 2Gi limit throughout run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional gateway proxy memory tuning for end-to-end test runs via `GATEWAY_PROXY_MEMORY`.
  * Gateways now reference a shared configuration source for `istio-proxy` memory limits/requests when tuning is enabled.
* **Bug Fixes**
  * Improved reliability by automatically creating or updating the shared configuration when it’s missing.
* **Chores**
  * Updated the OpenShift E2E test runner to set `GATEWAY_PROXY_MEMORY` by default to `2Gi` for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->