### PR TITLE
RHOAIENG-75464: add fast-version annotation to fast-1 and fast-2

### DIFF
--- a/config/overlays/odh/accelerators-fast/fast-1/kustomization.yaml
+++ b/config/overlays/odh/accelerators-fast/fast-1/kustomization.yaml
@@ -6,5 +6,8 @@ nameSuffix: -fast-1
 commonLabels:
   opendatahub.io/config-type: accelerator
 
+commonAnnotations:
+  opendatahub.io/fast-version: '1'
+
 resources:
 - ../../accelerators

--- a/config/overlays/odh/accelerators-fast/fast-2/kustomization.yaml
+++ b/config/overlays/odh/accelerators-fast/fast-2/kustomization.yaml
@@ -6,5 +6,8 @@ nameSuffix: -fast-2
 commonLabels:
   opendatahub.io/config-type: accelerator
 
+commonAnnotations:
+  opendatahub.io/fast-version: '2'
+
 resources:
 - ../../accelerators


### PR DESCRIPTION
Add a new annotation opendatahub.io/fast-version to the fast LLMInferenceServiceConfig template kustomize overlays.

The dashboard needs this to visually distinguish between multiple fast versions of the same config.

