### PR TITLE
fix: mark llmisvc webhook TLS secret volume as optional

### DIFF
--- a/config/llmisvc/manager.yaml
+++ b/config/llmisvc/manager.yaml
@@ -94,3 +94,4 @@ spec:
           secret:
             defaultMode: 420
             secretName: llmisvc-webhook-server-cert
+            optional: true


### PR DESCRIPTION
## Summary
Mark the `llmisvc-webhook-server-cert` secret volume as `optional: true` in the llmisvc controller manager deployment.

## Problem
On OpenShift, the secret is provisioned by service-ca when it processes the `service.beta.openshift.io/serving-cert-secret-name` annotation on the webhook Service. If the pod is scheduled before service-ca creates the secret, it fails with:
```
FailedMount: secret "llmisvc-webhook-server-cert" not found
```
Observed in nightly smoke tests ([RHOAIENG-72306](https://redhat.atlassian.net/browse/RHOAIENG-72306)).

## Fix
Adding `optional: true` allows the pod to start without the cert. controller-runtime generates self-signed certs when no cert files are found, and picks up the service-ca cert once it appears.

## Jira
[RHOAIENG-72306](https://issues.redhat.com/browse/RHOAIENG-72306)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by allowing the certificate volume to mount even when the backing secret is temporarily unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->