### PR TITLE
feat(e2e): add Envoy memory monitor for gateway diagnostics

### DIFF
--- a/test/e2e/common/gateway_proxy_istio.py
+++ b/test/e2e/common/gateway_proxy_istio.py
@@ -76,28 +76,18 @@ def _ensure_configmap(namespace, api_client):
     }
     data = {"deployment": yaml.dump(patch, default_flow_style=False)}
     try:
-        existing = core_api.read_namespaced_config_map(
-            _RESOURCE_NAME, namespace
-        )
+        existing = core_api.read_namespaced_config_map(_RESOURCE_NAME, namespace)
         existing.data = data
-        core_api.replace_namespaced_config_map(
-            _RESOURCE_NAME, namespace, existing
-        )
-        logger.info(
-            "Updated ConfigMap %s/%s", namespace, _RESOURCE_NAME
-        )
+        core_api.replace_namespaced_config_map(_RESOURCE_NAME, namespace, existing)
+        logger.info("Updated ConfigMap %s/%s", namespace, _RESOURCE_NAME)
     except client.rest.ApiException as e:
         if e.status == 404:
             body = client.V1ConfigMap(
-                metadata=client.V1ObjectMeta(
-                    name=_RESOURCE_NAME, namespace=namespace
-                ),
+                metadata=client.V1ObjectMeta(name=_RESOURCE_NAME, namespace=namespace),
                 data=data,
             )
             try:
-                core_api.create_namespaced_config_map(
-                    namespace, body
-                )
+                core_api.create_namespaced_config_map(namespace, body)
                 logger.info(
                     "Created ConfigMap %s/%s",
                     namespace,
@@ -243,13 +233,17 @@ def _run_cli(cli, args, timeout=15):
     except subprocess.TimeoutExpired:
         logger.debug(
             "CLI timeout after %ds: %s %s",
-            timeout, cli, " ".join(args[:3]),
+            timeout,
+            cli,
+            " ".join(args[:3]),
         )
         return None
     except Exception as e:
         logger.debug(
             "CLI failed (%s): %s %s",
-            type(e).__name__, cli, " ".join(args[:3]),
+            type(e).__name__,
+            cli,
+            " ".join(args[:3]),
         )
         return None
 
@@ -492,8 +486,7 @@ def gateway_diagnostics_monitor(request):
     )
     thread.start()
     logger.info(
-        "Gateway diagnostics started "
-        "(interval=%ds, cli=%s, output=%s)",
+        "Gateway diagnostics started (interval=%ds, cli=%s, output=%s)",
         _SNAPSHOT_INTERVAL,
         cli,
         out_path,
@@ -505,6 +498,5 @@ def gateway_diagnostics_monitor(request):
     thread.join(timeout=30)
     if thread.is_alive():
         logger.warning(
-            "Monitor thread did not stop within 30s;"
-            " final snapshot may be missing"
+            "Monitor thread did not stop within 30s; final snapshot may be missing"
         )

--- a/test/e2e/common/gateway_proxy_istio.py
+++ b/test/e2e/common/gateway_proxy_istio.py
@@ -12,18 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Istio gateway proxy memory tuning -- pytest plugin.
+"""Istio gateway proxy memory tuning and diagnostics -- pytest plugin.
 
 Activate via ``-p common.gateway_proxy_istio`` when GATEWAY_PROXY_MEMORY
-is set.  Ensures a ConfigMap with an Istio deployment strategic merge
-patch exists and patches every Gateway in the test namespace to reference
-it via ``parametersRef``, then waits for gateways to become Programmed.
+is set.  Two fixtures:
+
+1. **ensure_gateway_proxy_memory** (per-test, autouse) -- ensures a ConfigMap
+   with an Istio deployment strategic merge patch exists and patches every
+   Gateway in the test namespace to reference it via ``parametersRef``, then
+   waits for gateways to become Programmed.
+
+2. **gateway_diagnostics_monitor** (session, autouse) -- background thread
+   that periodically snapshots Envoy memory/stats, gateway pod restarts,
+   resource counts, and node metrics to JSONL.  Only active when
+   ``--network-layer=gateway-api``.
 
 No upstream files are modified.
 """
 
+import json
 import logging
 import os
+import subprocess
+import threading
 import time
 
 import pytest
@@ -35,6 +46,10 @@ logger = logging.getLogger(__name__)
 GATEWAY_PROXY_MEMORY = os.environ.get("GATEWAY_PROXY_MEMORY")
 _RESOURCE_NAME = "gateway-proxy-config"
 _ensured_namespaces: set = set()
+
+# ---------------------------------------------------------------------------
+# Proxy memory tuning
+# ---------------------------------------------------------------------------
 
 
 def _ensure_configmap(namespace, api_client):
@@ -61,19 +76,33 @@ def _ensure_configmap(namespace, api_client):
     }
     data = {"deployment": yaml.dump(patch, default_flow_style=False)}
     try:
