### PR TITLE
fix(ci): match llmisvc markers in setup-kserve gateway gate

### DIFF
--- a/test/scripts/openshift-ci/setup-kserve.sh
+++ b/test/scripts/openshift-ci/setup-kserve.sh
@@ -79,7 +79,7 @@ fi
 
 # LLMISvc dependencies: cert-manager, LeaderWorkerSet, Gateway API, Kuadrant.
 # These are core cluster infrastructure required for LLMInferenceService to function.
-if [[ "${1:-}" =~ "llminferenceservice" ]]; then
+if [[ "${1:-}" =~ llminferenceservice|llmisvc ]]; then
   "${SCRIPT_DIR}/setup-llm.sh" --skip-kserve --deploy-kuadrant
 fi
 


### PR DESCRIPTION
## Summary

- The marker rename from `llminferenceservice` to `llmisvc_core` (openshift/release 4a2a9e018b5) broke the substring match that gates `setup-llm.sh` execution
- Without `setup-llm.sh`, Gateway and Kuadrant CRDs are never deployed, causing all llmisvc e2e failures with `RouterReady=False` ("Managed HTTPRoute references non-existent Gateway openshift-ingress/openshift-ai-inference")
- Broadens the regex to match any `llmisvc`-prefixed marker

## Test plan

- [ ] `e2e-llm-inference-service` Prow job passes (Gateway is now deployed)
- [ ] Existing `llminferenceservice` marker still matches (regex is additive)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated setup behavior to recognize both supported service names when preparing LLM inference service dependencies.
  * Added support for the `llmisvc` alias during deployment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->