### PR TITLE
fix(modelcache): use MustRunAs SELinux context for localmodel agent SCC

### DIFF
--- a/config/overlays/odh-modelcache/localmodel-scc.yaml
+++ b/config/overlays/odh-modelcache/localmodel-scc.yaml
@@ -17,7 +17,12 @@ runAsUser:
   type: MustRunAs
   uid: 1000
 seLinuxContext:
-  type: RunAsAny
+  # MustRunAs (with no explicit level) makes OpenShift derive the pod's SELinux
+  # MCS category from the namespace's `openshift.io/sa.scc.mcs` annotation, the
+  # same category the model-cache permission-fix Job relabels the hostPath
+  # directory to. RunAsAny let CRI-O assign an unrelated per-pod category,
+  # causing a permanent SELinux permission-denied loop on the agent.
+  type: MustRunAs
 fsGroup:
   type: MustRunAs
   ranges:

--- a/kserve-module/pkg/kservemodule/localmodel_scc_test.go
+++ b/kserve-module/pkg/kservemodule/localmodel_scc_test.go
@@ -1,0 +1,50 @@
+package kservemodule
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+)
+
+// localModelSCCManifestPath points at the source-of-truth SecurityContextConstraints
+// manifest consumed both by the legacy operator kustomize overlay and by
+// ModelCacheManifestSourcePath ("overlays/odh-modelcache") here in kserve-module.
+const localModelSCCManifestPath = "../../../config/overlays/odh-modelcache/localmodel-scc.yaml"
+
+type sccStrategy struct {
+	Type string `yaml:"type"`
+}
+
+type securityContextConstraintsManifest struct {
+	Kind           string      `yaml:"kind"`
+	SELinuxContext sccStrategy `yaml:"seLinuxContext"`
+}
+
+// TestLocalModelSCC_SELinuxContextMustRunAs guards against regressing the
+// openshift-ai-localmodel-scc SCC back to seLinuxContext.type: RunAsAny.
+//
+// RunAsAny lets CRI-O assign the kserve-localmodelnode-agent DaemonSet pods an
+// arbitrary, per-pod SELinux MCS category instead of deriving it from the
+// namespace's `openshift.io/sa.scc.mcs` annotation. The model-cache
+// permission-fix Job relabels the shared hostPath directory to that
+// namespace-derived category, so a RunAsAny agent pod permanently mismatches
+// it and every model download gets stuck in NodeDownloadPending with
+// permission-denied errors. MustRunAs (with no explicit level) makes
+// OpenShift derive the same namespace category for the agent too.
+func TestLocalModelSCC_SELinuxContextMustRunAs(t *testing.T) {
+	g := NewWithT(t)
+
+	raw, err := os.ReadFile(localModelSCCManifestPath)
+	g.Expect(err).NotTo(HaveOccurred(), "failed to read %s", localModelSCCManifestPath)
+
+	var scc securityContextConstraintsManifest
+	g.Expect(yaml.Unmarshal(raw, &scc)).To(Succeed())
+
+	g.Expect(scc.Kind).To(Equal("SecurityContextConstraints"))
+	g.Expect(scc.SELinuxContext.Type).To(Equal("MustRunAs"),
+		"openshift-ai-localmodel-scc must use seLinuxContext.type: MustRunAs so the "+
+			"kserve-localmodelnode-agent DaemonSet gets the namespace's SELinux MCS "+
+			"category instead of an arbitrary one from CRI-O")
+}


### PR DESCRIPTION
## Summary

The `openshift-ai-localmodel-scc` SCC used by the `kserve-localmodelnode-agent` DaemonSet set `seLinuxContext.type: RunAsAny`, so CRI-O assigned the agent pods an arbitrary per-pod SELinux MCS category instead of deriving one from the namespace's `openshift.io/sa.scc.mcs` annotation.

The model-cache permission-fix Job relabels the shared hostPath model directory to that namespace-derived category, so a `RunAsAny` agent pod permanently mismatched it: every model download got stuck in `NodeDownloadPending` with permission-denied errors on `/var/lib/kserve/models`, even after the permission-fix Job completed successfully.

This manifest (`config/overlays/odh-modelcache/localmodel-scc.yaml`) is shared by the legacy `opendatahub-operator` kustomize path and by `kserve-module` (`ModelCacheManifestSourcePath`), so the fix applies to both deployment paths.

## Fix

Switch `seLinuxContext.type` from `RunAsAny` to `MustRunAs` (no explicit level), so OpenShift derives the same namespace MCS category for the agent as the permission-fix Job already gets.

## Test plan

- Added `TestLocalModelSCC_SELinuxContextMustRunAs` (`kserve-module/pkg/kservemodule/localmodel_scc_test.go`) asserting the SCC keeps `seLinuxContext.type: MustRunAs`; verified it fails against the prior `RunAsAny` value and passes with the fix.
- `go vet ./pkg/kservemodule/...` and `go test ./pkg/kservemodule/...` pass (203 tests).
- Reproduced the original bug on an OpenShift cluster running the `opendatahub-tests` model-cache smoke/lifecycle tests (nodes stuck in `NodeDownloadPending`, agent logs showing SELinux permission-denied on `/var/lib/kserve/models` despite successful permission-fix Jobs); will re-run those tests against this fix to confirm nodes reach `NodeDownloaded`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated local model security controls to require namespace-based SELinux enforcement.
  * Helps prevent recurring SELinux permission-denied errors when running local model workloads.

* **Tests**
  * Added validation to ensure the security configuration retains the required SELinux enforcement policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->