### PR TITLE
fix(kserve-module): report LWS CRD absence to WideEPDependencies on xKS

### DIFF
--- a/kserve-module/pkg/kservemodule/dependencies.go
+++ b/kserve-module/pkg/kservemodule/dependencies.go
@@ -115,7 +115,14 @@ var kserveDependencies = []dependencyCheck{
 	crdDep("cert-manager-clusterissuer", "clusterissuers.cert-manager.io", "xks", true),
 
 	// LeaderWorkerSet CRD
-	crdDep("leaderworkersets", "leaderworkersets.leaderworkerset.x-k8s.io", "xks", false),
+	{
+		name:           "leaderworkersets",
+		checkType:      checkCRD,
+		crdName:        "leaderworkersets.leaderworkerset.x-k8s.io",
+		platform:       "xks",
+		critical:       false,
+		conditionGroup: conditionLLMISVCWideEPDeps,
+	},
 
 	// OCP Subscription checks
 	subscriptionDep("Red Hat Connectivity Link", rhclSubscription, conditionLLMISVCDeps, "ocp", false),


### PR DESCRIPTION
**What this PR does / why we need it**:

On xKS the LWS CRD check used `crdDep()` which does not set `conditionGroup`, so a missing LWS CRD only showed up in general Degraded but never in `KserveLLMInferenceServiceWideEPDependencies`. This broke the `Validate_external_operator_degraded_condition_monitoring` e2e test because the condition stayed True even when LWS was absent.

Switched to an inline struct with `conditionGroup: conditionLLMISVCWideEPDeps` to match the OCP subscription check behavior (line 125).

**Which issue(s) this PR fixes**:

**Feature/Issue validation/testing**:
- Existing `Validate_external_operator_degraded_condition_monitoring` e2e test should now pass on xKS

**Checklist**:
- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [] Have you made corresponding changes to the documentation?
- [] Have you linked the JIRA issue(s) to this PR?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency status reporting for leader worker sets.
  * Degraded dependency messages are now grouped with the appropriate wide-endpoint service status, providing clearer condition summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->