### PR TITLE
[RHOAIENG-55229] fix(ci): replace sleep with webhook probe

### DIFF
--- a/test/scripts/kind/setup-odh-xks.sh
+++ b/test/scripts/kind/setup-odh-xks.sh
@@ -209,8 +209,27 @@ install_cert_manager() {
   log_wait "Waiting for cert-manager to be ready..."
   wait_for_pods "cert-manager" "app in (cert-manager,webhook)" 180s
 
-  # Wait for webhook to be ready
-  sleep 5
+  # Wait for the webhook to accept requests -- pod readiness alone does not
+  # guarantee the API server trusts the webhook's self-signed CA.
+  log_wait "Waiting for cert-manager webhook to accept requests..."
+  local max_wait=60
+  local start=$SECONDS
+  while ! kubectl apply --dry-run=server -f - <<'PROBE' &>/dev/null; do
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: cert-manager-webhook-probe
+spec:
+  selfSigned: {}
+PROBE
+    if (( SECONDS - start >= max_wait )); then
+      log_error "Timed out after ${max_wait}s waiting for cert-manager webhook"
+      kubectl get validatingwebhookconfigurations -o wide || true
+      return 1
+    fi
+    log_wait "  cert-manager webhook not ready yet ($(( SECONDS - start ))s elapsed)..."
+    sleep 2
+  done
 
   log_success "cert-manager installed"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces the fixed `sleep 5` in `install_cert_manager()` with an active webhook readiness probe. Pod readiness does not guarantee the API server trusts the webhook's self-signed CA, causing intermittent failures when `setup_cert_manager_pki()` applies ClusterIssuer/Certificate resources.

The new probe uses `kubectl apply --dry-run=server` of a trivial self-signed ClusterIssuer in a retry loop (60s timeout, 2s interval) -- succeeds only when the webhook is actually accepting requests.

**Which issue(s) this PR fixes**:

- [RHOAIENG-55229](https://redhat.atlassian.net/browse/RHOAIENG-55229)

**Feature/Issue validation/testing**:

- [x] CI job `test-odh-xks-kind` exercises this code path on every run

**Special notes for your reviewer**:

The dry-run probe never creates a real resource -- `--dry-run=server` validates server-side (hitting the webhook) but does not persist.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note
NONE
```

**Involved repos**: https://github.com/opendatahub-io/kserve

[RHOAIENG-55229]: https://redhat.atlassian.net/browse/RHOAIENG-55229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cert-manager setup reliability by waiting until its validating webhook is ready before continuing.
  * Added a timeout and diagnostic logging when webhook readiness is not achieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->