### PR TITLE
ci(kserve-module): increase e2e test timeout to 60 minutes

### DIFF
--- a/.github/workflows/e2e-test-kserve-module.yml
+++ b/.github/workflows/e2e-test-kserve-module.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:


### PR DESCRIPTION
## Summary
- Increase kserve-module e2e test job timeout from 30 to 60 minutes. Cluster setup and operand deployment can exceed 30 minutes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the end-to-end test workflow timeout to improve reliability for longer-running test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->