### PR TITLE
feat(kserve-module): read platform version from ConfigMap

### DIFF
--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -84,7 +84,7 @@ func kservePostRender(ctx context.Context, r *KserveModuleReconciler,
 		return nil, fmt.Errorf("customizing configmap: %w", err)
 	}
 
-	versionPrefix := r.getVersionPrefix(kserve)
+	versionPrefix := r.getVersionPrefix(ctx, kserve)
 	resources, err = versionedWellKnownLLMInferenceServiceConfigs(resources, versionPrefix)
 	if err != nil {
 		return nil, fmt.Errorf("versioning LLMInferenceServiceConfigs: %w", err)

--- a/kserve-module/pkg/kservemodule/constants.go
+++ b/kserve-module/pkg/kservemodule/constants.go
@@ -24,6 +24,10 @@ const (
 	// SSA field manager
 	fieldOwner = "kserve-module-controller"
 
+	// Platform version ConfigMap
+	platformVersionConfigMap    = "odh-kserve-config"
+	platformVersionConfigMapKey = "platformVersion"
+
 	// ConfigMap keys
 	kserveConfigMapName     = "inferenceservice-config"
 	ingressConfigKeyName    = "ingress"

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -13,8 +13,10 @@ import (
 	"sync"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -332,9 +334,21 @@ func (r *KserveModuleReconciler) getApplicationsNamespace() string {
 	return "opendatahub"
 }
 
-// TODO: for now, we can use the annotation but the version will be set by data of configmap
-// We need to confirm with platform team what configmap name is used for the version.
-func (r *KserveModuleReconciler) getVersionPrefix(kserve *platformv1alpha1.Kserve) string {
+func (r *KserveModuleReconciler) getPlatformVersion(ctx context.Context) string {
+	cm := &corev1.ConfigMap{}
+	key := types.NamespacedName{Name: platformVersionConfigMap, Namespace: r.getApplicationsNamespace()}
+	if err := r.Get(ctx, key, cm); err != nil {
+		ctrl.LoggerFrom(ctx).V(1).Info("ConfigMap not found, platform version unknown",
+			"configmap", key, "error", err)
+		return ""
+	}
+	return cm.Data[platformVersionConfigMapKey]
+}
+
+func (r *KserveModuleReconciler) getVersionPrefix(ctx context.Context, kserve *platformv1alpha1.Kserve) string {
+	if v := r.getPlatformVersion(ctx); v != "" {
+		return "v" + strings.ReplaceAll(v, ".", "-")
+	}
 	if ann := kserve.GetAnnotations(); ann != nil {
 		if v := ann["platform.opendatahub.io/version"]; v != "" {
 			return "v" + strings.ReplaceAll(v, ".", "-")

--- a/kserve-module/pkg/kservemodule/setup.go
+++ b/kserve-module/pkg/kservemodule/setup.go
@@ -84,6 +84,13 @@ func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(mapToKserve),
 			builder.WithPredicates(crdNamePredicate()),
 		).
+		Watches(&corev1.ConfigMap{},
+			handler.EnqueueRequestsFromMapFunc(mapToKserve),
+			builder.WithPredicates(predicate.NewPredicateFuncs(func(o client.Object) bool {
+				return o.GetName() == platformVersionConfigMap &&
+					o.GetNamespace() == r.getApplicationsNamespace()
+			})),
+		).
 		// Watch Nodes so that newly added or relabeled nodes trigger
 		// reconciliation of labelModelCacheNodes.
 		Watches(&corev1.Node{}, handler.EnqueueRequestsFromMapFunc(mapToKserve),

--- a/kserve-module/pkg/kservemodule/status.go
+++ b/kserve-module/pkg/kservemodule/status.go
@@ -143,7 +143,7 @@ func (r *KserveModuleReconciler) updateComponentReadiness(ctx context.Context, k
 }
 
 func (r *KserveModuleReconciler) updateStatus(ctx context.Context, kserve *platformv1alpha1.Kserve, condMgr *conditions.Manager) error {
-	r.setReleaseStatus(kserve)
+	r.setReleaseStatus(ctx, kserve)
 	condMgr.Sort()
 
 	if condMgr.IsHappy() {
@@ -167,12 +167,19 @@ func (r *KserveModuleReconciler) updateStatus(ctx context.Context, kserve *platf
 	})
 }
 
-func (r *KserveModuleReconciler) setReleaseStatus(kserve *platformv1alpha1.Kserve) {
+func (r *KserveModuleReconciler) setReleaseStatus(ctx context.Context, kserve *platformv1alpha1.Kserve) {
 	releases, err := loadComponentReleases(r.ManifestsTemplatePath,
 		[]string{KserveComponentName, OdhModelControllerComponentName})
 	if err != nil {
 		ctrl.Log.Error(err, "failed to load component releases")
 		return
+	}
+
+	if v := r.getPlatformVersion(ctx); v != "" {
+		releases = append(releases, common.ComponentRelease{
+			Name:    "platform",
+			Version: v,
+		})
 	}
 
 	kserve.SetReleaseStatus(common.ComponentReleaseStatus{Releases: releases})

--- a/kserve-module/tests/e2e/conftest.py
+++ b/kserve-module/tests/e2e/conftest.py
@@ -397,3 +397,49 @@ def model_cache_enabled(kubectl, cluster_info, apply_kserve_cr):
         TIMEOUT_120S,
         f"ModelCache disable not reconciled within {TIMEOUT_120S}s",
     )
+
+
+PLATFORM_VERSION_CM = "odh-kserve-config"
+TEST_PLATFORM_VERSION = "99.0.0"
+
+
+def platform_configmap_exists(kubectl_bin):
+    """Check if the platform version ConfigMap already exists."""
+    return resource_exists(kubectl_bin, "configmap", PLATFORM_VERSION_CM, namespace=NAMESPACE)
+
+
+@pytest.fixture
+def ensure_platform_configmap(kubectl, apply_kserve_cr):
+    """Ensure odh-kserve-config ConfigMap exists with a platformVersion.
+
+    If it already exists (e.g. platform operator created it), leave it alone.
+    Otherwise create a test one and clean up after.
+    """
+    already_existed = platform_configmap_exists(kubectl)
+
+    if not already_existed:
+        cm_yaml = yaml.safe_dump({
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": PLATFORM_VERSION_CM, "namespace": NAMESPACE},
+            "data": {"platformVersion": TEST_PLATFORM_VERSION},
+        })
+        run([kubectl, "apply", "-f", "-"], input_text=cm_yaml)
+        _poll_cr(
+            kubectl,
+            KSERVE_CR_NAME,
+            lambda cr: any(
+                r.get("name") == "platform"
+                for r in cr.get("status", {}).get("releases", [])
+            ),
+            TIMEOUT_60S,
+            "platform release not reported after ConfigMap creation",
+        )
+
+    yield
+
+    if not already_existed:
+        run(
+            [kubectl, "delete", "configmap", PLATFORM_VERSION_CM, "-n", NAMESPACE, "--ignore-not-found"],
+            check=False,
+        )

--- a/kserve-module/tests/e2e/test_status.py
+++ b/kserve-module/tests/e2e/test_status.py
@@ -39,4 +39,12 @@ class TestStatusConditions:
         assert cr["status"]["phase"] == "Ready"
         assert cr["status"]["observedGeneration"] == cr["metadata"]["generation"]
 
+    def test_releases_include_platform_version(self, kubectl, ensure_platform_configmap):
+        """status.releases includes a platform entry from the odh-kserve-config ConfigMap."""
+        cr = get_cr(kubectl)
+        releases = cr.get("status", {}).get("releases", [])
+        release_names = {r["name"] for r in releases}
+        assert "platform" in release_names, f"expected 'platform' in releases, got {release_names}"
 
+        platform = next(r for r in releases if r["name"] == "platform")
+        assert platform["version"] != "", "platform version should not be empty"


### PR DESCRIPTION
## Summary
- Read platformVersion from odh-kserve-config ConfigMap instead of CR annotation. Falls back to annotation if ConfigMap is absent.
- Write name=platform entry to status.releases for platform version handshake.
- Watch odh-kserve-config ConfigMap to trigger reconcile on version changes.
- E2E test for platform release in status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform version information is now included in KServe release status as an additional `platform` entry.
  * Versioned configuration updates now respect a platform version sourced from a dedicated ConfigMap.
  * Updates to the platform version ConfigMap are detected and reconciled automatically.
* **Tests**
  * Added end-to-end coverage ensuring `status.releases` includes a non-empty `platform` version, using a test ConfigMap fixture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->