### PR TITLE
fix(llmisvc): cast gateway-api PortNumber for ServicePort comparison

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/router_discovery.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_discovery.go
@@ -458,7 +458,7 @@ func listenerMatchesServicePorts(listener *gwapiv1.Listener, svcPorts []corev1.S
 		return true
 	}
 	for _, sp := range svcPorts {
-		if listener.Port == sp.Port {
+		if int32(listener.Port) == sp.Port { //nolint:unconvert // required when gateway-api is pinned to v1.2.x (omc)
 			return true
 		}
 	}


### PR DESCRIPTION
## Summary
Cast `listener.Port` to `int32` in `listenerMatchesServicePorts` to fix a compile error when building odh-model-controller against kserve.

## Problem
odh-model-controller pins `sigs.k8s.io/gateway-api` to v1.2.1 via a replace directive. This pin is required because `kuadrant/policy-machinery` (a transitive dependency via `kuadrant/kuadrant-operator`) references `gwapiv1alpha2.BackendLBPolicy`, which was removed in gateway-api v1.4+ when `BackendLBPolicy` graduated from `v1alpha2` to `v1`.

Even the latest tagged release of policy-machinery (v0.9.0) and latest main commit (July 9, 2026) still use the old `v1alpha2` type. There is an open upstream issue tracking this: https://github.com/kuadrant/policy-machinery/issues/75

In gateway-api v1.2.x, `PortNumber` is a distinct named type (`type PortNumber int32`), not directly comparable with `int32`. In v1.5.x it became a type alias (`type PortNumber = int32`). The direct comparison `listener.Port == sp.Port` compiles with v1.5.x but fails with v1.2.1:

```
router_discovery.go:461:23: invalid operation: listener.Port == sp.Port
  (mismatched types "sigs.k8s.io/gateway-api/apis/v1".PortNumber and int32)
```

### Dependency chain
```
omc → kuadrant-operator → policy-machinery → gwapiv1alpha2.BackendLBPolicy
                                              ↑ removed in gateway-api v1.4+
                                              ↑ forces omc to pin gateway-api v1.2.1
                                              ↑ v1.2.1 PortNumber is a distinct type
                                              ↑ breaks kserve's direct int32 comparison
```

## Fix
`int32(listener.Port)` works with both gateway-api versions. A `//nolint:unconvert` directive suppresses the linter in this repo (where gateway-api is v1.5.x and the cast is technically unnecessary).

## Follow-up
Unpinning gateway-api in omc is tracked separately — it depends on kuadrant/policy-machinery updating to gateway-api v1.4+ (https://github.com/kuadrant/policy-machinery/issues/75).

🤖 Generated with [Claude Code](https://claude.ai/code)