### PR TITLE
feat(kserve-module): deploy odh-model-controller on XKS

### DIFF
--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -49,6 +49,7 @@ var components = []componentConfig{
 	{
 		name:        OdhModelControllerComponentName,
 		sourcePath:  ModelControllerSourcePath,
+		sourcePathXKS: ModelControllerSourcePathXKS,
 		imageMap:    modelControllerImageParamMap,
 		extraParams: modelControllerExtraParams,
 		postRender:  modelControllerPostRender,

--- a/kserve-module/pkg/kservemodule/constants.go
+++ b/kserve-module/pkg/kservemodule/constants.go
@@ -31,6 +31,7 @@ const (
 	KserveCRDManifestSourcePath     = "overlays/odh-crds"
 	ModelCacheManifestSourcePath    = "overlays/odh-modelcache"
 	ModelControllerSourcePath       = "overlays/odh"
+	ModelControllerSourcePathXKS    = "overlays/xks"
 	WVAManifestSourcePathOCP        = "overlays/namespace-scoped/openshift"
 	ObservabilityManifestSourcePath      = "monitoring/llmisvc/dashboards"
 	ConsoleDashboardsManifestSourcePath = "monitoring/llmisvc/dashboards-odc"
@@ -40,6 +41,7 @@ const (
 	llmISVCControllerDeployment    = "llmisvc-controller-manager"
 	localmodelControllerDeployment = "kserve-localmodel-controller-manager"
 	odhModelControllerDeployment   = "odh-model-controller"
+	modelServingAPIDeployment      = "model-serving-api"
 	wvaControllerDeployment        = "workload-variant-autoscaler-controller-manager"
 
 	// Console dashboards target namespace

--- a/kserve-module/pkg/kservemodule/fixture/envtest.go
+++ b/kserve-module/pkg/kservemodule/fixture/envtest.go
@@ -183,6 +183,7 @@ data:
 	writeKustomizeDir(filepath.Join(workDir, kservemodule.KserveComponentName, kservemodule.ObservabilityManifestSourcePath), observabilityManifest)
 	writeKustomizeDir(filepath.Join(workDir, kservemodule.KserveComponentName, kservemodule.ConsoleDashboardsManifestSourcePath), consoleDashboardsManifest)
 	writeKustomizeDir(filepath.Join(workDir, kservemodule.OdhModelControllerComponentName, kservemodule.ModelControllerSourcePath), modelCtrlManifest)
+	writeKustomizeDir(filepath.Join(workDir, kservemodule.OdhModelControllerComponentName, kservemodule.ModelControllerSourcePathXKS), modelCtrlManifest)
 	writeKustomizeDir(filepath.Join(workDir, kservemodule.WVAComponentName, kservemodule.WVAManifestSourcePathOCP), wvaManifest)
 }
 

--- a/kserve-module/pkg/kservemodule/reconciler_int_test.go
+++ b/kserve-module/pkg/kservemodule/reconciler_int_test.go
@@ -94,6 +94,7 @@ var _ = Describe("KserveModule Reconciler", func() {
 				"kserve-controller-manager",
 				"llmisvc-controller-manager",
 				"odh-model-controller",
+				"model-serving-api",
 			}
 			for _, name := range deployments {
 				createReadyDeployment(ctx, name, "opendatahub")
@@ -125,8 +126,13 @@ var _ = Describe("KserveModule Reconciler", func() {
 				testEnv.Reconciler.SetClusterType(cluster.ClusterTypeOpenShift)
 			})
 
-			// XKS only requires llmisvc-controller-manager
-			createReadyDeployment(ctx, "llmisvc-controller-manager", "opendatahub")
+			deployments := []string{
+				"llmisvc-controller-manager",
+				"odh-model-controller",
+			}
+			for _, name := range deployments {
+				createReadyDeployment(ctx, name, "opendatahub")
+			}
 
 			triggerReconcile(ctx, cr, "readiness-xks")
 
@@ -142,7 +148,6 @@ var _ = Describe("KserveModule Reconciler", func() {
 				g.Expect(kserveReady).NotTo(BeNil())
 				g.Expect(kserveReady.Status).To(Equal(metav1.ConditionTrue))
 
-				// XKS does not deploy model controller, so readiness is always true
 				modelCtrlReady := fixture.FindCondition(cr, kservemodule.ConditionModelControllerReady)
 				g.Expect(modelCtrlReady).NotTo(BeNil())
 				g.Expect(modelCtrlReady.Status).To(Equal(metav1.ConditionTrue))

--- a/kserve-module/pkg/kservemodule/releases_test.go
+++ b/kserve-module/pkg/kservemodule/releases_test.go
@@ -1,11 +1,16 @@
 package kservemodule
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
 	. "github.com/onsi/gomega"
+
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
+
+	platformv1alpha1 "github.com/opendatahub-io/kserve-module/pkg/apis/v1alpha1"
 )
 
 func TestLoadComponentReleases_ParsesBothFiles(t *testing.T) {
@@ -64,6 +69,70 @@ func TestLoadComponentReleases_Fallback(t *testing.T) {
 	g.Expect(releases[0].Name).Should(Equal("KServe"))
 	g.Expect(releases[0].Version).Should(Equal("unknown"))
 	g.Expect(releases[0].RepoURL).Should(Equal("https://github.com/kserve/kserve/"))
+}
+
+func TestSetReleaseStatus_ExcludesModelControllerOnXKS(t *testing.T) {
+	kserveMeta := `releases:
+  - name: KServe
+    version: v0.19.0
+    repoUrl: https://github.com/kserve/kserve/
+`
+	omcMeta := `releases:
+  - name: OpenVINO Model Server
+    version: v2025.4
+    repoUrl: https://github.com/openvinotoolkit/model_server
+  - name: MLServer
+    version: 1.7.1
+    repoUrl: https://github.com/SeldonIO/MLServer
+`
+
+	omcRuntimes := []string{"OpenVINO Model Server", "MLServer"}
+
+	tests := []struct {
+		name            string
+		clusterType     cluster.ClusterType
+		wantOMCRuntimes bool
+	}{
+		{
+			name:            "OCP includes modelcontroller runtimes",
+			clusterType:     cluster.ClusterTypeOpenShift,
+			wantOMCRuntimes: true,
+		},
+		{
+			name:            "XKS excludes modelcontroller runtimes",
+			clusterType:     cluster.ClusterTypeKubernetes,
+			wantOMCRuntimes: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			dir := t.TempDir()
+			writeMetadata(t, dir, KserveComponentName, kserveMeta)
+			writeMetadata(t, dir, OdhModelControllerComponentName, omcMeta)
+
+			r := newReconcilerWithFakeClient()
+			r.ManifestsTemplatePath = dir
+			r.SetClusterType(tc.clusterType)
+
+			kserve := &platformv1alpha1.Kserve{}
+			r.setReleaseStatus(context.Background(), kserve)
+
+			releases := kserve.GetReleaseStatus().Releases
+			// KServe (from the kserve component) is always present on both platforms.
+			g.Expect(releases).To(ContainElement(HaveField("Name", "KServe")))
+
+			for _, rt := range omcRuntimes {
+				if tc.wantOMCRuntimes {
+					g.Expect(releases).To(ContainElement(HaveField("Name", rt)))
+				} else {
+					g.Expect(releases).NotTo(ContainElement(HaveField("Name", rt)))
+				}
+			}
+		})
+	}
 }
 
 func writeMetadata(t *testing.T, base, component, content string) {

--- a/kserve-module/pkg/kservemodule/resource_manager.go
+++ b/kserve-module/pkg/kservemodule/resource_manager.go
@@ -29,6 +29,10 @@ var (
 	}
 	modelControllerDeploymentsOCP = []string{
 		odhModelControllerDeployment,
+		modelServingAPIDeployment,
+	}
+	modelControllerDeploymentsXKS = []string{
+		odhModelControllerDeployment,
 	}
 	wvaDeploymentsOCP = []string{
 		wvaControllerDeployment,
@@ -59,7 +63,7 @@ func checkKServeReadiness(ctx context.Context, cli client.Client, namespace stri
 
 func checkModelControllerReadiness(ctx context.Context, cli client.Client, namespace string, isXKS bool) error {
 	if isXKS {
-		return nil
+		return checkDeploymentsReady(ctx, cli, namespace, modelControllerDeploymentsXKS)
 	}
 	return checkDeploymentsReady(ctx, cli, namespace, modelControllerDeploymentsOCP)
 }

--- a/kserve-module/pkg/kservemodule/resource_manager_test.go
+++ b/kserve-module/pkg/kservemodule/resource_manager_test.go
@@ -47,6 +47,7 @@ func TestCheckModelControllerReadiness_OCP_Ready(t *testing.T) {
 
 	deps := []appsv1.Deployment{
 		buildDeployment(odhModelControllerDeployment, 1),
+		buildDeployment(modelServingAPIDeployment, 1),
 	}
 
 	cli := buildFakeClient(deps...)
@@ -55,10 +56,14 @@ func TestCheckModelControllerReadiness_OCP_Ready(t *testing.T) {
 	g.Expect(err).ShouldNot(HaveOccurred())
 }
 
-func TestCheckModelControllerReadiness_XKS_Skipped(t *testing.T) {
+func TestCheckModelControllerReadiness_XKS_Ready(t *testing.T) {
 	g := NewWithT(t)
 
-	cli := fake.NewClientBuilder().WithScheme(testScheme()).Build()
+	deps := []appsv1.Deployment{
+		buildDeployment(odhModelControllerDeployment, 1),
+	}
+
+	cli := buildFakeClient(deps...)
 
 	err := checkModelControllerReadiness(context.Background(), cli, "opendatahub", true)
 	g.Expect(err).ShouldNot(HaveOccurred())

--- a/kserve-module/pkg/kservemodule/resource_manager_test.go
+++ b/kserve-module/pkg/kservemodule/resource_manager_test.go
@@ -56,6 +56,20 @@ func TestCheckModelControllerReadiness_OCP_Ready(t *testing.T) {
 	g.Expect(err).ShouldNot(HaveOccurred())
 }
 
+func TestCheckModelControllerReadiness_OCP_MissingModelServingAPI(t *testing.T) {
+	g := NewWithT(t)
+
+	deps := []appsv1.Deployment{
+		buildDeployment(odhModelControllerDeployment, 1),
+	}
+
+	cli := buildFakeClient(deps...)
+
+	err := checkModelControllerReadiness(context.Background(), cli, "opendatahub", false)
+	g.Expect(err).Should(HaveOccurred())
+	g.Expect(err.Error()).Should(ContainSubstring("model-serving-api"))
+}
+
 func TestCheckModelControllerReadiness_XKS_Ready(t *testing.T) {
 	g := NewWithT(t)
 
@@ -67,6 +81,16 @@ func TestCheckModelControllerReadiness_XKS_Ready(t *testing.T) {
 
 	err := checkModelControllerReadiness(context.Background(), cli, "opendatahub", true)
 	g.Expect(err).ShouldNot(HaveOccurred())
+}
+
+func TestCheckModelControllerReadiness_XKS_MissingOdhModelController(t *testing.T) {
+	g := NewWithT(t)
+
+	cli := fake.NewClientBuilder().WithScheme(testScheme()).Build()
+
+	err := checkModelControllerReadiness(context.Background(), cli, "opendatahub", true)
+	g.Expect(err).Should(HaveOccurred())
+	g.Expect(err.Error()).Should(ContainSubstring("odh-model-controller"))
 }
 
 func TestCheckKServeReadiness_XKS_AllReady(t *testing.T) {

--- a/kserve-module/pkg/kservemodule/status.go
+++ b/kserve-module/pkg/kservemodule/status.go
@@ -198,8 +198,15 @@ func (r *KserveModuleReconciler) updateStatus(ctx context.Context, kserve *platf
 }
 
 func (r *KserveModuleReconciler) setReleaseStatus(ctx context.Context, kserve *platformv1alpha1.Kserve) {
-	releases, err := loadComponentReleases(r.ManifestsTemplatePath,
-		[]string{KserveComponentName, OdhModelControllerComponentName})
+	// The modelcontroller component_metadata.yaml only lists serving runtime
+	// releases (OVMS, MLServer, Caikit, ...). On XKS those runtimes are not
+	// installed, so exclude them from status.releases.
+	componentDirs := []string{KserveComponentName}
+	if !r.isKubernetes(ctx) {
+		componentDirs = append(componentDirs, OdhModelControllerComponentName)
+	}
+
+	releases, err := loadComponentReleases(r.ManifestsTemplatePath, componentDirs)
 	if err != nil {
 		ctrl.Log.Error(err, "failed to load component releases")
 		return

--- a/kserve-module/tests/e2e/conftest.py
+++ b/kserve-module/tests/e2e/conftest.py
@@ -20,6 +20,7 @@ TIMEOUT_60S = 60
 
 OPERAND_DEPLOYMENTS_XKS = [
     "llmisvc-controller-manager",
+    "odh-model-controller",
 ]
 OPERAND_DEPLOYMENTS_OCP = [
     "kserve-controller-manager",

--- a/kserve-module/tests/e2e/test_status.py
+++ b/kserve-module/tests/e2e/test_status.py
@@ -41,9 +41,8 @@ class TestStatusConditions:
         assert conditions["Degraded"]["status"] == "False"
         assert conditions["Degraded"]["reason"] == "NoDegradation"
 
-        if cluster_info.is_openshift:
-            assert conditions["ModelControllerReady"]["status"] == "True"
-            assert conditions["ModelControllerReady"]["reason"] == "AllDeploymentsAvailable"
+        assert conditions["ModelControllerReady"]["status"] == "True"
+        assert conditions["ModelControllerReady"]["reason"] == "AllDeploymentsAvailable"
 
         cr = get_cr(kubectl)
         assert cr["status"]["phase"] == "Ready"

--- a/kserve-module/tests/e2e/test_status.py
+++ b/kserve-module/tests/e2e/test_status.py
@@ -9,10 +9,8 @@ impossible to simulate in E2E.
 import pytest
 
 from conftest import (
-    MODEL_CONTROLLER_DEPLOYMENT,
     get_cr,
     get_conditions,
-    operand_deployments,
 )
 
 
@@ -63,8 +61,9 @@ class TestStatusConditions:
     ):
         """Real component_metadata lands on the CR (envtest only sees the fallback).
 
-        Asserts KServe (always) and, where omc is deployed, one runtime it contributes
-        (MLServer) as proof its metadata was loaded.
+        Asserts KServe (always) and, on OpenShift, one runtime omc contributes
+        (MLServer) as proof its metadata was loaded. On XKS omc is deployed but
+        does not install those runtimes, so they are excluded from status.releases.
         """
         cr = get_cr(kubectl)
         releases = cr.get("status", {}).get("releases", [])
@@ -74,8 +73,12 @@ class TestStatusConditions:
         assert kserve_version is not None, f"expected 'KServe' in releases, got {names}"
         assert kserve_version != "", "KServe version should not be empty"
 
-        # Gate on omc being deployed, not on OpenShift — omc runs on XKS too (PR #1798).
-        if MODEL_CONTROLLER_DEPLOYMENT in operand_deployments(cluster_info.is_openshift):
-            mlserver_version = _release_version(releases, "MLServer")
+        # omc runtime metadata (MLServer, OVMS, ...) is loaded only on OpenShift.
+        # On XKS omc runs but installs no runtimes, so they are dropped from
+        # status.releases (see setReleaseStatus).
+        mlserver_version = _release_version(releases, "MLServer")
+        if cluster_info.is_openshift:
             assert mlserver_version is not None, f"expected 'MLServer' in releases, got {names}"
             assert mlserver_version != "", "MLServer version should not be empty"
+        else:
+            assert mlserver_version is None, f"MLServer should be excluded on XKS, got {names}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Deploy odh-model-controller (omc) on XKS clusters. Previously omc was only deployed on OCP. Also adds model-serving-api to the OCP model controller readiness check which was missing.

After this change:
- **XKS:** llmisvc-controller-manager + odh-model-controller
- **OCP:** kserve-controller-manager + llmisvc-controller-manager + odh-model-controller + model-serving-api
- NIM/WVA remain OCP-only

**Which issue(s) this PR fixes**:
Fixes #

**Feature/Issue validation/testing**:

- [x] Unit tests updated (resource_manager_test.go)
- [x] Integration tests updated (reconciler_int_test.go)
- [x] E2E tests updated (conftest.py, test_status.py)

**Special notes for your reviewer**:

- `checkModelControllerReadiness` no longer skips on XKS — it checks omc deployment readiness
- `modelControllerDeploymentsOCP` now includes `model-serving-api`
- envtest fixture writes omc XKS overlay manifests for integration tests

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model controller readiness detection across OpenShift and Kubernetes environments.
  * Included required model-serving deployments in readiness checks.
  * Ensured the correct manifests are used when configuring the model controller.
  * Improved release status reporting across supported cluster types.
  * Preserved required custom resources during workload lifecycle changes.
  * Updated cleanup handling for model controller resources.

* **Tests**
  * Expanded coverage for readiness, status conditions, release reporting, version information, and missing-deployment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->