### PR TITLE
fix(kserve-module): update WVA manifest path for restructured layout

### DIFF
--- a/kserve-module/config/rbac/role.yaml
+++ b/kserve-module/config/rbac/role.yaml
@@ -58,6 +58,7 @@ rules:
   - ""
   resourceNames:
   - kserve-webhook-server-secret
+  - workload-variant-autoscaler-controller-manager-token
   - workload-variant-autoscaler-epp-metrics-token
   - workload-variant-autoscaler-metrics-reader-token
   resources:

--- a/kserve-module/hack/get_kserve_manifests.sh
+++ b/kserve-module/hack/get_kserve_manifests.sh
@@ -16,14 +16,14 @@ DST_MANIFESTS_DIR="${1:-${MODULE_DIR}/opt/manifests}"
 declare -A ODH_COMPONENT_MANIFESTS=(
     ["kserve"]="opendatahub-io:kserve:release-v0.17:config"
     ["modelcontroller"]="opendatahub-io:odh-model-controller:incubating:config"
-    ["wva"]="opendatahub-io:workload-variant-autoscaler:main@0641ee03e8430cce5821797137b1b53bf70b98a2:config"
+    ["wva"]="opendatahub-io:workload-variant-autoscaler:main@1a169dc38b70593a8ca85ebec86a209fa4075bd5:config"
 )
 
 # RHOAI Component Manifests
 declare -A RHOAI_COMPONENT_MANIFESTS=(
     ["kserve"]="red-hat-data-services:kserve:rhoai-3.5-ea.1:config"
     ["modelcontroller"]="red-hat-data-services:odh-model-controller:rhoai-3.5-ea.2:config"
-    ["wva"]="red-hat-data-services:workload-variant-autoscaler:rhoai-3.5-ea.2@a3a58e17d82ae982f8f7c145394782bacb6c410c:config"
+    ["wva"]="red-hat-data-services:workload-variant-autoscaler:rhoai-3.5-ea.2@ca9194f661a6891c48430ee5dd7b76211f510a2f:config"
 )
 
 # Select manifests based on platform type

--- a/kserve-module/pkg/kservemodule/components_test.go
+++ b/kserve-module/pkg/kservemodule/components_test.go
@@ -67,6 +67,7 @@ func TestComponentsConfig_WVAHasEnabled(t *testing.T) {
 	}
 	g.Expect(wva).ShouldNot(BeNil(), "WVA component not registered")
 	g.Expect(wva.enabled).ShouldNot(BeNil(), "WVA must have enabled predicate")
+	g.Expect(wva.sourcePath).Should(Equal(WVAManifestSourcePathOCP), "WVA OCP source path must match upstream WVA kustomize overlay")
 	g.Expect(wva.sourcePathXKS).Should(BeEmpty(), "WVA is OCP-only, must not have XKS overlay")
 }
 

--- a/kserve-module/pkg/kservemodule/constants.go
+++ b/kserve-module/pkg/kservemodule/constants.go
@@ -12,14 +12,14 @@ const (
 	KserveManifestSourcePathXKS  = "overlays/odh-xks"
 	ModelCacheManifestSourcePath = "overlays/odh-modelcache"
 	ModelControllerSourcePath    = "base"
-	WVAManifestSourcePathOCP     = "openshift"
+	WVAManifestSourcePathOCP     = "overlays/namespace-scoped/openshift"
 
 	// Deployment names
-	kserveControllerDeployment  = "kserve-controller-manager"
-	llmISVCControllerDeployment = "llmisvc-controller-manager"
+	kserveControllerDeployment     = "kserve-controller-manager"
+	llmISVCControllerDeployment    = "llmisvc-controller-manager"
 	localmodelControllerDeployment = "kserve-localmodel-controller-manager"
-	odhModelControllerDeployment = "odh-model-controller"
-	wvaControllerDeployment      = "workload-variant-autoscaler-controller-manager"
+	odhModelControllerDeployment   = "odh-model-controller"
+	wvaControllerDeployment        = "workload-variant-autoscaler-controller-manager"
 
 	// SSA field manager
 	fieldOwner = "kserve-module-controller"
@@ -28,7 +28,7 @@ const (
 	kserveConfigMapName     = "inferenceservice-config"
 	ingressConfigKeyName    = "ingress"
 	serviceConfigKeyName    = "service"
-	configHashAnnotationKey  = "kserve-module/config-hash"
+	configHashAnnotationKey = "kserve-module/config-hash"
 	oauthProxyConfigKeyName = "oauthProxy"
 	openshiftConfigKeyName  = "openshiftConfig"
 

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -40,7 +40,7 @@ import (
 // +kubebuilder:rbac:groups="",resources=configmaps;services;serviceaccounts,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=secrets,verbs=create;delete;patch;update,resourceNames=kserve-webhook-server-secret;workload-variant-autoscaler-epp-metrics-token;workload-variant-autoscaler-metrics-reader-token
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=create;delete;patch;update,resourceNames=kserve-webhook-server-secret;workload-variant-autoscaler-controller-manager-token;workload-variant-autoscaler-epp-metrics-token;workload-variant-autoscaler-metrics-reader-token
 // +kubebuilder:rbac:groups="",resources=configmaps/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups="",resources=serviceaccounts/finalizers,verbs=update
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch


### PR DESCRIPTION
## Summary
- Update `WVAManifestSourcePathOCP` from `openshift` to `overlays/namespace-scoped/openshift` to match the WVA repo's restructured `config/` directory
- Bump WVA manifest pin in `get_kserve_manifests.sh` to track latest commit
- Add `workload-variant-autoscaler-controller-manager-token` to RBAC secret resourceNames allowlist

## Context
The WVA repo (`opendatahub-io/workload-variant-autoscaler`) restructured its `config/` directory from a flat layout (`openshift/`, `rbac/`, `manager/`) to a kustomize component layout (`base/`, `components/`, `overlays/namespace-scoped/openshift/`). The kserve-module's WVA source path no longer matched, causing "manifest directory not found" errors when WVA was enabled.

## Test plan
- [x] `go build ./...` compiles
- [x] Manual testing on CRC: WVA renders 28 resources, deploys successfully
- [x] No manifest directory not found errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded support for the workload variant autoscaler by updating its manifest references and namespace-scoped deployment path.

* **Bug Fixes**
  * Updated controller access rules to allow use of an additional required Kubernetes secret.
  * Improved platform-specific manifest pinning for the workload variant autoscaler.

* **Tests**
  * Enhanced validation to confirm the workload variant autoscaler uses the correct namespace-scoped source path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->