### PR TITLE
fix: add stable config-base-name identity annotation to LLM accelerator presets

### DIFF
--- a/config/overlays/odh/accelerators-fast/fast-1/kustomization.yaml
+++ b/config/overlays/odh/accelerators-fast/fast-1/kustomization.yaml
@@ -11,3 +11,68 @@ commonAnnotations:
 
 resources:
 - ../../accelerators
+
+patches:
+- patch: |
+    apiVersion: serving.kserve.io/v1alpha2
+    kind: LLMInferenceServiceConfig
+    metadata:
+      name: kserve-config-llm-template-amd-rocm
+      annotations:
+        opendatahub.io/config-base-name: kserve-config-llm-template-amd-rocm-fast-1
+- patch: |
+    apiVersion: serving.kserve.io/v1alpha2
+    kind: LLMInferenceServiceConfig
+    metadata:
+      name: kserve-config-llm-template-ibm-spyre-ppc64le
+      annotations:
+        opendatahub.io/config-base-name: kserve-config-llm-template-ibm-spyre-ppc64le-fast-1
+- patch: |
+    apiVersion: serving.kserve.io/v1alpha2
+    kind: LLMInferenceServiceConfig
+    metadata:
+      name: kserve-config-llm-template-ibm-spyre-s390x
+      annotations:
+        opendatahub.io/config-base-name: kserve-config-llm-template-ibm-spyre-s390x-fast-1
+- patch: |
+    apiVersion: serving.kserve.io/v1alpha2
+    kind: LLMInferenceServiceConfig
+    metadata:
+      name: kserve-config-llm-template-ibm-spyre-x86
+      annotations:
+        opendatahub.io/config-base-name: kserve-config-llm-template-ibm-spyre-x86-fast-1
+- patch: |
+    apiVersion: serving.kserve.io/v1alpha2
+    kind: LLMInferenceServiceConfig
+    metadata:
+      name: kserve-config-llm-template-intel-gaudi
+      annotations:
+        opendatahub.io/config-base-name: kserve-config-llm-template-intel-gaudi-fast-1
+- patch: |
+    apiVersion: serving.kserve.io/v1alpha2
+    kind: LLMInferenceServiceConfig
+    metadata:
+      name: kserve-config-llm-multi-node-pd-template-nvidia-cuda
+      annotations:
+        opendatahub.io/config-base-name: kserve-config-llm-multi-node-pd-template-nvidia-cuda-fast-1
+- patch: |
+    apiVersion: serving.kserve.io/v1alpha2
+    kind: LLMInferenceServiceConfig
+    metadata:
+      name: kserve-config-llm-multi-node-template-nvidia-cuda
+      annotations:
+        opendatahub.io/config-base-name: kserve-config-llm-multi-node-template-nvidia-cuda-fast-1
+- patch: |
+    apiVersion: serving.kserve.io/v1alpha2
+    kind: LLMInferenceServiceConfig
+    metadata:
+      name: kserve-config-llm-single-node-pd-template-nvidia-cuda
+      annotations:
+        opendatahub.io/config-base-name: kserve-config-llm-single-node-pd-template-nvidia-cuda-fast-1
+- patch: |
+    apiVersion: serving.kserve.io/v1alpha2
+    kind: LLMInferenceServiceConfig
+    metadata:
+      name: kserve-config-llm-single-node-template-nvidia-cuda
+      annotations:
+        opendatahub.io/config-base-name: kserve-config-llm-single-node-template-nvidia-cuda-fast-1

--- a/config/overlays/odh/accelerators-fast/fast-2/kustomization.yaml
+++ b/config/overlays/odh/accelerators-fast/fast-2/kustomization.yaml
@@ -11,3 +11,68 @@ commonAnnotations:
 
 resources:
 - ../../accelerators
