### PR TITLE
fix(e2e): gateway proxy memory via pytest plugin (no upstream changes)

### DIFF
--- a/test/e2e/common/gateway_proxy_istio.py
+++ b/test/e2e/common/gateway_proxy_istio.py
@@ -71,8 +71,12 @@ def _ensure_configmap(namespace, api_client):
                 metadata=client.V1ObjectMeta(name=_RESOURCE_NAME, namespace=namespace),
                 data=data,
             )
-            core_api.create_namespaced_config_map(namespace, body)
-            logger.info("Created ConfigMap %s/%s", namespace, _RESOURCE_NAME)
+            try:
+                core_api.create_namespaced_config_map(namespace, body)
+                logger.info("Created ConfigMap %s/%s", namespace, _RESOURCE_NAME)
+            except client.rest.ApiException as create_err:
+                if create_err.status != 409:
+                    raise
         else:
             raise
     _ensured_namespaces.add(namespace)

--- a/test/e2e/common/gateway_proxy_istio.py
+++ b/test/e2e/common/gateway_proxy_istio.py
@@ -119,10 +119,14 @@ def _patch_gateways(namespace, api_client):
 
 
 @pytest.fixture(autouse=True)
-def ensure_gateway_proxy_memory(test_case):
-    """After test_case creates router gateways, patch them for proxy memory."""
+def ensure_gateway_proxy_memory(request):
+    """After test setup creates gateways, patch them for proxy memory."""
     if not GATEWAY_PROXY_MEMORY:
         return
+
+    # Establish ordering: if the test uses test_case (llmisvc), let it run first
+    if "test_case" in request.fixturenames:
+        request.getfixturevalue("test_case")
 
     from kserve import KServeClient
 

--- a/test/e2e/common/gateway_proxy_istio.py
+++ b/test/e2e/common/gateway_proxy_istio.py
@@ -1,0 +1,134 @@
+# Copyright 2025 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Istio gateway proxy memory tuning -- pytest plugin.
+
+Activate via ``-p common.gateway_proxy_istio`` when GATEWAY_PROXY_MEMORY
+is set.  After each test's ``test_case`` fixture creates router gateways,
+this plugin ensures a ConfigMap with an Istio deployment strategic merge
+patch exists and patches every Gateway in the test namespace to reference
+it via ``parametersRef``.
+
+No upstream files are modified.
+"""
+
+import logging
+import os
+
+import pytest
+import yaml
+from kubernetes import client
+
+logger = logging.getLogger(__name__)
+
+GATEWAY_PROXY_MEMORY = os.environ.get("GATEWAY_PROXY_MEMORY")
+_RESOURCE_NAME = "gateway-proxy-config"
+_ensured_namespaces: set = set()
+
+
+def _ensure_configmap(namespace, api_client):
+    """Create or update the Istio strategic-merge-patch ConfigMap."""
+    if namespace in _ensured_namespaces:
+        return
+    core_api = client.CoreV1Api(api_client)
+    patch = {
+        "spec": {
+            "template": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "istio-proxy",
+                            "resources": {
+                                "limits": {"memory": GATEWAY_PROXY_MEMORY},
+                                "requests": {"memory": "256Mi"},
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+    }
+    data = {"deployment": yaml.dump(patch, default_flow_style=False)}
+    try:
+        existing = core_api.read_namespaced_config_map(_RESOURCE_NAME, namespace)
+        existing.data = data
+        core_api.replace_namespaced_config_map(_RESOURCE_NAME, namespace, existing)
+        logger.info("Updated ConfigMap %s/%s", namespace, _RESOURCE_NAME)
+    except client.rest.ApiException as e:
+        if e.status == 404:
+            body = client.V1ConfigMap(
+                metadata=client.V1ObjectMeta(
+                    name=_RESOURCE_NAME, namespace=namespace
+                ),
+                data=data,
+            )
+            core_api.create_namespaced_config_map(namespace, body)
+            logger.info("Created ConfigMap %s/%s", namespace, _RESOURCE_NAME)
+        else:
+            raise
+    _ensured_namespaces.add(namespace)
+
+
+_PARAMETERS_REF = {
+    "group": "",
+    "kind": "ConfigMap",
+    "name": _RESOURCE_NAME,
+}
+
+
+def _patch_gateways(namespace, api_client):
+    """Patch all Gateways in namespace to include parametersRef."""
+    custom_api = client.CustomObjectsApi(api_client)
+    gateways = custom_api.list_namespaced_custom_object(
+        "gateway.networking.k8s.io", "v1", namespace, "gateways"
+    )
+    for gw in gateways.get("items", []):
+        infra = gw.get("spec", {}).get("infrastructure", {})
+        if infra.get("parametersRef") == _PARAMETERS_REF:
+            continue
+        name = gw["metadata"]["name"]
+        patch = {
+            "spec": {
+                "infrastructure": {
+                    "parametersRef": _PARAMETERS_REF,
+                }
+            }
+        }
+        custom_api.patch_namespaced_custom_object(
+            "gateway.networking.k8s.io",
+            "v1",
+            namespace,
+            "gateways",
+            name,
+            patch,
+        )
+        logger.info("Patched Gateway %s/%s with parametersRef", namespace, name)
+
+
+@pytest.fixture(autouse=True)
+def ensure_gateway_proxy_memory(test_case):
+    """After test_case creates router gateways, patch them for proxy memory."""
+    if not GATEWAY_PROXY_MEMORY:
+        return
+
+    from kserve import KServeClient
+
+    kserve_client = KServeClient(
+        config_file=os.environ.get("KUBECONFIG", "~/.kube/config")
+    )
+    api_client = kserve_client.api_instance.api_client
+
+    namespace = os.environ.get("KSERVE_TEST_NAMESPACE", "kserve-ci-e2e-test")
+    _ensure_configmap(namespace, api_client)
+    _patch_gateways(namespace, api_client)

--- a/test/e2e/common/gateway_proxy_istio.py
+++ b/test/e2e/common/gateway_proxy_istio.py
@@ -15,16 +15,16 @@
 """Istio gateway proxy memory tuning -- pytest plugin.
 
 Activate via ``-p common.gateway_proxy_istio`` when GATEWAY_PROXY_MEMORY
