### PR TITLE
fix(e2e): thread network_layer through autogluon tests

### DIFF
--- a/test/e2e/predictor/autogluon_helpers.py
+++ b/test/e2e/predictor/autogluon_helpers.py
@@ -91,6 +91,9 @@ async def deploy_and_predict(
     rest_client,
     input_path: str,
     timeout_seconds: int = AUTOGLUON_ISVC_WAIT_TIMEOUT,
+    network_layer: str = "istio",
 ):
     async with autogluon_isvc(service_name, predictor, timeout_seconds):
-        return await predict_isvc(rest_client, service_name, input_path)
+        return await predict_isvc(
+            rest_client, service_name, input_path, network_layer=network_layer
+        )

--- a/test/e2e/predictor/autogluon_helpers.py
+++ b/test/e2e/predictor/autogluon_helpers.py
@@ -28,6 +28,10 @@ from kserve import (
     V1beta1PredictorSpec,
     constants,
 )
+from kserve.constants import (
+    KSERVE_LABEL_NETWORKING_VISIBILITY,
+    KSERVE_LABEL_NETWORKING_VISIBILITY_EXPOSED,
+)
 from ..common.utils import (
     AUTOGLUON_ISVC_WAIT_TIMEOUT,
     KSERVE_TEST_NAMESPACE,
@@ -42,7 +46,11 @@ def create_autogluon_isvc(
         api_version=constants.KSERVE_V1BETA1,
         kind=constants.KSERVE_KIND_INFERENCESERVICE,
         metadata=client.V1ObjectMeta(
-            name=service_name, namespace=KSERVE_TEST_NAMESPACE
+            name=service_name,
+            namespace=KSERVE_TEST_NAMESPACE,
+            labels={
+                KSERVE_LABEL_NETWORKING_VISIBILITY: KSERVE_LABEL_NETWORKING_VISIBILITY_EXPOSED,
+            },
         ),
         spec=V1beta1InferenceServiceSpec(predictor=predictor),
     )

--- a/test/e2e/predictor/autogluon_helpers.py
+++ b/test/e2e/predictor/autogluon_helpers.py
@@ -28,10 +28,6 @@ from kserve import (
     V1beta1PredictorSpec,
     constants,
 )
-from kserve.constants import (
-    KSERVE_LABEL_NETWORKING_VISIBILITY,
-    KSERVE_LABEL_NETWORKING_VISIBILITY_EXPOSED,
-)
 from ..common.utils import (
     AUTOGLUON_ISVC_WAIT_TIMEOUT,
     KSERVE_TEST_NAMESPACE,
@@ -49,7 +45,7 @@ def create_autogluon_isvc(
             name=service_name,
             namespace=KSERVE_TEST_NAMESPACE,
             labels={
-                KSERVE_LABEL_NETWORKING_VISIBILITY: KSERVE_LABEL_NETWORKING_VISIBILITY_EXPOSED,
+                constants.KSERVE_LABEL_NETWORKING_VISIBILITY: constants.KSERVE_LABEL_NETWORKING_VISIBILITY_EXPOSED,
             },
         ),
         spec=V1beta1InferenceServiceSpec(predictor=predictor),

--- a/test/e2e/predictor/test_autogluon.py
+++ b/test/e2e/predictor/test_autogluon.py
@@ -57,7 +57,7 @@ def _create_predictor(
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_autogluon_runtime_kserve_v1(rest_v1_client):
+async def test_autogluon_runtime_kserve_v1(rest_v1_client, network_layer):
     service_name = "isvc-autogluon-v1"
     predictor = _create_predictor(service_name)
     response = await deploy_and_predict(
@@ -65,6 +65,7 @@ async def test_autogluon_runtime_kserve_v1(rest_v1_client):
         predictor,
         rest_v1_client,
         "./data/autogluon_titanic_input.json",
+        network_layer=network_layer,
     )
     assert "predictions" in response
     assert len(response["predictions"]) > 0
@@ -72,7 +73,7 @@ async def test_autogluon_runtime_kserve_v1(rest_v1_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_autogluon_runtime_kserve_v2(rest_v2_client):
+async def test_autogluon_runtime_kserve_v2(rest_v2_client, network_layer):
     service_name = "isvc-autogluon-v2"
     predictor = _create_predictor(service_name, protocol_version="v2")
     response = await deploy_and_predict(
@@ -80,6 +81,7 @@ async def test_autogluon_runtime_kserve_v2(rest_v2_client):
         predictor,
         rest_v2_client,
         "./data/autogluon_titanic_input_v2.json",
+        network_layer=network_layer,
     )
     assert len(response.outputs) > 0
     assert len(response.outputs[0].data) > 0
@@ -87,7 +89,9 @@ async def test_autogluon_runtime_kserve_v2(rest_v2_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_autogluon_runtime_kserve_v2_input_variants(rest_v2_client):
+async def test_autogluon_runtime_kserve_v2_input_variants(
+    rest_v2_client, network_layer
+):
     service_name = "isvc-autogluon-v2-variants"
     predictor = _create_predictor(service_name, protocol_version="v2")
     async with autogluon_isvc(service_name, predictor):
@@ -96,7 +100,9 @@ async def test_autogluon_runtime_kserve_v2_input_variants(rest_v2_client):
             "./data/autogluon_titanic_input_v2_binary.json",
             "./data/autogluon_titanic_input_v2_all_binary.json",
         ]:
-            response = await predict_isvc(rest_v2_client, service_name, input_path)
+            response = await predict_isvc(
+                rest_v2_client, service_name, input_path, network_layer=network_layer
+            )
             assert len(response.outputs) > 0
             assert len(response.outputs[0].data) > 0
 
@@ -105,6 +111,7 @@ async def test_autogluon_runtime_kserve_v2_input_variants(rest_v2_client):
 @pytest.mark.asyncio(scope="session")
 async def test_autogluon_runtime_kserve_v2_storage_uri_without_trailing_slash(
     rest_v2_client,
+    network_layer,
 ):
     service_name = "isvc-autogluon-v2-noslash"
     storage_uri = AUTOGLUON_STORAGE_URI.rstrip("/")
@@ -116,6 +123,7 @@ async def test_autogluon_runtime_kserve_v2_storage_uri_without_trailing_slash(
         predictor,
         rest_v2_client,
         "./data/autogluon_titanic_input_v2.json",
+        network_layer=network_layer,
     )
     assert len(response.outputs) > 0
     assert len(response.outputs[0].data) > 0

--- a/test/e2e/predictor/test_autogluon_timeseries.py
+++ b/test/e2e/predictor/test_autogluon_timeseries.py
@@ -60,20 +60,31 @@ def _create_ts_predictor(service_name: str, storage_uri: str = None):
 
 
 async def _deploy_and_predict_v1(
-    service_name: str, rest_v1_client, input_path: str, storage_uri: str = None
+    service_name: str,
+    rest_v1_client,
+    input_path: str,
+    storage_uri: str = None,
+    network_layer: str = "istio",
 ):
     predictor = _create_ts_predictor(service_name, storage_uri=storage_uri)
-    return await deploy_and_predict(service_name, predictor, rest_v1_client, input_path)
+    return await deploy_and_predict(
+        service_name,
+        predictor,
+        rest_v1_client,
+        input_path,
+        network_layer=network_layer,
+    )
 
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_autogluon_timeseries_runtime_kserve_v1(rest_v1_client):
+async def test_autogluon_timeseries_runtime_kserve_v1(rest_v1_client, network_layer):
     service_name = "isvc-autogluon-ts-v1"
     response = await _deploy_and_predict_v1(
         service_name,
         rest_v1_client,
         "./data/autogluon_timeseries_input.json",
+        network_layer=network_layer,
     )
     assert "predictions" in response
     assert len(response["predictions"]) > 0
@@ -83,6 +94,7 @@ async def test_autogluon_timeseries_runtime_kserve_v1(rest_v1_client):
 @pytest.mark.asyncio(scope="session")
 async def test_autogluon_timeseries_runtime_kserve_v1_storage_uri_without_trailing_slash(
     rest_v1_client,
+    network_layer,
 ):
     service_name = "isvc-autogluon-ts-v1-noslash"
     response = await _deploy_and_predict_v1(
@@ -90,6 +102,7 @@ async def test_autogluon_timeseries_runtime_kserve_v1_storage_uri_without_traili
         rest_v1_client,
         "./data/autogluon_timeseries_input_long.json",
         storage_uri=AUTOGLUON_TS_STORAGE_URI.rstrip("/"),
+        network_layer=network_layer,
     )
     assert "predictions" in response
     assert len(response["predictions"]) > 0


### PR DESCRIPTION
## Summary
- Thread `network_layer` pytest fixture through all autogluon e2e tests and helpers
- Add `networking.kserve.io/visibility: exposed` label to autogluon ISVCs so OpenShift Routes are created
- Fixes consistent e2e failures (`e2e-predictor` and `e2e-raw`) on OpenShift CI

## Root Cause
The autogluon e2e tests had two issues preventing them from running on OpenShift CI:

1. **Missing `network_layer` fixture**: `predict_isvc()` defaults to `network_layer="istio"`, which calls `get_cluster_ip()` looking for an Istio ingress gateway service. OpenShift CI clusters use `"openshift-route"` networking — no Istio. Every other predictor test threads the `network_layer` fixture; the autogluon tests did not.

2. **Missing networking visibility label**: Without the `networking.kserve.io/visibility: exposed` label on the ISVC metadata, the omc Route reconciler skips Route creation. The ISVC status URL resolves to a `svc.cluster.local` address unreachable from the test runner. Every other predictor test sets this label; the autogluon tests did not.

Both issues were introduced when the autogluon tests were added upstream (#5269, #5749).

## Files Changed
- `test/e2e/predictor/autogluon_helpers.py` — add `network_layer` param to `deploy_and_predict`, add visibility label to `create_autogluon_isvc`
- `test/e2e/predictor/test_autogluon.py` — add `network_layer` fixture to all 4 test functions
- `test/e2e/predictor/test_autogluon_timeseries.py` — add `network_layer` fixture to both test functions and `_deploy_and_predict_v1`

## Test plan
- [x] `e2e-predictor` CI job passes
- [x] `e2e-raw` CI job passes
- [x] `e2e-graph` CI job passes
- [x] No behavior change for upstream CI (istio is the default)

🤖 Generated with [Claude Code](https://claude.ai/code)