+
+patches:
+- patch: |
+    apiVersion: serving.kserve.io/v1alpha2
+    kind: LLMInferenceServiceConfig
+    metadata:
+      name: kserve-config-llm-template-amd-rocm
+      annotations:
+        opendatahub.io/config-base-name: kserve-config-llm-template-amd-rocm-fast-2
+- patch: |
+    apiVersion: serving.kserve.io/v1alpha2
+    kind: LLMInferenceServiceConfig
+    metadata:
+      name: kserve-config-llm-template-ibm-spyre-ppc64le
+      annotations:
+        opendatahub.io/config-base-name: kserve-config-llm-template-ibm-spyre-ppc64le-fast-2
+- patch: |
+    apiVersion: serving.kserve.io/v1alpha2
+    kind: LLMInferenceServiceConfig
+    metadata:
+      name: kserve-config-llm-template-ibm-spyre-s390x
+      annotations:
+        opendatahub.io/config-base-name: kserve-config-llm-template-ibm-spyre-s390x-fast-2
+- patch: |
+    apiVersion: serving.kserve.io/v1alpha2
+    kind: LLMInferenceServiceConfig
+    metadata:
+      name: kserve-config-llm-template-ibm-spyre-x86
+      annotations:
+        opendatahub.io/config-base-name: kserve-config-llm-template-ibm-spyre-x86-fast-2
+- patch: |
+    apiVersion: serving.kserve.io/v1alpha2
+    kind: LLMInferenceServiceConfig
+    metadata:
+      name: kserve-config-llm-template-intel-gaudi
+      annotations:
+        opendatahub.io/config-base-name: kserve-config-llm-template-intel-gaudi-fast-2
+- patch: |
+    apiVersion: serving.kserve.io/v1alpha2
+    kind: LLMInferenceServiceConfig
+    metadata:
+      name: kserve-config-llm-multi-node-pd-template-nvidia-cuda
+      annotations:
+        opendatahub.io/config-base-name: kserve-config-llm-multi-node-pd-template-nvidia-cuda-fast-2
+- patch: |
+    apiVersion: serving.kserve.io/v1alpha2
+    kind: LLMInferenceServiceConfig
+    metadata:
+      name: kserve-config-llm-multi-node-template-nvidia-cuda
+      annotations:
+        opendatahub.io/config-base-name: kserve-config-llm-multi-node-template-nvidia-cuda-fast-2
+- patch: |
+    apiVersion: serving.kserve.io/v1alpha2
+    kind: LLMInferenceServiceConfig
+    metadata:
+      name: kserve-config-llm-single-node-pd-template-nvidia-cuda
+      annotations:
+        opendatahub.io/config-base-name: kserve-config-llm-single-node-pd-template-nvidia-cuda-fast-2
+- patch: |
+    apiVersion: serving.kserve.io/v1alpha2
+    kind: LLMInferenceServiceConfig
+    metadata:
+      name: kserve-config-llm-single-node-template-nvidia-cuda
+      annotations:
+        opendatahub.io/config-base-name: kserve-config-llm-single-node-template-nvidia-cuda-fast-2

--- a/config/overlays/odh/accelerators/amd-rocm-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/amd-rocm-config-llm-template.yaml
@@ -7,6 +7,7 @@ metadata:
     openshift.io/description: vLLM AMD ROCm GPU LLMInferenceServiceConfig for LLMInferenceService.
     opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
     opendatahub.io/runtime-version: ""
+    opendatahub.io/config-base-name: kserve-config-llm-template-amd-rocm
     # supported-topologies values must be consistent with the samples API and Dashboard usage.
     # See https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/samples/llm-d/llm-d-ui-flow-mechanics.md
     # and https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/llm-d/samples/samples-api.md

--- a/config/overlays/odh/accelerators/ibm-spyre-ppc64le-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/ibm-spyre-ppc64le-config-llm-template.yaml
@@ -7,6 +7,7 @@ metadata:
     openshift.io/description: vLLM IBM Spyre ppc64le LLMInferenceServiceConfig for LLMInferenceService.
     opendatahub.io/recommended-accelerators: '["ibm.com/spyre_pf"]'
     opendatahub.io/runtime-version: ""
+    opendatahub.io/config-base-name: kserve-config-llm-template-ibm-spyre-ppc64le
     # supported-topologies values must be consistent with the samples API and Dashboard usage.
     # See https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/samples/llm-d/llm-d-ui-flow-mechanics.md
     # and https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/llm-d/samples/samples-api.md

--- a/config/overlays/odh/accelerators/ibm-spyre-s390x-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/ibm-spyre-s390x-config-llm-template.yaml
@@ -7,6 +7,7 @@ metadata:
     openshift.io/description: vLLM IBM Spyre s390x LLMInferenceServiceConfig for LLMInferenceService.
     opendatahub.io/recommended-accelerators: '["ibm.com/spyre_vf"]'
     opendatahub.io/runtime-version: ""
