### PR TITLE
perf(kserve-module): skip render+deploy when spec unchanged

### DIFF
--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -143,14 +143,19 @@ func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	log.Info("reconciling Kserve CR", "name", kserve.Name)
 
-	r.registerDynamicWatches(ctx)
-
 	condMgr := newConditionManager(kserve)
 	defer func() {
 		if err := r.updateStatus(ctx, kserve, condMgr); err != nil && retErr == nil {
 			retErr = err
 		}
 	}()
+
+	if kserve.Generation == kserve.Status.ObservedGeneration {
+		r.updateComponentReadiness(ctx, kserve, condMgr)
+		return ctrl.Result{}, nil
+	}
+
+	r.registerDynamicWatches(ctx)
 
 	depResult := r.checkDependencies(ctx, kserve)
 	applyDependencyConditions(condMgr, depResult)


### PR DESCRIPTION
## Summary
- Skip full reconcile cycle (dependency check, kustomize render, SSA deploy) when Kserve CR generation matches observedGeneration
- Only readiness checks run on no-op reconciles
- Moves registerDynamicWatches after generation check to avoid adding latency to no-op reconciles
- Reduces no-op reconcile time from ~20s to <1ms, eliminating queue wait for actual spec changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconciliation efficiency by skipping unnecessary watch registration when no configuration changes are detected.
  * Ensured component readiness status is updated before completing reconciliation for already-observed generations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->