### PR TITLE
feat(kserve-module): install CRDs once per pod start via odh-crds overlay

### DIFF
--- a/kserve-module/pkg/kservemodule/constants.go
+++ b/kserve-module/pkg/kservemodule/constants.go
@@ -18,6 +18,7 @@ const (
 	// Manifest source paths
 	KserveManifestSourcePath        = "overlays/odh"
 	KserveManifestSourcePathXKS     = "overlays/odh-xks"
+	KserveCRDManifestSourcePath     = "overlays/odh-crds"
 	ModelCacheManifestSourcePath    = "overlays/odh-modelcache"
 	ModelControllerSourcePath       = "base"
 	WVAManifestSourcePathOCP        = "overlays/namespace-scoped/openshift"

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -201,6 +201,12 @@ func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 func (r *KserveModuleReconciler) reconcile(ctx context.Context, kserve *platformv1alpha1.Kserve) map[string]error {
 	log := ctrl.LoggerFrom(ctx)
 
+	if !r.initDone {
+		if err := r.installCRDs(ctx, kserve); err != nil {
+			return map[string]error{"crds": fmt.Errorf("installing CRDs: %w", err)}
+		}
+	}
+
 	manifestDir, err := r.ensureWorkDir()
 	if err != nil {
 		errs := make(map[string]error, len(components))
@@ -422,6 +428,22 @@ func (r *KserveModuleReconciler) SetClusterType(ct cluster.ClusterType) {
 func (r *KserveModuleReconciler) SetWorkDir(dir string) {
 	r.workDir = dir
 	r.initDone = true
+}
+
+func (r *KserveModuleReconciler) installCRDs(ctx context.Context, kserve *platformv1alpha1.Kserve) error {
+	crdPath := filepath.Join(r.ManifestsTemplatePath, KserveComponentName, KserveCRDManifestSourcePath)
+	resources, err := kustomize.Render(crdPath, nil)
+	if err != nil {
+		return fmt.Errorf("rendering CRD manifests: %w", err)
+	}
+	if err := r.Deployer.Deploy(ctx, deploy.DeployInput{
+		Client:    r.Client,
+		Owner:     kserve,
+		Resources: resources,
+	}); err != nil {
+		return fmt.Errorf("applying CRDs: %w", err)
+	}
+	return nil
 }
 
 func (r *KserveModuleReconciler) ensureWorkDir() (string, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Install kserve and llmisvc CRDs on the first reconcile using the odh-crds overlay, then comment out the odh-crds reference in the copied kustomization so subsequent reconciles skip CRD rendering.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
