### PR TITLE
fix(e2e): OpenShift e2e auth and diagnostics improvements

### DIFF
--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -14,6 +14,7 @@
 
 import copy
 import hashlib
+import json
 import os
 import re
 import time
@@ -73,6 +74,16 @@ else:
         "runAsUser": 65532,
         "runAsGroup": 65532,
     }
+
+# Default annotations applied to every LLMInferenceService created by the
+# test harness. Set LLMISVC_DEFAULT_ANNOTATIONS as a JSON object in CI to
+# inject platform-specific annotations without modifying test code.
+try:
+    DEFAULT_LLMISVC_ANNOTATIONS = json.loads(
+        os.environ.get("LLMISVC_DEFAULT_ANNOTATIONS", "{}")
+    )
+except (json.JSONDecodeError, TypeError):
+    DEFAULT_LLMISVC_ANNOTATIONS = {}
 
 UPSTREAM_K8S_VLLM_ENV_OVERRIDES = [
     {"name": "USER", "value": "nonroot"},
@@ -1501,7 +1512,11 @@ def _setup_test_case_service(
     tc.llm_service = V1alpha1LLMInferenceService(
         api_version="serving.kserve.io/v1alpha1",
         kind="LLMInferenceService",
-        metadata=client.V1ObjectMeta(name=tc.service_name, namespace=namespace),
+        metadata=client.V1ObjectMeta(
+            name=tc.service_name,
+            namespace=namespace,
+            annotations=dict(DEFAULT_LLMISVC_ANNOTATIONS) or None,
+        ),
         spec={
             "baseRefs": [{"name": base_ref} for base_ref in unique_base_refs],
         },

--- a/test/e2e/llmisvc/test_flow_control.py
+++ b/test/e2e/llmisvc/test_flow_control.py
@@ -108,15 +108,11 @@ def test_flow_control_smoke(test_case: TestCase, flow_control_auth):
     prefix = test_case.log_prefix
     test_failed = False
 
-    if not test_case.llm_service.metadata.annotations:
-        test_case.llm_service.metadata.annotations = {}
     if flow_control_auth:
+        if not test_case.llm_service.metadata.annotations:
+            test_case.llm_service.metadata.annotations = {}
         test_case.llm_service.metadata.annotations.update(
             flow_control_auth.get("annotations", {})
-        )
-    else:
-        test_case.llm_service.metadata.annotations.setdefault(
-            "security.opendatahub.io/enable-auth", "false"
         )
 
     try:

--- a/test/e2e/llmisvc/test_llm_auth.py
+++ b/test/e2e/llmisvc/test_llm_auth.py
@@ -260,6 +260,7 @@ def test_llm_auth_enabled_requires_token(test_case: TestCase):  # noqa: F811
 
     service_name = test_case.llm_service.metadata.name
     sa_name = f"{service_name}-test-sa"
+    ns = test_case.llm_service.metadata.namespace
     test_failed = False
 
     # Enable auth for this test
@@ -278,7 +279,7 @@ def test_llm_auth_enabled_requires_token(test_case: TestCase):  # noqa: F811
 
         # Create ServiceAccount with get+post access (required for inference-access and endpoint-access)
         token = create_service_account_with_inference_access(
-            kserve_client, sa_name, service_name
+            kserve_client, sa_name, service_name, namespace=ns
         )
 
         service_url = get_llm_service_url(kserve_client, test_case.llm_service)
@@ -352,7 +353,7 @@ def test_llm_auth_enabled_requires_token(test_case: TestCase):  # noqa: F811
         raise
     finally:
         try:
-            cleanup_service_account(kserve_client, sa_name)
+            cleanup_service_account(kserve_client, sa_name, namespace=ns)
 
             skip_all_deletion = os.getenv(
                 "SKIP_RESOURCE_DELETION", "False"
@@ -423,6 +424,7 @@ def test_llm_auth_invalid_token_rejected(test_case: TestCase):  # noqa: F811
 
     service_name = test_case.llm_service.metadata.name
     sa_name = f"{service_name}-test-sa"
+    ns = test_case.llm_service.metadata.namespace
     test_failed = False
 
     # Enable auth for this test
@@ -441,7 +443,7 @@ def test_llm_auth_invalid_token_rejected(test_case: TestCase):  # noqa: F811
 
         # Create ServiceAccount to get a valid token format reference
         create_service_account_with_inference_access(
-            kserve_client, sa_name, service_name
+            kserve_client, sa_name, service_name, namespace=ns
         )
 
         service_url = get_llm_service_url(kserve_client, test_case.llm_service)
@@ -488,7 +490,7 @@ def test_llm_auth_invalid_token_rejected(test_case: TestCase):  # noqa: F811
         raise
     finally:
         try:
-            cleanup_service_account(kserve_client, sa_name)
+            cleanup_service_account(kserve_client, sa_name, namespace=ns)
 
             skip_all_deletion = os.getenv(
                 "SKIP_RESOURCE_DELETION", "False"

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -838,12 +838,6 @@ def test_llm_inference_service(test_case: TestCase):  # noqa: F811
     )
 
     service_name = test_case.llm_service.metadata.name
-    if not test_case.llm_service.metadata.annotations:
-        test_case.llm_service.metadata.annotations = {}
-
-    test_case.llm_service.metadata.annotations[
-        "security.opendatahub.io/enable-auth"
-    ] = "false"
     prefix = test_case.log_prefix
 
     test_failed = False

--- a/test/e2e/llmisvc/test_llm_lora_adapters.py
+++ b/test/e2e/llmisvc/test_llm_lora_adapters.py
@@ -24,6 +24,7 @@ from typing import List, Optional
 
 from .diagnostic import collect_diagnostics
 from .fixtures import (
+    DEFAULT_LLMISVC_ANNOTATIONS,
     LLMINFERENCESERVICE_CONFIGS,
     _create_or_update_llmisvc_config,
     _get_model_name_from_configs,
@@ -69,7 +70,11 @@ def build_llm_service_from_refs(
     return V1alpha1LLMInferenceService(
         api_version="serving.kserve.io/v1alpha1",
         kind="LLMInferenceService",
-        metadata=client.V1ObjectMeta(name=service_name, namespace=namespace),
+        metadata=client.V1ObjectMeta(
+            name=service_name,
+            namespace=namespace,
+            annotations=dict(DEFAULT_LLMISVC_ANNOTATIONS) or None,
+        ),
         spec={"baseRefs": [{"name": ref} for ref in base_refs]},
     )
 
@@ -120,11 +125,6 @@ def run_lora_test(test_case: LoRATestCase, namespace: str):
         # Create the service with unique base refs
         llm_service = build_llm_service_from_refs(
             service_name, unique_base_refs, namespace
-        )
-        if not llm_service.metadata.annotations:
-            llm_service.metadata.annotations = {}
-        llm_service.metadata.annotations["security.opendatahub.io/enable-auth"] = (
-            "false"
         )
         logger.info("Creating LLMInferenceService: %s", service_name)
         create_llmisvc(kserve_client, llm_service)

--- a/test/e2e/llmisvc/test_llm_tls.py
+++ b/test/e2e/llmisvc/test_llm_tls.py
@@ -127,12 +127,6 @@ def test_llm_tls_resources(test_case: TestCase):
     )
 
     service_name = test_case.llm_service.metadata.name
-    if not test_case.llm_service.metadata.annotations:
-        test_case.llm_service.metadata.annotations = {}
-
-    test_case.llm_service.metadata.annotations[
-        "security.opendatahub.io/enable-auth"
-    ] = "false"
 
     try:
         create_llmisvc(kserve_client, test_case.llm_service)

--- a/test/e2e/llmisvc/test_rolling_upgrade.py
+++ b/test/e2e/llmisvc/test_rolling_upgrade.py
@@ -79,12 +79,6 @@ def test_rolling_upgrade_coordination(test_case: TestCase):
     namespace = test_case.llm_service.metadata.namespace
     test_failed = False
 
-    if not test_case.llm_service.metadata.annotations:
-        test_case.llm_service.metadata.annotations = {}
-    test_case.llm_service.metadata.annotations[
-        "security.opendatahub.io/enable-auth"
-    ] = "false"
-
     try:
         print(f"Creating LLMInferenceService {service_name}")
         create_llmisvc(kserve_client, test_case.llm_service)

--- a/test/scripts/openshift-ci/infra/deploy.kuadrant.sh
+++ b/test/scripts/openshift-ci/infra/deploy.kuadrant.sh
@@ -120,6 +120,7 @@ metadata:
 spec:
   replicas: 1
   clusterWide: true
+  logLevel: debug
   listener:
     tls:
       enabled: true

--- a/test/scripts/openshift-ci/run-e2e-tests.sh
+++ b/test/scripts/openshift-ci/run-e2e-tests.sh
@@ -61,6 +61,8 @@ else
 fi
 export PYTEST_ARGS="${PYTEST_ARGS:-} -p common.gateway_proxy_istio"
 export RUN_AS_NON_ROOT="${RUN_AS_NON_ROOT:-true}"
+: ${LLMISVC_DEFAULT_ANNOTATIONS:='{"security.opendatahub.io/enable-auth":"false"}'}
+export LLMISVC_DEFAULT_ANNOTATIONS
 export KUBE_CLI=${KUBE_CLI_COMMAND:-oc}
 
 export GITHUB_SHA=stable # Need to use stable as this is what the CI tags the images to for success-200 and error-404


### PR DESCRIPTION
**What this PR does / why we need it**:

Midstream-only fixes for e2e test auth and observability on OpenShift CI.

**Commits:**

1. **Auth RBAC namespace** - SA/Role/RoleBinding for auth tests created in the per-test namespace (matching where the LLMISVC lives), not the seed namespace

2. **Default annotations env var** - Sets `LLMISVC_DEFAULT_ANNOTATIONS` in `run-e2e-tests.sh` to inject `enable-auth=false` on all non-auth tests. Removes scattered hardcoded copies from individual test files. Works with the upstream `DEFAULT_LLMISVC_ANNOTATIONS` in `fixtures.py`

3. **Authorino debug logging** - `logLevel: debug` on the Authorino CR for auth decision visibility in must-gather

**Release note**:
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved authentication E2E reliability by explicitly using the target namespace when creating and cleaning up inference-access service accounts.
  * Simplified multiple LLMInferenceService E2E scenarios by removing test-time mutation of the default auth-disabling annotation, while keeping existing validation logic intact.
* **Chores**
  * Updated OpenShift CI TLS apply to use `debug` logging for the Kuadrant/Authorino Authorino SSL/TLS configuration step.
  * Set a default `LLMISVC_DEFAULT_ANNOTATIONS` value in the E2E runner script when not already provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->