+    opendatahub.io/config-base-name: kserve-config-llm-template-ibm-spyre-s390x
     # supported-topologies values must be consistent with the samples API and Dashboard usage.
     # See https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/samples/llm-d/llm-d-ui-flow-mechanics.md
     # and https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/llm-d/samples/samples-api.md

--- a/config/overlays/odh/accelerators/ibm-spyre-x86-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/ibm-spyre-x86-config-llm-template.yaml
@@ -7,6 +7,7 @@ metadata:
     openshift.io/description: vLLM IBM Spyre x86 LLMInferenceServiceConfig for LLMInferenceService.
     opendatahub.io/recommended-accelerators: '["ibm.com/spyre_pf"]'
     opendatahub.io/runtime-version: ""
+    opendatahub.io/config-base-name: kserve-config-llm-template-ibm-spyre-x86
     # supported-topologies values must be consistent with the samples API and Dashboard usage.
     # See https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/samples/llm-d/llm-d-ui-flow-mechanics.md
     # and https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/llm-d/samples/samples-api.md

--- a/config/overlays/odh/accelerators/intel-gaudi-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/intel-gaudi-config-llm-template.yaml
@@ -7,6 +7,7 @@ metadata:
     openshift.io/description: vLLM Intel Gaudi LLMInferenceServiceConfig for LLMInferenceService.
     opendatahub.io/recommended-accelerators: '["habana.ai/gaudi"]'
     opendatahub.io/runtime-version: ""
+    opendatahub.io/config-base-name: kserve-config-llm-template-intel-gaudi
     # supported-topologies values must be consistent with the samples API and Dashboard usage.
     # See https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/samples/llm-d/llm-d-ui-flow-mechanics.md
     # and https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/llm-d/samples/samples-api.md

--- a/config/overlays/odh/accelerators/nvidia-cuda-config-llm-multi-node-pd-template.yaml
+++ b/config/overlays/odh/accelerators/nvidia-cuda-config-llm-multi-node-pd-template.yaml
@@ -7,6 +7,7 @@ metadata:
     openshift.io/description: vLLM NVIDIA CUDA GPU LLMInferenceServiceConfig (Prefill/Decode) for LLMInferenceService.
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
     opendatahub.io/runtime-version: ""
+    opendatahub.io/config-base-name: kserve-config-llm-multi-node-pd-template-nvidia-cuda
     # supported-topologies values must be consistent with the samples API and Dashboard usage.
     # See https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/samples/llm-d/llm-d-ui-flow-mechanics.md
     # and https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/llm-d/samples/samples-api.md

--- a/config/overlays/odh/accelerators/nvidia-cuda-config-llm-multi-node-template.yaml
+++ b/config/overlays/odh/accelerators/nvidia-cuda-config-llm-multi-node-template.yaml
@@ -7,6 +7,7 @@ metadata:
     openshift.io/description: vLLM NVIDIA CUDA GPU LLMInferenceServiceConfig Multi Node for LLMInferenceService.
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
     opendatahub.io/runtime-version: ""
+    opendatahub.io/config-base-name: kserve-config-llm-multi-node-template-nvidia-cuda
     # supported-topologies values must be consistent with the samples API and Dashboard usage.
     # See https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/samples/llm-d/llm-d-ui-flow-mechanics.md
     # and https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/llm-d/samples/samples-api.md

--- a/config/overlays/odh/accelerators/nvidia-cuda-config-llm-single-node-pd-template.yaml
+++ b/config/overlays/odh/accelerators/nvidia-cuda-config-llm-single-node-pd-template.yaml
@@ -7,6 +7,7 @@ metadata:
     openshift.io/description: vLLM NVIDIA CUDA GPU LLMInferenceServiceConfig Single Node P/D (Prefill/Decode) for LLMInferenceService.
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
     opendatahub.io/runtime-version: ""
+    opendatahub.io/config-base-name: kserve-config-llm-single-node-pd-template-nvidia-cuda
     # supported-topologies values must be consistent with the samples API and Dashboard usage.
     # See https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/samples/llm-d/llm-d-ui-flow-mechanics.md
     # and https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/llm-d/samples/samples-api.md

