### PR TITLE
fix(storage): bump PyJWT to 2.13.0 for CVE-2026-48526

### DIFF
--- a/python/storage/poetry.lock
+++ b/python/storage/poetry.lock
@@ -862,13 +862,13 @@ files = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"},
-    {file = "pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"},
+    {file = "pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728"},
+    {file = "pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423"},
 ]
 
 [package.dependencies]
@@ -877,9 +877,6 @@ typing_extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 crypto = ["cryptography (>=3.4.0)"]
-dev = ["coverage[toml] (==7.10.7)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=8.4.2,<9.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
-docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
-tests = ["coverage[toml] (==7.10.7)", "pytest (>=8.4.2,<9.0.0)"]
 
 [[package]]
 name = "python-dateutil"
@@ -1072,4 +1069,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "1db0519c75c10e682b54e6ee431935ac9862244516df3cca69d2dffacbe42c5c"
+content-hash = "8083cf20ad6a926402d398384351c06d8ef15738ff11fc6ec4e0065d92b3ef1e"

--- a/python/storage/pyproject.toml
+++ b/python/storage/pyproject.toml
@@ -29,8 +29,9 @@ azure-identity = { version = "^1.15.0"}
 boto3 = { version = "^1.29.0"}
 huggingface-hub = { version = "^0.30.0", extras = ["hf-transfer"]}
 # CVE-2026-32597 PyJWT accepts unknown `crit` header extensions (RFC 7515 §4.1.11 MUST violation)
+# CVE-2026-48526 PyJWT authentication bypass via JWK accepted as HMAC secret
 # Pinning because it is a transitive dependency.
-PyJWT = {version = ">=2.12.0"}
+PyJWT = {version = ">=2.13.0"}
 # CVE-2026-26007 cryptography fails to validate EC public key subgroup membership (SECT curves)
 # Pinning because it is a transitive dependency.
 cryptography = {version = ">=46.0.5"}


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-66562 
## Summary

- Bump `PyJWT` from `>=2.12.0` to `>=2.13.0` in `kserve-storage` to address [RHOAIENG-66597](https://redhat.atlassian.net/browse/RHOAIENG-66597) / CVE-2026-48526 (PyJWT authentication bypass via JWK accepted as HMAC secret).
- Regenerate `python/storage/poetry.lock` for the storage initializer image on the `stable-2.x` release line.
