### PR TITLE
fix(ci): detect INFERENCE_POOL_GROUP from OCP version at test time

### DIFF
--- a/test/scripts/openshift-ci/run-e2e-tests.sh
+++ b/test/scripts/openshift-ci/run-e2e-tests.sh
@@ -40,7 +40,19 @@ case "${DEPLOYMENT_PROFILE}" in
 esac
 
 export GATEWAY_CLASS_NAME=${GATEWAY_CLASS_NAME:-"openshift-default"}
-export INFERENCE_POOL_GROUP="${INFERENCE_POOL_GROUP:-inference.networking.k8s.io}"
+# Detect the correct InferencePool API group from the cluster version.
+# setup-kserve.sh does this too, but its export doesn't survive across CI steps.
+if [[ -z "${INFERENCE_POOL_GROUP:-}" ]]; then
+  source "$SCRIPT_DIR/version.sh"
+  server_version=$(get_openshift_server_version)
+  ocp_major_minor=$(echo "$server_version" | awk -F. '{print $1"."$2}')
+  if awk "BEGIN{exit !($ocp_major_minor <= 4.20)}"; then
+    export INFERENCE_POOL_GROUP="inference.networking.x-k8s.io"
+  else
+    export INFERENCE_POOL_GROUP="inference.networking.k8s.io"
+  fi
+  echo "INFERENCE_POOL_GROUP=${INFERENCE_POOL_GROUP} (detected from OCP ${server_version})"
+fi
 export RUN_AS_NON_ROOT="${RUN_AS_NON_ROOT:-true}"
 export KUBE_CLI=${KUBE_CLI_COMMAND:-oc}
 


### PR DESCRIPTION
## Summary
- `setup-kserve.sh` exports `INFERENCE_POOL_GROUP` during setup, but the export doesn't survive across Prow CI steps
- After #1686 changed the fallback default to the GA API group (`k8s.io`), Prow on OCP 4.19 started using the wrong group for router-with-refs tests
- Replicate the OCP version detection in `run-e2e-tests.sh` so the correct API group is set regardless of whether `setup-kserve.sh`'s export persists

## Test plan
- [x] Konflux kserve-group-test: no InferencePool/InvalidKind errors (verified on PR #1683)
- [x] Prow e2e-llm-inference-service: no InferencePool/InvalidKind errors (verified on PR #1683)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * E2E tests now dynamically detect and configure the appropriate API group based on the OpenShift cluster version to ensure compatibility across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->