### PR TITLE
integrate llm-d dashboards with kserve-module operator

### DIFF
--- a/config/monitoring/llmisvc/dashboards/llm-d-traffic-dashboard.yaml
+++ b/config/monitoring/llmisvc/dashboards/llm-d-traffic-dashboard.yaml
@@ -1,7 +1,7 @@
 apiVersion: perses.dev/v1alpha2
 kind: PersesDashboard
 metadata:
-  name: dashboard-2-llm-d-health-admin
+  name: dashboard-2-llm-d-traffic-admin
 spec:
   config:
     display:

--- a/config/monitoring/llmisvc/dashboards/llm-d-utilization-dashboard.yaml
+++ b/config/monitoring/llmisvc/dashboards/llm-d-utilization-dashboard.yaml
@@ -1,7 +1,7 @@
 apiVersion: perses.dev/v1alpha2
 kind: PersesDashboard
 metadata:
-  name: dashboard-3-llm-d-replica-admin
+  name: dashboard-3-llm-d-utilization-admin
 spec:
   config:
     display:

--- a/config/monitoring/llmisvc/dashboards/odh/kustomization.yaml
+++ b/config/monitoring/llmisvc/dashboards/odh/kustomization.yaml
@@ -1,7 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-namespace: opendatahub
-
-resources:
-- ..

--- a/config/monitoring/llmisvc/dashboards/rhoai/kustomization.yaml
+++ b/config/monitoring/llmisvc/dashboards/rhoai/kustomization.yaml
@@ -1,7 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-namespace: redhat-ods-monitoring
-
-resources:
-- ..

--- a/kserve-module/config/rbac/role.yaml
+++ b/kserve-module/config/rbac/role.yaml
@@ -239,6 +239,18 @@ rules:
   - list
   - watch
 - apiGroups:
+  - perses.dev
+  resources:
+  - persesdashboards
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings

--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -116,14 +116,21 @@ func filterOutNamespaces(resources []unstructured.Unstructured) []unstructured.U
 	return filtered
 }
 
-func isObservabilityEnabled(_ *platformv1alpha1.Kserve) bool {
-	// TODO: check if PersesDashboard CRD exists on cluster
-	return true
-}
-
-func observabilityPostRender(_ context.Context, r *KserveModuleReconciler,
+func observabilityPostRender(ctx context.Context, r *KserveModuleReconciler,
 	_ *platformv1alpha1.Kserve,
 	resources []unstructured.Unstructured) ([]unstructured.Unstructured, error) {
+
+	log := ctrl.LoggerFrom(ctx)
+
+	reasons := r.checkCRD(ctx, dependencyCheck{
+		name:    "PersesDashboard",
+		crdName: "persesdashboards.perses.dev",
+	})
+	if len(reasons) > 0 {
+		log.Info("PersesDashboard CRD not available, skipping observability dashboards")
+		return nil, nil
+	}
+
 	// TODO: override namespace to monitoring namespace from getMonitoringNamespace()
 	return resources, nil
 }

--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -70,7 +70,6 @@ var components = []componentConfig{
 		name:         ObservabilityComponentName,
 		manifestName: KserveComponentName,
 		sourcePath:   ObservabilityManifestSourcePath,
-		enabled:      isObservabilityEnabled,
 		postRender:   observabilityPostRender,
 	},
 }

