### PR TITLE
fix(kserve-module): preserve user-set replicas and resources on deployments

### DIFF
--- a/kserve-module/config/crd/components.platform.opendatahub.io_kserves.yaml
+++ b/kserve-module/config/crd/components.platform.opendatahub.io_kserves.yaml
@@ -225,29 +225,36 @@ spec:
                     Module controllers set conditions to communicate health signals to the
                     orchestrator and to human operators.
                   properties:
+                    lastHeartbeatTime:
+                      description: |-
+                        Deprecated: LastHeartbeatTime is present only for backward
+                        compatibility with existing CRDs. New code should not set this field.
+                      format: date-time
+                      type: string
                     lastTransitionTime:
                       description: |-
-                        LastTransitionTime is the last time the condition transitioned from one
-                        status to another.
+                        lastTransitionTime is the last time the condition transitioned from
+                        one status to another.
                       format: date-time
                       type: string
                     message:
                       description: |-
-                        Message is a human-readable description providing details about the
-                        condition's last transition.
+                        message is a human-readable message indicating details about the
+                        transition.
                       type: string
                     observedGeneration:
                       description: |-
-                        ObservedGeneration is the .metadata.generation of the resource that
-                        the condition was set based upon. If this does not match the resource's
+                        observedGeneration represents the .metadata.generation that the
+                        condition was set based upon. If this does not match the resource's
                         current generation, the condition is likely stale.
                       format: int64
                       minimum: 0
                       type: integer
                     reason:
                       description: |-
-                        Reason is a programmatic, one-word CamelCase identifier for the
-                        condition's last transition, suitable for machine consumption.
+                        reason contains a programmatic identifier indicating the reason for
+                        the condition's last transition. The value should be a CamelCase
+                        string.
                       type: string
                     severity:
                       description: |-
@@ -255,16 +262,18 @@ spec:
                         purely informational. Empty string (default) indicates error severity.
                       type: string
                     status:
-                      description: Status is the status of the condition (True, False,
-                        Unknown).
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
                       type: string
                     type:
-                      description: Type is the condition type, e.g. ConditionTypeReady,
-                        ConditionTypeDegraded.
-                      minLength: 1
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
                       type: string
                   required:
-                  - lastTransitionTime
                   - status
                   - type
                   type: object

--- a/kserve-module/go.mod
+++ b/kserve-module/go.mod
@@ -5,7 +5,7 @@ go 1.25.8
 require (
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
-	github.com/opendatahub-io/odh-platform-utilities v0.0.0-20260506180717-e15e712db78d
+	github.com/opendatahub-io/odh-platform-utilities v0.2.0
 	github.com/openshift/api v0.0.0-20260601143908-70f01b82bb53
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.2
@@ -72,8 +72,8 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.66.1 // indirect
-	github.com/prometheus/procfs v0.17.0 // indirect
+	github.com/prometheus/common v0.67.5 // indirect
+	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/kserve-module/go.sum
+++ b/kserve-module/go.sum
@@ -149,8 +149,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
-github.com/opendatahub-io/odh-platform-utilities v0.0.0-20260506180717-e15e712db78d h1:0IuciRgQR5moi+g3nxmoZL32EdH+BiR1cyTqHMZPhSM=
-github.com/opendatahub-io/odh-platform-utilities v0.0.0-20260506180717-e15e712db78d/go.mod h1:QEysGTqJgWEKTVPlKaym3DrUcbYtfhOLNRxiJ+rfSfg=
+github.com/opendatahub-io/odh-platform-utilities v0.2.0 h1:4qqIzw34eIxN6U94tzikmIq6SWBJBm7mbpKYaGADzjw=
+github.com/opendatahub-io/odh-platform-utilities v0.2.0/go.mod h1:U76jpNAMv6JO5HFRYTMcGfYObc3NF1IngxsIsgWAMj4=
 github.com/openshift/api v0.0.0-20260601143908-70f01b82bb53 h1:I9aH3KSRGfBxVacrjpA7r5AZQj12VCHBHMWEypeKBWE=
 github.com/openshift/api v0.0.0-20260601143908-70f01b82bb53/go.mod h1:pyVjK0nZ4sRs4fuQVQ4rubsJdahI1PB94LnQ8sGdvxo=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -162,10 +162,10 @@ github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
-github.com/prometheus/common v0.66.1 h1:h5E0h5/Y8niHc5DlaLlWLArTQI7tMrsfQjHV+d9ZoGs=
-github.com/prometheus/common v0.66.1/go.mod h1:gcaUsgf3KfRSwHY4dIMXLPV0K/Wg1oZ8+SbZk/HH/dA=
-github.com/prometheus/procfs v0.17.0 h1:FuLQ+05u4ZI+SS/w9+BWEM2TXiHKsUQ9TADiRH7DuK0=
-github.com/prometheus/procfs v0.17.0/go.mod h1:oPQLaDAMRbA+u8H5Pbfq+dl3VDAvHxMUOVhe0wYB2zw=
+github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTUGI4=
+github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
+github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
+github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/xid v1.6.0 h1:fV591PaemRlL6JfRxGDEPl69wICngIQ3shQtzfy2gxU=

--- a/kserve-module/pkg/kservemodule/resource_manager.go
+++ b/kserve-module/pkg/kservemodule/resource_manager.go
@@ -9,6 +9,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -37,6 +38,10 @@ func NewDeployer() *deploy.Deployer {
 		deploy.WithFieldOwner(fieldOwner),
 		deploy.WithApplyOrder(),
 		deploy.WithCache(),
+		deploy.WithMergeStrategy(
+			schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+			deploy.MergeDeployments,
+		),
 	)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Register MergeDeployments strategy so SSA apply preserves existing replicas and container resources instead of overwriting them with manifest defaults. Bump odh-platform-utilities to v0.2.0.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Kubernetes Deployment updates by applying a more precise merge strategy to reduce unintended changes during redeployments.
  - Updated platform/monitoring library versions to refresh compatibility and stability.
  - Enhanced the KServe CRD status conditions schema with stricter validation (including enums and constraints), while adding a deprecated `lastHeartbeatTime` field for backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->