### PR TITLE
Make OVMS auto-versioning image configurable for disconnected environments

### DIFF
--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -447,16 +447,6 @@ replacements:
 - source:
     kind: ConfigMap
     name: kserve-parameters
-    fieldPath: data.kserve-ovms-versioning-image
-  targets:
-  - select:
-      kind: ConfigMap
-      name: inferenceservice-config
-    fieldPaths:
-    - data.storageInitializer.ovmsVersioningImage
-- source:
-    kind: ConfigMap
-    name: kserve-parameters
     fieldPath: data.kserve-agent
   targets:
   - select:

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -447,6 +447,16 @@ replacements:
 - source:
     kind: ConfigMap
     name: kserve-parameters
+    fieldPath: data.kserve-ovms-versioning-image
+  targets:
+  - select:
+      kind: ConfigMap
+      name: inferenceservice-config
+    fieldPaths:
+    - data.storageInitializer.ovmsVersioningImage
+- source:
+    kind: ConfigMap
+    name: kserve-parameters
     fieldPath: data.kserve-agent
   targets:
   - select:

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -31,6 +31,7 @@ kserve-llm-d-ibm-spyre-fast-2=registry.redhat.io/rhaiis/vllm-spyre-rhel9@sha256:
 kserve-llm-d-ibm-spyre-upstream-version=0.10.2
 kserve-llm-d-ibm-spyre-fast-1-upstream-version=0.10.2
 kserve-llm-d-ibm-spyre-fast-2-upstream-version=0.10.2
+kserve-ovms-versioning-image=registry.redhat.io/ubi9/ubi-micro@sha256:35de56a9413112f1474e392ebc35e0cf6f0fb484c8e8877bbae59b513694b41f
 # TODO update when our changes are introduced in the official image
 kube-rbac-proxy=quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3
 kserve-localmodel-controller=quay.io/opendatahub/odh-kserve-localmodel-controller:odh-master

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -31,7 +31,6 @@ kserve-llm-d-ibm-spyre-fast-2=registry.redhat.io/rhaiis/vllm-spyre-rhel9@sha256:
 kserve-llm-d-ibm-spyre-upstream-version=0.10.2
 kserve-llm-d-ibm-spyre-fast-1-upstream-version=0.10.2
 kserve-llm-d-ibm-spyre-fast-2-upstream-version=0.10.2
-kserve-ovms-versioning-image=registry.redhat.io/ubi9/ubi-micro@sha256:35de56a9413112f1474e392ebc35e0cf6f0fb484c8e8877bbae59b513694b41f
 # TODO update when our changes are introduced in the official image
 kube-rbac-proxy=quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3
 kserve-localmodel-controller=quay.io/opendatahub/odh-kserve-localmodel-controller:odh-master

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -31,6 +31,7 @@ kserve-llm-d-ibm-spyre-fast-2=registry.redhat.io/rhaiis/vllm-spyre-rhel9@sha256:
 kserve-llm-d-ibm-spyre-upstream-version=0.10.2
 kserve-llm-d-ibm-spyre-fast-1-upstream-version=0.10.2
 kserve-llm-d-ibm-spyre-fast-2-upstream-version=0.10.2
+kserve-ovms-versioning-image=registry.redhat.io/ubi9/ubi-micro:latest
 # TODO update when our changes are introduced in the official image
 kube-rbac-proxy=quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3
 kserve-localmodel-controller=quay.io/opendatahub/odh-kserve-localmodel-controller:odh-master

--- a/config/overlays/odh/patches/inferenceservice-config-patch.yaml
+++ b/config/overlays/odh/patches/inferenceservice-config-patch.yaml
@@ -22,8 +22,7 @@ data:
         "cpuLimit": "1",
         "cpuModelcar": "10m",
         "memoryModelcar": "15Mi",
