### PR TITLE
feat: extract CRD management to standalone odh-crds overlay

### DIFF
--- a/config/overlays/odh-crds/kustomization.yaml
+++ b/config/overlays/odh-crds/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../crd/full
+- ../../crd/full/llmisvc
+
+patches:
+- path: patches/remove-clusterservingruntime.yaml
+- target:
+    kind: CustomResourceDefinition
+    annotationSelector: cert-manager.io/inject-ca-from
+  path: patches/openshift-ca-patch.yaml

--- a/config/overlays/odh-crds/patches/openshift-ca-patch.yaml
+++ b/config/overlays/odh-crds/patches/openshift-ca-patch.yaml
@@ -1,0 +1,5 @@
+- op: remove
+  path: /metadata/annotations/cert-manager.io~1inject-ca-from
+- op: add
+  path: /metadata/annotations/service.beta.openshift.io~1inject-cabundle
+  value: "true"

--- a/config/overlays/odh-crds/patches/remove-clusterservingruntime.yaml
+++ b/config/overlays/odh-crds/patches/remove-clusterservingruntime.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterservingruntimes.serving.kserve.io

--- a/config/overlays/odh-test/kustomization.yaml
+++ b/config/overlays/odh-test/kustomization.yaml
@@ -5,5 +5,6 @@ namespace: kserve
 
 resources:
 - ../../crd/external
+- ../odh-crds
 - ../odh
 - ../test/s3-local-backend

--- a/config/overlays/odh-xks/kustomization.yaml
+++ b/config/overlays/odh-xks/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 namespace: opendatahub
 
 resources:
+- ../odh-crds
 - ../odh
 - cert-manager/
 

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -3,16 +3,15 @@ kind: Kustomization
 
 resources:
 - ../../base
-# - ../../crd/full/localmodel
 - rbac/
 - accelerators/
 - accelerators-fast/
 - network-policies.yaml
 - ../../monitoring/llmisvc
+- ../../default
+- ../../llmisvc
 
 components:
-- ../../components/kserve
-- ../../components/llmisvc
 # - ../../localmodels
 # LLMInferenceServiceConfig resources listed last so they appear after all other
 # resources in FIFO sort order (components are appended after resources).
@@ -43,10 +42,6 @@ patches:
   path: patches/openshift-ca-patch.yaml
 - target:
     kind: MutatingWebhookConfiguration
-    annotationSelector: cert-manager.io/inject-ca-from
-  path: patches/openshift-ca-patch.yaml
-- target:
-    kind: CustomResourceDefinition
     annotationSelector: cert-manager.io/inject-ca-from
   path: patches/openshift-ca-patch.yaml
 - target:

--- a/config/overlays/odh/patches/cainjection_conversion_webhook.yaml
+++ b/config/overlays/odh/patches/cainjection_conversion_webhook.yaml
@@ -1,8 +1,0 @@
-# The following patch adds a directive for certmanager to inject CA into the CRD
-# CRD conversion requires k8s 1.16 or later.
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    service.beta.openshift.io/inject-cabundle: "true"
-  name: inferenceservices.serving.kserve.io

--- a/config/overlays/odh/patches/remove-clusterservingruntime.yaml
+++ b/config/overlays/odh/patches/remove-clusterservingruntime.yaml
@@ -3,9 +3,3 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: clusterservingruntime.serving.kserve.io
----
-$patch: delete
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: clusterservingruntimes.serving.kserve.io

--- a/test/scripts/openshift-ci/deploy.kserve-manual.sh
+++ b/test/scripts/openshift-ci/deploy.kserve-manual.sh
@@ -86,6 +86,8 @@ sed -i "s|kserve-storage-initializer=.*|kserve-storage-initializer=${STORAGE_INI
 echo "=== Final params.env"
 cat "${PARAMS_ENV}"
 
+kustomize build "${PROJECT_ROOT}/config/overlays/odh-crds" | oc apply --server-side=true --force-conflicts -f -
+
 ODH_MANIFESTS=$(kustomize build "${PROJECT_ROOT}/config/overlays/odh-test")
 
 # Apply CRDs first and wait for them to be established before applying the rest

--- a/test/scripts/openshift-ci/deploy.odh.sh
+++ b/test/scripts/openshift-ci/deploy.odh.sh
@@ -105,6 +105,9 @@ else
     "${PROJECT_ROOT}/config/overlays/odh-test/dsci.yaml" | oc apply -f -
 fi
 
+echo "Installing KServe CRDs..."
+kustomize build "${PROJECT_ROOT}/config/overlays/odh-crds" | oc apply --server-side=true --force-conflicts -f -
+
 echo "Applying DSC to trigger operator deployment..."
 oc apply -f "${PROJECT_ROOT}/config/overlays/odh-test/dsc.yaml"
 


### PR DESCRIPTION
Added standalone odh-crds overlay for independent CRD installation. 

odh overlay now references odh-crds, so CRDs can be installed separately by kserve-module or as part of full odh deployment. Updated CI scripts to install CRDs first.

Also fixed precommit workflow paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenShift-specific deployment support for required custom resources and certificate authority injection.
  * Ensured test and cross-cluster deployments include the necessary resource definitions automatically.

* **Bug Fixes**
  * Prevented conflicting or unsupported serving runtime resources and webhooks from being installed.
  * Improved deployment ordering so required definitions are available before dependent components start.

* **Chores**
  * Enhanced deployment scripts with clearer configuration output and reliable resource application during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->