### PR TITLE
feat(rbac): add model-access aggregate roles for publisher path authorization

### DIFF
--- a/config/overlays/odh/rbac/models/kustomization.yaml
+++ b/config/overlays/odh/rbac/models/kustomization.yaml
@@ -1,7 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - inferenceservice
-  - llmisvc
-  - models
   - user-cluster-roles.yaml

--- a/config/overlays/odh/rbac/models/user-cluster-roles.yaml
+++ b/config/overlays/odh/rbac/models/user-cluster-roles.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kserve-models-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+aggregationRule:
+  clusterRoleSelectors:
+    - matchLabels:
+        rbac.authorization.k8s.io/aggregate-to-kserve-models-admin: "true"
+rules: []
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kserve-models-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-kserve-models-admin: "true"
+rules:
+  - apiGroups:
+      - serving.opendatahub.io
+    resources:
+      - models
+    verbs:
+      - post
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kserve-models-view
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - apiGroups:
+      - serving.opendatahub.io
+    resources:
+      - models
+    verbs:
+      - post


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds `kserve-models-admin`, `kserve-models-edit`, and `kserve-models-view` aggregate ClusterRoles granting the virtual `post` verb on `serving.opendatahub.io/models`.

When traffic uses publisher paths (`/publishers/<ns>/models/<name>/...`), the gateway AuthPolicy evaluates model-level SAR (`serving.opendatahub.io/models`) instead of the existing instance-level SAR (`serving.kserve.io/llminferenceservices`). Without these aggregate roles, namespace viewers and editors lose access to publisher-routed models because the built-in `view`/`edit` roles only aggregate `serving.kserve.io` permissions.

The structure mirrors the existing `kserve-admin`/`kserve-edit`/`kserve-view` pattern but is scoped to the `serving.opendatahub.io` API group. The `post-delegate` verb is intentionally excluded - that permission is reserved for authorized batch processors (MaaS delegation anti-spoofing).

**Which issue(s) this PR fixes**:

Related to [RHOAIENG-69638](https://redhat.atlassian.net/browse/RHOAIENG-69638)

**Special notes for your reviewer**:

The `post` verb is a virtual verb - it doesn't correspond to any standard K8s CRUD operation. It exists solely for SAR evaluation by the gateway AuthPolicy's `model-access-path` authorization rule.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

```release-note
Adds model-access aggregate ClusterRoles for publisher path authorization via gateway SAR.
```

[RHOAIENG-69638]: https://redhat.atlassian.net/browse/RHOAIENG-69638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