### PR TITLE
fix(e2e): default INFERENCE_POOL_GROUP to GA API group

### DIFF
--- a/test/scripts/openshift-ci/run-e2e-tests.sh
+++ b/test/scripts/openshift-ci/run-e2e-tests.sh
@@ -40,7 +40,7 @@ case "${DEPLOYMENT_PROFILE}" in
 esac
 
 export GATEWAY_CLASS_NAME=${GATEWAY_CLASS_NAME:-"openshift-default"}
-export INFERENCE_POOL_GROUP="${INFERENCE_POOL_GROUP:-inference.networking.x-k8s.io}"
+export INFERENCE_POOL_GROUP="${INFERENCE_POOL_GROUP:-inference.networking.k8s.io}"
 export RUN_AS_NON_ROOT="${RUN_AS_NON_ROOT:-true}"
 export KUBE_CLI=${KUBE_CLI_COMMAND:-oc}
 


### PR DESCRIPTION
## Summary
- `run-e2e-tests.sh:43` defaults `INFERENCE_POOL_GROUP` to `inference.networking.x-k8s.io` (experimental)
- On OCP 4.21+ (Konflux clusters), `setup-kserve.sh` correctly skips setting the var, but `run-e2e-tests.sh` overrides with the experimental fallback
- Istio rejects `x-k8s.io` as `InvalidKind` for backendRef on 4.21 -- managed routes survive via controller auto-migration, but external ref routes (`router-with-refs`) do not
- Change default to `inference.networking.k8s.io` (GA). OCP ≤4.20 is unaffected: `setup-kserve.sh` explicitly exports `x-k8s.io` before the fallback is read

## Evidence
Verified on PR #1680:
- **Before fix**: 2/42 Konflux tests failed (`router-with-refs-*`) with `InvalidKind: referencing unsupported backendRef: group "inference.networking.x-k8s.io" kind "InferencePool"`
- **After fix**: 0/42 `router-with-refs` failures. Both tests pass.

Full root cause analysis: [EVIDENCE-1680-KONFLUX-INFERENCEPOOL.md](https://github.com/opendatahub-io/kserve/blob/flakiness-resolution-2026-06-27/EVIDENCE-1680-KONFLUX-INFERENCEPOOL.md)

## Test plan
- [ ] Konflux `kserve-group-test` passes `router-with-refs` tests
- [ ] Prow e2e-llm-inference-service unaffected (setup-kserve.sh sets var explicitly on OCP ≤4.20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default inference pool group used by end-to-end test runs to the newer `inference.networking.k8s.io` value.
  * Existing environment overrides still take precedence, so custom configurations continue to work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->