--- a/config/overlays/odh/accelerators/nvidia-cuda-config-llm-single-node-template.yaml
+++ b/config/overlays/odh/accelerators/nvidia-cuda-config-llm-single-node-template.yaml
@@ -7,6 +7,7 @@ metadata:
     openshift.io/description: vLLM NVIDIA CUDA GPU LLMInferenceServiceConfig Single Node for LLMInferenceService.
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
     opendatahub.io/runtime-version: ""
+    opendatahub.io/config-base-name: kserve-config-llm-single-node-template-nvidia-cuda
     # supported-topologies values must be consistent with the samples API and Dashboard usage.
     # See https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/samples/llm-d/llm-d-ui-flow-mechanics.md
     # and https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/llm-d/samples/samples-api.md

--- a/hack/verify-odh-runtime-version.sh
+++ b/hack/verify-odh-runtime-version.sh
@@ -16,6 +16,15 @@
 # hardcoded, so legitimate version bumps do not break this check; it asserts
 # wiring, not pinned values.
 #
+# Also verified here: every accelerator config must carry a non-empty
+# opendatahub.io/config-base-name annotation equal to its own rendered
+# metadata.name (RHOAIENG-78121). The operators prefix metadata.name with the
+# platform version at reconcile time while annotations pass through untouched,
+# so this annotation is the version-stable identity the Dashboard matches on.
+# In kustomize output the name is still unprefixed, so the assertion is exact
+# equality, which also pins the fast-variant semantic: a -fast-N config must
+# carry its own -fast-N name, not its base template's.
+#
 # The odh-xks and odh-test overlays include the odh overlay without patching
 # or renaming the accelerator configs, so asserting on config/overlays/odh
 # covers all three.
@@ -29,6 +38,7 @@ YQ=${YQ:-yq}
 OVERLAY="config/overlays/odh"
 PARAMS_ENV="config/overlays/odh/params.env"
 ANNOTATION="opendatahub.io/runtime-version"
+BASENAME_ANNOTATION="opendatahub.io/config-base-name"
 FAMILIES="nvidia-cuda amd-rocm intel-gaudi ibm-spyre"
 # 9 base accelerator presets + 18 fast (-fast-1/-fast-2) variants. Update this
 # count (plus a params.env key and replacement block) when adding presets.
@@ -74,7 +84,7 @@ trap 'rm -f "$rendered"' EXIT
 "$KUSTOMIZE" build "$OVERLAY" > "$rendered"
 
 count=0
-while IFS='|' read -r name value; do
+while IFS='|' read -r name value basename_value; do
   count=$((count + 1))
   if [[ "$value" == "$ABSENT_MARKER" ]]; then
     echo "FAIL: $name is missing the $ANNOTATION annotation"
@@ -83,6 +93,16 @@ while IFS='|' read -r name value; do
   fi
   if [[ -z "$value" ]]; then
     echo "FAIL: $name has an empty $ANNOTATION annotation"
+    rc=1
+    continue
+  fi
+  if [[ "$basename_value" == "$ABSENT_MARKER" ]]; then
+    echo "FAIL: $name is missing the $BASENAME_ANNOTATION annotation"
+    rc=1
+    continue
+  fi
+  if [[ "$basename_value" != "$name" ]]; then
+    echo "FAIL: $name has $BASENAME_ANNOTATION '$basename_value'; it must equal the config's own unprefixed name (fast variants carry their own -fast-N name)"
     rc=1
     continue
   fi
