### PR TITLE
test(kserve-module): add deletion recovery integration tests for owned resources

### DIFF
--- a/kserve-module/tests/e2e/test_lifecycle.py
+++ b/kserve-module/tests/e2e/test_lifecycle.py
@@ -8,6 +8,8 @@ from conftest import (
     run,
     _poll_cr,
     get_conditions,
+    get_jsonpath,
+    resource_exists,
     wait_for,
     wait_for_kserve_cleanup,
     trigger_reconcile,
@@ -290,3 +292,71 @@ class TestDriftCorrection:
             assert conditions["ProvisioningSucceeded"]["status"] == "True"
 
         wait_for(assert_provisioning_succeeded, timeout=TIMEOUT_60S, interval=5)
+
+
+@pytest.mark.sanity
+class TestDeletionRecovery:
+    """Owned resources are recreated after external deletion on next reconcile."""
+
+    def test_configmap_recovered_after_deletion(self, kubectl, apply_kserve_cr):
+        """Deleting an owned ConfigMap triggers recreation with a new UID."""
+        cm_name = "inferenceservice-config"
+        uid_before = get_jsonpath(
+            kubectl, "configmap", cm_name, "{.metadata.uid}", namespace=NAMESPACE
+        )
+        assert uid_before, f"{cm_name} should exist before deletion"
+
+        run([kubectl, "delete", "configmap", cm_name, "-n", NAMESPACE])
+        assert not resource_exists(kubectl, "configmap", cm_name, namespace=NAMESPACE)
+
+        def assert_recreated_with_new_uid():
+            uid_after = get_jsonpath(
+                kubectl, "configmap", cm_name, "{.metadata.uid}", namespace=NAMESPACE
+            )
+            assert uid_after, f"{cm_name} should be recreated"
+            assert uid_after != uid_before, (
+                f"{cm_name} should have a new UID after recreation"
+            )
+
+        wait_for(assert_recreated_with_new_uid, timeout=TIMEOUT_120S, interval=5)
+
+    def test_deployment_recovered_after_deletion(self, kubectl, cluster_info, apply_kserve_cr):
+        """Deleting owned Deployments triggers recreation with new UIDs."""
+        targets = list(operand_deployments(cluster_info.is_openshift))
+
+        if cluster_info.is_openshift:
+            patch = json.dumps({"spec": {"wva": {"managementState": "Managed"}}})
+            run([kubectl, "patch", "kserve", KSERVE_CR_NAME, "--type", "merge", "-p", patch])
+            _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, TIMEOUT_120S,
+                     f"observedGeneration not matching within {TIMEOUT_120S}s")
+            wait_for_deployment(kubectl, WVA_DEPLOYMENT)
+            targets.append(WVA_DEPLOYMENT)
+
+        try:
+            for dep_name in targets:
+                uid_before = get_jsonpath(
+                    kubectl, "deployment", dep_name, "{.metadata.uid}", namespace=NAMESPACE
+                )
+                assert uid_before, f"{dep_name} should exist before deletion"
+
+                run([kubectl, "delete", "deployment", dep_name, "-n", NAMESPACE])
+
+                def assert_recreated(name=dep_name, expected_old_uid=uid_before):
+                    uid_after = get_jsonpath(
+                        kubectl, "deployment", name, "{.metadata.uid}", namespace=NAMESPACE
+                    )
+                    assert uid_after, f"{name} should be recreated"
+                    assert uid_after != expected_old_uid, (
+                        f"{name} should have a new UID after recreation"
+                    )
+
+                wait_for(assert_recreated, timeout=TIMEOUT_120S, interval=5)
+                wait_for_deployment(kubectl, dep_name)
+        finally:
+            if cluster_info.is_openshift:
+                patch = json.dumps({"spec": {"wva": {"managementState": "Removed"}}})
+                run([kubectl, "patch", "kserve", KSERVE_CR_NAME, "--type", "merge", "-p", patch],
+                    check=False)
+                _poll_cr(kubectl, KSERVE_CR_NAME, _generation_matches, TIMEOUT_120S,
+                         f"observedGeneration not matching within {TIMEOUT_120S}s")
+                wait_for_deployment_gone(kubectl, WVA_DEPLOYMENT)


### PR DESCRIPTION
## What this tests
Fix: [RHOAIENG-78532](https://redhat.atlassian.net/browse/RHOAIENG-78532)

Adds `TestDeletionRecovery` to `test_lifecycle.py` — verifies that externally deleted owned resources get recreated by the controller through Owns() watches.

Two tests:
  - `test_configmap_recovered_after_deletion` — deletes `inferenceservice-config`, waits for recreation, checks UID changed
  - `test_deployment_recovered_after_deletion` — iterates all operand deployments per platform (xKS: llmisvc-controller-manager only, OCP: all 4 core + WVA), deletes each one
  and verifies recreation with new UID + Available=True

WVA is enabled via Kserve CR patch (`managementState: Managed`) at the start of the deployment test on OCP and reverted to `Removed` at the end. No `trigger_reconcile()` needed — the Owns() watch auto-enqueues reconcile on deletion.

Tested on OCP cluster — both tests pass.


## Test cases

- Owned ConfigMap deletion → reconcile triggered
- Owned Deployment deletion → reconcile triggered


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage confirming that deleted configuration resources are automatically recreated.
  * Added validation that deleted operand deployments return with new identities.
  * Added platform-specific coverage for managing the WVA deployment lifecycle during recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-78532]: https://redhat.atlassian.net/browse/RHOAIENG-78532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