### PR TITLE
fix(e2e): add ocp_only marker to skip OCP tests before fixture setup

### DIFF
--- a/kserve-module/tests/e2e/conftest.py
+++ b/kserve-module/tests/e2e/conftest.py
@@ -1,5 +1,6 @@
 """Shared fixtures for kserve-module E2E tests."""
 
+import shutil
 import subprocess
 import time
 from dataclasses import dataclass
@@ -47,6 +48,53 @@ LMNG_RESOURCE = "localmodelnodegroups.serving.kserve.io"
 class ClusterInfo:
     is_openshift: bool
     kubectl: str  # "oc" or "kubectl"
+
+
+# ---------------------------------------------------------------------------
+# Cluster detection (shared by hook and fixture)
+# ---------------------------------------------------------------------------
+_cluster_detection_cache = None
+
+
+def _detect_openshift():
+    """Detect cluster type once; cached for the process lifetime."""
+    global _cluster_detection_cache
+    if _cluster_detection_cache is not None:
+        return _cluster_detection_cache
+
+    cli = "oc" if shutil.which("oc") else "kubectl"
+    if not shutil.which(cli):
+        _cluster_detection_cache = (False, cli)
+        return _cluster_detection_cache
+
+    result = subprocess.run(
+        [cli, "api-resources", "--api-group=config.openshift.io"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    is_ocp = result.returncode == 0 and "clusterversions" in result.stdout.lower()
+    _cluster_detection_cache = (is_ocp, cli)
+    return _cluster_detection_cache
+
+
+# ---------------------------------------------------------------------------
+# Pytest hooks
+# ---------------------------------------------------------------------------
+def pytest_collection_modifyitems(config, items):
+    """Skip @pytest.mark.ocp_only tests on non-OpenShift clusters.
+
+    Runs at collection time — before any fixture setup — so expensive
+    fixtures like apply_kserve_cr never execute on vanilla-k8s clusters.
+    """
+    is_ocp, _ = _detect_openshift()
+    if is_ocp:
+        return
+
+    skip_marker = pytest.mark.skip(reason="OCP-only test (not running on OpenShift)")
+    for item in items:
+        if "ocp_only" in item.keywords:
+            item.add_marker(skip_marker)
 
 
 # ---------------------------------------------------------------------------
@@ -326,19 +374,9 @@ def _wait_for_managed_deployments_gc(kubectl_bin, is_openshift, timeout=TIMEOUT_
 @pytest.fixture(scope="session")
 def cluster_info():
     """Detect cluster type and pick the right CLI binary (oc or kubectl)."""
-    import shutil
-
-    cli = "oc" if shutil.which("oc") else "kubectl"
+    is_ocp, cli = _detect_openshift()
     if not shutil.which(cli):
         pytest.fail("Neither 'oc' nor 'kubectl' found in PATH")
-
-    result = subprocess.run(
-        [cli, "api-resources", "--api-group=config.openshift.io"],
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-    is_ocp = result.returncode == 0 and "clusterversions" in result.stdout.lower()
     return ClusterInfo(is_openshift=is_ocp, kubectl=cli)
 
 
@@ -365,10 +403,10 @@ def apply_kserve_cr(kubectl, cluster_info):
 @pytest.fixture
 def model_cache_enabled(kubectl, cluster_info, apply_kserve_cr):
     """Enable ModelCache before the test and disable it after.
-    Skipped on non-OpenShift clusters (no XKS overlay for modelcache).
+
+    Requires @pytest.mark.ocp_only on the test; the collection hook
+    skips non-OpenShift clusters before this fixture runs.
     """
-    if not cluster_info.is_openshift:
-        pytest.skip("ModelCache reconciliation requires OpenShift")
     worker = get_worker_node(kubectl, is_openshift=cluster_info.is_openshift)
     enable_model_cache(kubectl, worker)
     _poll_cr(

--- a/kserve-module/tests/e2e/pytest.ini
+++ b/kserve-module/tests/e2e/pytest.ini
@@ -3,3 +3,4 @@ markers =
     sanity: core lifecycle tests that must pass on every cluster
     status: status condition and error handling tests
     modelcache: ModelCache enable/disable lifecycle and CEL validation tests
+    ocp_only: tests that require an OpenShift cluster (skipped on vanilla k8s)

--- a/kserve-module/tests/e2e/test_lifecycle.py
+++ b/kserve-module/tests/e2e/test_lifecycle.py
@@ -151,14 +151,12 @@ class TestCELValidation:
 
 
 @pytest.mark.sanity
+@pytest.mark.ocp_only
 class TestManagementState:
     """Verify managementState transitions for sub-components (WVA, NIM)."""
 
     def test_wva_default_removed_has_no_deployment(self, kubectl, cluster_info, apply_kserve_cr):
         """WVA defaults to Removed — no WVA deployment should exist."""
-        if not cluster_info.is_openshift:
-            pytest.skip("WVA is OCP-only")
-
         patch = json.dumps({"spec": {"wva": {"managementState": "Removed"}}})
         run([kubectl, "patch", "kserve", KSERVE_CR_NAME, "--type", "merge", "-p", patch])
         _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, TIMEOUT_120S,
@@ -174,9 +172,6 @@ class TestManagementState:
 
     def test_wva_managed_deploys_resources(self, kubectl, cluster_info, apply_kserve_cr):
         """Setting wva.managementState to Managed deploys WVA resources."""
-        if not cluster_info.is_openshift:
-            pytest.skip("WVA is OCP-only")
-
         patch = json.dumps({"spec": {"wva": {"managementState": "Managed"}}})
         run([kubectl, "patch", "kserve", KSERVE_CR_NAME, "--type", "merge", "-p", patch])
 
@@ -188,9 +183,6 @@ class TestManagementState:
 
     def test_wva_managed_to_removed_cleans_up(self, kubectl, cluster_info, apply_kserve_cr):
         """Switching WVA from Managed to Removed removes WVA deployment but keeps others."""
-        if not cluster_info.is_openshift:
-            pytest.skip("WVA is OCP-only")
-
         patch = json.dumps({"spec": {"wva": {"managementState": "Managed"}}})
         run([kubectl, "patch", "kserve", KSERVE_CR_NAME, "--type", "merge", "-p", patch])
         wait_for_deployment(kubectl, WVA_DEPLOYMENT)
@@ -207,9 +199,6 @@ class TestManagementState:
 
     def test_nim_default_managed_env_var(self, kubectl, cluster_info, apply_kserve_cr):
         """NIM defaults to Managed — odh-model-controller should have NIM_STATE=managed."""
-        if not cluster_info.is_openshift:
-            pytest.skip("odh-model-controller is OCP-only")
-
         _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, TIMEOUT_120S,
                  f"observedGeneration not matching within {TIMEOUT_120S}s")
         wait_for_deployment(kubectl, MODEL_CONTROLLER_DEPLOYMENT)
@@ -224,9 +213,6 @@ class TestManagementState:
 
     def test_nim_managed_to_removed_updates_env(self, kubectl, cluster_info, apply_kserve_cr):
         """Switching NIM to Removed updates odh-model-controller NIM_STATE env var."""
-        if not cluster_info.is_openshift:
-            pytest.skip("odh-model-controller is OCP-only")
-
         wait_for_deployment(kubectl, MODEL_CONTROLLER_DEPLOYMENT)
 
         patch = json.dumps({"spec": {"nim": {"managementState": "Removed"}}})
@@ -247,9 +233,6 @@ class TestManagementState:
 
     def test_nim_removed_to_managed_updates_env(self, kubectl, cluster_info, apply_kserve_cr):
         """Switching NIM back to Managed updates odh-model-controller NIM_STATE env var."""
-        if not cluster_info.is_openshift:
-            pytest.skip("odh-model-controller is OCP-only")
-
         patch = json.dumps({"spec": {"nim": {"managementState": "Removed"}}})
         run([kubectl, "patch", "kserve", KSERVE_CR_NAME, "--type", "merge", "-p", patch])
         _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, TIMEOUT_120S,

--- a/kserve-module/tests/e2e/test_modelcache.py
+++ b/kserve-module/tests/e2e/test_modelcache.py
@@ -27,6 +27,7 @@ from conftest import (
 
 
 @pytest.mark.modelcache
+@pytest.mark.ocp_only
 class TestModelCacheEnable:
     """Verify enabling ModelCache creates all expected resources."""
 
@@ -95,6 +96,7 @@ class TestModelCacheEnable:
 
 
 @pytest.mark.modelcache
+@pytest.mark.ocp_only
 class TestModelCacheDisable:
     """Verify disabling ModelCache cleans up all resources."""
 
@@ -102,8 +104,6 @@ class TestModelCacheDisable:
         """After enabling then disabling ModelCache, all managed resources
         are removed and the Kserve CR remains Ready.
         """
-        if not cluster_info.is_openshift:
-            pytest.skip("ModelCache reconciliation requires OpenShift")
         worker = get_worker_node(kubectl, is_openshift=cluster_info.is_openshift)
         enable_model_cache(kubectl, worker)
         _poll_cr(
@@ -267,6 +267,7 @@ class TestModelCacheCELValidation:
 
 
 @pytest.mark.modelcache
+@pytest.mark.ocp_only
 class TestModelCacheRecovery:
     """Verify deleted ModelCache resources are recreated on reconcile."""
 


### PR DESCRIPTION
**What this PR does / why we need it**:
OCP-only tests (WVA, NIM, ModelCache) had apply_kserve_cr fixture in their signature, causing CR create/delete cycles even when the test would immediately skip on non-OpenShift clusters. Each cycle takes ~3-4 minutes, wasting ~20 minutes total for skipped tests.

Add `@pytest.mark.ocp_only` custom marker and a `pytest_collection_modifyitems` hook that detects the cluster type at collection time and skips marked tests before any fixtures run. This keeps `apply_kserve_cr` in the test signatures (proper teardown on OCP) while preventing fixture execution on non-OCP clusters.

Changes:
- Register `ocp_only` marker in pytest.ini
- Extract `_detect_openshift()` helper with process-lifetime cache, shared by hook and `cluster_info` fixture
- Add `pytest_collection_modifyitems` hook to skip `ocp_only` tests on vanilla k8s
- Mark `TestManagementState`, `TestModelCacheEnable`, `TestModelCacheDisable`, `TestModelCacheRecovery` with `@pytest.mark.ocp_only`
- Remove inline `pytest.skip()` calls from OCP-only tests

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:

On xks: `pytest --collect-only -m ocp_only` shows all OCP-only tests collected with skip marker. No CR create/delete cycles.
On OCP: all tests run normally with apply_kserve_cr fixture providing CR lifecycle.

**Special notes for your reviewer**:

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automatic detection of OpenShift versus standard Kubernetes environments.
  * OpenShift-only end-to-end tests are now skipped automatically when running on standard Kubernetes.
  * Updated ModelCache testing to verify enablement, disablement, recovery, and reconciliation behavior.
  * Simplified lifecycle and ModelCache test setup while preserving existing assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->