### PR TITLE
fix(RHOAIENG-78938): dynamically discover cert-manager namespace for CA lookup

### DIFF
--- a/kserve-module/pkg/kservemodule/constants.go
+++ b/kserve-module/pkg/kservemodule/constants.go
@@ -69,9 +69,16 @@ const (
 	PlatformFinalizerName = "platform.opendatahub.io/finalizer"
 
 	// cert-manager defaults
-	defaultCAIssuerName    = "opendatahub-ca-issuer"
-	defaultIssuerRefKind   = "ClusterIssuer"
-	defaultCertName        = "opendatahub-ca"
+	defaultCAIssuerName  = "opendatahub-ca-issuer"
+	defaultIssuerRefKind = "ClusterIssuer"
+	defaultCertName      = "opendatahub-ca"
+	// defaultCertManagerNS is the fallback when dynamic detection fails.
+	// Prefer CA_SECRET_NAMESPACE env var or runtime discovery.
 	defaultCertManagerNS   = "cert-manager"
 	defaultIstioCACertPath = "/var/run/secrets/opendatahub/ca.crt"
+
+	// Well-known cert-manager namespace candidates for discovery.
+	certManagerNSCandidate        = "cert-manager"
+	certManagerOperatorNS         = "cert-manager-operator"
+	certManagerWebhookDeployment  = "cert-manager-webhook"
 )

--- a/kserve-module/pkg/kservemodule/images.go
+++ b/kserve-module/pkg/kservemodule/images.go
@@ -92,14 +92,14 @@ var wvaImageParamMap = map[string]string{
 	"wva-controller-image": "RELATED_IMAGE_ODH_WORKLOAD_VARIANT_AUTOSCALER_CONTROLLER_IMAGE",
 }
 
