### PR TITLE
fix(kserve-module): delete deployments/daemonset with legacy ODH operator selectors on upgrade

### DIFF
--- a/kserve-module/config/kustomization.yaml
+++ b/kserve-module/config/kustomization.yaml
@@ -10,5 +10,5 @@ resources:
 
 images:
 - name: kserve-module-controller
-  newName: quay.io/opendatahub/kserve-module-controller
-  newTag: latest
+  newName: quay.io/opendatahub/odh-kserve-module-controller
+  newTag: odh-stable

--- a/kserve-module/pkg/kservemodule/upgrade.go
+++ b/kserve-module/pkg/kservemodule/upgrade.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -14,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -75,12 +77,82 @@ func (u *upgradeRunnable) Start(ctx context.Context) error {
 // matching the pattern used by opendatahub-operator's LeaderElectionRunnableFunc.
 func (u *upgradeRunnable) NeedLeaderElection() bool { return true }
 
-// runUpgradeTasks checks whether both the HardwareProfile and AcceleratorProfile CRDs are present,
-// fetches OdhDashboardConfig, and delegates to attachHardwareProfileToInferenceServices.
+// legacySelectorDeployment defines a deployment that may carry legacy selector labels
+// injected by the in-tree ODH operator via kustomize.WithLabel.
+type legacySelectorDeployment struct {
+	name           string
+	legacyLabelKey string
+}
+
+// legacySelectorDeployments lists deployments whose spec.selector.matchLabels may contain
+// labels injected by the in-tree ODH operator (app.opendatahub.io/* and app.kubernetes.io/part-of).
+// Since Deployment spec.selector is immutable, these must be deleted so the reconciler can
+// recreate them with the correct selectors.
+var legacySelectorDeployments = []legacySelectorDeployment{
+	{name: "kserve-controller-manager", legacyLabelKey: "app.opendatahub.io/kserve"},
+	{name: "llmisvc-controller-manager", legacyLabelKey: "app.opendatahub.io/kserve"},
+	{name: "odh-model-controller", legacyLabelKey: "app.opendatahub.io/odh-model-controller"},
+	{name: "model-serving-api", legacyLabelKey: "app.opendatahub.io/odh-model-controller"},
+}
+
+// deleteLegacySelectorDeployments checks each deployment for legacy selector labels and
+// deletes those that carry them. The reconciler will recreate them with the correct selectors.
+func deleteLegacySelectorDeployments(ctx context.Context, cli client.Client, namespace string) error {
+	log := ctrl.LoggerFrom(ctx)
+	var errs []error
+
+	for _, ld := range legacySelectorDeployments {
+		dep := &appsv1.Deployment{}
+		if err := cli.Get(ctx, types.NamespacedName{Name: ld.name, Namespace: namespace}, dep); err != nil {
+			if k8serr.IsNotFound(err) {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("failed to get deployment %s: %w", ld.name, err))
+			continue
+		}
+
+		if dep.Spec.Selector == nil || dep.Spec.Selector.MatchLabels == nil {
+			continue
+		}
+
+		if _, hasLegacy := dep.Spec.Selector.MatchLabels[ld.legacyLabelKey]; !hasLegacy {
+			continue
+		}
+
+		log.Info("Deleting deployment with legacy selector labels",
+			"deployment", ld.name, "legacyLabel", ld.legacyLabelKey)
+
+		if err := cli.Delete(ctx, dep); err != nil && !k8serr.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("failed to delete deployment %s: %w", ld.name, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// runUpgradeTasks performs one-time migration tasks on startup:
+//  1. Deletes deployments carrying legacy selector labels from the in-tree ODH operator.
+//  2. Migrates HardwareProfile annotations on InferenceServices.
+func runUpgradeTasks(ctx context.Context, cli client.Client, applicationNS string) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	if err := deleteLegacySelectorDeployments(ctx, cli, applicationNS); err != nil {
+		log.Error(err, "legacy selector deployment cleanup encountered errors")
+	}
+
+	if err := migrateHardwareProfileAnnotations(ctx, cli, applicationNS); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// migrateHardwareProfileAnnotations checks whether both the HardwareProfile and AcceleratorProfile
+// CRDs are present, fetches OdhDashboardConfig, and delegates to attachHardwareProfileToInferenceServices.
 //
 // Returns nil (with an informational log) when either CRD is absent or when OdhDashboardConfig
 // is not found, since those conditions are expected on clusters that haven't deployed the relevant features.
-func runUpgradeTasks(ctx context.Context, cli client.Client, applicationNS string) error {
+func migrateHardwareProfileAnnotations(ctx context.Context, cli client.Client, applicationNS string) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	hwpGK := schema.GroupKind{Group: hardwareProfileGVK.Group, Kind: hardwareProfileGVK.Kind}

--- a/kserve-module/pkg/kservemodule/upgrade.go
+++ b/kserve-module/pkg/kservemodule/upgrade.go
@@ -77,27 +77,32 @@ func (u *upgradeRunnable) Start(ctx context.Context) error {
 // matching the pattern used by opendatahub-operator's LeaderElectionRunnableFunc.
 func (u *upgradeRunnable) NeedLeaderElection() bool { return true }
 
-// legacySelectorDeployment defines a deployment that may carry legacy selector labels
-// injected by the in-tree ODH operator via kustomize.WithLabel.
-type legacySelectorDeployment struct {
+// legacySelectorWorkload defines a Deployment or DaemonSet that may carry legacy selector
+// labels injected by the in-tree ODH operator via kustomize.WithLabel.
+type legacySelectorWorkload struct {
 	name           string
 	legacyLabelKey string
 }
 
-// legacySelectorDeployments lists deployments whose spec.selector.matchLabels may contain
+// legacySelectorDeployments lists Deployments whose spec.selector.matchLabels may contain
 // labels injected by the in-tree ODH operator (app.opendatahub.io/* and app.kubernetes.io/part-of).
-// Since Deployment spec.selector is immutable, these must be deleted so the reconciler can
-// recreate them with the correct selectors.
-var legacySelectorDeployments = []legacySelectorDeployment{
+// Since spec.selector is immutable, these must be deleted so the reconciler can recreate them.
+var legacySelectorDeployments = []legacySelectorWorkload{
 	{name: "kserve-controller-manager", legacyLabelKey: "app.opendatahub.io/kserve"},
 	{name: "llmisvc-controller-manager", legacyLabelKey: "app.opendatahub.io/kserve"},
+	{name: "kserve-localmodel-controller-manager", legacyLabelKey: "app.opendatahub.io/kserve"},
 	{name: "odh-model-controller", legacyLabelKey: "app.opendatahub.io/odh-model-controller"},
 	{name: "model-serving-api", legacyLabelKey: "app.opendatahub.io/odh-model-controller"},
 }
 
-// deleteLegacySelectorDeployments checks each deployment for legacy selector labels and
-// deletes those that carry them. The reconciler will recreate them with the correct selectors.
-func deleteLegacySelectorDeployments(ctx context.Context, cli client.Client, namespace string) error {
+// legacySelectorDaemonSets lists DaemonSets with the same legacy selector problem.
+var legacySelectorDaemonSets = []legacySelectorWorkload{
+	{name: "kserve-localmodelnode-agent", legacyLabelKey: "app.opendatahub.io/kserve"},
+}
+
+// deleteLegacySelectorWorkloads checks each Deployment and DaemonSet for legacy selector
+// labels and deletes those that carry them. The reconciler will recreate them with the correct selectors.
+func deleteLegacySelectorWorkloads(ctx context.Context, cli client.Client, namespace string) error {
 	log := ctrl.LoggerFrom(ctx)
 	var errs []error
 
@@ -127,16 +132,42 @@ func deleteLegacySelectorDeployments(ctx context.Context, cli client.Client, nam
 		}
 	}
 
+	for _, ld := range legacySelectorDaemonSets {
+		ds := &appsv1.DaemonSet{}
+		if err := cli.Get(ctx, types.NamespacedName{Name: ld.name, Namespace: namespace}, ds); err != nil {
+			if k8serr.IsNotFound(err) {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("failed to get daemonset %s: %w", ld.name, err))
+			continue
+		}
+
+		if ds.Spec.Selector == nil || ds.Spec.Selector.MatchLabels == nil {
+			continue
+		}
+
+		if _, hasLegacy := ds.Spec.Selector.MatchLabels[ld.legacyLabelKey]; !hasLegacy {
+			continue
+		}
+
+		log.Info("Deleting daemonset with legacy selector labels",
+			"daemonset", ld.name, "legacyLabel", ld.legacyLabelKey)
+
+		if err := cli.Delete(ctx, ds); err != nil && !k8serr.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("failed to delete daemonset %s: %w", ld.name, err))
+		}
+	}
+
 	return errors.Join(errs...)
 }
 
 // runUpgradeTasks performs one-time migration tasks on startup:
-//  1. Deletes deployments carrying legacy selector labels from the in-tree ODH operator.
+//  1. Deletes Deployments and DaemonSets carrying legacy selector labels from the in-tree ODH operator.
 //  2. Migrates HardwareProfile annotations on InferenceServices.
 func runUpgradeTasks(ctx context.Context, cli client.Client, applicationNS string) error {
 	log := ctrl.LoggerFrom(ctx)
 
-	if err := deleteLegacySelectorDeployments(ctx, cli, applicationNS); err != nil {
+	if err := deleteLegacySelectorWorkloads(ctx, cli, applicationNS); err != nil {
 		log.Error(err, "legacy selector deployment cleanup encountered errors")
 	}
 

--- a/kserve-module/pkg/kservemodule/upgrade_test.go
+++ b/kserve-module/pkg/kservemodule/upgrade_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -32,10 +33,11 @@ var (
 	testClusterScope   = testRESTScope{name: apimeta.RESTScopeNameRoot}
 )
 
-// makeUpgradeTestScheme returns a scheme with corev1 and apiextensionsv1 registered.
+// makeUpgradeTestScheme returns a scheme with corev1, appsv1, and apiextensionsv1 registered.
 func makeUpgradeTestScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
 	_ = corev1.AddToScheme(s)
+	_ = appsv1.AddToScheme(s)
 	_ = apiextensionsv1.AddToScheme(s)
 	return s
 }
@@ -48,6 +50,9 @@ func makeUpgradeTestRESTMapper() apimeta.RESTMapper {
 	rm.Add(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}, testClusterScope)
 	rm.Add(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Event"}, testNamespaceScope)
 	rm.Add(schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"}, testClusterScope)
+
+	// Typed GVKs
+	rm.Add(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, testNamespaceScope)
 
 	// Unstructured GVKs from upgrade.go
 	rm.Add(inferenceServiceGVK, testNamespaceScope)
@@ -1047,5 +1052,115 @@ func TestAttachHardwareProfileToInferenceServices_ErrorAggregation(t *testing.T)
 			g.Expect(updated.GetAnnotations()).To(HaveKey(hwpNameAnnotation),
 				"expected %s to have HWP annotation", name)
 		}
+	})
+}
+
+// ─── Legacy Selector Deployment Cleanup ─────────────────────────────────────
+
+func makeLegacyDeployment(name, namespace string, selectorLabels map[string]string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: selectorLabels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: selectorLabels},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+			},
+		},
+	}
+}
+
+func TestDeleteLegacySelectorDeployments(t *testing.T) {
+	ctx := context.Background()
+	const namespace = "test-namespace"
+
+	t.Run("DeletesAllFourLegacyDeployments", func(t *testing.T) {
+		g := NewWithT(t)
+
+		deps := []client.Object{
+			makeLegacyDeployment("kserve-controller-manager", namespace, map[string]string{
+				"control-plane":             "kserve-controller-manager",
+				"app.opendatahub.io/kserve": "true",
+			}),
+			makeLegacyDeployment("llmisvc-controller-manager", namespace, map[string]string{
+				"control-plane":             "llmisvc-controller-manager",
+				"app.opendatahub.io/kserve": "true",
+			}),
+			makeLegacyDeployment("odh-model-controller", namespace, map[string]string{
+				"control-plane":                            "odh-model-controller",
+				"app.opendatahub.io/odh-model-controller": "true",
+			}),
+			makeLegacyDeployment("model-serving-api", namespace, map[string]string{
+				"app":                                      "model-serving-api",
+				"app.opendatahub.io/odh-model-controller": "true",
+			}),
+		}
+
+		cli := makeISVCFakeClient(deps...)
+		g.Expect(deleteLegacySelectorDeployments(ctx, cli, namespace)).To(Succeed())
+
+		for _, name := range []string{"kserve-controller-manager", "llmisvc-controller-manager", "odh-model-controller", "model-serving-api"} {
+			got := &appsv1.Deployment{}
+			err := cli.Get(ctx, client.ObjectKeyFromObject(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}), got)
+			g.Expect(k8serr.IsNotFound(err)).To(BeTrue(), "deployment %s should be deleted", name)
+		}
+	})
+
+	t.Run("SkipsDeploymentsWithoutLegacySelector", func(t *testing.T) {
+		g := NewWithT(t)
+
+		dep := makeLegacyDeployment("kserve-controller-manager", namespace, map[string]string{
+			"control-plane":           "kserve-controller-manager",
+			"controller-tools.k8s.io": "1.0",
+		})
+
+		cli := makeISVCFakeClient(dep)
+		g.Expect(deleteLegacySelectorDeployments(ctx, cli, namespace)).To(Succeed())
+
+		got := &appsv1.Deployment{}
+		g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(dep), got)).To(Succeed())
+	})
+
+	t.Run("SkipsMissingDeployments", func(t *testing.T) {
+		g := NewWithT(t)
+		cli := makeISVCFakeClient()
+		g.Expect(deleteLegacySelectorDeployments(ctx, cli, namespace)).To(Succeed())
+	})
+
+	t.Run("PartialErrorContinuesProcessing", func(t *testing.T) {
+		g := NewWithT(t)
+
+		dep1 := makeLegacyDeployment("kserve-controller-manager", namespace, map[string]string{
+			"control-plane":             "kserve-controller-manager",
+			"app.opendatahub.io/kserve": "true",
+		})
+		dep2 := makeLegacyDeployment("llmisvc-controller-manager", namespace, map[string]string{
+			"control-plane":             "llmisvc-controller-manager",
+			"app.opendatahub.io/kserve": "true",
+		})
+
+		funcs := interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				if obj.GetName() == "kserve-controller-manager" {
+					return errors.New("simulated delete error")
+				}
+				return c.Delete(ctx, obj, opts...)
+			},
+		}
+
+		cli := fake.NewClientBuilder().
+			WithScheme(makeUpgradeTestScheme()).
+			WithRESTMapper(makeUpgradeTestRESTMapper()).
+			WithObjects(dep1, dep2).
+			WithInterceptorFuncs(funcs).
+			Build()
+
+		err := deleteLegacySelectorDeployments(ctx, cli, namespace)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err.Error()).To(ContainSubstring("kserve-controller-manager"))
+
+		got := &appsv1.Deployment{}
+		g.Expect(k8serr.IsNotFound(cli.Get(ctx, client.ObjectKeyFromObject(dep2), got))).
+			To(BeTrue(), "llmisvc-controller-manager should be deleted despite kserve error")
 	})
 }

