### PR TITLE
feat(ci): add Helm Jaeger infra for LLMISVC tracing e2e

### DIFF
--- a/hack/setup/infra/manage.jaeger-helm.sh
+++ b/hack/setup/infra/manage.jaeger-helm.sh
@@ -74,8 +74,8 @@ install() {
     # Keep JAEGER_EXTRA_ARGS for simple flags (e.g. --set key=val). Paths with
     # spaces should use JAEGER_VALUES_FILE instead of embedding -f here.
     if [[ -n "${JAEGER_EXTRA_ARGS:-}" ]]; then
-        # shellcheck disable=SC2206 # intentional word-split of simple CLI flags
-        helm_extra_args+=(${JAEGER_EXTRA_ARGS})
+        read -ra parsed_extra_args <<< "${JAEGER_EXTRA_ARGS}"
+        helm_extra_args+=("${parsed_extra_args[@]}")
     fi
 
     log_info "Installing Jaeger All-in-One ${JAEGER_VERSION}..."

--- a/hack/setup/infra/manage.jaeger-helm.sh
+++ b/hack/setup/infra/manage.jaeger-helm.sh
@@ -20,7 +20,8 @@
 #   or:  UNINSTALL=true manage.jaeger-helm.sh
 #
 # Environment variables for custom Helm values:
-#   JAEGER_EXTRA_ARGS   - Additional helm install arguments for Jaeger
+#   JAEGER_VALUES_FILE  - Path to a Helm values file (passed as a single quoted -f arg)
+#   JAEGER_EXTRA_ARGS   - Additional helm install arguments (word-split; use for simple flags)
 
 # INIT
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
@@ -46,9 +47,9 @@ JAEGER_RELEASE_NAME="${JAEGER_RELEASE_NAME:-jaeger}"
 
 uninstall() {
     log_info "Uninstalling Jaeger..."
-    helm uninstall "${JAEGER_RELEASE_NAME}" -n "${JAEGER_NAMESPACE}" 2>/dev/null || true
+    helm uninstall --namespace "${JAEGER_NAMESPACE}" -- "${JAEGER_RELEASE_NAME}" 2>/dev/null || true
     kubectl delete all --all -n "${JAEGER_NAMESPACE}" --force --grace-period=0 2>/dev/null || true
-    kubectl delete namespace "${JAEGER_NAMESPACE}" --wait=true --timeout=60s --force --grace-period=0 2>/dev/null || true
+    kubectl delete namespace --wait=true --timeout=60s --force --grace-period=0 -- "${JAEGER_NAMESPACE}" 2>/dev/null || true
     log_success "Jaeger uninstalled"
 }
 
@@ -66,14 +67,24 @@ install() {
     log_info "Adding Jaeger Helm repository..."
     helm repo add jaegertracing https://jaegertracing.github.io/helm-charts --force-update
 
+    local -a helm_extra_args=()
+    if [[ -n "${JAEGER_VALUES_FILE:-}" ]]; then
+        helm_extra_args+=(-f "${JAEGER_VALUES_FILE}")
+    fi
+    # Keep JAEGER_EXTRA_ARGS for simple flags (e.g. --set key=val). Paths with
+    # spaces should use JAEGER_VALUES_FILE instead of embedding -f here.
+    if [[ -n "${JAEGER_EXTRA_ARGS:-}" ]]; then
+        # shellcheck disable=SC2206 # intentional word-split of simple CLI flags
+        helm_extra_args+=(${JAEGER_EXTRA_ARGS})
+    fi
+
     log_info "Installing Jaeger All-in-One ${JAEGER_VERSION}..."
-    helm install "${JAEGER_RELEASE_NAME}" jaegertracing/jaeger \
-        --namespace "${JAEGER_NAMESPACE}" \
-        --create-namespace \
+    helm install --namespace "${JAEGER_NAMESPACE}" --create-namespace \
         --version "${JAEGER_VERSION}" \
         --wait \
         --timeout 5m \
-        ${JAEGER_EXTRA_ARGS:-}
+        "${helm_extra_args[@]}" \
+        -- "${JAEGER_RELEASE_NAME}" jaegertracing/jaeger
 
     log_success "Successfully installed Jaeger All-in-One via Helm"
 

--- a/test/scripts/openshift-ci/infra/deploy.jaeger.sh
+++ b/test/scripts/openshift-ci/infra/deploy.jaeger.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Install Jaeger All-in-One via Helm for LLMISVC tracing e2e on OpenShift CI.
+# Does NOT use the OpenShift Distributed Tracing / Tempo OLM operators.
+#
+# Wraps hack/setup/infra/manage.jaeger-helm.sh with:
+#   - Helm CLI install into the repo bin/
+#   - OpenShift-safe securityContext values
+#   - Service port verification for OTLP (:4317) and Query (:16686)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../common.sh"
+
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+JAEGER_NAMESPACE="${JAEGER_NAMESPACE:-observability}"
+JAEGER_RELEASE_NAME="${JAEGER_RELEASE_NAME:-jaeger}"
+VALUES_FILE="${SCRIPT_DIR}/jaeger/values-openshift.yaml"
+
+echo "⏳ Installing Jaeger All-in-One (Helm) into namespace ${JAEGER_NAMESPACE}"
+
+# Helm + kubectl for manage.jaeger-helm.sh (CI images often ship only oc).
+"${PROJECT_ROOT}/hack/setup/cli/install-helm.sh"
+export PATH="${PROJECT_ROOT}/bin:${PATH}"
+if ! command -v kubectl >/dev/null 2>&1; then
+  ln -sf "$(command -v oc)" "${PROJECT_ROOT}/bin/kubectl"
+fi
+
+export JAEGER_NAMESPACE JAEGER_RELEASE_NAME
+export JAEGER_EXTRA_ARGS="${JAEGER_EXTRA_ARGS:-} -f ${VALUES_FILE}"
+
+"${PROJECT_ROOT}/hack/setup/infra/manage.jaeger-helm.sh"
+
+echo "⏳ Verifying Jaeger Service ports (OTLP 4317, Query 16686)..."
+ports="$(oc get svc "${JAEGER_RELEASE_NAME}" -n "${JAEGER_NAMESPACE}" \
+  -o jsonpath='{range .spec.ports[*]}{.port}{"\n"}{end}')"
+for required in 4317 16686; do
+  if ! grep -qx "${required}" <<<"${ports}"; then
+    echo "ERROR: Service ${JAEGER_RELEASE_NAME} in ${JAEGER_NAMESPACE} missing port ${required}"
+    oc get svc "${JAEGER_RELEASE_NAME}" -n "${JAEGER_NAMESPACE}" -o yaml || true
+    exit 1
+  fi
+done
+
+echo "✅ Jaeger (Helm) ready — OTLP http://${JAEGER_RELEASE_NAME}.${JAEGER_NAMESPACE}.svc.cluster.local:4317"

--- a/test/scripts/openshift-ci/infra/deploy.jaeger.sh
+++ b/test/scripts/openshift-ci/infra/deploy.jaeger.sh
@@ -17,7 +17,7 @@
 #
 # Wraps hack/setup/infra/manage.jaeger-helm.sh with:
 #   - Helm CLI install into the repo bin/
-#   - OpenShift-safe securityContext values
+#   - OpenShift-safe values via JAEGER_VALUES_FILE (quoted -f)
 #   - Service port verification for OTLP (:4317) and Query (:16686)
 
 set -euo pipefail
@@ -36,21 +36,28 @@ echo "⏳ Installing Jaeger All-in-One (Helm) into namespace ${JAEGER_NAMESPACE}
 "${PROJECT_ROOT}/hack/setup/cli/install-helm.sh"
 export PATH="${PROJECT_ROOT}/bin:${PATH}"
 if ! command -v kubectl >/dev/null 2>&1; then
-  ln -sf "$(command -v oc)" "${PROJECT_ROOT}/bin/kubectl"
+  OC_PATH=$(command -v oc || true)
+  if [ -n "$OC_PATH" ]; then
+    ln -sf "$OC_PATH" "${PROJECT_ROOT}/bin/kubectl"
+  else
+    echo "ERROR: oc binary not found in PATH" >&2
+    exit 1
+  fi
 fi
 
 export JAEGER_NAMESPACE JAEGER_RELEASE_NAME
-export JAEGER_EXTRA_ARGS="${JAEGER_EXTRA_ARGS:-} -f ${VALUES_FILE}"
+# Prefer JAEGER_VALUES_FILE (quoted -f) over stuffing paths into JAEGER_EXTRA_ARGS.
+export JAEGER_VALUES_FILE="${VALUES_FILE}"
 
 "${PROJECT_ROOT}/hack/setup/infra/manage.jaeger-helm.sh"
 
 echo "⏳ Verifying Jaeger Service ports (OTLP 4317, Query 16686)..."
-ports="$(oc get svc "${JAEGER_RELEASE_NAME}" -n "${JAEGER_NAMESPACE}" \
-  -o jsonpath='{range .spec.ports[*]}{.port}{"\n"}{end}')"
+ports="$(oc get svc -n "${JAEGER_NAMESPACE}" \
+  -o jsonpath='{range .spec.ports[*]}{.port}{"\n"}{end}' -- "${JAEGER_RELEASE_NAME}")"
 for required in 4317 16686; do
   if ! grep -qx "${required}" <<<"${ports}"; then
     echo "ERROR: Service ${JAEGER_RELEASE_NAME} in ${JAEGER_NAMESPACE} missing port ${required}"
-    oc get svc "${JAEGER_RELEASE_NAME}" -n "${JAEGER_NAMESPACE}" -o yaml || true
+    oc get svc -n "${JAEGER_NAMESPACE}" -o yaml -- "${JAEGER_RELEASE_NAME}" || true
     exit 1
   fi
 done

--- a/test/scripts/openshift-ci/infra/jaeger/values-openshift.yaml
+++ b/test/scripts/openshift-ci/infra/jaeger/values-openshift.yaml
@@ -1,0 +1,11 @@
+# OpenShift overrides for jaegertracing/jaeger All-in-One (chart 4.x).
+# Clear fixed UIDs so the restricted SCC can assign IDs from the namespace range.
+# Helm merge does not clear keys with {}; null is required.
+#
+# Keeps the default Service name "jaeger" with OTLP :4317 and Query :16686
+# expected by test/e2e/llmisvc/test_tracing.py.
+jaeger:
+  podSecurityContext:
+    runAsUser: null
+    runAsGroup: null
+    fsGroup: null

--- a/test/scripts/openshift-ci/setup-kserve.sh
+++ b/test/scripts/openshift-ci/setup-kserve.sh
@@ -83,6 +83,13 @@ if [[ "${1:-}" =~ "llminferenceservice" ]]; then
   "${SCRIPT_DIR}/setup-llm.sh" --skip-kserve --deploy-kuadrant
 fi
 
+# LLMISvc tracing infrastructure: Jaeger All-in-One via Helm (not OLM).
+# Required by test/e2e/llmisvc/test_tracing.py (OTLP :4317, Query :16686).
+if [[ "${1:-}" =~ "tracing" ]]; then
+  echo "Setting up Jaeger (Helm) for LLMISVC tracing e2e..."
+  "${SCRIPT_DIR}/infra/deploy.jaeger.sh"
+fi
+
 # Early CA cert extraction for raw deployments. This reads from cluster-wide namespaces
 # (not KSERVE_NAMESPACE) so it can run immediately after the install.
 # setup-e2e-tests.sh overwrites /tmp/ca.crt later with the namespace-scoped cert for

--- a/test/scripts/openshift-ci/teardown-e2e-setup.sh
+++ b/test/scripts/openshift-ci/teardown-e2e-setup.sh
@@ -98,9 +98,9 @@ done
 echo "Delete Jaeger (Helm) tracing stack"
 # Prefer helm uninstall when available; always delete the namespace as a fallback.
 if command -v helm >/dev/null 2>&1; then
-  helm uninstall "${JAEGER_RELEASE_NAME:-jaeger}" -n "${JAEGER_NAMESPACE:-observability}" 2>/dev/null || true
+  helm uninstall --namespace "${JAEGER_NAMESPACE:-observability}" -- "${JAEGER_RELEASE_NAME:-jaeger}" 2>/dev/null || true
 fi
-oc delete namespace "${JAEGER_NAMESPACE:-observability}" --ignore-not-found || true
+oc delete namespace --ignore-not-found -- "${JAEGER_NAMESPACE:-observability}" || true
 
 echo "Delete CMA / KEDA operator"
 oc delete kedacontroller -n openshift-keda keda --ignore-not-found || true

--- a/test/scripts/openshift-ci/teardown-e2e-setup.sh
+++ b/test/scripts/openshift-ci/teardown-e2e-setup.sh
@@ -95,6 +95,13 @@ for ns in "${ALL_NAMESPACES[@]}"; do
   oc delete networkpolicy allow-all -n "$ns" --ignore-not-found || true
 done
 
+echo "Delete Jaeger (Helm) tracing stack"
+# Prefer helm uninstall when available; always delete the namespace as a fallback.
+if command -v helm >/dev/null 2>&1; then
+  helm uninstall "${JAEGER_RELEASE_NAME:-jaeger}" -n "${JAEGER_NAMESPACE:-observability}" 2>/dev/null || true
+fi
+oc delete namespace "${JAEGER_NAMESPACE:-observability}" --ignore-not-found || true
+
 echo "Delete CMA / KEDA operator"
 oc delete kedacontroller -n openshift-keda keda --ignore-not-found || true
 oc delete subscription -n openshift-keda openshift-custom-metrics-autoscaler-operator --ignore-not-found || true


### PR DESCRIPTION
## Summary
- Add OpenShift CI setup for Jaeger All-in-One via Helm (`deploy.jaeger.sh`), gated when the e2e marker contains `tracing`.
- Pass OpenShift-safe Helm values so restricted SCC can assign UIDs (no fixed `runAsUser`).
- Tear down the `observability` namespace / Jaeger release in e2e cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated Jaeger tracing infrastructure setup for OpenShift end-to-end tests, deployed via Helm.
  * Introduced OpenShift-specific Helm values to support restricted security policies.
  * Jaeger deployment can be enabled during KServe environment setup when tracing is selected.
  * Added support for custom Helm values and additional Helm install flags via environment variables.
* **Bug Fixes**
  * Improved teardown to reliably uninstall the Jaeger Helm release and remove its namespace.
  * Added deployment validation to confirm required Jaeger Service ports (OTLP 4317 and Query 16686) are exposed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->