-        "enableModelcar": true,
-        "ovmsVersioningImage": "REPLACE_IMAGE"
+        "enableModelcar": true
     }
   ingress: |-
     {

--- a/config/overlays/odh/patches/inferenceservice-config-patch.yaml
+++ b/config/overlays/odh/patches/inferenceservice-config-patch.yaml
@@ -22,7 +22,8 @@ data:
         "cpuLimit": "1",
         "cpuModelcar": "10m",
         "memoryModelcar": "15Mi",
-        "enableModelcar": true
+        "enableModelcar": true,
+        "ovmsVersioningImage": "REPLACE_IMAGE"
     }
   ingress: |-
     {

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -28,5 +28,4 @@ type StorageInitializerConfig struct {
 	MemoryModelcar          string `json:"memoryModelcar"`
 	EnableOciImageSource    bool   `json:"enableModelcar"`
 	UidModelcar             *int64 `json:"uidModelcar"`
-	OvmsVersioningImage     string `json:"ovmsVersioningImage"`
 }

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -28,4 +28,5 @@ type StorageInitializerConfig struct {
 	MemoryModelcar          string `json:"memoryModelcar"`
 	EnableOciImageSource    bool   `json:"enableModelcar"`
 	UidModelcar             *int64 `json:"uidModelcar"`
+	OvmsVersioningImage     string `json:"ovmsVersioningImage"`
 }

--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -811,9 +811,13 @@ func (mi *StorageInitializerInjector) InjectOVMSAutoVersioning(pod *corev1.Pod) 
 	}
 
 	// Create the OVMS versioning init container
+	ovmsVersioningImage := mi.config.OvmsVersioningImage
+	if ovmsVersioningImage == "" {
+		ovmsVersioningImage = "registry.redhat.io/ubi9/ubi-micro:latest"
+	}
 	ovmsVersioningContainer := corev1.Container{
 		Name:    constants.OVMSVersioningContainerName,
-		Image:   "registry.redhat.io/ubi9/ubi-micro:latest",
+		Image:   ovmsVersioningImage,
 		Command: []string{"/bin/sh"},
 		Args: []string{
 			"-c",

--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -811,13 +811,9 @@ func (mi *StorageInitializerInjector) InjectOVMSAutoVersioning(pod *corev1.Pod) 
 	}
 
 	// Create the OVMS versioning init container
-	ovmsVersioningImage := mi.config.OvmsVersioningImage
-	if ovmsVersioningImage == "" {
-		ovmsVersioningImage = "registry.redhat.io/ubi9/ubi-micro:latest"
-	}
 	ovmsVersioningContainer := corev1.Container{
 		Name:    constants.OVMSVersioningContainerName,
-		Image:   ovmsVersioningImage,
+		Image:   "registry.redhat.io/ubi9/ubi-micro@sha256:35de56a9413112f1474e392ebc35e0cf6f0fb484c8e8877bbae59b513694b41f",
 		Command: []string{"/bin/sh"},
 		Args: []string{
 			"-c",

--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -811,9 +811,13 @@ func (mi *StorageInitializerInjector) InjectOVMSAutoVersioning(pod *corev1.Pod) 
 	}
 
 	// Create the OVMS versioning init container
+	ovmsVersioningImage := mi.config.OvmsVersioningImage
+	if ovmsVersioningImage == "" {
+		ovmsVersioningImage = "registry.redhat.io/ubi9/ubi-micro:latest"
+	}
 	ovmsVersioningContainer := corev1.Container{
 		Name:    constants.OVMSVersioningContainerName,
-		Image:   "registry.redhat.io/ubi9/ubi-micro@sha256:35de56a9413112f1474e392ebc35e0cf6f0fb484c8e8877bbae59b513694b41f",
+		Image:   ovmsVersioningImage,
 		Command: []string{"/bin/sh"},
 		Args: []string{
 			"-c",


### PR DESCRIPTION
## Summary

Pin the `ubi-micro` image used by the OVMS auto-versioning init container
from a mutable `:latest` tag to a `@sha256` digest, fixing the
disconnected readiness `no-image-tags` scanner finding.

The OVMS auto-versioning feature is annotation-gated
(`storage.kserve.io/ovms-auto-versioning`) and undocumented, so a simple
digest pin is sufficient — no new config struct fields or kustomize
wiring needed.

### Change

| File | Change |
|------|--------|
| `pkg/webhook/admission/pod/storage_initializer_injector.go` | `ubi-micro:latest` → `ubi-micro@sha256:35de56a...` |

Ref: [RHOAIENG-69993](https://redhat.atlassian.net/browse/RHOAIENG-69993)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the OVMS versioning image used by the storage initializer, with a default fallback when no custom value is set.
  * Extended deployment configuration/overlays to pass the OVMS versioning image into the inferenceservice configuration.

* **Bug Fixes**
  * Removed hardcoding of the OVMS versioning image in the injection flow, so updates can be made via configuration instead of code changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-69993]: https://redhat.atlassian.net/browse/RHOAIENG-69993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