### PR TITLE
fix(kserve-module): set Degraded=False for optional dependencies and clear Ready reason

### DIFF
--- a/kserve-module/pkg/kservemodule/dependency_int_test.go
+++ b/kserve-module/pkg/kservemodule/dependency_int_test.go
@@ -102,7 +102,7 @@ var _ = Describe("Dependency Integration", Ordered, func() {
 		}).WithContext(ctx).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
 	})
 
-	It("sets Degraded=True with Info severity when critical CRDs exist but some optional CRDs are missing", func(ctx SpecContext) {
+	It("sets Degraded=False with Info severity when critical CRDs exist but some optional CRDs are missing", func(ctx SpecContext) {
 		for _, info := range criticalCRDs {
 			crd := fixture.CreateCRDByName(ctx, testEnv.Client, info.Name, info.Group, "v1", apiextensionsv1.NamespaceScoped)
 			testCRDs[crd.Name] = crd
@@ -120,7 +120,7 @@ var _ = Describe("Dependency Integration", Ordered, func() {
 
 			degradedCond := fixture.FindCondition(kserve, string(common.ConditionTypeDegraded))
 			g.Expect(degradedCond).NotTo(BeNil())
-			g.Expect(degradedCond.Status).To(Equal(metav1.ConditionTrue))
+			g.Expect(degradedCond.Status).To(Equal(metav1.ConditionFalse))
 			g.Expect(degradedCond.Severity).To(Equal(common.ConditionSeverityInfo))
 		}).WithContext(ctx).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
 	})

--- a/kserve-module/pkg/kservemodule/status.go
+++ b/kserve-module/pkg/kservemodule/status.go
@@ -52,7 +52,7 @@ func applyDependencyConditions(condMgr *conditions.Manager, result dependencyRes
 	} else if len(result.degradedReasons) > 0 {
 		condMgr.MarkTrue(ConditionDependenciesAvailable,
 			conditions.WithReason("AllCriticalDependenciesMet"))
-		condMgr.MarkTrue(string(common.ConditionTypeDegraded),
+		condMgr.MarkFalse(string(common.ConditionTypeDegraded),
 			conditions.WithSeverity(common.ConditionSeverityInfo),
 			conditions.WithReason("MissingOptionalDependency"),
 			conditions.WithMessage("%s", strings.Join(result.degradedReasons, "; ")))
@@ -148,6 +148,12 @@ func (r *KserveModuleReconciler) updateStatus(ctx context.Context, kserve *platf
 
 	if condMgr.IsHappy() {
 		kserve.Status.Phase = common.PhaseReady
+		for i := range kserve.Status.Conditions {
+			if kserve.Status.Conditions[i].Type == string(common.ConditionTypeReady) {
+				kserve.Status.Conditions[i].Reason = ""
+				break
+			}
+		}
 	} else {
 		kserve.Status.Phase = common.PhaseNotReady
 	}

--- a/kserve-module/pkg/kservemodule/status_test.go
+++ b/kserve-module/pkg/kservemodule/status_test.go
@@ -81,7 +81,7 @@ func TestApplyDependencyConditions_Degraded(t *testing.T) {
 
 	cond := condMgr.GetCondition(string(common.ConditionTypeDegraded))
 	g.Expect(cond).ShouldNot(BeNil())
-	g.Expect(cond.Status).Should(Equal(metav1.ConditionTrue))
+	g.Expect(cond.Status).Should(Equal(metav1.ConditionFalse))
 	g.Expect(cond.Severity).Should(Equal(common.ConditionSeverityInfo))
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

When optional CRD dependencies (e.g. Istio CRDs) are not installed, the operator was setting `Degraded=True`. Optional deps missing shouldn't mark the component degraded since all critical functionality still works. Also clears the Ready condition's Reason field when `Ready=True` — the conditions library sets it to `AllDependentsHealthy` which is noisy and inconsistent with other components.

Changes:
- Optional dependency missing → `Degraded=False` with `severity=Info` (was `Degraded=True`)
- `Ready=True` → Reason is cleared (was `AllDependentsHealthy`)
- Critical dependency missing behavior unchanged (`Degraded=True`, `severity=Error`)

**Which issue(s) this PR fixes**:
https://redhat.atlassian.net/browse/RHOAIENG-77670

**Feature/Issue validation/testing**:

- [x] Unit tests pass (`TestApplyDependencyConditions_Degraded` updated)
- [x] Integration tests pass (`Dependency Integration` suite, 4/4 specs)

**Special notes for your reviewer**:

Ready Reason is cleared by directly modifying the conditions slice in `updateStatus` to avoid `RecomputeHappiness` overwriting it.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

```release-note
NONE
```