### PR TITLE
fix(kserve-module): refactor availabilitySeverity and improve test coverage

### DIFF
--- a/kserve-module/pkg/kservemodule/dependencies.go
+++ b/kserve-module/pkg/kservemodule/dependencies.go
@@ -12,6 +12,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/opendatahub-io/odh-platform-utilities/api/common"
+
 	platformv1alpha1 "github.com/opendatahub-io/kserve-module/pkg/apis/v1alpha1"
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster/olm"
 )
@@ -23,8 +25,12 @@ const (
 	checkSubscription checkType = "subscription"
 	checkOperator     checkType = "operator"
 
+	// availSeverityNone means failures are not reported to DependenciesAvailable.
+	// Must differ from common.ConditionSeverityError (which is "").
+	availSeverityNone common.ConditionSeverity = "None"
+
 	// Dependency group condition types
-	conditionLLMISVCDeps       = "KserveLLMInferenceServiceDependencies"
+	conditionLLMISVCDeps = "KserveLLMInferenceServiceDependencies"
 	conditionLLMISVCWideEPDeps = "KserveLLMInferenceServiceWideEPDependencies"
 	conditionLLMDWVADeps       = "LLM-D-WVADependencies"
 
@@ -38,113 +44,118 @@ const (
 type conditionFilterFunc func(conditionType string, status string) bool
 
 type dependencyCheck struct {
-	name             string
-	checkType        checkType
-	crdName          string                                          // Full CRD name (e.g. "authorizationpolicies.security.istio.io")
-	subscriptionName string                                          // Subscription check
-	operatorGVK      schema.GroupVersionKind                         // Operator CR GVK
-	operatorCRName   string                                          // Operator CR name (empty = list first)
-	conditionFilter  conditionFilterFunc                             // Operator condition filter
-	critical         bool                                            // true → Ready=False, false → Degraded
-	platform         string                                          // "ocp", "xks", "" (both)
-	conditionGroup   string                                          // group into same condition
-	skipFunc         func(kserve *platformv1alpha1.Kserve) bool      // true → skip this check
+	name                 string
+	checkType            checkType
+	crdName              string                                     // Full CRD name (e.g. "authorizationpolicies.security.istio.io")
+	subscriptionName     string                                     // Subscription check
+	operatorGVK          schema.GroupVersionKind                    // Operator CR GVK
+	operatorCRName       string                                     // Operator CR name (empty = list first)
+	conditionFilter      conditionFilterFunc                        // Operator condition filter
+	availabilitySeverity common.ConditionSeverity                   // availSeverityNone = no report, Error = Ready=False, Info = Ready=True
+	platform             string                                     // "ocp", "xks", "" (both)
+	conditionGroup       string                                     // group into same condition
+	skipFunc             func(kserve *platformv1alpha1.Kserve) bool // true → skip this check
+}
+
+type availabilityReason struct {
+	severity common.ConditionSeverity
+	message  string
 }
 
 type dependencyResult struct {
-	degradedReasons []string
-	criticalErrors  []string
-	groupReasons    map[string][]string
+	availReasons []availabilityReason
+	allReasons   []string
+	groupReasons map[string][]string
 }
 
-func crdDep(name, crdName, platform string, critical bool) dependencyCheck {
+func crdDep(name, crdName, platform string, availSeverity common.ConditionSeverity) dependencyCheck {
 	return dependencyCheck{
-		name:      name,
-		checkType: checkCRD,
-		crdName:   crdName,
-		platform:  platform,
-		critical:  critical,
+		name:                 name,
+		checkType:            checkCRD,
+		crdName:              crdName,
+		platform:             platform,
+		availabilitySeverity: availSeverity,
 	}
 }
 
-func subscriptionDep(name, subName, condGroup, platform string, critical bool) dependencyCheck {
+func subscriptionDep(name, subName, condGroup, platform string, availSeverity common.ConditionSeverity) dependencyCheck {
 	return dependencyCheck{
-		name:             name,
-		checkType:        checkSubscription,
-		subscriptionName: subName,
-		conditionGroup:   condGroup,
-		platform:         platform,
-		critical:         critical,
+		name:                 name,
+		checkType:            checkSubscription,
+		subscriptionName:     subName,
+		conditionGroup:       condGroup,
+		platform:             platform,
+		availabilitySeverity: availSeverity,
 	}
 }
 
-func operatorDep(name string, gvk schema.GroupVersionKind, crName, condGroup, platform string, critical bool, filter conditionFilterFunc) dependencyCheck {
+func operatorDep(name string, gvk schema.GroupVersionKind, crName, condGroup, platform string, availSeverity common.ConditionSeverity, filter conditionFilterFunc) dependencyCheck {
 	return dependencyCheck{
-		name:            name,
-		checkType:       checkOperator,
-		operatorGVK:     gvk,
-		operatorCRName:  crName,
-		conditionGroup:  condGroup,
-		platform:        platform,
-		critical:        critical,
-		conditionFilter: filter,
+		name:                 name,
+		checkType:            checkOperator,
+		operatorGVK:          gvk,
+		operatorCRName:       crName,
+		conditionGroup:       condGroup,
+		platform:             platform,
+		availabilitySeverity: availSeverity,
+		conditionFilter:      filter,
 	}
 }
 
 var kserveDependencies = []dependencyCheck{
 	// xks only checks
-	// Istio CRDs
-	crdDep("istio-destinationrule", "destinationrules.networking.istio.io", "xks", false),
-	crdDep("istio-envoyfilter", "envoyfilters.networking.istio.io", "xks", false),
-	crdDep("istio-gateway", "gateways.networking.istio.io", "xks", false),
-	crdDep("istio-proxyconfig", "proxyconfigs.networking.istio.io", "xks", false),
-	crdDep("istio-serviceentry", "serviceentries.networking.istio.io", "xks", false),
-	crdDep("istio-sidecar", "sidecars.networking.istio.io", "xks", false),
-	crdDep("istio-workloadentry", "workloadentries.networking.istio.io", "xks", false),
-	crdDep("istio-workloadgroup", "workloadgroups.networking.istio.io", "xks", false),
-	crdDep("istio-authorizationpolicy", "authorizationpolicies.security.istio.io", "xks", false),
-	crdDep("istio-peerauthentication", "peerauthentications.security.istio.io", "xks", false),
-	crdDep("istio-requestauthentication", "requestauthentications.security.istio.io", "xks", false),
-	crdDep("istio-telemetry", "telemetries.telemetry.istio.io", "xks", false),
-	crdDep("istio-wasmplugin", "wasmplugins.extensions.istio.io", "xks", false),
+	// Istio CRDs — optional, degraded-only reporting
+	crdDep("istio-destinationrule", "destinationrules.networking.istio.io", "xks", availSeverityNone),
+	crdDep("istio-envoyfilter", "envoyfilters.networking.istio.io", "xks", availSeverityNone),
+	crdDep("istio-gateway", "gateways.networking.istio.io", "xks", availSeverityNone),
+	crdDep("istio-proxyconfig", "proxyconfigs.networking.istio.io", "xks", availSeverityNone),
+	crdDep("istio-serviceentry", "serviceentries.networking.istio.io", "xks", availSeverityNone),
+	crdDep("istio-sidecar", "sidecars.networking.istio.io", "xks", availSeverityNone),
+	crdDep("istio-workloadentry", "workloadentries.networking.istio.io", "xks", availSeverityNone),
+	crdDep("istio-workloadgroup", "workloadgroups.networking.istio.io", "xks", availSeverityNone),
+	crdDep("istio-authorizationpolicy", "authorizationpolicies.security.istio.io", "xks", availSeverityNone),
+	crdDep("istio-peerauthentication", "peerauthentications.security.istio.io", "xks", availSeverityNone),
+	crdDep("istio-requestauthentication", "requestauthentications.security.istio.io", "xks", availSeverityNone),
+	crdDep("istio-telemetry", "telemetries.telemetry.istio.io", "xks", availSeverityNone),
+	crdDep("istio-wasmplugin", "wasmplugins.extensions.istio.io", "xks", availSeverityNone),
 
-	// cert-manager CRDs
-	crdDep("cert-manager-certificate", "certificates.cert-manager.io", "xks", true),
-	crdDep("cert-manager-certificaterequest", "certificaterequests.cert-manager.io", "xks", true),
-	crdDep("cert-manager-issuer", "issuers.cert-manager.io", "xks", true),
-	crdDep("cert-manager-clusterissuer", "clusterissuers.cert-manager.io", "xks", true),
+	// cert-manager CRDs — critical, kserve cannot function without them
+	crdDep("cert-manager-certificate", "certificates.cert-manager.io", "xks", common.ConditionSeverityError),
+	crdDep("cert-manager-certificaterequest", "certificaterequests.cert-manager.io", "xks", common.ConditionSeverityError),
+	crdDep("cert-manager-issuer", "issuers.cert-manager.io", "xks", common.ConditionSeverityError),
+	crdDep("cert-manager-clusterissuer", "clusterissuers.cert-manager.io", "xks", common.ConditionSeverityError),
 
-	// LeaderWorkerSet CRD
+	// LeaderWorkerSet CRD — optional, group condition only
 	{
-		name:           "leaderworkersets",
-		checkType:      checkCRD,
-		crdName:        "leaderworkersets.leaderworkerset.x-k8s.io",
-		platform:       "xks",
-		critical:       false,
-		conditionGroup: conditionLLMISVCWideEPDeps,
+		name:                 "leaderworkersets",
+		checkType:            checkCRD,
+		crdName:              "leaderworkersets.leaderworkerset.x-k8s.io",
+		platform:             "xks",
+		availabilitySeverity: availSeverityNone,
+		conditionGroup:       conditionLLMISVCWideEPDeps,
 	},
 
-	// OCP Subscription checks
-	subscriptionDep("Red Hat Connectivity Link", rhclSubscription, conditionLLMISVCDeps, "ocp", false),
-	subscriptionDep("Red Hat Connectivity Link (Wide EP)", rhclSubscription, conditionLLMISVCWideEPDeps, "ocp", false),
-	subscriptionDep("cert-manager operator", certManagerSubscription, conditionLLMISVCDeps, "ocp", false),
-	subscriptionDep("cert-manager operator (Wide EP)", certManagerSubscription, conditionLLMISVCWideEPDeps, "ocp", false),
-	subscriptionDep("LeaderWorkerSet", lwsSubscription, conditionLLMISVCWideEPDeps, "ocp", false),
+	// OCP Subscription checks — optional, group condition only
+	subscriptionDep("Red Hat Connectivity Link", rhclSubscription, conditionLLMISVCDeps, "ocp", availSeverityNone),
+	subscriptionDep("Red Hat Connectivity Link (Wide EP)", rhclSubscription, conditionLLMISVCWideEPDeps, "ocp", availSeverityNone),
+	subscriptionDep("cert-manager operator", certManagerSubscription, conditionLLMISVCDeps, "ocp", availSeverityNone),
+	subscriptionDep("cert-manager operator (Wide EP)", certManagerSubscription, conditionLLMISVCWideEPDeps, "ocp", availSeverityNone),
+	subscriptionDep("LeaderWorkerSet", lwsSubscription, conditionLLMISVCWideEPDeps, "ocp", availSeverityNone),
 
-	// OCP LWS Operator health
+	// OCP LWS Operator health — report to DependenciesAvailable with Info (Ready stays True)
 	operatorDep("leaderworkerset-operator",
 		schema.GroupVersionKind{Group: "operator.openshift.io", Version: "v1", Kind: "LeaderWorkerSet"},
-		"", conditionLLMISVCWideEPDeps, "ocp", false, lwsConditionFilter),
+		"", conditionLLMISVCWideEPDeps, "ocp", common.ConditionSeverityInfo, lwsConditionFilter),
 }
 
 var modelControllerDependencies = []dependencyCheck{
 	{
-		name:             "Custom Metrics Autoscaler",
-		checkType:        checkSubscription,
-		subscriptionName: cmaSubscription,
-		conditionGroup:   conditionLLMDWVADeps,
-		platform:         "ocp",
-		critical:         false,
+		name:                 "Custom Metrics Autoscaler",
+		checkType:            checkSubscription,
+		subscriptionName:     cmaSubscription,
+		conditionGroup:       conditionLLMDWVADeps,
+		platform:             "ocp",
+		availabilitySeverity: availSeverityNone,
 		skipFunc: func(k *platformv1alpha1.Kserve) bool {
 			return !isWVAEnabled(k)
 		},
@@ -206,16 +217,19 @@ func (r *KserveModuleReconciler) checkDependencies(ctx context.Context, kserve *
 		}
 		for _, msg := range item.reasons {
 			log.Info("dependency not satisfied", "dependency", item.dep.name,
-				"type", item.dep.checkType, "critical", item.dep.critical, "message", msg)
+				"type", item.dep.checkType, "availabilitySeverity", item.dep.availabilitySeverity, "message", msg)
 
-			if item.dep.critical {
-				result.criticalErrors = append(result.criticalErrors, msg)
-			} else {
-				result.degradedReasons = append(result.degradedReasons, msg)
-				if item.dep.conditionGroup != "" {
-					result.groupReasons[item.dep.conditionGroup] = append(
-						result.groupReasons[item.dep.conditionGroup], msg)
-				}
+			result.allReasons = append(result.allReasons, msg)
+
+			if item.dep.availabilitySeverity != availSeverityNone {
+				result.availReasons = append(result.availReasons, availabilityReason{
+					severity: item.dep.availabilitySeverity,
+					message:  msg,
+				})
+			}
+			if item.dep.conditionGroup != "" {
+				result.groupReasons[item.dep.conditionGroup] = append(
+					result.groupReasons[item.dep.conditionGroup], msg)
 			}
 		}
 	}
@@ -342,6 +356,15 @@ func collectDegradedConditions(cr *unstructured.Unstructured, dep dependencyChec
 	}
 
 	return degraded
+}
+
+func hasCriticalFailure(result dependencyResult) bool {
+	for _, ar := range result.availReasons {
+		if ar.severity == common.ConditionSeverityError {
+			return true
+		}
+	}
+	return false
 }
 
 // lwsConditionFilter returns true when the given condition indicates an unhealthy state.

--- a/kserve-module/pkg/kservemodule/dependencies_export_test.go
+++ b/kserve-module/pkg/kservemodule/dependencies_export_test.go
@@ -3,6 +3,8 @@ package kservemodule
 import (
 	"fmt"
 	"strings"
+
+	"github.com/opendatahub-io/odh-platform-utilities/api/common"
 )
 
 type CRDInfo struct {
@@ -42,7 +44,7 @@ func XKSCRDDependenciesForTest() []CRDInfo {
 func CriticalCRDDependenciesForTest() []CRDInfo {
 	var result []CRDInfo
 	for _, dep := range allDependencies {
-		if dep.checkType == checkCRD && dep.critical {
+		if dep.checkType == checkCRD && dep.availabilitySeverity == common.ConditionSeverityError {
 			result = append(result, parseCRDName(dep.crdName))
 		}
 	}

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -170,7 +170,7 @@ func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	depResult := r.checkDependencies(ctx, kserve)
 	applyDependencyConditions(condMgr, depResult)
-	if len(depResult.criticalErrors) > 0 {
+	if hasCriticalFailure(depResult) {
 		applyProvisioningCondition(condMgr, map[string]error{
 			"dependencies": fmt.Errorf("critical dependencies unavailable"),
 		})

--- a/kserve-module/pkg/kservemodule/status.go
+++ b/kserve-module/pkg/kservemodule/status.go
@@ -38,27 +38,48 @@ func newConditionManager(kserve *platformv1alpha1.Kserve) *conditions.Manager {
 }
 
 func applyDependencyConditions(condMgr *conditions.Manager, result dependencyResult) {
-	slices.Sort(result.criticalErrors)
-	slices.Sort(result.degradedReasons)
+	slices.Sort(result.allReasons)
 
-	if len(result.criticalErrors) > 0 {
+	// DependenciesAvailable: only deps with availabilitySeverity != availSeverityNone contribute.
+	// Severity=Info keeps IsHappy()=True (findUnhappyDependent skips non-Error severities).
+	if len(result.availReasons) > 0 {
+		worstSeverity := common.ConditionSeverityInfo
+		msgs := make([]string, 0, len(result.availReasons))
+		for _, ar := range result.availReasons {
+			msgs = append(msgs, ar.message)
+			if ar.severity == common.ConditionSeverityError {
+				worstSeverity = common.ConditionSeverityError
+			}
+		}
+		slices.Sort(msgs)
 		condMgr.MarkFalse(ConditionDependenciesAvailable,
+			conditions.WithSeverity(worstSeverity),
 			conditions.WithReason("DependencyDegraded"),
-			conditions.WithMessage("%s", strings.Join(result.criticalErrors, "; ")))
-		condMgr.MarkTrue(string(common.ConditionTypeDegraded),
-			conditions.WithSeverity(common.ConditionSeverityError),
-			conditions.WithReason("MissingCriticalDependency"),
-			conditions.WithMessage("%s", strings.Join(result.criticalErrors, "; ")))
-	} else if len(result.degradedReasons) > 0 {
-		condMgr.MarkTrue(ConditionDependenciesAvailable,
-			conditions.WithReason("AllCriticalDependenciesMet"))
-		condMgr.MarkFalse(string(common.ConditionTypeDegraded),
-			conditions.WithSeverity(common.ConditionSeverityInfo),
-			conditions.WithReason("MissingOptionalDependency"),
-			conditions.WithMessage("%s", strings.Join(result.degradedReasons, "; ")))
+			conditions.WithMessage("%s", strings.Join(msgs, "; ")))
 	} else {
 		condMgr.MarkTrue(ConditionDependenciesAvailable,
 			conditions.WithReason("AllDependenciesMet"))
+	}
+
+	// Degraded: any failure contributes, severity escalates if Error-level deps failed
+	if hasCriticalFailure(result) {
+		var criticalMsgs []string
+		for _, ar := range result.availReasons {
+			if ar.severity == common.ConditionSeverityError {
+				criticalMsgs = append(criticalMsgs, ar.message)
+			}
+		}
+		slices.Sort(criticalMsgs)
+		condMgr.MarkTrue(string(common.ConditionTypeDegraded),
+			conditions.WithSeverity(common.ConditionSeverityError),
+			conditions.WithReason("MissingCriticalDependency"),
+			conditions.WithMessage("%s", strings.Join(criticalMsgs, "; ")))
+	} else if len(result.allReasons) > 0 {
+		condMgr.MarkFalse(string(common.ConditionTypeDegraded),
+			conditions.WithSeverity(common.ConditionSeverityInfo),
+			conditions.WithReason("MissingOptionalDependency"),
+			conditions.WithMessage("%s", strings.Join(result.allReasons, "; ")))
+	} else {
 		condMgr.MarkFalse(string(common.ConditionTypeDegraded),
 			conditions.WithSeverity(common.ConditionSeverityInfo),
 			conditions.WithReason("NoDegradation"))

--- a/kserve-module/pkg/kservemodule/status_test.go
+++ b/kserve-module/pkg/kservemodule/status_test.go
@@ -76,7 +76,7 @@ func TestApplyDependencyConditions_Degraded(t *testing.T) {
 	condMgr := newConditionManager(kserve)
 
 	applyDependencyConditions(condMgr, dependencyResult{
-		degradedReasons: []string{"Istio CRD not found"},
+		allReasons: []string{"Istio CRD not found"},
 	})
 
 	cond := condMgr.GetCondition(string(common.ConditionTypeDegraded))
@@ -135,6 +135,75 @@ func TestHappyCondition_DependenciesNotAvailable(t *testing.T) {
 	g.Expect(condMgr.IsHappy()).Should(BeFalse())
 }
 
+func depResultWithAvail(severity common.ConditionSeverity, msg string) dependencyResult {
+	return dependencyResult{
+		availReasons: []availabilityReason{{severity: severity, message: msg}},
+		allReasons:   []string{msg},
+	}
+}
+
+func TestApplyDependencyConditions_AvailInfoKeepsReady(t *testing.T) {
+	g := NewWithT(t)
+
+	kserve := &platformv1alpha1.Kserve{}
+	condMgr := newConditionManager(kserve)
+	markAllHealthy(condMgr)
+
+	applyDependencyConditions(condMgr, depResultWithAvail(common.ConditionSeverityInfo, "LWS operator degraded"))
+
+	depCond := condMgr.GetCondition(ConditionDependenciesAvailable)
+	g.Expect(depCond).ShouldNot(BeNil())
+	g.Expect(depCond.Status).Should(Equal(metav1.ConditionFalse))
+	g.Expect(depCond.Severity).Should(Equal(common.ConditionSeverityInfo))
+
+	g.Expect(condMgr.IsHappy()).Should(BeTrue())
+}
+
+func TestApplyDependencyConditions_AvailErrorBreaksReady(t *testing.T) {
+	g := NewWithT(t)
+
+	kserve := &platformv1alpha1.Kserve{}
+	condMgr := newConditionManager(kserve)
+	markAllHealthy(condMgr)
+
+	applyDependencyConditions(condMgr, depResultWithAvail(common.ConditionSeverityError, "cert-manager CRD not found"))
+
+	depCond := condMgr.GetCondition(ConditionDependenciesAvailable)
+	g.Expect(depCond).ShouldNot(BeNil())
+	g.Expect(depCond.Status).Should(Equal(metav1.ConditionFalse))
+
+	g.Expect(condMgr.IsHappy()).Should(BeFalse())
+}
+
+func TestApplyDependencyConditions_MixedSeverityUsesWorst(t *testing.T) {
+	g := NewWithT(t)
+
+	kserve := &platformv1alpha1.Kserve{}
+	condMgr := newConditionManager(kserve)
+	markAllHealthy(condMgr)
+
+	applyDependencyConditions(condMgr, dependencyResult{
+		availReasons: []availabilityReason{
+			{severity: common.ConditionSeverityInfo, message: "LWS operator degraded"},
+			{severity: common.ConditionSeverityError, message: "cert-manager CRD not found"},
+		},
+		allReasons: []string{"LWS operator degraded", "cert-manager CRD not found"},
+	})
+
+	depCond := condMgr.GetCondition(ConditionDependenciesAvailable)
+	g.Expect(depCond).ShouldNot(BeNil())
+	g.Expect(depCond.Status).Should(Equal(metav1.ConditionFalse))
+	g.Expect(depCond.Severity).Should(Equal(common.ConditionSeverityError))
+
+	degradedCond := condMgr.GetCondition(string(common.ConditionTypeDegraded))
+	g.Expect(degradedCond).ShouldNot(BeNil())
+	g.Expect(degradedCond.Status).Should(Equal(metav1.ConditionTrue))
+	g.Expect(degradedCond.Message).Should(ContainSubstring("cert-manager"))
+	g.Expect(degradedCond.Message).ShouldNot(ContainSubstring("LWS"))
+
+	g.Expect(condMgr.IsHappy()).Should(BeFalse())
+}
+
 func TestDegradedDoesNotAffectReady(t *testing.T) {
 	g := NewWithT(t)
 
@@ -143,7 +212,7 @@ func TestDegradedDoesNotAffectReady(t *testing.T) {
 	markAllHealthy(condMgr)
 
 	applyDependencyConditions(condMgr, dependencyResult{
-		degradedReasons: []string{"optional dep missing"},
+		allReasons: []string{"optional dep missing"},
 	})
 
 	g.Expect(condMgr.IsHappy()).Should(BeTrue())


### PR DESCRIPTION
Refactor dependency checking from boolean `critical` field to typed `availabilitySeverity` with three reporting levels:

  - `ConditionSeverityError` ("") — DependenciesAvailable=False, Ready=False (cert-manager CRDs)  <-- shared lib has this so can not change.
  - `ConditionSeverityInfo` ("Info") — DependenciesAvailable=False, Ready=True (LWS operator health)
  - `availSeverityNone` ("None") — no DependenciesAvailable report, Degraded only (Istio CRDs, subscriptions)

  Changes:
  - Replace `critical bool` with `availabilitySeverity common.ConditionSeverity` in dependencyCheck
  - Replace `degradedReasons/criticalErrors` with `availReasons/allReasons` in dependencyResult
  - Filter Degraded(Error) message to only include Error-severity failures
  - Add unit tests for mixed severity, Info-keeps-Ready, Error-breaks-Ready scenarios
  - Export CriticalCRDDependenciesForTest() for integration tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency health reporting by switching to severity-based handling (error vs optional/info).
  * Error-severity dependency failures now block readiness and mark the component degraded; info/optional issues no longer incorrectly mark it unavailable.
  * Dependency status messaging now reflects the most severe unmet dependency and provides clearer aggregated reasons.

* **Tests**
  * Updated and added coverage for severity-driven availability and degraded-condition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->