### PR TITLE
fix(kserve-module): remove platform finalizer on CR deletion

### DIFF
--- a/kserve-module/pkg/kservemodule/constants.go
+++ b/kserve-module/pkg/kservemodule/constants.go
@@ -54,6 +54,9 @@ const (
 	templateGroup = "template.openshift.io"
 	templateKind  = "Template"
 
+	// Platform finalizer (inherited from ODH operator component reconciler)
+	PlatformFinalizerName = "platform.opendatahub.io/finalizer"
+
 	// cert-manager defaults
 	defaultCAIssuerName    = "opendatahub-ca-issuer"
 	defaultIssuerRefKind   = "ClusterIssuer"

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -21,6 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/deploy"
@@ -139,6 +140,17 @@ func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			}
 		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if !kserve.DeletionTimestamp.IsZero() {
+		log.Info("KServe CR is being deleted, removing platform finalizer")
+		if controllerutil.RemoveFinalizer(kserve, PlatformFinalizerName) {
+			if err := r.Update(ctx, kserve); err != nil {
+				return ctrl.Result{}, fmt.Errorf("removing platform finalizer: %w", err)
+			}
+			log.Info("platform finalizer removed")
+		}
+		return ctrl.Result{}, nil
 	}
 
 	log.Info("reconciling Kserve CR", "name", kserve.Name)

--- a/kserve-module/pkg/kservemodule/reconciler_int_test.go
+++ b/kserve-module/pkg/kservemodule/reconciler_int_test.go
@@ -421,6 +421,25 @@ var _ = Describe("KserveModule Reconciler", func() {
 		})
 	})
 
+	Context("platform finalizer removal", func() {
+		It("removes the platform finalizer on CR deletion", func(ctx SpecContext) {
+			cr := fixture.KserveCR()
+			cr.Finalizers = append(cr.Finalizers, kservemodule.PlatformFinalizerName)
+			Expect(testEnv.Client.Create(ctx, cr)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(testEnv.Client.Get(ctx, client.ObjectKeyFromObject(cr), cr)).To(Succeed())
+			}).WithContext(ctx).Should(Succeed())
+
+			Expect(testEnv.Client.Delete(ctx, cr)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				err := testEnv.Client.Get(ctx, client.ObjectKeyFromObject(cr), cr)
+				g.Expect(k8serr.IsNotFound(err)).To(BeTrue(), "CR should be fully deleted, not stuck in Deleting")
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
 	Context("oauthProxy configuration", Ordered, func() {
 		var cr *platformv1alpha1.Kserve
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Kserve CR gets stuck in `Deleting` state when `managementState` is set to `Removed` in DSC.

The ODH operator's component reconciler framework adds `platform.opendatahub.io/finalizer` to the Kserve CR. After migrating to module architecture, the kserve-module reconciler had no DeletionTimestamp handling — nobody removes the finalizer, so the CR never deletes.

Added a DeletionTimestamp check early in `Reconcile()` that strips the inherited finalizer via `controllerutil.RemoveFinalizer`. No changes to existing reconcile logic.

**Which issue(s) this PR fixes**:
Fixes # https://redhat.atlassian.net/browse/RHOAIENG-77642

**Feature/Issue validation/testing**:

- [x] Integration test — creates CR with platform finalizer, deletes CR, asserts CR is fully deleted (not stuck in Deleting)

```
$ go test ./pkg/kservemodule/ -v -run "platform finalizer"
=== RUN   TestKserveModuleReconciler
--- PASS: TestKserveModuleReconciler (16.89s)
PASS
```

**Special notes for your reviewer**:

Flow after this fix:
1. `Reconcile()` detects `DeletionTimestamp` → removes `platform.opendatahub.io/finalizer` → returns
2. CR deletion completes (no more finalizers blocking)
3. Next reconcile hits `NotFound` → existing `cleanupOnDelete()` runs

The constant is defined locally instead of importing from `odh-platform-utilities/framework/controller/reconciler`
because that package pulls in heavy transitive deps (helm renderer, k8s-manifest-kit, framework/api).

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

```release-note
Fix Kserve CR stuck in Deleting state by removing inherited platform finalizer during deletion
```