### PR TITLE
fix(llmisvc): bump scheduler version gate for llm-d-router image

### DIFF
--- a/config/overlays/odh/patches/config-scheduler-patch.yaml
+++ b/config/overlays/odh/patches/config-scheduler-patch.yaml
@@ -9,3 +9,8 @@ spec:
         # This annotation is kept for compatibility with previous versions when we needed to restart the scheduler
         # to pick the TLS certs changes. (see https://github.com/opendatahub-io/kserve/commit/3c96712ad0a28b6c89c0997475fd0fac8deb3857)
         "certificates.kserve.io/expiration-v2": "true"
+        # TEMPORARY: remove once upstream preset aligns with the downstream image.
+        # Downstream llm-d-router image is rebuilt from a pre-release branch and
+        # already removed --model-server-metrics-scheme (a 0.10.0 change). Bump
+        # the version gate so the controller-side migration (#5877) fires.
+        "app.kubernetes.io/version": "0.10.0"


### PR DESCRIPTION
**What this PR does / why we need it**:

The downstream llm-d-router image is rebuilt from a pre-release branch that already removed `--model-server-metrics-scheme` (a 0.10.0 change), but the upstream preset pins the version annotation at `0.9.0`. This mismatch prevents the controller-side migration from firing, causing the EPP pod to crash on startup with an unrecognized flag error.

Bumps `app.kubernetes.io/version` to `0.10.0` in the odh scheduler overlay so the migration logic from upstream kserve/kserve#5877 activates and strips the deprecated flag.

This is a temporary workaround - remove once the upstream preset aligns with the downstream image version.

**Which issue(s) this PR fixes**:

[RHOAIENG-78216](https://redhat.atlassian.net/browse/RHOAIENG-78216)

**Feature/Issue validation/testing**:

- [x] Verified via `kustomize build` that the patch correctly overrides the annotation from `0.9.0` to `0.10.0`

See also upstream PRs:
- kserve/kserve#5877 (EPP metrics scheme migration)
- kserve/kserve#5875 (routing sidecar TLS flag migration)

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
  - N/A - overlay patch only, no code changes
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

```release-note
NONE
```

[RHOAIENG-78216]: https://redhat.atlassian.net/browse/RHOAIENG-78216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated scheduler routing configuration to support version 0.10.0.
  * Ensured the required controller migration is triggered during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->