### PR TITLE
fix(kserve-module): fix controller image name to odh-kserve-module-operator

### DIFF
--- a/kserve-module/config/kustomization.yaml
+++ b/kserve-module/config/kustomization.yaml
@@ -10,5 +10,5 @@ resources:
 
 images:
 - name: kserve-module-controller
-  newName: quay.io/opendatahub/odh-kserve-module-controller
+  newName: quay.io/opendatahub/odh-kserve-module-operator
   newTag: odh-stable


### PR DESCRIPTION
## Summary
- Fix controller image name in kustomization.yaml from odh-kserve-module-controller to odh-kserve-module-operator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the deployed component image reference to use the operator image, ensuring the correct container is deployed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->