### PR TITLE
fix(e2e): thread network_layer through Autogluon predictor tests

### DIFF
--- a/test/e2e/predictor/autogluon_helpers.py
+++ b/test/e2e/predictor/autogluon_helpers.py
@@ -91,6 +91,9 @@ async def deploy_and_predict(
     rest_client,
     input_path: str,
     timeout_seconds: int = AUTOGLUON_ISVC_WAIT_TIMEOUT,
+    network_layer: str = "istio",
 ):
     async with autogluon_isvc(service_name, predictor, timeout_seconds):
-        return await predict_isvc(rest_client, service_name, input_path)
+        return await predict_isvc(
+            rest_client, service_name, input_path, network_layer=network_layer
+        )

--- a/test/e2e/predictor/test_autogluon.py
+++ b/test/e2e/predictor/test_autogluon.py
@@ -57,7 +57,7 @@ def _create_predictor(
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_autogluon_runtime_kserve_v1(rest_v1_client):
+async def test_autogluon_runtime_kserve_v1(rest_v1_client, network_layer):
     service_name = "isvc-autogluon-v1"
     predictor = _create_predictor(service_name)
     response = await deploy_and_predict(
@@ -65,6 +65,7 @@ async def test_autogluon_runtime_kserve_v1(rest_v1_client):
         predictor,
         rest_v1_client,
         "./data/autogluon_titanic_input.json",
+        network_layer=network_layer,
     )
     assert "predictions" in response
     assert len(response["predictions"]) > 0
@@ -72,7 +73,7 @@ async def test_autogluon_runtime_kserve_v1(rest_v1_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_autogluon_runtime_kserve_v2(rest_v2_client):
+async def test_autogluon_runtime_kserve_v2(rest_v2_client, network_layer):
     service_name = "isvc-autogluon-v2"
     predictor = _create_predictor(service_name, protocol_version="v2")
     response = await deploy_and_predict(
@@ -80,6 +81,7 @@ async def test_autogluon_runtime_kserve_v2(rest_v2_client):
         predictor,
         rest_v2_client,
         "./data/autogluon_titanic_input_v2.json",
+        network_layer=network_layer,
     )
     assert len(response.outputs) > 0
     assert len(response.outputs[0].data) > 0
@@ -87,7 +89,9 @@ async def test_autogluon_runtime_kserve_v2(rest_v2_client):
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_autogluon_runtime_kserve_v2_input_variants(rest_v2_client):
+async def test_autogluon_runtime_kserve_v2_input_variants(
+    rest_v2_client, network_layer
+):
     service_name = "isvc-autogluon-v2-variants"
     predictor = _create_predictor(service_name, protocol_version="v2")
     async with autogluon_isvc(service_name, predictor):
@@ -96,7 +100,9 @@ async def test_autogluon_runtime_kserve_v2_input_variants(rest_v2_client):
             "./data/autogluon_titanic_input_v2_binary.json",
             "./data/autogluon_titanic_input_v2_all_binary.json",
         ]:
-            response = await predict_isvc(rest_v2_client, service_name, input_path)
+            response = await predict_isvc(
+                rest_v2_client, service_name, input_path, network_layer=network_layer
+            )
             assert len(response.outputs) > 0
             assert len(response.outputs[0].data) > 0
 
@@ -105,6 +111,7 @@ async def test_autogluon_runtime_kserve_v2_input_variants(rest_v2_client):
 @pytest.mark.asyncio(scope="session")
 async def test_autogluon_runtime_kserve_v2_storage_uri_without_trailing_slash(
     rest_v2_client,
+    network_layer,
 ):
     service_name = "isvc-autogluon-v2-noslash"
     storage_uri = AUTOGLUON_STORAGE_URI.rstrip("/")
@@ -116,6 +123,7 @@ async def test_autogluon_runtime_kserve_v2_storage_uri_without_trailing_slash(
         predictor,
         rest_v2_client,
         "./data/autogluon_titanic_input_v2.json",
+        network_layer=network_layer,
     )
     assert len(response.outputs) > 0
     assert len(response.outputs[0].data) > 0

--- a/test/e2e/predictor/test_autogluon_timeseries.py
+++ b/test/e2e/predictor/test_autogluon_timeseries.py
@@ -60,20 +60,31 @@ def _create_ts_predictor(service_name: str, storage_uri: str = None):
 
 
 async def _deploy_and_predict_v1(
-    service_name: str, rest_v1_client, input_path: str, storage_uri: str = None
+    service_name: str,
+    rest_v1_client,
+    input_path: str,
+    storage_uri: str = None,
+    network_layer: str = "istio",
 ):
     predictor = _create_ts_predictor(service_name, storage_uri=storage_uri)
-    return await deploy_and_predict(service_name, predictor, rest_v1_client, input_path)
+    return await deploy_and_predict(
+        service_name,
+        predictor,
+        rest_v1_client,
+        input_path,
+        network_layer=network_layer,
+    )
 
 
 @pytest.mark.predictor
 @pytest.mark.asyncio(scope="session")
-async def test_autogluon_timeseries_runtime_kserve_v1(rest_v1_client):
+async def test_autogluon_timeseries_runtime_kserve_v1(rest_v1_client, network_layer):
     service_name = "isvc-autogluon-ts-v1"
     response = await _deploy_and_predict_v1(
         service_name,
         rest_v1_client,
         "./data/autogluon_timeseries_input.json",
+        network_layer=network_layer,
     )
     assert "predictions" in response
     assert len(response["predictions"]) > 0
@@ -83,6 +94,7 @@ async def test_autogluon_timeseries_runtime_kserve_v1(rest_v1_client):
 @pytest.mark.asyncio(scope="session")
 async def test_autogluon_timeseries_runtime_kserve_v1_storage_uri_without_trailing_slash(
     rest_v1_client,
+    network_layer,
 ):
     service_name = "isvc-autogluon-ts-v1-noslash"
     response = await _deploy_and_predict_v1(
@@ -90,6 +102,7 @@ async def test_autogluon_timeseries_runtime_kserve_v1_storage_uri_without_traili
         rest_v1_client,
         "./data/autogluon_timeseries_input_long.json",
         storage_uri=AUTOGLUON_TS_STORAGE_URI.rstrip("/"),
+        network_layer=network_layer,
     )
     assert "predictions" in response
     assert len(response["predictions"]) > 0


### PR DESCRIPTION
## Summary

Autogluon e2e tests (`test_autogluon.py`, `test_autogluon_timeseries.py`) call
`predict_isvc()` / `deploy_and_predict()` without passing the `network_layer`
fixture, so they always default to `istio` regardless of the
`--network-layer` CLI option passed to pytest.

On OpenShift CI, which runs with `--network-layer=openshift-route`, this makes
`get_isvc_endpoint()` look up an `istio-ingressgateway` Service that does not
exist in that topology:

```
RuntimeError: No service found with labels: {'app': 'istio-ingressgateway', 'istio': 'ingressgateway'}
```

Observed failing every Autogluon test in `ci/prow/e2e-predictor` on
[#1711](https://github.com/opendatahub-io/kserve/pull/1711) (and other
`release-v0.17` sync PRs), while sibling tests like `test_batcher.py` pass
because they already thread `network_layer` through.

## Fix

Thread the `network_layer` pytest fixture through:
- `deploy_and_predict()` in `autogluon_helpers.py`
- Every test in `test_autogluon.py` and `test_autogluon_timeseries.py`,
  including the direct `predict_isvc()` call in
  `test_autogluon_runtime_kserve_v2_input_variants`

This matches the pattern already used by `test_batcher.py` and other e2e
tests that accept `network_layer` as a fixture and forward it explicitly.

## Test plan

- [x] `python3 -m py_compile` on the changed files
- [ ] `ci/prow/e2e-predictor` passes Autogluon tests under
      `--network-layer=openshift-route`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end prediction test coverage to work consistently across different network routing setups.
  * Fixed handling for deployment requests in scenarios with and without trailing slashes in storage paths.

* **Tests**
  * Updated AutoGluon prediction and time-series test flows to pass network configuration through the full request path.
  * Expanded test coverage for multiple prediction variants to better validate deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->