-        existing = core_api.read_namespaced_config_map(_RESOURCE_NAME, namespace)
+        existing = core_api.read_namespaced_config_map(
+            _RESOURCE_NAME, namespace
+        )
         existing.data = data
-        core_api.replace_namespaced_config_map(_RESOURCE_NAME, namespace, existing)
-        logger.info("Updated ConfigMap %s/%s", namespace, _RESOURCE_NAME)
+        core_api.replace_namespaced_config_map(
+            _RESOURCE_NAME, namespace, existing
+        )
+        logger.info(
+            "Updated ConfigMap %s/%s", namespace, _RESOURCE_NAME
+        )
     except client.rest.ApiException as e:
         if e.status == 404:
             body = client.V1ConfigMap(
-                metadata=client.V1ObjectMeta(name=_RESOURCE_NAME, namespace=namespace),
+                metadata=client.V1ObjectMeta(
+                    name=_RESOURCE_NAME, namespace=namespace
+                ),
                 data=data,
             )
             try:
-                core_api.create_namespaced_config_map(namespace, body)
-                logger.info("Created ConfigMap %s/%s", namespace, _RESOURCE_NAME)
+                core_api.create_namespaced_config_map(
+                    namespace, body
+                )
+                logger.info(
+                    "Created ConfigMap %s/%s",
+                    namespace,
+                    _RESOURCE_NAME,
+                )
             except client.rest.ApiException as create_err:
                 if create_err.status != 409:
                     raise
@@ -119,7 +148,11 @@ def _patch_gateways(namespace, api_client):
             name,
             patch,
         )
-        logger.info("Patched Gateway %s/%s with parametersRef", namespace, name)
+        logger.info(
+            "Patched Gateway %s/%s with parametersRef",
+            namespace,
+            name,
+        )
         patched.append(name)
     return patched
 
@@ -154,7 +187,8 @@ def ensure_gateway_proxy_memory(request):
     if not GATEWAY_PROXY_MEMORY:
         return
 
-    # Establish ordering: if the test uses test_case (llmisvc), let it run first
+    # Let test_case (llmisvc) create gateways first
+
     if "test_case" in request.fixturenames:
         request.getfixturevalue("test_case")
 