--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -118,7 +118,7 @@ func filterOutNamespaces(resources []unstructured.Unstructured) []unstructured.U
 }
 
 func observabilityPostRender(ctx context.Context, r *KserveModuleReconciler,
-	kserve *platformv1alpha1.Kserve,
+	_ *platformv1alpha1.Kserve,
 	resources []unstructured.Unstructured) ([]unstructured.Unstructured, error) {
 
 	log := ctrl.LoggerFrom(ctx)
@@ -135,9 +135,6 @@ func observabilityPostRender(ctx context.Context, r *KserveModuleReconciler,
 	ns := r.getMonitoringNamespace()
 	for i := range resources {
 		resources[i].SetNamespace(ns)
-		if err := ctrl.SetControllerReference(kserve, &resources[i], r.Scheme); err != nil {
-			return nil, fmt.Errorf("failed to set owner reference on %s: %w", resources[i].GetName(), err)
-		}
 	}
 	log.Info("set monitoring namespace on observability resources", "namespace", ns, "count", len(resources))
 

--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -67,6 +67,7 @@ var components = []componentConfig{
 		extraCleanup: cleanupModelCacheComponent,
 	},
 	{
+		// No enabled func: CRD check requires API client, handled in postRender.
 		name:         ObservabilityComponentName,
 		manifestName: KserveComponentName,
 		sourcePath:   ObservabilityManifestSourcePath,

--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -117,7 +117,7 @@ func filterOutNamespaces(resources []unstructured.Unstructured) []unstructured.U
 }
 
 func observabilityPostRender(ctx context.Context, r *KserveModuleReconciler,
-	_ *platformv1alpha1.Kserve,
+	kserve *platformv1alpha1.Kserve,
 	resources []unstructured.Unstructured) ([]unstructured.Unstructured, error) {
 
 	log := ctrl.LoggerFrom(ctx)
@@ -134,6 +134,9 @@ func observabilityPostRender(ctx context.Context, r *KserveModuleReconciler,
 	ns := r.getMonitoringNamespace()
 	for i := range resources {
 		resources[i].SetNamespace(ns)
+		if err := ctrl.SetControllerReference(kserve, &resources[i], r.Scheme); err != nil {
+			return nil, fmt.Errorf("failed to set owner reference on %s: %w", resources[i].GetName(), err)
+		}
 	}
 	log.Info("set monitoring namespace on observability resources", "namespace", ns, "count", len(resources))
 

--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -117,6 +117,18 @@ func filterOutNamespaces(resources []unstructured.Unstructured) []unstructured.U
 	return filtered
 }
 
+func isObservabilityEnabled(_ *platformv1alpha1.Kserve) bool {
+	// TODO: check if PersesDashboard CRD exists on cluster
+	return true
+}
+
+func observabilityPostRender(_ context.Context, r *KserveModuleReconciler,
+	_ *platformv1alpha1.Kserve,
+	resources []unstructured.Unstructured) ([]unstructured.Unstructured, error) {
+	// TODO: override namespace to monitoring namespace from getMonitoringNamespace()
+	return resources, nil
+}
+
 func isWVAEnabled(kserve *platformv1alpha1.Kserve) bool {
 	return kserve.Spec.WVA.ManagementState == common.Managed
 }

--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -70,6 +70,7 @@ var components = []componentConfig{
 		name:         ObservabilityComponentName,
 		manifestName: KserveComponentName,
 		sourcePath:   ObservabilityManifestSourcePath,
+		imageMap:     map[string]string{},
 		postRender:   observabilityPostRender,
 	},
 }

--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -66,6 +66,13 @@ var components = []componentConfig{
 		postRender:   modelCacheComponentPostRender,
 		extraCleanup: cleanupModelCacheComponent,
 	},
+	{
+		name:         ObservabilityComponentName,
+		manifestName: KserveComponentName,
+		sourcePath:   ObservabilityManifestSourcePath,
+		enabled:      isObservabilityEnabled,
+		postRender:   observabilityPostRender,
+	},
 }
 
 func kservePostRender(ctx context.Context, r *KserveModuleReconciler,

--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -131,7 +131,12 @@ func observabilityPostRender(ctx context.Context, r *KserveModuleReconciler,
 		return nil, nil
 	}
 
-	// TODO: override namespace to monitoring namespace from getMonitoringNamespace()
+	ns := r.getMonitoringNamespace()
+	for i := range resources {
+		resources[i].SetNamespace(ns)
+	}
+	log.Info("set monitoring namespace on observability resources", "namespace", ns, "count", len(resources))
+
 	return resources, nil
 }
 

--- a/kserve-module/pkg/kservemodule/constants.go
+++ b/kserve-module/pkg/kservemodule/constants.go
@@ -6,13 +6,15 @@ const (
 	OdhModelControllerComponentName = "modelcontroller"
 	WVAComponentName                = "wva"
 	ModelCacheComponentName         = "modelcache"
+	ObservabilityComponentName      = "observability"
 
 	// Manifest source paths
-	KserveManifestSourcePath     = "overlays/odh"
-	KserveManifestSourcePathXKS  = "overlays/odh-xks"
-	ModelCacheManifestSourcePath = "overlays/odh-modelcache"
-	ModelControllerSourcePath    = "base"
-	WVAManifestSourcePathOCP     = "overlays/namespace-scoped/openshift"
+	KserveManifestSourcePath        = "overlays/odh"
+	KserveManifestSourcePathXKS     = "overlays/odh-xks"
+	ModelCacheManifestSourcePath    = "overlays/odh-modelcache"
+	ModelControllerSourcePath       = "base"
+	WVAManifestSourcePathOCP        = "overlays/namespace-scoped/openshift"
+	ObservabilityManifestSourcePath = "monitoring/llmisvc/dashboards"
 
 	// Deployment names
 	kserveControllerDeployment     = "kserve-controller-manager"

--- a/kserve-module/pkg/kservemodule/fixture/envtest.go
+++ b/kserve-module/pkg/kservemodule/fixture/envtest.go
@@ -139,8 +139,21 @@ spec:
       - name: manager
         image: ghcr.io/llm-d/llm-d-workload-variant-autoscaler:latest
 `
+	observabilityManifest := `apiVersion: perses.dev/v1alpha2
+kind: PersesDashboard
+metadata:
+  name: dashboard-2-llm-d-health-admin
+spec:
+  config:
+    display:
+      name: LLM Traffic
+    duration: 1h
+    panels: {}
+    layouts: []
+`
 	writeKustomizeDir(filepath.Join(workDir, kservemodule.KserveComponentName, kservemodule.KserveManifestSourcePath), kserveManifest)
 	writeKustomizeDir(filepath.Join(workDir, kservemodule.KserveComponentName, kservemodule.KserveManifestSourcePathXKS), kserveManifest)
+	writeKustomizeDir(filepath.Join(workDir, kservemodule.KserveComponentName, kservemodule.ObservabilityManifestSourcePath), observabilityManifest)
 	writeKustomizeDir(filepath.Join(workDir, kservemodule.OdhModelControllerComponentName, kservemodule.ModelControllerSourcePath), modelCtrlManifest)
 	writeKustomizeDir(filepath.Join(workDir, kservemodule.WVAComponentName, kservemodule.WVAManifestSourcePathOCP), wvaManifest)
 }

--- a/kserve-module/pkg/kservemodule/fixture/envtest.go
+++ b/kserve-module/pkg/kservemodule/fixture/envtest.go
@@ -142,7 +142,7 @@ spec:
 	observabilityManifest := `apiVersion: perses.dev/v1alpha2
 kind: PersesDashboard
 metadata:
-  name: dashboard-2-llm-d-health-admin
+  name: dashboard-2-llm-d-traffic-admin
 spec:
   config:
     display:

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -117,6 +117,7 @@ type KserveModuleReconciler struct {
 	workDir               string
 	initDone              bool
 	applicationsNamespace string
+	monitoringNamespace   string
 	clusterType           *cluster.ClusterType
 
 	controller     controller.Controller
@@ -323,7 +324,12 @@ func (r *KserveModuleReconciler) isKubernetes(ctx context.Context) bool {
 }
 
 func (r *KserveModuleReconciler) getMonitoringNamespace() string {
+	if r.monitoringNamespace != "" {
+		return r.monitoringNamespace
+	}
+
 	if ns := os.Getenv("MONITORING_NAMESPACE"); ns != "" {
+		r.monitoringNamespace = ns
 		return ns
 	}
 

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -83,6 +83,9 @@ import (
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheuses/api,resourceNames=k8s,verbs=get;create;update
 
+// --- Observability (Perses dashboards deployed to monitoring namespace when COO is present) ---
+// +kubebuilder:rbac:groups=perses.dev,resources=persesdashboards,verbs=create;delete;get;list;patch;update;watch
+
 // --- Dependency detection (read-only: check if required operators are installed) ---
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=leaderworkersets,verbs=get;list;watch

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -327,7 +327,7 @@ func (r *KserveModuleReconciler) getMonitoringNamespace() string {
 		return ns
 	}
 
-	return r.getApplicationsNamespace()
+	return "opendatahub"
 }
 
 func (r *KserveModuleReconciler) getApplicationsNamespace() string {

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -319,6 +319,14 @@ func (r *KserveModuleReconciler) isKubernetes(ctx context.Context) bool {
 	return ct == cluster.ClusterTypeKubernetes
 }
 
+func (r *KserveModuleReconciler) getMonitoringNamespace() string {
+	if ns := os.Getenv("MONITORING_NAMESPACE"); ns != "" {
+		return ns
+	}
+
+	return r.getApplicationsNamespace()
+}
+
 func (r *KserveModuleReconciler) getApplicationsNamespace() string {
 	if r.applicationsNamespace != "" {
 		return r.applicationsNamespace

--- a/kserve-module/pkg/kservemodule/setup.go
+++ b/kserve-module/pkg/kservemodule/setup.go
@@ -39,6 +39,7 @@ var dependencyCRDSuffixes = []string{
 var dependencyCRDNames = map[string]bool{
 	"leaderworkersets.operator.openshift.io": true,
 	"subscriptions.operators.coreos.com":     true,
+	"persesdashboards.perses.dev":            true,
 }
 
 var watchedSubscriptions = map[string]bool{


### PR DESCRIPTION
**What this PR does / why we need it**:

Following up on #1606, this PR itegrates the llm-d observability dashboards with the kserve-module operator so they are automatically deployed when COO is present. Without this, the ODH/RHOAI operator will not apply the PersesDashboard CRs to target clusters, leaving dashboards unavailable in Observe & Monitor despite the manifests being present in the repo.

This PR adds an **observability component** to the kserve-module reconciler that:
- Renders the dashboard manifests from `config/monitoring/llmisvc/dashboards/`
- Checks for the PersesDashboard CRD at reconciliation time and skips deployment when COO is absent
- Watches for the CRD to appear so dashboards are deployed automatically when COO is installed after KServe
- Sets the monitoring namespace at runtime via `MONITORING_NAMESPACE` env var (set in ODH operator)
- Skips on xKS clusters (OpenShift only)

**Why a separate component instead of adding to the kserve overlay:**

The dashboards need to be deployed to the _monitoring namespace_ (`opendatahub` for ODH,
`redhat-ods-monitoring` for RHOAI), which differs from the _applications namespace_ on RHOAI. The KServe component renders all resources with `kustomize.WithNamespace(getApplicationsNamespace())` and there is no mechanism to set a different namespace on specific resources within a single kustomize render.

A separate component allows the dashboards to be rendered independently and have their namespace overridden in `postRender`.

**Release note**:
```release-note
Automatically deploy llm-d observability dashboards (Traffic, Utilization, Performance) when the Cluster Observability Operator is installed.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added support for loading Perses observability dashboards when available.

* **Bug Fixes**
  * Dashboards now deploy into the monitoring namespace, with a default fallback when unset.
  * Observability dashboard processing is skipped when the required dashboard CRD isn’t present.

* **Chores**
  * Expanded controller permissions and CRD handling for Perses dashboards.
  * Removed empty monitoring dashboard kustomization manifests.
  * Updated test fixtures to include minimal observability manifests.

* **Documentation**
  * Renamed the LLM traffic and utilization dashboard resources for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->