### PR TITLE
RHOAIENG-73191: add scheduled sync workflow for master to release branch

### DIFF
--- a/.github/actions/sync-branches/action.yml
+++ b/.github/actions/sync-branches/action.yml
@@ -1,13 +1,13 @@
 # Composite action that keeps a release branch in sync with a source branch
 # by creating a merge PR. The merge is straightforward except for .tekton
-# pipelines, which intentionally differ between branches:
+# pipelines and params.env files, which intentionally differ between branches:
 #   - source branch tags images with the source tag (e.g., "odh-master")
 #   - release branch tags images with the release tag (e.g., "odh-stable")
 #   - CEL expressions target the branch they live on
-# Because these files always diverge, the action auto-resolves .tekton
-# conflicts by taking the source branch's version and transforming the
-# tags/CEL expressions for the release branch. Non-.tekton conflicts
-# require manual intervention (an issue is opened).
+# Because these files always diverge, the action auto-resolves .tekton and
+# params.env conflicts by taking the source branch's version and transforming
+# the tags/CEL expressions for the release branch. Other conflicts require
+# manual intervention (an issue is opened).
 #
 # The calling workflow must set permissions for contents, pull-requests,
 # and issues to write.
@@ -104,25 +104,24 @@ runs:
         git checkout -B "$SYNC_BRANCH"
 
         # --no-commit keeps the merge staged so we can transform .tekton
-        # files before creating a single merge commit (avoids a separate
-        # "fix tekton tags" commit on every sync).
-        TEKTON_CONFLICTS=""
+        # and params.env files before creating a single merge commit.
+        EXPECTED_CONFLICTS=""
         if ! git merge "origin/${SOURCE_BRANCH}" --no-commit --no-edit; then
           CONFLICTED=$(git diff --name-only --diff-filter=U)
-          NON_TEKTON=$(echo "$CONFLICTED" | grep -v '^\.tekton/' || true)
+          # .tekton and params.env conflicts are expected (tags diverge by
+          # design). Anything else means real source conflicts that need a human.
+          UNEXPECTED=$(echo "$CONFLICTED" | grep -v '^\.tekton/' | grep -v 'params\.env$' || true)
 
-          # .tekton conflicts are expected (tags/CEL diverge by design).
-          # Anything else means real source conflicts that need a human.
-          if [ -n "$NON_TEKTON" ]; then
-            echo "::error::Merge conflicts in non-.tekton files require manual resolution:"
-            echo "$NON_TEKTON"
+          if [ -n "$UNEXPECTED" ]; then
+            echo "::error::Merge conflicts in unexpected files require manual resolution:"
+            echo "$UNEXPECTED"
 
             # Capture the conflict markers so the issue shows what failed
-            CONFLICT_DIFF=$(git diff --diff-filter=U -- $NON_TEKTON)
+            CONFLICT_DIFF=$(git diff --diff-filter=U -- $UNEXPECTED)
             git merge --abort
 
             echo "has_source_conflicts=true" >> "$GITHUB_OUTPUT"
-            ESCAPED=$(echo "$NON_TEKTON" | sed ':a;N;$!ba;s/\n/\\n/g')
+            ESCAPED=$(echo "$UNEXPECTED" | sed ':a;N;$!ba;s/\n/\\n/g')
             echo "source_conflicts=$ESCAPED" >> "$GITHUB_OUTPUT"
 
             # Use a file to pass the diff (too large for GITHUB_OUTPUT)
@@ -130,28 +129,28 @@ runs:
             exit 0
           fi
 
-          TEKTON_CONFLICTS="$CONFLICTED"
-          echo "Resolving .tekton conflicts by taking ${SOURCE_BRANCH}'s version"
+          EXPECTED_CONFLICTS="$CONFLICTED"
+          echo "Resolving expected conflicts by taking ${SOURCE_BRANCH}'s version"
           echo "$CONFLICTED" | xargs git checkout --theirs --
-          git add .tekton/
+          git add .tekton/ config/overlays/
         fi
 
         # Source branch uses source tags and target_branch == source_branch.
         # The release branch needs the release tag and
         # target_branch == release_branch.
