### PR TITLE
feat(ci): add KEDA WVA autoscaling infrastructure for OpenShift CI

### DIFF
--- a/test/scripts/openshift-ci/infra/deploy.keda-thanos-auth.sh
+++ b/test/scripts/openshift-ci/infra/deploy.keda-thanos-auth.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Create the ClusterTriggerAuthentication that allows KEDA ScaledObjects
+# to query Thanos Querier using bearer-token authentication.
+#
+# The LLMISVC controller references this auth by name
+# ("ai-inference-keda-thanos") via the autoscaling-wva-controller-config
+# in inferenceservice-config.
+
+set -euo pipefail
+
+: "${KEDA_NAMESPACE:=openshift-keda}"
+KEDA_SA="keda-operator"
+
+echo "Creating ServiceAccount token secret for KEDA..."
+cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${KEDA_SA}-token
+  namespace: ${KEDA_NAMESPACE}
+  annotations:
+    kubernetes.io/service-account.name: ${KEDA_SA}
+type: kubernetes.io/service-account-token
+EOF
+
+echo "Waiting for token to be populated..."
+for i in $(seq 1 30); do
+  TOKEN=$(oc get secret "${KEDA_SA}-token" -n "${KEDA_NAMESPACE}" \
+    -o jsonpath='{.data.token}' 2>/dev/null || true)
+  if [[ -n "$TOKEN" ]]; then
+    break
+  fi
+  sleep 2
+done
+if [[ -z "${TOKEN:-}" ]]; then
+  echo "ERROR: Timed out waiting for SA token secret to be populated" >&2
+  exit 1
+fi
+
+echo "Granting cluster-monitoring-view to KEDA SA..."
+cat <<EOF | oc apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: keda-thanos-sa-monitoring-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-monitoring-view
+subjects:
+- kind: ServiceAccount
+  name: ${KEDA_SA}
+  namespace: ${KEDA_NAMESPACE}
+EOF
+
+echo "Extracting Thanos Querier CA certificate..."
+THANOS_CA=""
+if oc get configmap serving-certs-ca-bundle -n openshift-monitoring -o jsonpath='{.data.service-ca\.crt}' &>/dev/null; then
+  THANOS_CA=$(oc get configmap serving-certs-ca-bundle -n openshift-monitoring \
+    -o jsonpath='{.data.service-ca\.crt}')
+elif oc get configmap openshift-service-ca.crt -n openshift-config-managed -o jsonpath='{.data.service-ca\.crt}' &>/dev/null; then
+  THANOS_CA=$(oc get configmap openshift-service-ca.crt -n openshift-config-managed \
+    -o jsonpath='{.data.service-ca\.crt}')
+fi
+
+echo "Creating ClusterTriggerAuthentication ai-inference-keda-thanos..."
+if [[ -n "$THANOS_CA" ]]; then
+  cat <<EOF | oc apply -f -
+apiVersion: keda.sh/v1alpha1
+kind: ClusterTriggerAuthentication
+metadata:
+  name: ai-inference-keda-thanos
+spec:
+  secretTargetRef:
+    - parameter: bearerToken
+      name: ${KEDA_SA}-token
+      namespace: ${KEDA_NAMESPACE}
+      key: token
+    - parameter: ca
+      name: ${KEDA_SA}-token
+      namespace: ${KEDA_NAMESPACE}
+      key: service-ca.crt
+EOF
+
+  echo "Injecting Thanos CA into the SA token secret..."
+  CA_B64=$(echo -n "$THANOS_CA" | base64 -w 0)
+  oc patch secret "${KEDA_SA}-token" -n "${KEDA_NAMESPACE}" --type=merge \
+    -p "{\"data\":{\"service-ca.crt\":\"${CA_B64}\"}}"
+else
+  echo "WARNING: Could not extract Thanos CA; creating auth without CA parameter."
+  echo "KEDA will use system trust store for TLS verification."
+  cat <<EOF | oc apply -f -
+apiVersion: keda.sh/v1alpha1
+kind: ClusterTriggerAuthentication
+metadata:
+  name: ai-inference-keda-thanos
+spec:
+  secretTargetRef:
+  - parameter: bearerToken
+    name: ${KEDA_SA}-token
+    namespace: ${KEDA_NAMESPACE}
+    key: token
+EOF
+fi
+
+echo "ClusterTriggerAuthentication ai-inference-keda-thanos created"

