### PR TITLE
feat(kserve-module): separate LLMISVCConfig from ownerReference chain and add deletion cleanup

### DIFF
--- a/kserve-module/config/rbac/role.yaml
+++ b/kserve-module/config/rbac/role.yaml
@@ -363,6 +363,12 @@ rules:
 - apiGroups:
   - serving.kserve.io
   resources:
+  - llminferenceservices
+  verbs:
+  - list
+- apiGroups:
+  - serving.kserve.io
+  resources:
   - servingruntimes
   verbs:
   - get

--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -2,6 +2,7 @@ package kservemodule
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -264,11 +265,15 @@ func cleanupKServeComponent(ctx context.Context, r *KserveModuleReconciler) erro
 		return fmt.Errorf("listing LLMInferenceServiceConfigs: %w", err)
 	}
 
+	var deleteErrs []error
 	for i := range configList.Items {
 		config := &configList.Items[i]
 		if err := r.Delete(ctx, config); client.IgnoreNotFound(err) != nil {
-			log.Error(err, "deleting LLMInferenceServiceConfig", "name", config.GetName())
+			deleteErrs = append(deleteErrs, fmt.Errorf("%s: %w", config.GetName(), err))
 		}
+	}
+	if len(deleteErrs) > 0 {
+		return errors.Join(deleteErrs...)
 	}
 
 	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {

--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,6 +50,7 @@ var components = []componentConfig{
 		sourcePathXKS: KserveManifestSourcePathXKS,
 		imageMap:      kserveImageParamMap,
 		postRender:    kservePostRender,
+		extraCleanup:  cleanupKServeComponent,
 	},
 	{
 		name:        OdhModelControllerComponentName,
@@ -228,4 +234,62 @@ func applyManagedByLabel(resources []unstructured.Unstructured, componentName st
 		labels[odhLabels.PlatformPartOf] = componentName
 		resources[i].SetLabels(labels)
 	}
+}
+
+func cleanupKServeComponent(ctx context.Context, r *KserveModuleReconciler) error {
+	log := ctrl.LoggerFrom(ctx)
+
+	llmisvcList := &unstructured.UnstructuredList{}
+	llmisvcList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: llmISVCConfigGroup, Version: "v1alpha2", Kind: llmISVCKind,
+	})
+	if err := r.Client.List(ctx, llmisvcList, client.Limit(1)); err != nil {
+		if !meta.IsNoMatchError(err) {
+			return fmt.Errorf("listing LLMInferenceServices: %w", err)
+		}
+	}
+	if len(llmisvcList.Items) > 0 {
+		log.Info("LLMInferenceService instances exist, keeping configs")
+		return nil
+	}
+
+	configList := &unstructured.UnstructuredList{}
+	configList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: llmISVCConfigGroup, Version: "v1alpha2", Kind: llmISVCConfigKind,
+	})
+	if err := r.Client.List(ctx, configList); err != nil {
+		if meta.IsNoMatchError(err) {
+			return nil
+		}
+		return fmt.Errorf("listing LLMInferenceServiceConfigs: %w", err)
+	}
+
+	for i := range configList.Items {
+		config := &configList.Items[i]
+		if err := r.Delete(ctx, config); client.IgnoreNotFound(err) != nil {
+			log.Error(err, "deleting LLMInferenceServiceConfig", "name", config.GetName())
+		}
+	}
+
+	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, 60*time.Second, true, func(ctx context.Context) (bool, error) {
+		remaining := &unstructured.UnstructuredList{}
+		remaining.SetGroupVersionKind(schema.GroupVersionKind{
+			Group: llmISVCConfigGroup, Version: "v1alpha2", Kind: llmISVCConfigKind,
+		})
+		if err := r.Client.List(ctx, remaining, client.Limit(1)); err != nil {
+			if k8serr.IsNotFound(err) || meta.IsNoMatchError(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		if len(remaining.Items) == 0 {
+			return true, nil
+		}
+		log.V(1).Info("waiting for LLMInferenceServiceConfig deletion", "remaining", len(remaining.Items))
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("waiting for LLMInferenceServiceConfig deletion: %w", err)
+	}
+	return nil
 }

--- a/kserve-module/pkg/kservemodule/components_test.go
+++ b/kserve-module/pkg/kservemodule/components_test.go
@@ -139,6 +139,68 @@ func TestModelControllerExtraParams(t *testing.T) {
 	}
 }
 