-        sed -i "s|${SOURCE_TAG}|${RELEASE_TAG}|g" .tekton/*-push*.yaml .tekton/*-push.yaml 2>/dev/null || true
+        sed -i "s|${SOURCE_TAG}|${RELEASE_TAG}|g" .tekton/*-push*.yaml .tekton/*-push.yaml config/overlays/*/params.env 2>/dev/null || true
         sed -i "s|== \"${SOURCE_BRANCH}\"|== \"${RELEASE_BRANCH}\"|g" .tekton/*.yaml
-        git add .tekton/
+        git add .tekton/ config/overlays/
 
         git commit -m "Sync ${SOURCE_BRANCH} to ${RELEASE_BRANCH}"
 
         echo "branch=$SYNC_BRANCH" >> "$GITHUB_OUTPUT"
 
-        # Surface which .tekton files conflicted so the PR description
+        # Surface which files conflicted so the PR description
         # can call them out for reviewers.
-        if [ -n "$TEKTON_CONFLICTS" ]; then
+        if [ -n "$EXPECTED_CONFLICTS" ]; then
           echo "had_conflicts=true" >> "$GITHUB_OUTPUT"
-          ESCAPED=$(echo "$TEKTON_CONFLICTS" | sed ':a;N;$!ba;s/\n/\\n/g')
+          ESCAPED=$(echo "$EXPECTED_CONFLICTS" | sed ':a;N;$!ba;s/\n/\\n/g')
           echo "conflicted_files=$ESCAPED" >> "$GITHUB_OUTPUT"
         else
           echo "had_conflicts=false" >> "$GITHUB_OUTPUT"
@@ -185,7 +184,7 @@ runs:
           CONFLICT_NOTE=$(cat <<'NOTEEOF'
 
         > [!NOTE]
-        > The following `.tekton` files had merge conflicts and were auto-resolved
+        > The following files had merge conflicts and were auto-resolved
         > by taking the source branch's version and transforming the tags for the
         > release branch:
         NOTEEOF
@@ -201,7 +200,7 @@ runs:
         ## What this PR does
 
         - Merges latest changes from ${SOURCE_BRANCH} into ${RELEASE_BRANCH}
-        - Transforms \`.tekton\` pipeline files for the release branch:
+        - Transforms \`.tekton\` pipeline files and \`params.env\` for the release branch:
           - Image tags: \`${SOURCE_TAG}\` -> \`${RELEASE_TAG}\`
           - CEL expressions: \`target_branch == \"${SOURCE_BRANCH}\"\` -> \`target_branch == \"${RELEASE_BRANCH}\"\`
         ${CONFLICT_NOTE}
@@ -210,7 +209,8 @@ runs:
 
         - [ ] \`.tekton\` push files use \`${RELEASE_TAG}\` image tags
         - [ ] \`.tekton\` CEL expressions reference \`${RELEASE_BRANCH}\`
-        - [ ] No unintended changes outside \`.tekton\`
+        - [ ] \`params.env\` files use \`${RELEASE_TAG}\` image tags
+        - [ ] No unintended changes outside \`.tekton\` and \`params.env\`
 
         _This PR was created automatically by the sync-branches action._"
 

--- a/.github/actions/sync-branches/action.yml
+++ b/.github/actions/sync-branches/action.yml
@@ -1,0 +1,311 @@
+# Composite action that keeps a release branch in sync with a source branch
+# by creating a merge PR. The merge is straightforward except for .tekton
+# pipelines, which intentionally differ between branches:
+#   - source branch tags images with the source tag (e.g., "odh-master")
+#   - release branch tags images with the release tag (e.g., "odh-stable")
+#   - CEL expressions target the branch they live on
+# Because these files always diverge, the action auto-resolves .tekton
+# conflicts by taking the source branch's version and transforming the
+# tags/CEL expressions for the release branch. Non-.tekton conflicts
+# require manual intervention (an issue is opened).
+#
+# The calling workflow must set permissions for contents, pull-requests,
+# and issues to write.
+
+name: 'Sync branches'
+description: 'Merges a source branch into a release branch, transforming .tekton tags/CEL expressions'
+
+inputs:
+  source_branch:
+    description: 'Branch to sync from (e.g., master, main)'
+    required: true
+  release_branch:
+    description: 'Target release branch (e.g., release-v0.17)'
+    required: true
+  source_tag:
+    description: 'Image tag used on the source branch (e.g., odh-master)'
+    required: true
+  release_tag:
+    description: 'Image tag for the release branch (e.g., odh-stable)'
+    required: true
+  release_captain:
+    description: 'GitHub username assigned to conflict issues'
+    required: false
+    default: 'jlost'
+
+runs:
+  using: "composite"
+  steps:
+    # Guard against malformed input -- the branch name and tag are
+    # interpolated into sed patterns and git commands.
+    - name: Validate inputs
+      shell: bash
+      env:
+        SOURCE_BRANCH: ${{ inputs.source_branch }}
+        RELEASE_BRANCH: ${{ inputs.release_branch }}
+        SOURCE_TAG: ${{ inputs.source_tag }}
+        RELEASE_TAG: ${{ inputs.release_tag }}
+      run: |
+        if [[ ! "$SOURCE_BRANCH" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+          echo "::error::Invalid source branch name: '$SOURCE_BRANCH'"
+          exit 1
+        fi
+        if [[ ! "$RELEASE_BRANCH" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+          echo "::error::Invalid release branch name: '$RELEASE_BRANCH'"
+          exit 1
+        fi
+        if [[ ! "$SOURCE_TAG" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+          echo "::error::Invalid source tag: '$SOURCE_TAG'. Only alphanumeric characters, dots, hyphens, and underscores are allowed."
+          exit 1
+        fi
+        if [[ ! "$RELEASE_TAG" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+          echo "::error::Invalid release tag: '$RELEASE_TAG'. Only alphanumeric characters, dots, hyphens, and underscores are allowed."
+          exit 1
+        fi
+
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      with:
+        ref: ${{ inputs.release_branch }}
+        fetch-depth: 0
+
+    - name: Configure git
+      shell: bash
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+    - name: Check for new changes
+      id: check
+      shell: bash
+      env:
+        SOURCE_BRANCH: ${{ inputs.source_branch }}
+        RELEASE_BRANCH: ${{ inputs.release_branch }}
+      run: |
+        BEHIND=$(git rev-list --count "HEAD..origin/${SOURCE_BRANCH}")
+        if [ "$BEHIND" -eq 0 ]; then
+          echo "${RELEASE_BRANCH} is up to date with ${SOURCE_BRANCH}, nothing to sync"
+          echo "skip=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "$BEHIND commit(s) to sync from ${SOURCE_BRANCH}"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Create sync branch and merge
+      if: steps.check.outputs.skip != 'true'
+      id: merge
+      shell: bash
+      env:
+        SOURCE_BRANCH: ${{ inputs.source_branch }}
+        RELEASE_BRANCH: ${{ inputs.release_branch }}
+        SOURCE_TAG: ${{ inputs.source_tag }}
+        RELEASE_TAG: ${{ inputs.release_tag }}
+      run: |
+        SYNC_BRANCH="auto-sync/${SOURCE_BRANCH}-to-${RELEASE_BRANCH}"
+        git checkout -B "$SYNC_BRANCH"
+
+        # --no-commit keeps the merge staged so we can transform .tekton
+        # files before creating a single merge commit (avoids a separate
+        # "fix tekton tags" commit on every sync).
+        TEKTON_CONFLICTS=""
+        if ! git merge "origin/${SOURCE_BRANCH}" --no-commit --no-edit; then
+          CONFLICTED=$(git diff --name-only --diff-filter=U)
+          NON_TEKTON=$(echo "$CONFLICTED" | grep -v '^\.tekton/' || true)
+
+          # .tekton conflicts are expected (tags/CEL diverge by design).
+          # Anything else means real source conflicts that need a human.
+          if [ -n "$NON_TEKTON" ]; then
+            echo "::error::Merge conflicts in non-.tekton files require manual resolution:"
+            echo "$NON_TEKTON"
+
+            # Capture the conflict markers so the issue shows what failed
+            CONFLICT_DIFF=$(git diff --diff-filter=U -- $NON_TEKTON)
+            git merge --abort
+
+            echo "has_source_conflicts=true" >> "$GITHUB_OUTPUT"
+            ESCAPED=$(echo "$NON_TEKTON" | sed ':a;N;$!ba;s/\n/\\n/g')
+            echo "source_conflicts=$ESCAPED" >> "$GITHUB_OUTPUT"
+
+            # Use a file to pass the diff (too large for GITHUB_OUTPUT)
+            echo "$CONFLICT_DIFF" > /tmp/conflict_diff.txt
+            exit 0
+          fi
+
+          TEKTON_CONFLICTS="$CONFLICTED"
+          echo "Resolving .tekton conflicts by taking ${SOURCE_BRANCH}'s version"
+          echo "$CONFLICTED" | xargs git checkout --theirs --
+          git add .tekton/
+        fi
+
+        # Source branch uses source tags and target_branch == source_branch.
+        # The release branch needs the release tag and
+        # target_branch == release_branch.
+        sed -i "s|${SOURCE_TAG}|${RELEASE_TAG}|g" .tekton/*-push*.yaml .tekton/*-push.yaml 2>/dev/null || true
+        sed -i "s|== \"${SOURCE_BRANCH}\"|== \"${RELEASE_BRANCH}\"|g" .tekton/*.yaml
+        git add .tekton/
+
+        git commit -m "Sync ${SOURCE_BRANCH} to ${RELEASE_BRANCH}"
+
+        echo "branch=$SYNC_BRANCH" >> "$GITHUB_OUTPUT"
+
+        # Surface which .tekton files conflicted so the PR description
+        # can call them out for reviewers.
+        if [ -n "$TEKTON_CONFLICTS" ]; then
+          echo "had_conflicts=true" >> "$GITHUB_OUTPUT"
+          ESCAPED=$(echo "$TEKTON_CONFLICTS" | sed ':a;N;$!ba;s/\n/\\n/g')
+          echo "conflicted_files=$ESCAPED" >> "$GITHUB_OUTPUT"
+        else
+          echo "had_conflicts=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Push sync branch
+      if: steps.check.outputs.skip != 'true' && steps.merge.outputs.has_source_conflicts != 'true'
+      shell: bash
+      env:
+        SOURCE_BRANCH: ${{ inputs.source_branch }}
+        RELEASE_BRANCH: ${{ inputs.release_branch }}
+      run: |
+        git push --force-with-lease origin "auto-sync/${SOURCE_BRANCH}-to-${RELEASE_BRANCH}"
+
+    - name: Create or update pull request
+      if: steps.check.outputs.skip != 'true' && steps.merge.outputs.has_source_conflicts != 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        SOURCE_BRANCH: ${{ inputs.source_branch }}
+        RELEASE_BRANCH: ${{ inputs.release_branch }}
+        SOURCE_TAG: ${{ inputs.source_tag }}
+        RELEASE_TAG: ${{ inputs.release_tag }}
+        RELEASE_CAPTAIN: ${{ inputs.release_captain }}
+        SYNC_BRANCH: ${{ steps.merge.outputs.branch }}
+        HAD_CONFLICTS: ${{ steps.merge.outputs.had_conflicts }}
+        CONFLICTED_FILES: ${{ steps.merge.outputs.conflicted_files }}
+      run: |
+        CONFLICT_NOTE=""
+        if [ "$HAD_CONFLICTS" = "true" ]; then
+          CONFLICT_NOTE=$(cat <<'NOTEEOF'
+
+        > [!NOTE]
+        > The following `.tekton` files had merge conflicts and were auto-resolved
+        > by taking the source branch's version and transforming the tags for the
+        > release branch:
+        NOTEEOF
+        )
+          while IFS= read -r file; do
+            CONFLICT_NOTE="${CONFLICT_NOTE}
+        > - \`${file}\`"
+          done <<< "$(echo -e "$CONFLICTED_FILES")"
+        fi
+
+        BODY="Automated sync of ${SOURCE_BRANCH} into ${RELEASE_BRANCH}.
+
+        ## What this PR does
+
+        - Merges latest changes from ${SOURCE_BRANCH} into ${RELEASE_BRANCH}
+        - Transforms \`.tekton\` pipeline files for the release branch:
+          - Image tags: \`${SOURCE_TAG}\` -> \`${RELEASE_TAG}\`
+          - CEL expressions: \`target_branch == \"${SOURCE_BRANCH}\"\` -> \`target_branch == \"${RELEASE_BRANCH}\"\`
+        ${CONFLICT_NOTE}
+
+        ## Verification
+
+        - [ ] \`.tekton\` push files use \`${RELEASE_TAG}\` image tags
+        - [ ] \`.tekton\` CEL expressions reference \`${RELEASE_BRANCH}\`
+        - [ ] No unintended changes outside \`.tekton\`
+
+        _This PR was created automatically by the sync-branches action._"
+
+        # Reuse an existing open sync PR instead of creating duplicates.
+        EXISTING_PR=$(gh pr list --base "$RELEASE_BRANCH" --head "$SYNC_BRANCH" --json number --jq '.[0].number // empty')
+
+        if [ -n "$EXISTING_PR" ]; then
+          echo "Updating existing PR #$EXISTING_PR"
+          gh pr comment "$EXISTING_PR" --body "Sync branch updated with latest changes from ${SOURCE_BRANCH}."
+        else
+          gh pr create \
+            --base "$RELEASE_BRANCH" \
+            --head "$SYNC_BRANCH" \
+            --title "Sync ${SOURCE_BRANCH} to ${RELEASE_BRANCH}" \
+            --body "$BODY" \
+            --label "tide/merge-method-merge" \
+            --assignee "$RELEASE_CAPTAIN"
+        fi
+
+    # Non-.tekton merge conflicts cannot be resolved automatically.
+    # Open (or update) an issue so the team is aware and can resolve
+    # manually, rather than silently failing.
+    - name: Open or update conflict issue
+      if: steps.merge.outputs.has_source_conflicts == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        SOURCE_BRANCH: ${{ inputs.source_branch }}
+        RELEASE_BRANCH: ${{ inputs.release_branch }}
+        SOURCE_TAG: ${{ inputs.source_tag }}
+        RELEASE_CAPTAIN: ${{ inputs.release_captain }}
+        SOURCE_CONFLICTS: ${{ steps.merge.outputs.source_conflicts }}
+      run: |
+        TITLE="Sync ${SOURCE_BRANCH} to ${RELEASE_BRANCH}: merge conflicts need manual resolution"
+        FILE_LIST=""
+        while IFS= read -r file; do
+          FILE_LIST="${FILE_LIST}
+        - \`${file}\`"
+        done <<< "$(echo -e "$SOURCE_CONFLICTS")"
+
+        CONFLICT_DIFF=""
+        if [ -f /tmp/conflict_diff.txt ]; then
+          # Truncate to stay within GitHub's 65536-char issue body limit,
+          # leaving room for the surrounding markdown template.
+          CONFLICT_DIFF=$(head -c 40000 /tmp/conflict_diff.txt)
+          if [ "$(wc -c < /tmp/conflict_diff.txt)" -gt 40000 ]; then
+            CONFLICT_DIFF="${CONFLICT_DIFF}
+        ... (truncated, see workflow run for full output)"
+          fi
+        fi
+
+        BODY="The automated sync from ${SOURCE_BRANCH} to \`${RELEASE_BRANCH}\` failed due to merge conflicts in the following files:
+        ${FILE_LIST}
+
+        ### Conflict diff
+
+        \`\`\`diff
+        ${CONFLICT_DIFF}
+        \`\`\`
+
+        ### How to resolve
+
+        \`\`\`bash
+        git fetch origin
+        git checkout -b sync-${SOURCE_BRANCH}-to-${RELEASE_BRANCH} origin/${RELEASE_BRANCH}
+        git merge origin/${SOURCE_BRANCH}
+        # resolve conflicts
+        git push origin sync-${SOURCE_BRANCH}-to-${RELEASE_BRANCH}
+        # open a PR targeting ${RELEASE_BRANCH}
+        \`\`\`
+
+        Once the sync PR is merged into \`${RELEASE_BRANCH}\`, this issue can be closed.
+
+        _Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}_"
+
+        EXISTING=$(gh issue list --search "\"${TITLE}\" in:title" --state open --json number --jq '.[0].number // empty')
+
+        if [ -n "$EXISTING" ]; then
+          gh issue edit "$EXISTING" --body "$BODY"
+          COMMENT="@${RELEASE_CAPTAIN} sync failed again at $(date -u +%Y-%m-%dT%H:%M:%SZ). [Workflow run](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})
+
+        <details>
+        <summary>Release captain responsibilities</summary>
+
+        As the current release captain, you are responsible for:
+        - Resolving merge conflicts between ${SOURCE_BRANCH} and \`${RELEASE_BRANCH}\`
+        - Ensuring the release branch stays in sync before each code freeze
+        - Opening the sync PR manually when the automation cannot proceed
+        - Closing this issue once the sync is complete
+
+        If you are no longer on rotation, update the \`release_captain\` input in
+        the caller workflow and reassign this issue.
+        </details>"
+          gh issue comment "$EXISTING" --body "$COMMENT"
+          echo "Updated existing issue #$EXISTING"
+        else
+          gh issue create --title "$TITLE" --body "$BODY" --assignee "$RELEASE_CAPTAIN" --label "area/release" --label "p0"
+        fi

--- a/.github/workflows/sync-master-to-release.yaml
+++ b/.github/workflows/sync-master-to-release.yaml
@@ -1,0 +1,76 @@
+# Kserve-specific caller for the sync-branches action.
+# Defines the schedule and defaults for syncing master -> release-v0.17.
+
+name: Sync master to release branch
+
+on:
+  schedule:
+    # Weekly sync to keep the release branch reasonably close to master,
+    # reducing the size of each merge and catching integration issues early.
+    - cron: '0 8 * * 3'
+    # Every Friday at 06:00 UTC (08:00 CEST). The schedule-gate job checks
+    # whether this Friday falls on a 4-week boundary starting from
+    # CODE_FREEZE_EPOCH, matching the project's code-freeze cadence.
+    - cron: '0 6 * * 5'
+  workflow_dispatch:
+    inputs:
+      release_branch:
+        description: 'Target release branch'
+        required: false
+        default: 'release-v0.17'
+      release_tag:
+        description: 'Image tag for the release branch'
+        required: false
+        default: 'odh-stable'
+
+env:
+  # First code-freeze date. The Friday schedule runs every 4 weeks
+  # from this epoch. Update when the cadence shifts.
+  CODE_FREEZE_EPOCH: '2026-07-24'
+
+jobs:
+  # Cron cannot express "every 4 weeks", so the Friday schedule fires
+  # weekly. This job skips Fridays that don't land on the 4-week
+  # code-freeze cadence. Wednesday runs and manual triggers pass through.
+  schedule-gate:
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+    steps:
+      - name: Check 4-week cadence
+        id: check
+        if: github.event_name == 'schedule'
+        run: |
+          DAY_OF_WEEK=$(date +%u)
+          # 5 = Friday: only run on 4-week code-freeze boundaries
+          if [ "$DAY_OF_WEEK" -eq 5 ]; then
+            EPOCH=$(date -d "$CODE_FREEZE_EPOCH" +%s)
+            TODAY=$(date -d "$(date +%Y-%m-%d)" +%s)
+            WEEKS_SINCE=$(( (TODAY - EPOCH) / 604800 ))
+            if (( WEEKS_SINCE < 0 || WEEKS_SINCE % 4 != 0 )); then
+              echo "Not on a 4-week boundary from $CODE_FREEZE_EPOCH, skipping"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+  sync:
+    needs: schedule-gate
+    if: needs.schedule-gate.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      # Checkout needed so the runner can resolve the local composite action.
+      # The action itself re-checks out at the release branch with full history.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/sync-branches
+        with:
+          source_branch: master
+          source_tag: odh-master
+          release_branch: ${{ inputs.release_branch || 'release-v0.17' }}
+          release_tag: ${{ inputs.release_tag || 'odh-stable' }}

--- a/.tekton/kserve-agent-push.yaml
+++ b/.tekton/kserve-agent-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-agent:odh-stable
+    value: quay.io/opendatahub/kserve-agent:odh-master
   - name: dockerfile
     value: agent.Dockerfile
   - name: path-context
@@ -33,7 +33,8 @@ spec:
     - "GOTAGS=distro"
   - name: additional-tags
     value:
-    - 'odh-stable'
+    - 'odh-master'
+    - 'odh-master-{{revision}}'
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/kserve-controller-push.yaml
+++ b/.tekton/kserve-controller-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-controller:odh-stable
+    value: quay.io/opendatahub/kserve-controller:odh-master
   - name: dockerfile
     value: Dockerfile
   - name: path-context
@@ -33,7 +33,8 @@ spec:
     - "GOTAGS=distro"
   - name: additional-tags
     value:
-    - 'odh-stable'
+    - 'odh-master'
+    - 'odh-master-{{revision}}'
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/kserve-router-push.yaml
+++ b/.tekton/kserve-router-push.yaml
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-router:odh-stable
+    value: quay.io/opendatahub/kserve-router:odh-master
   - name: dockerfile
     value: router.Dockerfile
   - name: path-context
@@ -33,7 +33,8 @@ spec:
     - "GOTAGS=distro"
   - name: additional-tags
     value:
-    - 'odh-stable'
+    - 'odh-master'
+    - 'odh-master-{{revision}}'
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/kserve-storage-initializer-push.yaml
+++ b/.tekton/kserve-storage-initializer-push.yaml
@@ -23,14 +23,15 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/kserve-storage-initializer:odh-stable
+    value: quay.io/opendatahub/kserve-storage-initializer:odh-master
   - name: dockerfile
     value: storage-initializer.Dockerfile
   - name: path-context
     value: python
   - name: additional-tags
     value:
-    - 'odh-stable'
+    - 'odh-master'
+    - 'odh-master-{{revision}}'
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-kserve-autogluon-server-push.yaml
+++ b/.tekton/odh-kserve-autogluon-server-push.yaml
@@ -26,7 +26,11 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-kserve-autogluon-server:odh-stable
+    value: quay.io/opendatahub/odh-kserve-autogluon-server:odh-master
+  - name: additional-tags
+    value:
+    - 'odh-master'
+    - 'odh-master-{{revision}}'
   - name: dockerfile
     value: python/autogluon.Dockerfile
   - name: path-context

--- a/.tekton/odh-kserve-llmisvc-controller-push.yaml
+++ b/.tekton/odh-kserve-llmisvc-controller-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "release-v0.17"
+      == "master"
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: opendatahub-builds
@@ -23,14 +23,15 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-kserve-llmisvc-controller:odh-stable
+    value: quay.io/opendatahub/odh-kserve-llmisvc-controller:odh-master
   - name: dockerfile
     value: llmisvc-controller.Dockerfile
   - name: path-context
     value: .
   - name: additional-tags
     value:
-    - 'odh-stable'
+    - 'odh-master'
+    - 'odh-master-{{revision}}'
   - name: build-args
     value:
     - "GOTAGS=distro"

--- a/.tekton/odh-kserve-localmodel-controller-push.yaml
+++ b/.tekton/odh-kserve-localmodel-controller-push.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-kserve-localmodel-controller:odh-stable
+    value: quay.io/opendatahub/odh-kserve-localmodel-controller:odh-master
   - name: dockerfile
     value: localmodel.Dockerfile
   - name: path-context
@@ -34,7 +34,8 @@ spec:
     - "GOTAGS=distro"
   - name: additional-tags
     value:
-    - 'odh-stable'
+    - 'odh-master'
+    - 'odh-master-{{revision}}'
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-kserve-localmodelnode-agent-push.yaml
+++ b/.tekton/odh-kserve-localmodelnode-agent-push.yaml
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-kserve-localmodelnode-agent:odh-stable
+    value: quay.io/opendatahub/odh-kserve-localmodelnode-agent:odh-master
   - name: dockerfile
     value: localmodel-agent.Dockerfile
   - name: path-context
@@ -34,7 +34,8 @@ spec:
     - "GOTAGS=distro"
   - name: additional-tags
     value:
-    - 'odh-stable'
+    - 'odh-master'
+    - 'odh-master-{{revision}}'
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/odh-kserve-module-operator-push.yaml
+++ b/.tekton/odh-kserve-module-operator-push.yaml
@@ -24,7 +24,11 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/opendatahub/odh-kserve-module-operator:odh-stable
+    value: quay.io/opendatahub/odh-kserve-module-operator:odh-master
+  - name: additional-tags
+    value:
+    - 'odh-master'
+    - 'odh-master-{{revision}}'
   - name: dockerfile
     value: kserve-module-controller.Dockerfile
   - name: path-context

--- a/config/overlays/odh-modelcache/params.env
+++ b/config/overlays/odh-modelcache/params.env
@@ -1,2 +1,2 @@
-kserve-localmodel-controller=quay.io/opendatahub/kserve-localmodel-controller:latest
-kserve-localmodelnode-agent=quay.io/opendatahub/kserve-localmodelnode-agent:latest
+kserve-localmodel-controller=quay.io/opendatahub/odh-kserve-localmodel-controller:odh-master
+kserve-localmodelnode-agent=quay.io/opendatahub/odh-kserve-localmodelnode-agent:odh-master

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -1,8 +1,8 @@
-kserve-controller=quay.io/opendatahub/kserve-controller:latest
-llmisvc-controller=ghcr.io/opendatahub-io/kserve/odh-kserve-llmisvc-controller:release-v0.17
-kserve-agent=quay.io/opendatahub/kserve-agent:latest
-kserve-router=quay.io/opendatahub/kserve-router:latest
-kserve-storage-initializer=quay.io/opendatahub/kserve-storage-initializer:latest
+kserve-controller=quay.io/opendatahub/kserve-controller:odh-master
+llmisvc-controller=quay.io/opendatahub/odh-kserve-llmisvc-controller:odh-master
+kserve-agent=quay.io/opendatahub/kserve-agent:odh-master
+kserve-router=quay.io/opendatahub/kserve-router:odh-master
+kserve-storage-initializer=quay.io/opendatahub/kserve-storage-initializer:odh-master
 kserve-llm-d=registry.redhat.io/rhaiis/vllm-cuda-rhel9@sha256:fc68d623d1bfc36c8cb2fe4a71f19c8578cfb420ce8ce07b20a02c1ee0be0cf3
 kserve-llm-d-inference-scheduler=quay.io/opendatahub/odh-llm-d-router-endpoint-picker:v0.9.0
 kserve-llm-d-routing-sidecar=quay.io/opendatahub/odh-llm-d-router-disagg-sidecar:v0.9.0
@@ -33,5 +33,5 @@ kserve-llm-d-ibm-spyre-fast-1-upstream-version=0.10.2
 kserve-llm-d-ibm-spyre-fast-2-upstream-version=0.10.2
 # TODO update when our changes are introduced in the official image
 kube-rbac-proxy=quay.io/opendatahub/odh-kube-auth-proxy@sha256:dcb09fbabd8811f0956ef612a0c9ddd5236804b9bd6548a0647d2b531c9d01b3
-kserve-localmodel-controller=quay.io/opendatahub/kserve-localmodel-controller:latest
-kserve-localmodelnode-agent=quay.io/opendatahub/kserve-localmodelnode-agent:latest
+kserve-localmodel-controller=quay.io/opendatahub/odh-kserve-localmodel-controller:odh-master
+kserve-localmodelnode-agent=quay.io/opendatahub/odh-kserve-localmodelnode-agent:odh-master


### PR DESCRIPTION
Add a reusable composite action (.github/actions/sync-branches) and a kserve-specific caller workflow that automatically creates PRs to sync master into the release branch. The workflow runs weekly on Wednesdays and every 4 weeks on Fridays (matching code-freeze cadence).

The .tekton push pipelines on master now use odh-master image tags, and the sync action transforms them to odh-stable (or the configured release tag) when merging into the release branch. Non-.tekton merge conflicts open a GitHub issue assigned to the release captain.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated syncing of `master` into configurable release branches via scheduled and manual runs.
  * Added conflict-aware automation that can open/update issues and PRs for release updates.
* **Changes**
  * Updated KServe-related image publishing to use `odh-master` tags, including revision-based tags, across Tekton push pipelines and deployment overlays.
* **Bug Fixes**
  * Improved sync conflict handling by resolving known expected configuration differences and clearly surfacing unexpected conflicts for review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->