--- a/test/scripts/openshift-ci/infra/deploy.wva.sh
+++ b/test/scripts/openshift-ci/infra/deploy.wva.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Deploy the Workload Variant Autoscaler (WVA) controller on OpenShift.
+# Uses the ODH fork's cluster-scoped OpenShift Kustomize overlay which
+# includes RBAC, monitoring (ServiceMonitor + bearer-token auth), and
+# the OpenShift component (Thanos Querier config, service-CA mount).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/../common.sh"
+
+WVA_KUSTOMIZE_DIR="${SCRIPT_DIR}/wva"
+WVA_NAMESPACE="wva-system"
+
+echo "Deploying WVA (ODH) via kustomize..."
+
+kustomize build "${WVA_KUSTOMIZE_DIR}" | oc apply -f -
+
+echo "Waiting for WVA controller to become ready..."
+wait_for_pod_ready "${WVA_NAMESPACE}" "control-plane=controller-manager" 300s
+
+echo "WVA deployed successfully (namespace: ${WVA_NAMESPACE})"

--- a/test/scripts/openshift-ci/infra/verify-autoscaling-health.sh
+++ b/test/scripts/openshift-ci/infra/verify-autoscaling-health.sh
@@ -92,7 +92,10 @@ echo "  [PASS] WVA controller pod is Ready"
 
 check_wva_no_errors() {
     local logs
-    logs=$(oc logs -n "${WVA_NAMESPACE}" deployment/"${WVA_DEPLOY}" --tail=50 2>/dev/null || echo "")
+    if ! logs=$(oc logs -n "${WVA_NAMESPACE}" \
+        deployment/"${WVA_DEPLOY}" --tail=50 2>/dev/null); then
+        return 1
+    fi
     if echo "${logs}" | grep -qi "error.*prometheus\|connection refused\|no such host\|x509.*certificate"; then
         return 1
     fi
@@ -107,30 +110,28 @@ echo ""
 echo "--- Step 3: Verifying KEDA/CMA operator ---"
 
 check_keda_operator() {
-    local running
     for selector in "app=keda-operator" "app.kubernetes.io/name=keda-operator"; do
-        running=$(oc get pods -n "${KEDA_NAMESPACE}" -l "${selector}" \
-            -o jsonpath='{.items[?(@.status.phase=="Running")].metadata.name}' 2>/dev/null)
-        if [[ -n "$running" ]]; then
+        if oc wait --for=condition=Ready pod \
+            -l "${selector}" -n "${KEDA_NAMESPACE}" \
+            --timeout=0s 2>/dev/null; then
             return 0
         fi
     done
     return 1
 }
-retry "KEDA operator pod is Running" 60 5 check_keda_operator
+retry "KEDA operator pod is Ready" 60 5 check_keda_operator
 
 check_keda_metrics_server() {
-    local running
     for selector in "app=keda-metrics-apiserver" "app.kubernetes.io/name=keda-operator-metrics-apiserver"; do
-        running=$(oc get pods -n "${KEDA_NAMESPACE}" -l "${selector}" \
-            -o jsonpath='{.items[?(@.status.phase=="Running")].metadata.name}' 2>/dev/null)
-        if [[ -n "$running" ]]; then
+        if oc wait --for=condition=Ready pod \
+            -l "${selector}" -n "${KEDA_NAMESPACE}" \
+            --timeout=0s 2>/dev/null; then
             return 0
         fi
     done
     return 1
 }
-retry "KEDA metrics API server is Running" 60 5 check_keda_metrics_server
+retry "KEDA metrics API server is Ready" 60 5 check_keda_metrics_server
 
 # ---------------------------------------------------------------------------
 # 4. ClusterTriggerAuthentication

--- a/test/scripts/openshift-ci/infra/verify-autoscaling-health.sh
+++ b/test/scripts/openshift-ci/infra/verify-autoscaling-health.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Fail-fast health check for the KEDA autoscaling metrics pipeline on OpenShift.
+#
+# Validates that User Workload Monitoring (UWM), WVA, KEDA, and the
+# ClusterTriggerAuthentication are wired correctly BEFORE running e2e tests.
+# Exits non-zero on first failure.
+#
+# Metrics pipeline:
+#   simulator pod → PodMonitor → UWM Prometheus → Thanos Querier ← WVA
+#                                                                 ← KEDA (via ScaledObject)
+#
+# Usage: verify-autoscaling-health.sh
+
+set -euo pipefail
+
+: "${KEDA_NAMESPACE:=openshift-keda}"
+WVA_NAMESPACE="wva-system"
+WVA_DEPLOY="workload-variant-autoscaler-controller-manager"
+
+retry() {
+    local description="$1"
+    local timeout="$2"
+    local interval="${3:-5}"
+    shift 3
+    local cmd=("$@")
+
+    local deadline=$((SECONDS + timeout))
+    local attempt=0
+    while true; do
+        attempt=$((attempt + 1))
+        if "${cmd[@]}" 2>/dev/null; then
+            echo "  [PASS] ${description}"
+            return 0
+        fi
+        if [ $SECONDS -ge $deadline ]; then
+            echo "  [FAIL] ${description} (timed out after ${timeout}s, ${attempt} attempts)"
+            return 1
+        fi
+        sleep "$interval"
+    done
+}
+
+echo "======================================================================"
+echo "KEDA Autoscaling Pipeline Health Check (OpenShift)"
+echo "======================================================================"
+
+# ---------------------------------------------------------------------------
+# 1. User Workload Monitoring
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Step 1: Verifying User Workload Monitoring ---"
+
+echo "  Checking UWM Prometheus pods..."
+oc wait --for=condition=Ready pod \
+    -l app.kubernetes.io/name=prometheus \
+    -n openshift-user-workload-monitoring \
+    --timeout=120s
+echo "  [PASS] UWM Prometheus pods are Ready"
+
+echo "  Checking Thanos Querier pods..."
+oc wait --for=condition=Ready pod \
+    -l app.kubernetes.io/name=thanos-query \
+    -n openshift-monitoring \
+    --timeout=120s
+echo "  [PASS] Thanos Querier pods are Ready"
+
+# ---------------------------------------------------------------------------
+# 2. WVA controller
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Step 2: Verifying WVA controller ---"
+
+echo "  Checking WVA pods..."
+oc wait --for=condition=Ready pod \
+    -l control-plane=controller-manager \
+    -n "${WVA_NAMESPACE}" \
+    --timeout=120s
+echo "  [PASS] WVA controller pod is Ready"
+
+check_wva_no_errors() {
+    local logs
+    logs=$(oc logs -n "${WVA_NAMESPACE}" deployment/"${WVA_DEPLOY}" --tail=50 2>/dev/null || echo "")
+    if echo "${logs}" | grep -qi "error.*prometheus\|connection refused\|no such host\|x509.*certificate"; then
+        return 1
+    fi
+    return 0
+}
+retry "WVA logs show no Prometheus/TLS errors" 30 5 check_wva_no_errors
+
+# ---------------------------------------------------------------------------
+# 3. KEDA operator
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Step 3: Verifying KEDA/CMA operator ---"
+
+check_keda_operator() {
+    local running
+    for selector in "app=keda-operator" "app.kubernetes.io/name=keda-operator"; do
+        running=$(oc get pods -n "${KEDA_NAMESPACE}" -l "${selector}" \
+            -o jsonpath='{.items[?(@.status.phase=="Running")].metadata.name}' 2>/dev/null)
+        if [[ -n "$running" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+retry "KEDA operator pod is Running" 60 5 check_keda_operator
+
+check_keda_metrics_server() {
+    local running
+    for selector in "app=keda-metrics-apiserver" "app.kubernetes.io/name=keda-operator-metrics-apiserver"; do
+        running=$(oc get pods -n "${KEDA_NAMESPACE}" -l "${selector}" \
+            -o jsonpath='{.items[?(@.status.phase=="Running")].metadata.name}' 2>/dev/null)
+        if [[ -n "$running" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+retry "KEDA metrics API server is Running" 60 5 check_keda_metrics_server
+
+# ---------------------------------------------------------------------------
+# 4. ClusterTriggerAuthentication
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Step 4: Verifying KEDA → Thanos authentication ---"
+
+check_cluster_trigger_auth() {
+    oc get clustertriggerauthentication ai-inference-keda-thanos \
+        -o jsonpath='{.metadata.name}' | grep -q "ai-inference-keda-thanos"
+}
+retry "ClusterTriggerAuthentication ai-inference-keda-thanos exists" 10 2 check_cluster_trigger_auth
+
+check_keda_sa_token() {
+    local token
+    token=$(oc get secret keda-operator-token -n "${KEDA_NAMESPACE}" \
+        -o jsonpath='{.data.token}' 2>/dev/null)
+    [[ -n "$token" ]]
+}
+retry "KEDA SA token secret is populated" 30 5 check_keda_sa_token
+
+check_keda_monitoring_rbac() {
+    oc get clusterrolebinding keda-thanos-sa-monitoring-view \
+        -o jsonpath='{.roleRef.name}' 2>/dev/null | grep -q "cluster-monitoring-view"
+}
+retry "KEDA SA has cluster-monitoring-view role" 10 2 check_keda_monitoring_rbac
+
+# ---------------------------------------------------------------------------
+# 5. External Metrics API
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Step 5: Verifying External Metrics API ---"
+
+check_external_metrics_api() {
+    oc get --raw /apis/external.metrics.k8s.io/v1beta1 >/dev/null 2>&1
+}
+retry "External Metrics API discovery endpoint" 60 5 check_external_metrics_api
+
+# ---------------------------------------------------------------------------
+# 6. WVA ServiceMonitor (so wva_desired_replicas is scraped)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Step 6: Verifying WVA metrics scraping ---"
+
+check_wva_servicemonitor() {
+    oc get servicemonitor -n "${WVA_NAMESPACE}" -o name 2>/dev/null | grep -q "servicemonitor"
+}
+retry "WVA ServiceMonitor exists" 30 5 check_wva_servicemonitor
+
+# ---------------------------------------------------------------------------
+# 7. inferenceservice-config has autoscaling-wva-controller-config
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Step 7: Verifying inferenceservice-config ---"
+
+: "${KSERVE_NAMESPACE:=kserve}"
+
+check_wva_config() {
+    local config
+    config=$(oc get configmap inferenceservice-config -n "${KSERVE_NAMESPACE}" \
+        -o jsonpath='{.data.autoscaling-wva-controller-config}' 2>/dev/null)
+    echo "$config" | grep -q "ai-inference-keda-thanos"
+}
+retry "autoscaling-wva-controller-config references ClusterTriggerAuthentication" 10 2 check_wva_config
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "======================================================================"
+echo "All KEDA autoscaling pipeline health checks PASSED"
+echo "======================================================================"

--- a/test/scripts/openshift-ci/infra/wva/kustomization.yaml
+++ b/test/scripts/openshift-ci/infra/wva/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - github.com/opendatahub-io/workload-variant-autoscaler/config/overlays/cluster-scoped/openshift?ref=main

--- a/test/scripts/openshift-ci/run-e2e-tests.sh
+++ b/test/scripts/openshift-ci/run-e2e-tests.sh
@@ -71,6 +71,8 @@ export SKIP_DELETION_ON_FAILURE="${SKIP_DELETION_ON_FAILURE:=true}"
 # Export the controller namespace so that E2E tests
 # (e.g. storage version migration) can find the controller.
 export KSERVE_NAMESPACE=${KSERVE_NAMESPACE:-"kserve"}
+export KEDA_NAMESPACE=${KEDA_NAMESPACE:-"openshift-keda"}
+export KEDA_OPERATOR_POD_LABEL=${KEDA_OPERATOR_POD_LABEL:-"app=keda-operator"}
 
 if [[ "$RUNNING_LOCAL" == "true" ]]; then
   export CUSTOM_MODEL_GRPC_IMG_TAG=kserve/custom-model-grpc:latest

--- a/test/scripts/openshift-ci/setup-kserve.sh
+++ b/test/scripts/openshift-ci/setup-kserve.sh
@@ -90,6 +90,28 @@ if [[ "${1:-}" =~ "tracing" ]]; then
   "${SCRIPT_DIR}/infra/deploy.jaeger.sh"
 fi
 
+# LLMISvc autoscaling infrastructure (KEDA path only):
+#   1. User Workload Monitoring (provides Prometheus + Thanos Querier)
+#   2. WVA controller (computes desired replicas from saturation metrics)
+#   3. KEDA ClusterTriggerAuthentication (bearer token auth for Thanos)
+#
+# deploy.cma.sh (KEDA/CMA operator) is already called by deploy.kserve-manual.sh.
+# The autoscaling-wva-controller-config in inferenceservice-config is already set
+# by the ODH overlay (config/overlays/odh/patches/inferenceservice-config-patch.yaml).
+if [[ "${1:-}" =~ "autoscaling_keda" ]]; then
+  echo "Setting up KEDA autoscaling infrastructure for LLMISVC..."
+  "${SCRIPT_DIR}/infra/deploy.wva.sh"
+  "${SCRIPT_DIR}/infra/deploy.keda-thanos-auth.sh"
+
+  echo "Restarting llmisvc-controller-manager to pick up autoscaling config..."
+  oc delete pod -n "${KSERVE_NAMESPACE}" -l control-plane=llmisvc-controller-manager
+  wait_for_pod_ready "${KSERVE_NAMESPACE}" "control-plane=llmisvc-controller-manager" 300s
+
+  echo "Running KEDA autoscaling pipeline health check..."
+  KSERVE_NAMESPACE="${KSERVE_NAMESPACE}" "${SCRIPT_DIR}/infra/verify-autoscaling-health.sh"
+  echo "KEDA autoscaling infrastructure ready"
+fi
+
 # Early CA cert extraction for raw deployments. This reads from cluster-wide namespaces
 # (not KSERVE_NAMESPACE) so it can run immediately after the install.
 # setup-e2e-tests.sh overwrites /tmp/ca.crt later with the namespace-scoped cert for

--- a/test/scripts/openshift-ci/teardown-e2e-setup.sh
+++ b/test/scripts/openshift-ci/teardown-e2e-setup.sh
@@ -102,6 +102,13 @@ if command -v helm >/dev/null 2>&1; then
 fi
 oc delete namespace --ignore-not-found -- "${JAEGER_NAMESPACE:-observability}" || true
 
+echo "Delete WVA controller and autoscaling auth resources"
+kustomize build "$MY_PATH/infra/wva" 2>/dev/null |
+  oc delete --ignore-not-found -f - || true
+oc delete namespace wva-system --ignore-not-found || true
+oc delete clustertriggerauthentication ai-inference-keda-thanos --ignore-not-found || true
+oc delete clusterrolebinding keda-thanos-sa-monitoring-view --ignore-not-found || true
+
 echo "Delete CMA / KEDA operator"
 oc delete kedacontroller -n openshift-keda keda --ignore-not-found || true
 oc delete subscription -n openshift-keda openshift-custom-metrics-autoscaler-operator --ignore-not-found || true


### PR DESCRIPTION
## What does this PR do?

Adds OpenShift CI scripts to deploy and verify the KEDA WVA autoscaling infrastructure before running autoscaling_keda e2e tests.

## Changes

- infra/deploy.wva.sh: Deploy WVA controller via ODH kustomize overlay
- infra/deploy.keda-thanos-auth.sh: KEDA bearer token + CA auth for Thanos Querier
- infra/verify-autoscaling-health.sh: Pre-flight health check (UWM, WVA, KEDA, auth, metrics API)
- infra/wva/kustomization.yaml: WVA OpenShift overlay reference
- setup-kserve.sh: Orchestrate autoscaling_keda setup
- run-e2e-tests.sh: Export KEDA env vars
- teardown-e2e-setup.sh: Clean up WVA, CTA, RBAC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenShift CI support to deploy Workload Variant Autoscaler plus KEDA/Thanos authentication.
  * Added an autoscaling metrics pipeline health check to gate E2E runs.
  * Exported KEDA-related environment settings for E2E execution.
  * Extended the KServe post-install flow to enable autoscaling via the new WVA/KEDA setup.
* **Bug Fixes**
  * Improved reliability by using strict, fail-fast deployment and verification with bounded retries.
* **Chores**
  * Enhanced teardown to remove WVA and related autoscaling/auth resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->