### PR TITLE
chore: bump version for 3.5 ga release

### DIFF
--- a/config/component_metadata.yaml
+++ b/config/component_metadata.yaml
@@ -3,11 +3,14 @@ releases:
     version: v0.19.0
     repoUrl: https://github.com/kserve/kserve/
   - name: vLLM
-    version: v0.21.0
+    version: v0.24.0
     repoUrl: https://github.com/vllm-project/vllm
   - name: llm-d-router
-    version: v0.9.0
+    version: v0.10.0
     repoUrl: https://github.com/llm-d/llm-d-router
   - name: llm-d-workload-variant-autoscaler
-    version: v0.8.0
+    version: v0.9.0
     repoUrl: https://github.com/llm-d/llm-d-workload-variant-autoscaler
+  - name: llm-d-latency-predictor
+    version: v0.9.0
+    reporUrl: https://github.com/llm-d/llm-d-latency-predictor


### PR DESCRIPTION
# Notes
- add new latency-predictor
- bump versoin for llm-d component: these have not been released but as planned version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated component release metadata for vLLM, llm-d-router, and llm-d-workload-variant-autoscaler.
  - Added the llm-d-latency-predictor v0.9.0 release entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->