@@ -170,3 +204,307 @@ def ensure_gateway_proxy_memory(request):
     patched = _patch_gateways(namespace, api_client)
     if patched:
         _wait_for_gateways_programmed(namespace, api_client, patched)
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics monitoring
+# ---------------------------------------------------------------------------
+
+_TEST_NAMESPACE = os.environ.get("KSERVE_TEST_NAMESPACE", "kserve-ci-e2e-test")
+
+_GATEWAY_PODS = [
+    (_TEST_NAMESPACE, "router-gateway-1-openshift-default"),
+    (_TEST_NAMESPACE, "router-gateway-2-openshift-default"),
+    ("openshift-ingress", "openshift-ai-inference-openshift-default"),
+]
+
+_ENVOY_ENDPOINTS = [
+    ("memory", "/memory"),
+    ("cluster_stats", "/stats?filter=cluster_manager"),
+    ("server_memory", "/stats?filter=server.memory"),
+    ("wasm_stats", "/stats?usedonly&filter=wasm"),
+]
+
+_SNAPSHOT_INTERVAL = int(os.environ.get("GATEWAY_DIAG_INTERVAL", "300"))
+
+
+def _run_cli(cli, args, timeout=15):
+    """Run a CLI command and return stdout, or None on failure."""
+    try:
+        result = subprocess.run(
+            [cli] + args,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        if result.returncode != 0:
+            return None
+        return result.stdout.strip()
+    except subprocess.TimeoutExpired:
+        logger.debug(
+            "CLI timeout after %ds: %s %s",
+            timeout, cli, " ".join(args[:3]),
+        )
+        return None
+    except Exception as e:
+        logger.debug(
+            "CLI failed (%s): %s %s",
+            type(e).__name__, cli, " ".join(args[:3]),
+        )
+        return None
+
+
+def _find_running_pod(cli, namespace, name_prefix):
+    """Find a running pod whose name starts with name_prefix."""
+    out = _run_cli(
+        cli,
+        [
+            "get",
+            "pods",
+            "-n",
+            namespace,
+            "--field-selector=status.phase=Running",
+            "-o",
+            "jsonpath={.items[*].metadata.name}",
+        ],
+    )
+    if not out:
+        return None
+    for name in out.split():
+        if name.startswith(name_prefix):
+            return name
+    return None
+
+
+def _exec_in_pod(cli, namespace, pod_name, endpoint):
+    """Hit an Envoy admin endpoint inside a pod's istio-proxy container."""
+    try:
+        result = subprocess.run(
+            [
+                cli,
+                "exec",
+                "-n",
+                namespace,
+                pod_name,
+                "-c",
+                "istio-proxy",
+                "--",
+                "pilot-agent",
+                "request",
+                "GET",
+                endpoint,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode != 0:
+            return f"error: exit {result.returncode}"
+        return result.stdout.strip()
+    except subprocess.TimeoutExpired:
+        return "error: timeout"
+    except Exception as e:
+        return f"error: {e}"
+
+
+def _get_gateway_restarts(cli):
+    """Get restart counts for all gateway pods."""
+    restarts = {}
+    for namespace, prefix in _GATEWAY_PODS:
+        pod_key = f"{namespace}/{prefix}"
+        out = _run_cli(
+            cli,
+            [
+                "get",
+                "pods",
+                "-n",
+                namespace,
+                "--field-selector=status.phase=Running",
+                "-o",
+                "jsonpath={range .items[*]}"
+                "{.metadata.name}{'\\t'}"
+                "{range .status.containerStatuses[*]}"
+                "{.restartCount}{'\\t'}{.state}"
+                "{end}{'\\n'}{end}",
+            ],
+        )
+        if not out:
+            restarts[pod_key] = "error"
+            continue
+        for line in out.strip().split("\n"):
+            if not line:
+                continue
+            parts = line.split("\t", 1)
+            name = parts[0]
+            if name.startswith(prefix):
+                restarts[pod_key] = parts[1] if len(parts) > 1 else "?"
+                break
+    return restarts
+
+
+def _get_resource_counts(cli):
+    """Count HTTPRoutes, LLMISvcs, and AuthPolicies in test namespace."""
+    counts = {}
+    resources = [
+        ("httproutes", "gateway.networking.k8s.io"),
+        ("llminferenceservices", "serving.kserve.io"),
+        ("authpolicies", "kuadrant.io"),
+    ]
+    for resource, group in resources:
+        out = _run_cli(
+            cli,
+            [
+                "get",
+                f"{resource}.{group}",
+                "-n",
+                _TEST_NAMESPACE,
+                "--no-headers",
+                "--ignore-not-found",
+            ],
+        )
+        if out is None:
+            counts[resource] = "error"
+        else:
+            lines = [ln for ln in out.split("\n") if ln.strip()]
+            counts[resource] = len(lines)
+    return counts
+
+
+def _get_node_resources(cli):
+    """Get node CPU/memory usage."""
+    out = _run_cli(cli, ["top", "nodes", "--no-headers"], timeout=20)
+    if not out:
+        return "unavailable"
+    nodes = []
+    for line in out.strip().split("\n"):
+        parts = line.split()
+        if len(parts) >= 5:
+            nodes.append(
+                {
+                    "name": parts[0],
+                    "cpu": parts[1],
+                    "cpu_pct": parts[2],
+                    "mem": parts[3],
+                    "mem_pct": parts[4],
+                }
+            )
+    return nodes
+
+
+def _take_snapshot(cli, snapshot_index, out_path):
+    """Capture cluster diagnostics and append to file."""
+    entry = {
+        "index": snapshot_index,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "gateway_restarts": _get_gateway_restarts(cli),
+        "resource_counts": _get_resource_counts(cli),
+        "node_resources": _get_node_resources(cli),
+        "pods": {},
+    }
+
+    for namespace, prefix in _GATEWAY_PODS:
+        pod_key = f"{namespace}/{prefix}"
+        pod_name = _find_running_pod(cli, namespace, prefix)
+        if not pod_name:
+            entry["pods"][pod_key] = {"status": "not_found"}
+            continue
+
+        pod_data = {"pod_name": pod_name}
+        for label, endpoint in _ENVOY_ENDPOINTS:
+            raw = _exec_in_pod(cli, namespace, pod_name, endpoint)
+            if label == "memory":
+                try:
+                    pod_data[label] = json.loads(raw)
+                except (json.JSONDecodeError, TypeError):
+                    pod_data[label] = raw
+            else:
+                pod_data[label] = raw
+        entry["pods"][pod_key] = pod_data
+
+    with open(out_path, "a") as f:
+        f.write(json.dumps(entry) + "\n")
+
+    logger.info(
+        "Snapshot %d: restarts=%s resources=%s",
+        snapshot_index,
+        json.dumps(entry["gateway_restarts"], default=str),
+        json.dumps(entry["resource_counts"], default=str),
+    )
+
+
+def _monitor_loop(cli, out_path, stop_event):
+    """Background loop taking periodic snapshots."""
+    index = 0
+    try:
+        _take_snapshot(cli, index, out_path)
+    except Exception:
+        logger.exception("Snapshot %d failed", index)
+    while not stop_event.wait(_SNAPSHOT_INTERVAL):
+        index += 1
+        try:
+            _take_snapshot(cli, index, out_path)
+        except Exception:
+            logger.exception("Snapshot %d failed", index)
+    index += 1
+    try:
+        _take_snapshot(cli, index, out_path)
+    except Exception:
+        logger.exception("Final snapshot %d failed", index)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def gateway_diagnostics_monitor(request):
+    """Background monitor for Istio gateway proxy health.
+
+    Periodically captures Envoy memory/stats from gateway pods,
+    restart counts, resource counts, and node metrics.  Writes JSONL
+    to $ARTIFACT_DIR/gateway_diagnostics.jsonl.
+    Only active when --network-layer=gateway-api.
+    """
+    if not GATEWAY_PROXY_MEMORY:
+        yield
+        return
+
+    network = request.config.getoption("--network-layer", default="istio")
+    if network != "gateway-api":
+        yield
+        return
+
+    # Run on controller (non-xdist) or first worker (gw0)
+    # so exactly one monitor runs regardless of parallelism.
+    try:
+        worker = request.config.workerinput["workerid"]
+    except (AttributeError, KeyError):
+        worker = "master"
+    if worker not in ("master", "gw0"):
+        yield
+        return
+
+    cli = os.environ.get("KUBE_CLI", "oc")
+    artifact_dir = os.environ.get("ARTIFACT_DIR", "/tmp")
+    out_path = os.path.join(artifact_dir, "gateway_diagnostics.jsonl")
+    stop_event = threading.Event()
+
+    thread = threading.Thread(
+        target=_monitor_loop,
+        args=(cli, out_path, stop_event),
+        daemon=True,
+    )
+    thread.start()
+    logger.info(
+        "Gateway diagnostics started "
+        "(interval=%ds, cli=%s, output=%s)",
+        _SNAPSHOT_INTERVAL,
+        cli,
+        out_path,
+    )
+
+    yield
+
+    stop_event.set()
+    thread.join(timeout=30)
+    if thread.is_alive():
+        logger.warning(
+            "Monitor thread did not stop within 30s;"
+            " final snapshot may be missing"
+        )


### PR DESCRIPTION
## Summary
- Background thread captures Envoy admin `/memory`, cluster count, and wasm stats from all gateway pods every 5 minutes during e2e-llmisvc runs
- Writes timestamped JSONL snapshots to `$ARTIFACT_DIR/gateway_diagnostics.jsonl` for post-run analysis
- Also tracks gateway pod restart counts and container state (running/waiting/CrashLoopBackOff)
- Only active when `--network-layer=gateway-api` (LLM e2e on ODH). No effect on e2e-predictor, e2e-raw, or upstream

## Evidence
This monitor proved its value during flakiness resolution on PR #1680:
- **Run 8** (without gateway 2Gi fix): diagnostics showed `openshift-ai-inference` gateway at **16 restarts** with `CrashLoopBackOff` status, confirming the gateway memory fix was necessary
- **Run 9** (with fix): diagnostics showed stable memory (peak 246MB heap) and 0 restarts
- Without this monitor, gateway OOM/restarts would have been invisible until manually checking pod status

## Test plan
- [ ] `gateway_diagnostics.jsonl` appears in Konflux artifact browser under `e2e-llm-inference-service/`
- [ ] No effect on non-gateway-api test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an automatic gateway diagnostics monitor for eligible end-to-end runs.
  * When the relevant memory-tuning setting is enabled (and the test worker matches), it runs a background collector and periodically snapshots gateway and cluster state.
  * Captures gateway pod restart counts, key resource counts, node CPU/memory usage, and Envoy admin diagnostics, then appends results as JSONL to `ARTIFACT_DIR/gateway_diagnostics.jsonl` (default `/tmp/gateway_diagnostics.jsonl`).
  * Stops cleanly on teardown, including a final snapshot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->