### PR TITLE
fix(kserve-module): correct LeaderWorkerSetOperator GVK and patch CRD webhook namespace

### DIFF
--- a/kserve-module/config/rbac/role.yaml
+++ b/kserve-module/config/rbac/role.yaml
@@ -225,7 +225,7 @@ rules:
 - apiGroups:
   - operator.openshift.io
   resources:
-  - leaderworkersets
+  - leaderworkersetoperators
   verbs:
   - get
   - list

--- a/kserve-module/pkg/kservemodule/dependencies.go
+++ b/kserve-module/pkg/kservemodule/dependencies.go
@@ -144,7 +144,7 @@ var kserveDependencies = []dependencyCheck{
 
 	// OCP LWS Operator health — report to DependenciesAvailable with Info (Ready stays True)
 	operatorDep("leaderworkerset-operator",
-		schema.GroupVersionKind{Group: "operator.openshift.io", Version: "v1", Kind: "LeaderWorkerSet"},
+		schema.GroupVersionKind{Group: "operator.openshift.io", Version: "v1", Kind: "LeaderWorkerSetOperator"},
 		"", conditionLLMISVCWideEPDeps, "ocp", common.ConditionSeverityInfo, lwsConditionFilter),
 }
 

--- a/kserve-module/pkg/kservemodule/dynamic_watch_int_test.go
+++ b/kserve-module/pkg/kservemodule/dynamic_watch_int_test.go
@@ -124,7 +124,7 @@ var _ = Describe("Dynamic Watch Integration", Ordered, func() {
 	Context("LeaderWorkerSet operator watch", func() {
 		var lwsCRD *apiextensionsv1.CustomResourceDefinition
 
-		lwsGVK := schema.GroupVersionKind{Group: "operator.openshift.io", Version: "v1", Kind: "LeaderWorkerSet"}
+		lwsGVK := schema.GroupVersionKind{Group: "operator.openshift.io", Version: "v1", Kind: "LeaderWorkerSetOperator"}
 
 		BeforeAll(func(ctx SpecContext) {
 			lwsCRD = fixture.CreateCRD(ctx, testEnv.Client,

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -91,7 +91,7 @@ import (
 
 // --- Dependency detection (read-only: check if required operators are installed) ---
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions,verbs=get;list;watch
-// +kubebuilder:rbac:groups=operator.openshift.io,resources=leaderworkersets,verbs=get;list;watch
+// +kubebuilder:rbac:groups=operator.openshift.io,resources=leaderworkersetoperators,verbs=get;list;watch
 //
 // ModelCache RBAC
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;patch;update
@@ -432,10 +432,11 @@ func (r *KserveModuleReconciler) SetWorkDir(dir string) {
 
 func (r *KserveModuleReconciler) installCRDs(ctx context.Context, kserve *platformv1alpha1.Kserve) error {
 	crdPath := filepath.Join(r.ManifestsTemplatePath, KserveComponentName, KserveCRDManifestSourcePath)
-	resources, err := kustomize.Render(crdPath, nil)
+	resources, err := kustomize.Render(crdPath, nil, kustomize.WithNamespace(r.getApplicationsNamespace()))
 	if err != nil {
 		return fmt.Errorf("rendering CRD manifests: %w", err)
 	}
+
 	if err := r.Deployer.Deploy(ctx, deploy.DeployInput{
 		Client:    r.Client,
 		Owner:     kserve,

--- a/kserve-module/pkg/kservemodule/setup.go
+++ b/kserve-module/pkg/kservemodule/setup.go
@@ -127,8 +127,8 @@ func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	r.dynamicWatches = []*dynamicWatch{
 		{
-			groupKind: schema.GroupKind{Group: "operator.openshift.io", Kind: "LeaderWorkerSet"},
-			gvk:       schema.GroupVersionKind{Group: "operator.openshift.io", Version: "v1", Kind: "LeaderWorkerSet"},
+			groupKind: schema.GroupKind{Group: "operator.openshift.io", Kind: "LeaderWorkerSetOperator"},
+			gvk:       schema.GroupVersionKind{Group: "operator.openshift.io", Version: "v1", Kind: "LeaderWorkerSetOperator"},
 		},
 		{
 			groupKind: schema.GroupKind{Group: "serving.kserve.io", Kind: "LocalModelNodeGroup"},


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes two issues in the kserve module operator:

1. **LeaderWorkerSetOperator GVK Kind**: The dynamic watch and dependency check used `LeaderWorkerSet` as the Kind, but the actual CRD is `LeaderWorkerSetOperator`. Fixed across dependencies.go, setup.go, RBAC role, and integration test.

2. **CRD conversion webhook namespace**: KServe CRDs with conversion webhooks (e.g. `llminferenceserviceconfigs`) hard-code `namespace: kserve` in their webhook service config. When deployed to a different namespace (e.g. `opendatahub`), the webhook call fails. Added `patchCRDConversionWebhookNamespace` to rewrite the service namespace and `cert-manager.io/inject-ca-from` annotation at deploy time.

**Which issue(s) this PR fixes**:


**Feature/Issue validation/testing**:

- [x] Unit tests for `patchCRDConversionWebhookNamespace` (3 cases: patch, skip non-CRD, skip CRDs without conversion webhook)
- [x] Integration test updated for correct LWS GVK Kind
- [x] RBAC role.yaml updated (`leaderworkersets` → `leaderworkersetoperators`)

**Special notes for your reviewer**:

The `patchCRDConversionWebhookNamespace` is called from `applyManifests` for each resource, only acting on CRDs that have a webhook conversion strategy with a service config.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note
Fix LeaderWorkerSetOperator GVK Kind mismatch and patch CRD conversion webhook namespace for multi-namespace deployments
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated LeaderWorkerSet Operator detection, permissions, and watches to use the correct OpenShift resource.
  * Ensured installed KServe CRDs use the platform’s applications namespace for conversion webhooks and certificate injection.

* **Tests**
  * Added coverage for conversion webhook namespace updates and non-webhook resources.

* **Chores**
  * Refreshed generated API schema formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->