-func buildCertManagerParams(namespace string) map[string]string {
+func buildCertManagerParams(namespace, certManagerNS string) map[string]string {
 	return map[string]string{
 		"NAMESPACE":                 namespace,
 		"ISSUER_REF_NAME":           getEnvOrDefault("ISSUER_NAME", defaultCAIssuerName),
 		"ISSUER_REF_KIND":           getEnvOrDefault("ISSUER_KIND", defaultIssuerRefKind),
 		"ISSUER_REF_GROUP":          "cert-manager.io",
 		"CA_SECRET_NAME":            getEnvOrDefault("CA_SECRET_NAME", defaultCertName),
-		"CA_SECRET_NAMESPACE":       getEnvOrDefault("CA_SECRET_NAMESPACE", defaultCertManagerNS),
+		"CA_SECRET_NAMESPACE":       getEnvOrDefault("CA_SECRET_NAMESPACE", certManagerNS),
 		"ISTIO_CA_CERTIFICATE_PATH": getEnvOrDefault("ISTIO_CA_CERT_PATH", defaultIstioCACertPath),
 	}
 }

--- a/kserve-module/pkg/kservemodule/params_test.go
+++ b/kserve-module/pkg/kservemodule/params_test.go
@@ -112,7 +112,7 @@ func TestApplyParams_ExtraParamsMap(t *testing.T) {
 func TestBuildCertManagerParams_Defaults(t *testing.T) {
 	g := NewWithT(t)
 
-	params := buildCertManagerParams("test-ns")
+	params := buildCertManagerParams("test-ns", defaultCertManagerNS)
 	g.Expect(params["NAMESPACE"]).Should(Equal("test-ns"))
 	g.Expect(params["ISSUER_REF_NAME"]).Should(Equal(defaultCAIssuerName))
 	g.Expect(params["ISSUER_REF_KIND"]).Should(Equal(defaultIssuerRefKind))
@@ -128,7 +128,14 @@ func TestBuildCertManagerParams_EnvOverrides(t *testing.T) {
 	t.Setenv("ISSUER_NAME", "custom-issuer")
 	t.Setenv("CA_SECRET_NAME", "custom-ca")
 
-	params := buildCertManagerParams("ns")
+	params := buildCertManagerParams("ns", "custom-ns")
 	g.Expect(params["ISSUER_REF_NAME"]).Should(Equal("custom-issuer"))
 	g.Expect(params["CA_SECRET_NAME"]).Should(Equal("custom-ca"))
+}
+
+func TestBuildCertManagerParams_DynamicNamespace(t *testing.T) {
+	g := NewWithT(t)
+
+	params := buildCertManagerParams("test-ns", "cert-manager-operator")
+	g.Expect(params["CA_SECRET_NAMESPACE"]).Should(Equal("cert-manager-operator"))
 }

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -315,9 +315,10 @@ func (r *KserveModuleReconciler) reconcileComponent(ctx context.Context,
 
 	if r.isKubernetes(ctx) {
 		ns := r.getApplicationsNamespace()
+		certNS := r.getCertManagerNamespace(ctx)
 		if err := applyParams(
 			filepath.Join(manifestDir, comp.dirName(), comp.sourcePathXKS),
-			nil, buildCertManagerParams(ns),
+			nil, buildCertManagerParams(ns, certNS),
 		); err != nil {
 			return nil, fmt.Errorf("applying cert-manager params: %w", err)
 		}
@@ -392,6 +393,28 @@ func (r *KserveModuleReconciler) getApplicationsNamespace() string {
 	}
 
 	return "opendatahub"
+}
+
+// getCertManagerNamespace dynamically discovers the namespace where cert-manager
+// stores its CA secrets. It checks (in order):
+// 1. CA_SECRET_NAMESPACE env var (explicit override)
+// 2. "cert-manager" namespace existence on the cluster
+// 3. "cert-manager-operator" namespace existence (OCP OLM install)
+// 4. Falls back to "cert-manager" constant
+func (r *KserveModuleReconciler) getCertManagerNamespace(ctx context.Context) string {
+	if ns := os.Getenv("CA_SECRET_NAMESPACE"); ns != "" {
+		return ns
+	}
+
+	for _, candidate := range []string{certManagerNSCandidate, certManagerOperatorNS} {
+		var ns corev1.Namespace
+		if err := r.Get(ctx, types.NamespacedName{Name: candidate}, &ns); err == nil {
+			ctrl.LoggerFrom(ctx).V(1).Info("Discovered cert-manager namespace", "namespace", candidate)
+			return candidate
+		}
+	}
+
+	return defaultCertManagerNS
 }
 
 func (r *KserveModuleReconciler) getPlatformVersion(ctx context.Context) string {


### PR DESCRIPTION
## Summary

The kserve-module hardcodes `defaultCertManagerNS = "cert-manager"` as the namespace where the CA signing secret is stored. On deployments where cert-manager runs in a different namespace (e.g. `cert-manager-operator` on OCP OLM installs, or custom installations), LLMInferenceService fails with `ReconcileCertsError: Secret "opendatahub-ca" not found`.

**Fix:** Add dynamic cert-manager namespace discovery via `getCertManagerNamespace()` that:
1. Checks `CA_SECRET_NAMESPACE` env var (explicit override — backwards compatible)
2. Probes for known namespace candidates (`cert-manager`, `cert-manager-operator`)
3. Falls back to `cert-manager` if nothing is found

This makes the lookup "dynamic" as requested, rather than relying on a hardcoded constant.

## Changes

- `constants.go`: Added well-known namespace candidates as named constants
- `images.go`: `buildCertManagerParams` now accepts the discovered namespace
- `reconciler.go`: Added `getCertManagerNamespace()` method with runtime discovery
- `params_test.go`: Updated tests + added dynamic namespace test

## Test plan

- [x] `go build ./...` — compiles cleanly
- [x] `TestBuildCertManagerParams_Defaults` passes
- [x] `TestBuildCertManagerParams_EnvOverrides` passes
- [x] `TestBuildCertManagerParams_DynamicNamespace` passes (new)
- [x] Validated on AKS: LLMISVC correctly finds CA in `cert-manager` namespace

Fixes: https://redhat.atlassian.net/browse/RHOAIENG-78938