--- a/kserve-module/pkg/kservemodule/upgrade_test.go
+++ b/kserve-module/pkg/kservemodule/upgrade_test.go
@@ -1070,20 +1070,37 @@ func makeLegacyDeployment(name, namespace string, selectorLabels map[string]stri
 	}
 }
 
-func TestDeleteLegacySelectorDeployments(t *testing.T) {
+func makeLegacyDaemonSet(name, namespace string, selectorLabels map[string]string) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: selectorLabels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: selectorLabels},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "img"}}},
+			},
+		},
+	}
+}
+
+func TestDeleteLegacySelectorWorkloads(t *testing.T) {
 	ctx := context.Background()
 	const namespace = "test-namespace"
 
-	t.Run("DeletesAllFourLegacyDeployments", func(t *testing.T) {
+	t.Run("DeletesAllLegacyWorkloads", func(t *testing.T) {
 		g := NewWithT(t)
 
-		deps := []client.Object{
+		workloads := []client.Object{
 			makeLegacyDeployment("kserve-controller-manager", namespace, map[string]string{
 				"control-plane":             "kserve-controller-manager",
 				"app.opendatahub.io/kserve": "true",
 			}),
 			makeLegacyDeployment("llmisvc-controller-manager", namespace, map[string]string{
 				"control-plane":             "llmisvc-controller-manager",
+				"app.opendatahub.io/kserve": "true",
+			}),
+			makeLegacyDeployment("kserve-localmodel-controller-manager", namespace, map[string]string{
+				"control-plane":             "kserve-localmodel-controller-manager",
 				"app.opendatahub.io/kserve": "true",
 			}),
 			makeLegacyDeployment("odh-model-controller", namespace, map[string]string{
@@ -1094,16 +1111,24 @@ func TestDeleteLegacySelectorDeployments(t *testing.T) {
 				"app":                                      "model-serving-api",
 				"app.opendatahub.io/odh-model-controller": "true",
 			}),
+			makeLegacyDaemonSet("kserve-localmodelnode-agent", namespace, map[string]string{
+				"control-plane":             "kserve-localmodelnode-agent",
+				"app.opendatahub.io/kserve": "true",
+			}),
 		}
 
-		cli := makeISVCFakeClient(deps...)
-		g.Expect(deleteLegacySelectorDeployments(ctx, cli, namespace)).To(Succeed())
+		cli := makeISVCFakeClient(workloads...)
+		g.Expect(deleteLegacySelectorWorkloads(ctx, cli, namespace)).To(Succeed())
 
-		for _, name := range []string{"kserve-controller-manager", "llmisvc-controller-manager", "odh-model-controller", "model-serving-api"} {
+		for _, name := range []string{"kserve-controller-manager", "llmisvc-controller-manager", "kserve-localmodel-controller-manager", "odh-model-controller", "model-serving-api"} {
 			got := &appsv1.Deployment{}
 			err := cli.Get(ctx, client.ObjectKeyFromObject(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}), got)
 			g.Expect(k8serr.IsNotFound(err)).To(BeTrue(), "deployment %s should be deleted", name)
 		}
+
+		ds := &appsv1.DaemonSet{}
+		dsErr := cli.Get(ctx, client.ObjectKeyFromObject(&appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: "kserve-localmodelnode-agent", Namespace: namespace}}), ds)
+		g.Expect(k8serr.IsNotFound(dsErr)).To(BeTrue(), "daemonset kserve-localmodelnode-agent should be deleted")
 	})
 
 	t.Run("SkipsDeploymentsWithoutLegacySelector", func(t *testing.T) {
@@ -1115,7 +1140,7 @@ func TestDeleteLegacySelectorDeployments(t *testing.T) {
 		})
 
 		cli := makeISVCFakeClient(dep)
-		g.Expect(deleteLegacySelectorDeployments(ctx, cli, namespace)).To(Succeed())
+		g.Expect(deleteLegacySelectorWorkloads(ctx, cli, namespace)).To(Succeed())
 
 		got := &appsv1.Deployment{}
 		g.Expect(cli.Get(ctx, client.ObjectKeyFromObject(dep), got)).To(Succeed())
@@ -1124,7 +1149,7 @@ func TestDeleteLegacySelectorDeployments(t *testing.T) {
 	t.Run("SkipsMissingDeployments", func(t *testing.T) {
 		g := NewWithT(t)
 		cli := makeISVCFakeClient()
-		g.Expect(deleteLegacySelectorDeployments(ctx, cli, namespace)).To(Succeed())
+		g.Expect(deleteLegacySelectorWorkloads(ctx, cli, namespace)).To(Succeed())
 	})
 
 	t.Run("PartialErrorContinuesProcessing", func(t *testing.T) {
@@ -1155,7 +1180,7 @@ func TestDeleteLegacySelectorDeployments(t *testing.T) {
 			WithInterceptorFuncs(funcs).
 			Build()
 
-		err := deleteLegacySelectorDeployments(ctx, cli, namespace)
+		err := deleteLegacySelectorWorkloads(ctx, cli, namespace)
 		g.Expect(err).To(HaveOccurred())
 		g.Expect(err.Error()).To(ContainSubstring("kserve-controller-manager"))
 


### PR DESCRIPTION
## Summary
- When migrating from the in-tree ODH operator, existing Deployments and DaemonSets carry immutable selector labels  (app.opendatahub.io/*, app.kubernetes.io/part-of) injected by kustomize.WithLabel.  The kserve-module reconciler fails to patch them because spec.selector is immutable.
- Added deleteLegacySelectorWorkloads to the upgrade runnable that detects and deletes these workloads on startup. The reconciler then recreates them with the correct selectors.
- Affected Deployments: kserve-controller-manager, llmisvc-controller-manager, kserve-localmodel-controller-manager, odh-model-controller, model-serving-api
- Affected DaemonSets: kserve-localmodelnode-agent
- Extracted migrateHardwareProfileAnnotations from runUpgradeTasks for readability.
- Fixed controller image name and tag in kustomization.yaml