### PR TITLE
fix(build): fix go.mod permission denied in UBI Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS deps
 ENV PATH="$PATH:/opt/app-root/src/go/bin"
 
 WORKDIR /go/src/github.com/kserve/kserve
-COPY go.mod  go.mod
-COPY go.sum  go.sum
+COPY --chown=1001:0 go.mod  go.mod
+COPY --chown=1001:0 go.sum  go.sum
 RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 

--- a/agent.Dockerfile
+++ b/agent.Dockerfile
@@ -4,8 +4,8 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS deps
 ENV PATH="$PATH:/opt/app-root/src/go/bin"
 
 WORKDIR /go/src/github.com/kserve/kserve
-COPY go.mod  go.mod
-COPY go.sum  go.sum
+COPY --chown=1001:0 go.mod  go.mod
+COPY --chown=1001:0 go.sum  go.sum
 RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 

--- a/llmisvc-controller.Dockerfile
+++ b/llmisvc-controller.Dockerfile
@@ -4,8 +4,8 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS deps
 ENV PATH="$PATH:/opt/app-root/src/go/bin"
 
 WORKDIR /go/src/github.com/kserve/kserve
-COPY go.mod  go.mod
-COPY go.sum  go.sum
+COPY --chown=1001:0 go.mod  go.mod
+COPY --chown=1001:0 go.sum  go.sum
 RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 

--- a/router.Dockerfile
+++ b/router.Dockerfile
@@ -4,8 +4,8 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS deps
 ENV PATH="$PATH:/opt/app-root/src/go/bin"
 
 WORKDIR /go/src/github.com/kserve/kserve
-COPY go.mod  go.mod
-COPY go.sum  go.sum
+COPY --chown=1001:0 go.mod  go.mod
+COPY --chown=1001:0 go.sum  go.sum
 RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 


### PR DESCRIPTION
## Summary

- Go 1.25 (`af1534b62`) changed `go mod download` to write back to `go.mod` (tool dependency tidying)
- UBI `go-toolset` runs as uid 1001 but `COPY` creates files owned by root
- Result: `go mod download` fails with permission denied since the Go 1.25 bump landed on odh/master via sync `6782e0dea`
- Adds `--chown=1001:0` to `COPY` for `go.mod`/`go.sum` in the 4 Dockerfiles that don't already use `USER 0`/root

## Test plan

- [ ] Konflux builds pass for kserve-controller, kserve-agent, kserve-router, llmisvc-controller