### PR TITLE
fix(ci): bump xKS e2e test step timeout to 90 minutes

### DIFF
--- a/.github/workflows/e2e-test-odh-xks-kind.yml
+++ b/.github/workflows/e2e-test-odh-xks-kind.yml
@@ -122,7 +122,7 @@ jobs:
           popd
 
       - name: Run E2E tests
-        timeout-minutes: 75
+        timeout-minutes: 90
         env:
           KSERVE_NAMESPACE: "opendatahub"
           SKIP_DELETION_ON_FAILURE: "true"


### PR DESCRIPTION
**What this PR does / why we need it**:

The tls-true xKS kind matrix variant runs 55 tests (including `llmd_simulator` tests excluded from tls-false) but only has 75 minutes to complete. At ~80s per test average, the suite consistently times out with all tests passing but incomplete.

The tls-false variant runs 38 tests and finishes in ~63 minutes. The extra 17 `llmd_simulator` tests push tls-true past the 75-minute limit.

Bumps the step timeout from 75 to 90 minutes to accommodate the full test suite.

**Release note**:
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the end-to-end test execution timeout to reduce premature failures during longer test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->