-is set.  After each test's ``test_case`` fixture creates router gateways,
-this plugin ensures a ConfigMap with an Istio deployment strategic merge
+is set.  Ensures a ConfigMap with an Istio deployment strategic merge
 patch exists and patches every Gateway in the test namespace to reference
-it via ``parametersRef``.
+it via ``parametersRef``, then waits for gateways to become Programmed.
 
 No upstream files are modified.
 """
 
 import logging
 import os
+import time
 
 import pytest
 import yaml
@@ -90,11 +90,15 @@ _PARAMETERS_REF = {
 
 
 def _patch_gateways(namespace, api_client):
-    """Patch all Gateways in namespace to include parametersRef."""
+    """Patch all Gateways in namespace to include parametersRef.
+
+    Returns the list of gateway names that were actually patched.
+    """
     custom_api = client.CustomObjectsApi(api_client)
     gateways = custom_api.list_namespaced_custom_object(
         "gateway.networking.k8s.io", "v1", namespace, "gateways"
     )
+    patched = []
     for gw in gateways.get("items", []):
         infra = gw.get("spec", {}).get("infrastructure", {})
         if infra.get("parametersRef") == _PARAMETERS_REF:
@@ -116,6 +120,32 @@ def _patch_gateways(namespace, api_client):
             patch,
         )
         logger.info("Patched Gateway %s/%s with parametersRef", namespace, name)
+        patched.append(name)
+    return patched
+
+
+def _wait_for_gateways_programmed(namespace, api_client, names, timeout=120):
+    """Wait until all named Gateways have Programmed=True."""
+    custom_api = client.CustomObjectsApi(api_client)
+    deadline = time.monotonic() + timeout
+    pending = set(names)
+    while pending and time.monotonic() < deadline:
+        for name in list(pending):
+            gw = custom_api.get_namespaced_custom_object(
+                "gateway.networking.k8s.io", "v1", namespace, "gateways", name
+            )
+            conditions = gw.get("status", {}).get("conditions", [])
+            for c in conditions:
+                if c.get("type") == "Programmed" and c.get("status") == "True":
+                    logger.info("Gateway %s/%s is Programmed", namespace, name)
+                    pending.discard(name)
+                    break
+        if pending:
+            time.sleep(2)
+    if pending:
+        logger.warning(
+            "Gateways not Programmed after %ds: %s", timeout, sorted(pending)
+        )
 
 
 @pytest.fixture(autouse=True)
@@ -137,4 +167,6 @@ def ensure_gateway_proxy_memory(request):
 
     namespace = os.environ.get("KSERVE_TEST_NAMESPACE", "kserve-ci-e2e-test")
     _ensure_configmap(namespace, api_client)
-    _patch_gateways(namespace, api_client)
+    patched = _patch_gateways(namespace, api_client)
+    if patched:
+        _wait_for_gateways_programmed(namespace, api_client, patched)

--- a/test/e2e/common/gateway_proxy_istio.py
+++ b/test/e2e/common/gateway_proxy_istio.py
@@ -68,9 +68,7 @@ def _ensure_configmap(namespace, api_client):
     except client.rest.ApiException as e:
         if e.status == 404:
             body = client.V1ConfigMap(
-                metadata=client.V1ObjectMeta(
-                    name=_RESOURCE_NAME, namespace=namespace
-                ),
+                metadata=client.V1ObjectMeta(name=_RESOURCE_NAME, namespace=namespace),
                 data=data,
             )
             core_api.create_namespaced_config_map(namespace, body)

--- a/test/scripts/openshift-ci/infra/deploy.gateway.ingress.sh
+++ b/test/scripts/openshift-ci/infra/deploy.gateway.ingress.sh
@@ -31,6 +31,29 @@ echo "⏳ Creating a Gateway"
 INGRESS_NS=openshift-ingress
 oc create namespace ${INGRESS_NS} || true
 
+if [[ -n "${GATEWAY_PROXY_MEMORY:-}" ]]; then
+  echo "⏳ Creating gateway memory ConfigMap for parametersRef (${GATEWAY_PROXY_MEMORY})"
+  oc apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gateway-proxy-config
+  namespace: ${INGRESS_NS}
+data:
+  deployment: |
+    spec:
+      template:
+        spec:
+          containers:
+          - name: istio-proxy
+            resources:
+              limits:
+                memory: ${GATEWAY_PROXY_MEMORY}
+              requests:
+                memory: 256Mi
+EOF
+fi
+
 oc apply -f - <<EOF
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
@@ -46,9 +69,21 @@ spec:
      allowedRoutes:
        namespaces:
          from: All
+$(if [[ -n "${GATEWAY_PROXY_MEMORY:-}" ]]; then cat <<INFRA
+  infrastructure:
+    parametersRef:
+      group: ""
+      kind: ConfigMap
+      name: gateway-proxy-config
+    labels:
+      serving.kserve.io/gateway: kserve-ingress-gateway
+INFRA
+else cat <<INFRA
   infrastructure:
     labels:
       serving.kserve.io/gateway: kserve-ingress-gateway
+INFRA
+fi)
 EOF
 
 wait_for_pod_ready "openshift-ingress" "serving.kserve.io/gateway=kserve-ingress-gateway"

--- a/test/scripts/openshift-ci/run-e2e-tests.sh
+++ b/test/scripts/openshift-ci/run-e2e-tests.sh
@@ -53,6 +53,8 @@ if [[ -z "${INFERENCE_POOL_GROUP:-}" ]]; then
   fi
   echo "INFERENCE_POOL_GROUP=${INFERENCE_POOL_GROUP} (detected from OCP ${server_version})"
 fi
+export GATEWAY_PROXY_MEMORY="${GATEWAY_PROXY_MEMORY:-2Gi}"
+export PYTEST_ARGS="${PYTEST_ARGS:-} -p common.gateway_proxy_istio"
 export RUN_AS_NON_ROOT="${RUN_AS_NON_ROOT:-true}"
 export KUBE_CLI=${KUBE_CLI_COMMAND:-oc}
 

--- a/test/scripts/openshift-ci/run-e2e-tests.sh
+++ b/test/scripts/openshift-ci/run-e2e-tests.sh
@@ -54,7 +54,11 @@ if [[ -z "${INFERENCE_POOL_GROUP:-}" ]]; then
   echo "INFERENCE_POOL_GROUP=${INFERENCE_POOL_GROUP} (detected from OCP ${server_version})"
 fi
 export GATEWAY_PROXY_MEMORY="${GATEWAY_PROXY_MEMORY:-2Gi}"
-export PYTHONPATH="${PYTHONPATH:-}:${PROJECT_ROOT}/test/e2e"
+if [[ -n "${PYTHONPATH:-}" ]]; then
+  export PYTHONPATH="${PYTHONPATH}:${PROJECT_ROOT}/test/e2e"
+else
+  export PYTHONPATH="${PROJECT_ROOT}/test/e2e"
+fi
 export PYTEST_ARGS="${PYTEST_ARGS:-} -p common.gateway_proxy_istio"
 export RUN_AS_NON_ROOT="${RUN_AS_NON_ROOT:-true}"
 export KUBE_CLI=${KUBE_CLI_COMMAND:-oc}

--- a/test/scripts/openshift-ci/run-e2e-tests.sh
+++ b/test/scripts/openshift-ci/run-e2e-tests.sh
@@ -54,6 +54,7 @@ if [[ -z "${INFERENCE_POOL_GROUP:-}" ]]; then
   echo "INFERENCE_POOL_GROUP=${INFERENCE_POOL_GROUP} (detected from OCP ${server_version})"
 fi
 export GATEWAY_PROXY_MEMORY="${GATEWAY_PROXY_MEMORY:-2Gi}"
+export PYTHONPATH="${PYTHONPATH:-}:${PROJECT_ROOT}/test/e2e"
 export PYTEST_ARGS="${PYTEST_ARGS:-} -p common.gateway_proxy_istio"
 export RUN_AS_NON_ROOT="${RUN_AS_NON_ROOT:-true}"
 export KUBE_CLI=${KUBE_CLI_COMMAND:-oc}


### PR DESCRIPTION
## Summary
- Alternative to #1683 -- same fix (2Gi proxy memory via parametersRef), different approach
- Self-contained pytest plugin (`-p common.gateway_proxy_istio`) patches gateways after creation
- Zero changes to `fixtures.py`, `conftest.py`, or any upstream Python
- Plugin is autouse but scoped via `test_case` fixture dependency -- only activates for llmisvc tests

## Approach
| Aspect | #1683 (pluggable backend) | This PR (pure plugin) |
|--------|-----------------------------|-----------------------------|
| Upstream Python changes | `gateway_proxy.py` + `fixtures.py` | None |
| New files | 2 Python modules | 1 Python module |
| Mechanism | Explicit call in `create_router_resources` | Post-creation gateway patch |
| Merge conflict risk | Medium (`fixtures.py`) | Low (shell scripts only) |

## Files changed
- `test/e2e/common/gateway_proxy_istio.py` (NEW) -- pytest plugin
- `test/scripts/openshift-ci/infra/deploy.gateway.ingress.sh` -- ConfigMap + parametersRef for cluster ingress gateway
- `test/scripts/openshift-ci/run-e2e-tests.sh` -- exports `GATEWAY_PROXY_MEMORY=2Gi` and plugin flag

## Test plan
- [ ] Konflux `kserve-group-test` passes without gateway CrashLoopBackOff
- [ ] Gateway memory stays under 2Gi limit throughout run
- [ ] Non-llmisvc tests unaffected (plugin fixture skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pytest autouse plugin that, when `GATEWAY_PROXY_MEMORY` is set, provisions an Istio `gateway-proxy-config` ConfigMap and updates Gateways to reference it.
  * Updated the OpenShift E2E gateway deployment to conditionally create the ConfigMap and set `infrastructure.parametersRef` accordingly.
* **Bug Fixes**
  * Improved E2E stability by avoiding redundant Gateway patching and waiting for Gateways to reach `Programmed` status.
* **Chores**
  * Updated the E2E runner to default `GATEWAY_PROXY_MEMORY=2Gi`, expand `PYTHONPATH` for test discovery, and enable the new pytest plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->