+func TestSplitByOwnership(t *testing.T) {
+	g := NewWithT(t)
+
+	resources := []unstructured.Unstructured{
+		{Object: map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]any{"name": "kserve-controller"},
+		}},
+		{Object: map[string]any{
+			"apiVersion": "serving.kserve.io/v1alpha2",
+			"kind":       "LLMInferenceServiceConfig",
+			"metadata":   map[string]any{"name": "vllm-config"},
+		}},
+		{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]any{"name": "inferenceservice-config"},
+		}},
+		{Object: map[string]any{
+			"apiVersion": "serving.kserve.io/v1alpha2",
+			"kind":       "LLMInferenceServiceConfig",
+			"metadata":   map[string]any{"name": "tgis-config"},
+		}},
+	}
+
+	owned, unowned := splitByOwnership(resources)
+
+	g.Expect(owned).To(HaveLen(2))
+	g.Expect(unowned).To(HaveLen(2))
+
+	for _, r := range owned {
+		g.Expect(r.GetKind()).NotTo(Equal("LLMInferenceServiceConfig"))
+	}
+	for _, r := range unowned {
+		g.Expect(r.GetKind()).To(Equal("LLMInferenceServiceConfig"))
+	}
+}
+
+func TestSplitByOwnership_AllOwned(t *testing.T) {
+	g := NewWithT(t)
+
+	resources := []unstructured.Unstructured{
+		{Object: map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]any{"name": "deploy"},
+		}},
+	}
+
+	owned, unowned := splitByOwnership(resources)
+	g.Expect(owned).To(HaveLen(1))
+	g.Expect(unowned).To(BeEmpty())
+}
+
+func TestSplitByOwnership_Empty(t *testing.T) {
+	g := NewWithT(t)
+	owned, unowned := splitByOwnership(nil)
+	g.Expect(owned).To(BeNil())
+	g.Expect(unowned).To(BeNil())
+}
+
 func TestApplyManagedByLabel(t *testing.T) {
 	g := NewWithT(t)
 

--- a/kserve-module/pkg/kservemodule/constants.go
+++ b/kserve-module/pkg/kservemodule/constants.go
@@ -1,5 +1,11 @@
 package kservemodule
 
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
+var unownedGroupKinds = map[schema.GroupKind]struct{}{
+	{Group: llmISVCConfigGroup, Kind: llmISVCConfigKind}: {},
+}
+
 const (
 	// Component names
 	KserveComponentName             = "kserve"
@@ -49,12 +55,15 @@ const (
 	llmISVCConfigPrefixEnv   = "LLM_INFERENCE_SERVICE_CONFIG_PREFIX"
 	llmISVCConfigGroup       = "serving.kserve.io"
 	llmISVCConfigKind        = "LLMInferenceServiceConfig"
+	llmISVCKind              = "LLMInferenceService"
+	llmISVCConfigFinalizer   = "serving.kserve.io/llmisvcconfig-finalizer"
 
 	// Template (ServingRuntime) resource type
 	templateGroup = "template.openshift.io"
 	templateKind  = "Template"
 
-	// Platform finalizer (inherited from ODH operator component reconciler)
+	// PlatformFinalizerName is set on the Kserve CR by the platform operator;
+	// the module operator removes it after cleanup is complete.
 	PlatformFinalizerName = "platform.opendatahub.io/finalizer"
 
 	// cert-manager defaults

--- a/kserve-module/pkg/kservemodule/constants.go
+++ b/kserve-module/pkg/kservemodule/constants.go
@@ -62,8 +62,11 @@ const (
 	templateGroup = "template.openshift.io"
 	templateKind  = "Template"
 
-	// PlatformFinalizerName is set on the Kserve CR by the platform operator;
-	// the module operator removes it after cleanup is complete.
+	// ModuleFinalizerName is managed by the module operator on the Kserve CR;
+	// added during reconcile, removed after cleanup on deletion.
+	ModuleFinalizerName = "kserve-module.opendatahub.io/finalizer"
+
+	// PlatformFinalizerName is set and removed by the platform operator.
 	PlatformFinalizerName = "platform.opendatahub.io/finalizer"
 
 	// cert-manager defaults

--- a/kserve-module/pkg/kservemodule/constants.go
+++ b/kserve-module/pkg/kservemodule/constants.go
@@ -55,8 +55,7 @@ const (
 	llmISVCConfigPrefixEnv   = "LLM_INFERENCE_SERVICE_CONFIG_PREFIX"
 	llmISVCConfigGroup       = "serving.kserve.io"
 	llmISVCConfigKind        = "LLMInferenceServiceConfig"
-	llmISVCKind              = "LLMInferenceService"
-	llmISVCConfigFinalizer   = "serving.kserve.io/llmisvcconfig-finalizer"
+	llmISVCKind = "LLMInferenceService"
 
 	// Template (ServingRuntime) resource type
 	templateGroup = "template.openshift.io"

--- a/kserve-module/pkg/kservemodule/dynamic_watch_int_test.go
+++ b/kserve-module/pkg/kservemodule/dynamic_watch_int_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -30,7 +31,15 @@ var _ = Describe("Dynamic Watch Integration", Ordered, func() {
 		Expect(client.IgnoreAlreadyExists(testEnv.Client.Create(ctx, ns))).To(Succeed())
 
 		kserve = fixture.KserveCR()
-		Expect(client.IgnoreAlreadyExists(testEnv.Client.Create(ctx, kserve))).To(Succeed())
+		// Ensure any leftover CR (possibly deleting with a finalizer) is fully gone.
+		Expect(client.IgnoreNotFound(testEnv.Client.Delete(ctx, kserve))).To(Succeed())
+		Eventually(func(g Gomega) {
+			err := testEnv.Client.Get(ctx, client.ObjectKeyFromObject(kserve), kserve)
+			g.Expect(k8serr.IsNotFound(err)).To(BeTrue())
+		}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
+
+		kserve = fixture.KserveCR()
+		Expect(testEnv.Client.Create(ctx, kserve)).To(Succeed())
 
 		Eventually(func(g Gomega) {
 			g.Expect(testEnv.Client.Get(ctx, client.ObjectKeyFromObject(kserve), kserve)).To(Succeed())
@@ -40,7 +49,11 @@ var _ = Describe("Dynamic Watch Integration", Ordered, func() {
 
 	AfterAll(func(ctx SpecContext) {
 		if kserve != nil {
-			client.IgnoreNotFound(testEnv.Client.Delete(ctx, kserve))
+			Expect(client.IgnoreNotFound(testEnv.Client.Delete(ctx, kserve))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := testEnv.Client.Get(ctx, client.ObjectKeyFromObject(kserve), kserve)
+				g.Expect(k8serr.IsNotFound(err)).To(BeTrue())
+			}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
 		}
 		testEnv.Reconciler.SetClusterType(cluster.ClusterTypeOpenShift)
 	})

--- a/kserve-module/pkg/kservemodule/fixture/mock_deployer.go
+++ b/kserve-module/pkg/kservemodule/fixture/mock_deployer.go
@@ -28,4 +28,3 @@ func (m *MockDeployer) LastCall() *deploy.DeployInput {
 	}
 	return &m.Calls[len(m.Calls)-1]
 }
-

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -142,13 +142,20 @@ func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 			log.Error(cleanupErr, "component extra-cleanup failed during CR deletion")
 			return ctrl.Result{}, cleanupErr
 		}
-		if controllerutil.RemoveFinalizer(kserve, PlatformFinalizerName) {
+		if controllerutil.RemoveFinalizer(kserve, ModuleFinalizerName) {
 			if err := r.Update(ctx, kserve); err != nil {
-				return ctrl.Result{}, fmt.Errorf("removing platform finalizer: %w", err)
+				return ctrl.Result{}, fmt.Errorf("removing module finalizer: %w", err)
 			}
-			log.Info("removed platform finalizer from Kserve CR")
+			log.Info("removed module finalizer from Kserve CR")
 		}
 		return ctrl.Result{}, nil
+	}
+
+	if controllerutil.AddFinalizer(kserve, ModuleFinalizerName) {
+		if err := r.Update(ctx, kserve); err != nil {
+			return ctrl.Result{}, fmt.Errorf("adding module finalizer: %w", err)
+		}
+		log.Info("added module finalizer to Kserve CR")
 	}
 
 	log.Info("reconciling Kserve CR", "name", kserve.Name)

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -75,6 +75,7 @@ import (
 
 // --- KServe cluster-scoped operand resources ---
 // +kubebuilder:rbac:groups=serving.kserve.io,resources=llminferenceserviceconfigs;clusterstoragecontainers,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=llminferenceservices,verbs=list
 
 // --- OpenShift-specific cluster-scoped resources ---
 // SCCs: required for InferenceService and LLMInferenceService workload pods
@@ -116,7 +117,6 @@ type KserveModuleReconciler struct {
 	Scheme                *runtime.Scheme
 	ManifestsTemplatePath string
 	Deployer              ResourceDeployer
-
 	workDir               string
 	initDone              bool
 	applicationsNamespace string
@@ -134,21 +134,19 @@ func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	kserve := &platformv1alpha1.Kserve{}
 	if err := r.Get(ctx, req.NamespacedName, kserve); err != nil {
-		if client.IgnoreNotFound(err) == nil {
-			if cleanupErr := r.cleanupOnDelete(ctx); cleanupErr != nil {
-				log.Error(cleanupErr, "component extra-cleanup failed during CR deletion")
-			}
-		}
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
 	if !kserve.DeletionTimestamp.IsZero() {
-		log.Info("KServe CR is being deleted, removing platform finalizer")
+		if cleanupErr := r.cleanupOnDelete(ctx); cleanupErr != nil {
+			log.Error(cleanupErr, "component extra-cleanup failed during CR deletion")
+			return ctrl.Result{}, cleanupErr
+		}
 		if controllerutil.RemoveFinalizer(kserve, PlatformFinalizerName) {
 			if err := r.Update(ctx, kserve); err != nil {
 				return ctrl.Result{}, fmt.Errorf("removing platform finalizer: %w", err)
 			}
-			log.Info("platform finalizer removed")
+			log.Info("removed platform finalizer from Kserve CR")
 		}
 		return ctrl.Result{}, nil
 	}
@@ -235,17 +233,38 @@ func (r *KserveModuleReconciler) reconcile(ctx context.Context, kserve *platform
 		return componentErrors
 	}
 
+	owned, unowned := splitByOwnership(allResources)
 	if err := r.Deployer.Deploy(ctx, deploy.DeployInput{
 		Client:    r.Client,
 		Owner:     kserve,
-		Resources: allResources,
+		Resources: owned,
 	}); err != nil {
-		return map[string]error{"deploy": fmt.Errorf("applying resources: %w", err)}
+		return map[string]error{"deploy": fmt.Errorf("applying owned resources: %w", err)}
+	}
+	if len(unowned) > 0 {
+		if err := r.Deployer.Deploy(ctx, deploy.DeployInput{
+			Client:    r.Client,
+			Resources: unowned,
+		}); err != nil {
+			return map[string]error{"deploy": fmt.Errorf("applying unowned resources: %w", err)}
+		}
 	}
 
-	log.Info("deployed all resources", "count", len(allResources))
+	log.Info("deployed all resources", "owned", len(owned), "unowned", len(unowned))
 
 	return nil
+}
+
+func splitByOwnership(resources []unstructured.Unstructured) (owned, unowned []unstructured.Unstructured) {
+	for i := range resources {
+		gk := resources[i].GroupVersionKind().GroupKind()
+		if _, excluded := unownedGroupKinds[gk]; excluded {
+			unowned = append(unowned, resources[i])
+		} else {
+			owned = append(owned, resources[i])
+		}
+	}
+	return
 }
 
 func (r *KserveModuleReconciler) cleanupOnDelete(ctx context.Context) error {
@@ -432,3 +451,4 @@ func (r *KserveModuleReconciler) ensureWorkDir() (string, error) {
 	r.initDone = true
 	return workDir, nil
 }
+

--- a/kserve-module/pkg/kservemodule/reconciler_int_test.go
+++ b/kserve-module/pkg/kservemodule/reconciler_int_test.go
@@ -425,8 +425,8 @@ var _ = Describe("KserveModule Reconciler", func() {
 		})
 	})
 
-	Context("CR deletion without platform finalizer", func() {
-		It("deletes CR immediately and runs cleanup via NotFound path", func(ctx SpecContext) {
+	Context("module finalizer lifecycle", func() {
+		It("adds finalizer during reconcile and removes it on deletion after cleanup", func(ctx SpecContext) {
 			cr := fixture.KserveCR()
 			Expect(testEnv.Client.Create(ctx, cr)).To(Succeed())
 
@@ -435,14 +435,14 @@ var _ = Describe("KserveModule Reconciler", func() {
 				g.Expect(cr.Status.ObservedGeneration).To(Equal(cr.Generation))
 			}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
 
-			Expect(cr.Finalizers).To(BeEmpty(),
-				"CR should have no finalizer — platform operator sets it, not module operator")
+			Expect(cr.Finalizers).To(ContainElement(kservemodule.ModuleFinalizerName),
+				"module operator should add its own finalizer during reconcile")
 
 			Expect(testEnv.Client.Delete(ctx, cr)).To(Succeed())
 
 			Eventually(func(g Gomega) {
 				err := testEnv.Client.Get(ctx, client.ObjectKeyFromObject(cr), cr)
-				g.Expect(k8serr.IsNotFound(err)).To(BeTrue(), "CR should be deleted immediately")
+				g.Expect(k8serr.IsNotFound(err)).To(BeTrue(), "CR should be deleted after module finalizer is removed")
 			}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
 		})
 	})
@@ -521,7 +521,6 @@ var _ = Describe("KserveModule Reconciler", func() {
 				Group: "serving.kserve.io", Version: "v1alpha2", Kind: "LLMInferenceServiceConfig",
 			})
 			config.SetName("test-config")
-			config.SetFinalizers([]string{"serving.kserve.io/llmisvcconfig-finalizer"})
 			Expect(testEnv.Client.Create(ctx, config)).To(Succeed())
 
 			cr := fixture.KserveCR()

--- a/kserve-module/pkg/kservemodule/reconciler_int_test.go
+++ b/kserve-module/pkg/kservemodule/reconciler_int_test.go
@@ -2,6 +2,7 @@ package kservemodule_test
 
 import (
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -9,6 +10,9 @@ import (
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,7 +44,7 @@ var _ = Describe("KserveModule Reconciler", func() {
 		cr := fixture.KserveCR()
 		Expect(testEnv.Client.Create(ctx, cr)).To(Succeed())
 		DeferCleanup(func(ctx SpecContext) {
-			Expect(client.IgnoreNotFound(testEnv.Client.Delete(ctx, cr))).To(Succeed())
+			deleteAndWaitGone(ctx, cr)
 		})
 
 		Eventually(func(g Gomega) {
@@ -61,7 +65,7 @@ var _ = Describe("KserveModule Reconciler", func() {
 			Expect(testEnv.Client.Create(ctx, cr)).To(Succeed())
 
 			DeferCleanup(func(ctx SpecContext) {
-				Expect(client.IgnoreNotFound(testEnv.Client.Delete(ctx, cr))).To(Succeed())
+				deleteAndWaitGone(ctx, cr)
 			})
 		})
 
@@ -178,7 +182,7 @@ var _ = Describe("KserveModule Reconciler", func() {
 			Expect(testEnv.Client.Create(ctx, cr)).To(Succeed())
 
 			DeferCleanup(func(ctx SpecContext) {
-				Expect(client.IgnoreNotFound(testEnv.Client.Delete(ctx, cr))).To(Succeed())
+				deleteAndWaitGone(ctx, cr)
 			})
 		})
 
@@ -260,7 +264,7 @@ var _ = Describe("KserveModule Reconciler", func() {
 			Expect(testEnv.Client.Create(ctx, cr)).To(Succeed())
 
 			DeferCleanup(func(ctx SpecContext) {
-				Expect(client.IgnoreNotFound(testEnv.Client.Delete(ctx, cr))).To(Succeed())
+				deleteAndWaitGone(ctx, cr)
 			})
 		})
 
@@ -321,7 +325,7 @@ var _ = Describe("KserveModule Reconciler", func() {
 			Expect(testEnv.Client.Create(ctx, cr)).To(Succeed())
 
 			DeferCleanup(func(ctx SpecContext) {
-				Expect(client.IgnoreNotFound(testEnv.Client.Delete(ctx, cr))).To(Succeed())
+				deleteAndWaitGone(ctx, cr)
 			})
 		})
 
@@ -421,22 +425,179 @@ var _ = Describe("KserveModule Reconciler", func() {
 		})
 	})
 
-	Context("platform finalizer removal", func() {
-		It("removes the platform finalizer on CR deletion", func(ctx SpecContext) {
+	Context("CR deletion without platform finalizer", func() {
+		It("deletes CR immediately and runs cleanup via NotFound path", func(ctx SpecContext) {
 			cr := fixture.KserveCR()
-			cr.Finalizers = append(cr.Finalizers, kservemodule.PlatformFinalizerName)
 			Expect(testEnv.Client.Create(ctx, cr)).To(Succeed())
 
 			Eventually(func(g Gomega) {
 				g.Expect(testEnv.Client.Get(ctx, client.ObjectKeyFromObject(cr), cr)).To(Succeed())
-			}).WithContext(ctx).Should(Succeed())
+				g.Expect(cr.Status.ObservedGeneration).To(Equal(cr.Generation))
+			}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
+
+			Expect(cr.Finalizers).To(BeEmpty(),
+				"CR should have no finalizer — platform operator sets it, not module operator")
 
 			Expect(testEnv.Client.Delete(ctx, cr)).To(Succeed())
 
 			Eventually(func(g Gomega) {
 				err := testEnv.Client.Get(ctx, client.ObjectKeyFromObject(cr), cr)
-				g.Expect(k8serr.IsNotFound(err)).To(BeTrue(), "CR should be fully deleted, not stuck in Deleting")
-			}).WithContext(ctx).Should(Succeed())
+				g.Expect(k8serr.IsNotFound(err)).To(BeTrue(), "CR should be deleted immediately")
+			}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
+		})
+	})
+
+	Context("deletion cleanup for LLMISVCConfig", Ordered, func() {
+		var (
+			llmisvcConfigCRD *apiextensionsv1.CustomResourceDefinition
+			llmisvcCRD       *apiextensionsv1.CustomResourceDefinition
+		)
+
+		BeforeAll(func(ctx SpecContext) {
+			llmisvcConfigCRD = &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "llminferenceserviceconfigs.serving.kserve.io"},
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+					Group: "serving.kserve.io",
+					Names: apiextensionsv1.CustomResourceDefinitionNames{
+						Kind:     "LLMInferenceServiceConfig",
+						Plural:   "llminferenceserviceconfigs",
+						Singular: "llminferenceserviceconfig",
+					},
+					Scope: apiextensionsv1.ClusterScoped,
+					Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+						Name:    "v1alpha2",
+						Served:  true,
+						Storage: true,
+						Schema: &apiextensionsv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+								Type:                   "object",
+								XPreserveUnknownFields: ptr.To(true),
+							},
+						},
+					}},
+				},
+			}
+			Expect(testEnv.Client.Create(ctx, llmisvcConfigCRD)).To(Succeed())
+
+			llmisvcCRD = &apiextensionsv1.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{Name: "llminferenceservices.serving.kserve.io"},
+				Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+					Group: "serving.kserve.io",
+					Names: apiextensionsv1.CustomResourceDefinitionNames{
+						Kind:     "LLMInferenceService",
+						Plural:   "llminferenceservices",
+						Singular: "llminferenceservice",
+					},
+					Scope: apiextensionsv1.NamespaceScoped,
+					Versions: []apiextensionsv1.CustomResourceDefinitionVersion{{
+						Name:    "v1alpha2",
+						Served:  true,
+						Storage: true,
+						Schema: &apiextensionsv1.CustomResourceValidation{
+							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+								Type:                   "object",
+								XPreserveUnknownFields: ptr.To(true),
+							},
+						},
+					}},
+				},
+			}
+			Expect(testEnv.Client.Create(ctx, llmisvcCRD)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				crd := &apiextensionsv1.CustomResourceDefinition{}
+				g.Expect(testEnv.Client.Get(ctx, client.ObjectKeyFromObject(llmisvcConfigCRD), crd)).To(Succeed())
+				for _, c := range crd.Status.Conditions {
+					if c.Type == apiextensionsv1.Established {
+						g.Expect(c.Status).To(Equal(apiextensionsv1.ConditionTrue))
+					}
+				}
+			}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
+		})
+
+		It("deletes configs when no LLMInferenceService instances exist", func(ctx SpecContext) {
+			config := &unstructured.Unstructured{}
+			config.SetGroupVersionKind(schema.GroupVersionKind{
+				Group: "serving.kserve.io", Version: "v1alpha2", Kind: "LLMInferenceServiceConfig",
+			})
+			config.SetName("test-config")
+			config.SetFinalizers([]string{"serving.kserve.io/llmisvcconfig-finalizer"})
+			Expect(testEnv.Client.Create(ctx, config)).To(Succeed())
+
+			cr := fixture.KserveCR()
+			Expect(testEnv.Client.Create(ctx, cr)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(testEnv.Client.Get(ctx, client.ObjectKeyFromObject(cr), cr)).To(Succeed())
+				g.Expect(cr.Status.ObservedGeneration).To(Equal(cr.Generation))
+			}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
+
+			Expect(testEnv.Client.Delete(ctx, cr)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				err := testEnv.Client.Get(ctx, client.ObjectKeyFromObject(cr), cr)
+				g.Expect(k8serr.IsNotFound(err)).To(BeTrue())
+			}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				err := testEnv.Client.Get(ctx, client.ObjectKeyFromObject(config), config)
+				g.Expect(k8serr.IsNotFound(err)).To(BeTrue(),
+					"LLMInferenceServiceConfig should be deleted when no LLMInferenceService instances exist")
+			}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
+		})
+
+		It("preserves configs when LLMInferenceService instances exist", func(ctx SpecContext) {
+			config := &unstructured.Unstructured{}
+			config.SetGroupVersionKind(schema.GroupVersionKind{
+				Group: "serving.kserve.io", Version: "v1alpha2", Kind: "LLMInferenceServiceConfig",
+			})
+			config.SetName("test-config-preserved")
+			config.SetFinalizers([]string{"serving.kserve.io/llmisvcconfig-finalizer"})
+			Expect(testEnv.Client.Create(ctx, config)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				cfg := &unstructured.Unstructured{}
+				cfg.SetGroupVersionKind(schema.GroupVersionKind{
+					Group: "serving.kserve.io", Version: "v1alpha2", Kind: "LLMInferenceServiceConfig",
+				})
+				cfg.SetName("test-config-preserved")
+				if err := testEnv.Client.Get(ctx, client.ObjectKeyFromObject(cfg), cfg); err == nil {
+					cfg.SetFinalizers(nil)
+					_ = testEnv.Client.Update(ctx, cfg)
+					_ = testEnv.Client.Delete(ctx, cfg)
+				}
+			})
+
+			llmisvc := &unstructured.Unstructured{}
+			llmisvc.SetGroupVersionKind(schema.GroupVersionKind{
+				Group: "serving.kserve.io", Version: "v1alpha2", Kind: "LLMInferenceService",
+			})
+			llmisvc.SetName("test-llmisvc")
+			llmisvc.SetNamespace("opendatahub")
+			Expect(testEnv.Client.Create(ctx, llmisvc)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				Expect(client.IgnoreNotFound(testEnv.Client.Delete(ctx, llmisvc))).To(Succeed())
+			})
+
+			cr := fixture.KserveCR()
+			Expect(testEnv.Client.Create(ctx, cr)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(testEnv.Client.Get(ctx, client.ObjectKeyFromObject(cr), cr)).To(Succeed())
+				g.Expect(cr.Status.ObservedGeneration).To(Equal(cr.Generation))
+			}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
+
+			Expect(testEnv.Client.Delete(ctx, cr)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				err := testEnv.Client.Get(ctx, client.ObjectKeyFromObject(cr), cr)
+				g.Expect(k8serr.IsNotFound(err)).To(BeTrue())
+			}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
+
+			Consistently(func(g Gomega) {
+				err := testEnv.Client.Get(ctx, client.ObjectKeyFromObject(config), config)
+				g.Expect(err).NotTo(HaveOccurred(),
+					"LLMInferenceServiceConfig should be preserved when LLMInferenceService instances exist")
+			}).WithContext(ctx).WithTimeout(3 * time.Second).Should(Succeed())
 		})
 	})
 
@@ -448,7 +609,7 @@ var _ = Describe("KserveModule Reconciler", func() {
 			Expect(testEnv.Client.Create(ctx, cr)).To(Succeed())
 
 			DeferCleanup(func(ctx SpecContext) {
-				Expect(client.IgnoreNotFound(testEnv.Client.Delete(ctx, cr))).To(Succeed())
+				deleteAndWaitGone(ctx, cr)
 			})
 		})
 
@@ -563,6 +724,15 @@ func createReadyDeployment(ctx SpecContext, name, namespace string) {
 	dep.Status.Replicas = 1
 	dep.Status.ReadyReplicas = 1
 	Expect(testEnv.Client.Status().Update(ctx, dep)).To(Succeed())
+}
+
+func deleteAndWaitGone(ctx SpecContext, obj client.Object) {
+	Expect(client.IgnoreNotFound(testEnv.Client.Delete(ctx, obj))).To(Succeed())
+	Eventually(func(g Gomega) {
+		err := testEnv.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+		g.Expect(k8serr.IsNotFound(err)).To(BeTrue(),
+			"waiting for %s %s to be fully deleted", obj.GetObjectKind().GroupVersionKind().Kind, obj.GetName())
+	}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
 }
 
 func triggerReconcile(ctx SpecContext, cr *platformv1alpha1.Kserve, trigger string) {

--- a/kserve-module/pkg/kservemodule/setup.go
+++ b/kserve-module/pkg/kservemodule/setup.go
@@ -238,3 +238,4 @@ func crdNamePredicate() predicate.Predicate {
 		return false
 	})
 }
+

--- a/kserve-module/pkg/kservemodule/setup.go
+++ b/kserve-module/pkg/kservemodule/setup.go
@@ -238,4 +238,3 @@ func crdNamePredicate() predicate.Predicate {
 		return false
 	})
 }
-


### PR DESCRIPTION
**What this PR does / why we need it**:

LLMInferenceServiceConfig was deployed with ownerReference to the Kserve CR, which meant foreground deletion would cascade-delete it along with everything else. Problem is the llmisvc controller holds a finalizer on those configs, and if the operator deployment gets killed first (also owned by the CR), nobody is left to remove that finalizer. Deadlock. Plus llmisvcConfig should not be removed if there are llmisvc referring to any llmisvcConfig.

Three changes to fix this:

- `splitByOwnership` splits rendered resources into owned (get ownerRef, GC'd with CR) and unowned (deployed standalone). LLMISVCConfig goes into the unowned bucket via `unownedGroupKinds` map.
- `cleanupKServeComponent` runs during CR deletion. If no LLMInferenceService instances exist, it deletes all LLMISVCConfig objects and polls until gone.
- Module-owned finalizer (`kserve-module.opendatahub.io/finalizer`) added during reconcile, removed after cleanup on deletion. Module operator manages its own finalizer lifecycle; platform finalizer is platform operator's responsibility.

Note: 
- Removed logic removing platform finalizer on kserve because platform team told that it will be controlled by platform operator.

**Which issue(s) this PR fixes**:

**Feature/Issue validation/testing**:

Integration tests cover finalizer lifecycle (add on reconcile, remove on deletion) and conditional cleanup (deletes configs when no LLMISVCs exist, preserves them when they do).

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

```release-note
NONE
```