@@ -99,7 +119,7 @@ while IFS='|' read -r name value; do
   fi
 done < <("$YQ" eval --no-doc "
   select(.kind == \"LLMInferenceServiceConfig\" and (.metadata.labels // {}).\"opendatahub.io/config-type\" == \"accelerator\")
-  | .metadata.name + \"|\" + (.metadata.annotations.\"$ANNOTATION\" // \"$ABSENT_MARKER\")
+  | .metadata.name + \"|\" + (.metadata.annotations.\"$ANNOTATION\" // \"$ABSENT_MARKER\") + \"|\" + (.metadata.annotations.\"$BASENAME_ANNOTATION\" // \"$ABSENT_MARKER\")
 " "$rendered")
 
 if [[ $count -ne $EXPECTED_TOTAL ]]; then
@@ -108,7 +128,7 @@ if [[ $count -ne $EXPECTED_TOTAL ]]; then
 fi
 
 if [[ $rc -eq 0 ]]; then
-  echo "verify-odh-runtime-version: OK ($count accelerator configs stamped from dedicated keys)"
+  echo "verify-odh-runtime-version: OK ($count accelerator configs stamped from dedicated keys; config-base-name identity verified)"
 fi
 
 exit $rc


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a static `opendatahub.io/config-base-name` annotation to the 9 well-known LLM accelerator preset templates in `config/overlays/odh/accelerators/`, carrying each config's own unversioned name as a version-stable identity.

Context ([RHOAIENG-78121](https://redhat.atlassian.net/browse/RHOAIENG-78121)): both operator paths (the classic kserve component and the kserve-module operator) rename well-known LLMInferenceServiceConfigs with a full platform-version prefix at reconcile time (`v3-5-0-<name>`), and old sets are retained across upgrades. The Dashboard links deployments to their parent preset by exact versioned name, so every version flip (including z-streams, since the patch component is in the prefix) breaks or freezes the parent link for all existing deployments. This annotation gives the Dashboard a rename-proof key to group and match on. Andrew Ballantyne (Dashboard) has accepted this annotation as the contract.

Why static-in-templates: the rename touches only `metadata.name`; annotations pass through both operator paths untouched (confirmed with the module operator work owner), so a static value in the templates survives every flip on both paths with no controller code, and is restart-safe by construction (no reconcile-time computation, no status writes).

Fast variants: the `-fast-1`/`-fast-2` configs are re-emitted from the base templates via `nameSuffix`, which would make them inherit the base template's annotation verbatim. That is the wrong identity for cross-version grouping (a fast-1 config's stable identity is its own fast-1 name), so the fast kustomizations patch the annotation to the config's own suffixed name. Rendered result: all 27 configs (9 base + 18 fast) carry `config-base-name` exactly equal to their own unversioned `metadata.name`, keeping base, fast-1, and fast-2 as distinct identities across versions.

Scope: accelerator presets only, matching the blocker (they are what the Dashboard links against). The 11 non-accelerator well-known templates in `config/llmisvcconfig/` also get version-renamed (the well-known marking is a blanket patch), but those files are upstream-owned; annotating them midstream would create a permanent sync-conflict surface, so they are deliberately excluded here and can follow up separately if needed.

Timing: safe for 3.5.0 and needed before it. Old config sets are never re-rendered after a version flip, so any release that ships without this annotation produces preset generations that can never be retrofitted with an identity.

**Which issue(s) this PR fixes**:

[RHOAIENG-78121](https://redhat.atlassian.net/browse/RHOAIENG-78121) (Epic [RHOAIENG-61100](https://redhat.atlassian.net/browse/RHOAIENG-61100), [RHAISTRAT-1395](https://redhat.atlassian.net/browse/RHAISTRAT-1395))

**Feature/Issue validation/testing**:

- `hack/verify-odh-runtime-version.sh` extended to assert every rendered accelerator config carries a non-empty `opendatahub.io/config-base-name` equal to its own name (which also pins the fast-variant semantic); runs in the existing `precommit` wiring via `Makefile.overrides.mk`. Green on this branch; negative-tested against a wrong value, a missing fast patch, and an inherited-instead-of-suffixed value.
- Full `kustomize build config/overlays/odh` diff against master shows exactly 27 added annotation lines and no other changes.
- `config/overlays/odh-xks` and `config/overlays/odh-test` build clean.

**Special notes for your reviewer**:

The annotation value duplicates each template's `metadata.name` by design; the verify script guards the equality so the two cannot drift silently. The fast-variant override lives in `accelerators-fast/fast-{1,2}/kustomization.yaml` as inline patches targeting the pre-suffix names.

**Release note**:

```release-note
Well-known LLM accelerator preset LLMInferenceServiceConfigs now carry a stable `opendatahub.io/config-base-name` identity annotation that survives platform-version renames.
```

[RHOAIENG-78121]: https://redhat.atlassian.net/browse/RHOAIENG-78121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-78121]: https://redhat.atlassian.net/browse/RHOAIENG-78121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