### PR TITLE
feat: add console-dashboards component for ODC dashboard installation

### DIFF
--- a/kserve-module/config/crd/components.platform.opendatahub.io_kserves.yaml
+++ b/kserve-module/config/crd/components.platform.opendatahub.io_kserves.yaml
@@ -46,6 +46,11 @@ spec:
             type: object
           spec:
             properties:
+              enableLLMInferenceServiceConsoleDashboards:
+                description: |-
+                  Enables OpenShift Developer Console dashboards for LLMInferenceService.
+                  Enabled by default.
+                type: boolean
               enableLLMInferenceServiceTLS:
                 description: |-
                   Enables TLS for LLMInferenceService deployments.

--- a/kserve-module/pkg/apis/v1alpha1/types.go
+++ b/kserve-module/pkg/apis/v1alpha1/types.go
@@ -61,13 +61,17 @@ type KserveSpec struct {
 	// +kubebuilder:default=Headless
 	RawDeploymentServiceConfig RawServiceConfig `json:"rawDeploymentServiceConfig,omitempty"`
 	// +optional
-	OAuthProxy                   *OAuthProxyConfig `json:"oauthProxy,omitempty"`
-	NIM                          NIMSpec           `json:"nim,omitempty"`
-	WVA                          WVASpec           `json:"wva,omitempty"`
+	OAuthProxy *OAuthProxyConfig `json:"oauthProxy,omitempty"`
+	NIM        NIMSpec           `json:"nim,omitempty"`
+	WVA        WVASpec           `json:"wva,omitempty"`
 	// Enables TLS for LLMInferenceService deployments.
 	// When unset, the KServe default (TLS enabled) is preserved.
 	EnableLLMInferenceServiceTLS *bool `json:"enableLLMInferenceServiceTLS,omitempty"`
-	ModelCache                   *ModelCacheSpec  `json:"modelCache,omitempty"`
+	// Enables OpenShift Developer Console dashboards for LLMInferenceService.
+	// Enabled by default.
+	EnableLLMInferenceServiceConsoleDashboards *bool `json:"enableLLMInferenceServiceConsoleDashboards,omitempty"`
+
+	ModelCache *ModelCacheSpec `json:"modelCache,omitempty"`
 }
 
 type NIMSpec struct {
@@ -101,7 +105,7 @@ type ModelCacheSpec struct {
 }
 
 type KserveStatus struct {
-	common.Status                `json:",inline"`
+	common.Status                 `json:",inline"`
 	common.ComponentReleaseStatus `json:",inline"`
 }
 

--- a/kserve-module/pkg/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/kserve-module/pkg/apis/v1alpha1/zz_generated.deepcopy.go
@@ -85,6 +85,11 @@ func (in *KserveSpec) DeepCopyInto(out *KserveSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableLLMInferenceServiceConsoleDashboards != nil {
+		in, out := &in.EnableLLMInferenceServiceConsoleDashboards, &out.EnableLLMInferenceServiceConsoleDashboards
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ModelCache != nil {
 		in, out := &in.ModelCache, &out.ModelCache
 		*out = new(ModelCacheSpec)

--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -174,6 +174,9 @@ func consoleDashboardsPostRender(ctx context.Context, r *KserveModuleReconciler,
 	}
 
 	for i := range resources {
+		if kind := resources[i].GetKind(); kind != "ConfigMap" {
+			return nil, fmt.Errorf("unauthorized resource kind %s in console dashboards manifest", kind)
+		}
 		resources[i].SetNamespace(consoleDashboardsNamespace)
 	}
 	log.Info("set namespace on console dashboard resources", "namespace", consoleDashboardsNamespace, "count", len(resources))

--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -7,6 +7,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -153,10 +154,15 @@ func observabilityPostRender(ctx context.Context, r *KserveModuleReconciler,
 }
 
 func consoleDashboardsPostRender(ctx context.Context, r *KserveModuleReconciler,
-	_ *platformv1alpha1.Kserve,
+	kserve *platformv1alpha1.Kserve,
 	resources []unstructured.Unstructured) ([]unstructured.Unstructured, error) {
 
 	log := ctrl.LoggerFrom(ctx)
+
+	if kserve == nil || !ptr.Deref(kserve.Spec.EnableLLMInferenceServiceConsoleDashboards, true) {
+		log.Info("EnableLLMInferenceServiceConsoleDashboards is disabled, skipping console dashboards")
+		return nil, nil
+	}
 
 	ns := &corev1.Namespace{}
 	if err := r.Client.Get(ctx, client.ObjectKey{Name: consoleDashboardsNamespace}, ns); err != nil {

--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/odh-platform-utilities/api/common"
 	odhLabels "github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
@@ -74,6 +76,14 @@ var components = []componentConfig{
 		imageMap:     map[string]string{},
 		postRender:   observabilityPostRender,
 	},
+	{
+		// No enabled func: namespace check requires API client, handled in postRender.
+		name:         ConsoleDashboardsComponentName,
+		manifestName: KserveComponentName,
+		sourcePath:   ConsoleDashboardsManifestSourcePath,
+		imageMap:     map[string]string{},
+		postRender:   consoleDashboardsPostRender,
+	},
 }
 
 func kservePostRender(ctx context.Context, r *KserveModuleReconciler,
@@ -138,6 +148,29 @@ func observabilityPostRender(ctx context.Context, r *KserveModuleReconciler,
 		resources[i].SetNamespace(ns)
 	}
 	log.Info("set monitoring namespace on observability resources", "namespace", ns, "count", len(resources))
+
+	return resources, nil
+}
+
+func consoleDashboardsPostRender(ctx context.Context, r *KserveModuleReconciler,
+	_ *platformv1alpha1.Kserve,
+	resources []unstructured.Unstructured) ([]unstructured.Unstructured, error) {
+
+	log := ctrl.LoggerFrom(ctx)
+
+	ns := &corev1.Namespace{}
+	if err := r.Client.Get(ctx, client.ObjectKey{Name: consoleDashboardsNamespace}, ns); err != nil {
+		if client.IgnoreNotFound(err) == nil {
+			log.Info("namespace not found, skipping console dashboards", "namespace", consoleDashboardsNamespace)
+			return nil, nil
+		}
+		return nil, fmt.Errorf("checking namespace %s: %w", consoleDashboardsNamespace, err)
+	}
+
+	for i := range resources {
+		resources[i].SetNamespace(consoleDashboardsNamespace)
+	}
+	log.Info("set namespace on console dashboard resources", "namespace", consoleDashboardsNamespace, "count", len(resources))
 
 	return resources, nil
 }

--- a/kserve-module/pkg/kservemodule/components_test.go
+++ b/kserve-module/pkg/kservemodule/components_test.go
@@ -71,6 +71,23 @@ func TestComponentsConfig_WVAHasEnabled(t *testing.T) {
 	g.Expect(wva.sourcePathXKS).Should(BeEmpty(), "WVA is OCP-only, must not have XKS overlay")
 }
 
+func TestComponentsConfig_ConsoleDashboardsRegistration(t *testing.T) {
+	g := NewWithT(t)
+	var cd *componentConfig
+	for i := range components {
+		if components[i].name == ConsoleDashboardsComponentName {
+			cd = &components[i]
+			break
+		}
+	}
+	g.Expect(cd).ShouldNot(BeNil(), "console-dashboards component not registered")
+	g.Expect(cd.sourcePath).Should(Equal(ConsoleDashboardsManifestSourcePath))
+	g.Expect(cd.dirName()).Should(Equal(KserveComponentName), "manifestName must resolve to kserve dir")
+	g.Expect(cd.sourcePathXKS).Should(BeEmpty(), "console-dashboards is OCP-only, must not have XKS overlay")
+	g.Expect(cd.enabled).Should(BeNil(), "gating is done in postRender, not enabled")
+	g.Expect(cd.postRender).ShouldNot(BeNil(), "postRender must be set for namespace check")
+}
+
 func TestModelControllerExtraParams(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/kserve-module/pkg/kservemodule/constants.go
+++ b/kserve-module/pkg/kservemodule/constants.go
@@ -7,6 +7,7 @@ const (
 	WVAComponentName                = "wva"
 	ModelCacheComponentName         = "modelcache"
 	ObservabilityComponentName      = "observability"
+	ConsoleDashboardsComponentName  = "console-dashboards"
 
 	// Manifest source paths
 	KserveManifestSourcePath        = "overlays/odh"
@@ -14,7 +15,8 @@ const (
 	ModelCacheManifestSourcePath    = "overlays/odh-modelcache"
 	ModelControllerSourcePath       = "base"
 	WVAManifestSourcePathOCP        = "overlays/namespace-scoped/openshift"
-	ObservabilityManifestSourcePath = "monitoring/llmisvc/dashboards"
+	ObservabilityManifestSourcePath      = "monitoring/llmisvc/dashboards"
+	ConsoleDashboardsManifestSourcePath = "monitoring/llmisvc/dashboards-odc"
 
 	// Deployment names
 	kserveControllerDeployment     = "kserve-controller-manager"
@@ -22,6 +24,9 @@ const (
 	localmodelControllerDeployment = "kserve-localmodel-controller-manager"
 	odhModelControllerDeployment   = "odh-model-controller"
 	wvaControllerDeployment        = "workload-variant-autoscaler-controller-manager"
+
+	// Console dashboards target namespace
+	consoleDashboardsNamespace = "openshift-config-managed"
 
 	// SSA field manager
 	fieldOwner = "kserve-module-controller"

--- a/kserve-module/pkg/kservemodule/fixture/envtest.go
+++ b/kserve-module/pkg/kservemodule/fixture/envtest.go
@@ -151,9 +151,17 @@ spec:
     panels: {}
     layouts: []
 `
+	consoleDashboardsManifest := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: model-serving-llms-cluster-health
+data:
+  model-serving-llms-cluster-health-odc.json: "{}"
+`
 	writeKustomizeDir(filepath.Join(workDir, kservemodule.KserveComponentName, kservemodule.KserveManifestSourcePath), kserveManifest)
 	writeKustomizeDir(filepath.Join(workDir, kservemodule.KserveComponentName, kservemodule.KserveManifestSourcePathXKS), kserveManifest)
 	writeKustomizeDir(filepath.Join(workDir, kservemodule.KserveComponentName, kservemodule.ObservabilityManifestSourcePath), observabilityManifest)
+	writeKustomizeDir(filepath.Join(workDir, kservemodule.KserveComponentName, kservemodule.ConsoleDashboardsManifestSourcePath), consoleDashboardsManifest)
 	writeKustomizeDir(filepath.Join(workDir, kservemodule.OdhModelControllerComponentName, kservemodule.ModelControllerSourcePath), modelCtrlManifest)
 	writeKustomizeDir(filepath.Join(workDir, kservemodule.WVAComponentName, kservemodule.WVAManifestSourcePathOCP), wvaManifest)
 }

--- a/kserve-module/pkg/kservemodule/fixture/kserve_builder.go
+++ b/kserve-module/pkg/kservemodule/fixture/kserve_builder.go
@@ -57,6 +57,12 @@ func WithEnableLLMInferenceServiceTLS(val *bool) KserveOption {
 	}
 }
 
+func WithEnableLLMInferenceServiceConsoleDashboards(val *bool) KserveOption {
+	return func(k *platformv1alpha1.Kserve) {
+		k.Spec.EnableLLMInferenceServiceConsoleDashboards = val
+	}
+}
+
 func WithAnnotation(key, value string) KserveOption {
 	return func(k *platformv1alpha1.Kserve) {
 		if k.Annotations == nil {

--- a/kserve-module/pkg/kservemodule/reconciler_int_test.go
+++ b/kserve-module/pkg/kservemodule/reconciler_int_test.go
@@ -312,6 +312,67 @@ var _ = Describe("KserveModule Reconciler", func() {
 		})
 	})
 
+	Context("console dashboards lifecycle", Ordered, func() {
+		var cr *platformv1alpha1.Kserve
+
+		BeforeAll(func(ctx SpecContext) {
+			cr = fixture.KserveCR()
+			Expect(testEnv.Client.Create(ctx, cr)).To(Succeed())
+
+			DeferCleanup(func(ctx SpecContext) {
+				Expect(client.IgnoreNotFound(testEnv.Client.Delete(ctx, cr))).To(Succeed())
+			})
+		})
+
+		BeforeEach(func() {
+			testEnv.Deployer = &fixture.MockDeployer{}
+			testEnv.Reconciler.Deployer = testEnv.Deployer
+		})
+
+		It("does not include console dashboard resources when namespace does not exist", func(ctx SpecContext) {
+			triggerReconcile(ctx, cr, "console-dashboards-no-ns")
+
+			Eventually(func(g Gomega) {
+				g.Expect(testEnv.Client.Get(ctx, client.ObjectKeyFromObject(cr), cr)).To(Succeed())
+				cond := fixture.FindCondition(cr, string(common.ConditionTypeProvisioningSucceeded))
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			}).WithContext(ctx).Should(Succeed())
+
+			lastCall := testEnv.Deployer.LastCall()
+			Expect(lastCall).NotTo(BeNil())
+			for _, res := range lastCall.Resources {
+				Expect(res.GetName()).NotTo(Equal("model-serving-llms-cluster-health"),
+					"console dashboard ConfigMaps should not be deployed when namespace does not exist")
+			}
+		})
+
+		It("includes console dashboard resources when namespace exists", func(ctx SpecContext) {
+			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "openshift-config-managed"}}
+			Expect(testEnv.Client.Create(ctx, ns)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				Expect(client.IgnoreNotFound(testEnv.Client.Delete(ctx, ns))).To(Succeed())
+			})
+
+			triggerReconcile(ctx, cr, "console-dashboards-with-ns")
+
+			Eventually(func(g Gomega) {
+				lastCall := testEnv.Deployer.LastCall()
+				g.Expect(lastCall).NotTo(BeNil())
+
+				hasDashboard := false
+				for _, res := range lastCall.Resources {
+					if res.GetKind() == "ConfigMap" && res.GetName() == "model-serving-llms-cluster-health" {
+						g.Expect(res.GetNamespace()).To(Equal("openshift-config-managed"))
+						hasDashboard = true
+						break
+					}
+				}
+				g.Expect(hasDashboard).To(BeTrue(), "console dashboard ConfigMap should be in deployed resources")
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
 	Context("oauthProxy configuration", Ordered, func() {
 		var cr *platformv1alpha1.Kserve
 

--- a/kserve-module/pkg/kservemodule/reconciler_int_test.go
+++ b/kserve-module/pkg/kservemodule/reconciler_int_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/odh-platform-utilities/api/common"
@@ -369,6 +370,53 @@ var _ = Describe("KserveModule Reconciler", func() {
 					}
 				}
 				g.Expect(hasDashboard).To(BeTrue(), "console dashboard ConfigMap should be in deployed resources")
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("does not include console dashboard resources when explicitly disabled", func(ctx SpecContext) {
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				if err := testEnv.Client.Get(ctx, client.ObjectKeyFromObject(cr), cr); err != nil {
+					return err
+				}
+				cr.Spec.EnableLLMInferenceServiceConsoleDashboards = ptr.To(false)
+				return testEnv.Client.Update(ctx, cr)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				lastCall := testEnv.Deployer.LastCall()
+				g.Expect(lastCall).NotTo(BeNil())
+
+				for _, res := range lastCall.Resources {
+					g.Expect(res.GetName()).NotTo(Equal("model-serving-llms-cluster-health"),
+						"console dashboard ConfigMaps should not be deployed when explicitly disabled")
+				}
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("re-enables console dashboard resources when flag is set back to true", func(ctx SpecContext) {
+			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				if err := testEnv.Client.Get(ctx, client.ObjectKeyFromObject(cr), cr); err != nil {
+					return err
+				}
+				cr.Spec.EnableLLMInferenceServiceConsoleDashboards = ptr.To(true)
+				return testEnv.Client.Update(ctx, cr)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func(g Gomega) {
+				lastCall := testEnv.Deployer.LastCall()
+				g.Expect(lastCall).NotTo(BeNil())
+
+				hasDashboard := false
+				for _, res := range lastCall.Resources {
+					if res.GetKind() == "ConfigMap" && res.GetName() == "model-serving-llms-cluster-health" {
+						g.Expect(res.GetNamespace()).To(Equal("openshift-config-managed"))
+						hasDashboard = true
+						break
+					}
+				}
+				g.Expect(hasDashboard).To(BeTrue(), "console dashboard ConfigMap should be deployed after re-enabling")
 			}).WithContext(ctx).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
Install ODC (OpenShift Developer Console) Grafana-format dashboards as ConfigMaps in the openshift-config-managed namespace. The new component follows the same pattern as the existing Perses observability component, with namespace-gated rendering: dashboards are only deployed when the openshift-config-managed namespace exists on the cluster.

See screenshots in https://github.com/opendatahub-io/kserve/pull/1457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional OpenShift Developer Console dashboards support for `LLMInferenceService`.
  * Introduced a configuration flag `enableLLMInferenceServiceConsoleDashboards` (enabled by default) to control dashboard rollout.

* **Bug Fixes**
  * Dashboard ConfigMaps are not deployed when the target namespace is missing.
  * Dashboard rollout is correctly disabled/enabled based on the feature flag during reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->