### PR TITLE
[RHOAIENG-76590] Enable ClusterServingRuntime in ODH

### DIFF
--- a/config/overlays/odh-crds/kustomization.yaml
+++ b/config/overlays/odh-crds/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
 - ../../crd/full/llmisvc
 
 patches:
-- path: patches/remove-clusterservingruntime.yaml
 - target:
     kind: CustomResourceDefinition
     annotationSelector: cert-manager.io/inject-ca-from

--- a/config/overlays/odh-crds/patches/remove-clusterservingruntime.yaml
+++ b/config/overlays/odh-crds/patches/remove-clusterservingruntime.yaml
@@ -1,5 +1,0 @@
-$patch: delete
-apiVersion: apiextensions.k8s.io/v1
-kind: CustomResourceDefinition
-metadata:
-  name: clusterservingruntimes.serving.kserve.io

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -31,7 +31,6 @@ namespace: opendatahub
 patches:
 - path: patches/remove-namespace.yaml
 - path: patches/remove-cert-manager.yaml
-- path: patches/remove-clusterservingruntime.yaml
 - path: patches/inferenceservice-config-patch.yaml
 - path: patches/set-resources-manager-patch.yaml
 - path: patches/remove-auth-proxy-patch.yaml

--- a/config/overlays/odh/patches/remove-clusterservingruntime.yaml
+++ b/config/overlays/odh/patches/remove-clusterservingruntime.yaml
@@ -1,5 +1,0 @@
-$patch: delete
-apiVersion: admissionregistration.k8s.io/v1
-kind: ValidatingWebhookConfiguration
-metadata:
-  name: clusterservingruntime.serving.kserve.io

--- a/pkg/apis/serving/v1beta1/predictor_model_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_model_test.go
@@ -42,7 +42,7 @@ func TestGetSupportingRuntimes(t *testing.T) {
 	mlserverRuntimeMMS := "mlserver-runtime-mms"
 	mlserverRuntime := "mlserver-runtime"
 	xgboostRuntime := "xgboost-runtime"
-	// clusterServingRuntimePrefix := "cluster-"
+	clusterServingRuntimePrefix := "cluster-"
 	tritonRuntime := "triton-runtime"
 	testRuntime := "test-runtime"
 	huggingfaceMultinodeRuntime := "huggingface-multinode-runtime"
@@ -319,29 +319,28 @@ func TestGetSupportingRuntimes(t *testing.T) {
 		},
 	}
 
-	// ODH does not support ClusterServingRuntimeList
-	// clusterRuntimes := &v1alpha1.ClusterServingRuntimeList{
-	//	Items: []v1alpha1.ClusterServingRuntime{
-	//		{
-	//			ObjectMeta: metav1.ObjectMeta{
-	//				Name: clusterServingRuntimePrefix + mlserverRuntimeMMS,
-	//			},
-	//			Spec: servingRuntimeSpecs[mlserverRuntimeMMS],
-	//		},
-	//		{
-	//			ObjectMeta: metav1.ObjectMeta{
-	//				Name: clusterServingRuntimePrefix + tfRuntime,
-	//			},
-	//			Spec: servingRuntimeSpecs[tfRuntime],
-	//		},
-	//		{
-	//			ObjectMeta: metav1.ObjectMeta{
-	//				Name: clusterServingRuntimePrefix + xgboostRuntime,
-	//			},
-	//			Spec: servingRuntimeSpecs[xgboostRuntime],
-	//		},
-	//	 },
-	// }
+	clusterRuntimes := &v1alpha1.ClusterServingRuntimeList{
+		Items: []v1alpha1.ClusterServingRuntime{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterServingRuntimePrefix + mlserverRuntimeMMS,
+				},
+				Spec: servingRuntimeSpecs[mlserverRuntimeMMS],
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterServingRuntimePrefix + tfRuntime,
+				},
+				Spec: servingRuntimeSpecs[tfRuntime],
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterServingRuntimePrefix + xgboostRuntime,
+				},
+				Spec: servingRuntimeSpecs[xgboostRuntime],
+			},
+		},
+	}
 
 	storageUri := "s3://test/model"
 	scenarios := map[string]struct {
@@ -361,7 +360,7 @@ func TestGetSupportingRuntimes(t *testing.T) {
 			},
 			isMMS:       false,
 			isMultinode: false,
-			expected:    []v1alpha1.SupportedRuntime{{Name: tfRuntime, Spec: servingRuntimeSpecs[tfRuntime]} /*, {Name: clusterServingRuntimePrefix + tfRuntime, Spec: servingRuntimeSpecs[tfRuntime]}*/},
+			expected:    []v1alpha1.SupportedRuntime{{Name: tfRuntime, Spec: servingRuntimeSpecs[tfRuntime]}, {Name: clusterServingRuntimePrefix + tfRuntime, Spec: servingRuntimeSpecs[tfRuntime]}},
 		},
 		"RuntimeNotFound": {
 			spec: &ModelSpec{
@@ -401,7 +400,7 @@ func TestGetSupportingRuntimes(t *testing.T) {
 			},
 			isMMS:       true,
 			isMultinode: false,
-			expected:    []v1alpha1.SupportedRuntime{ /*{Name: clusterServingRuntimePrefix + mlserverRuntimeMMS, Spec: servingRuntimeSpecs[mlserverRuntimeMMS]}*/ },
+			expected:    []v1alpha1.SupportedRuntime{{Name: clusterServingRuntimePrefix + mlserverRuntimeMMS, Spec: servingRuntimeSpecs[mlserverRuntimeMMS]}},
 		},
 		"SMSRuntimeModelFormatSpecified": {
 			spec: &ModelSpec{
@@ -428,7 +427,7 @@ func TestGetSupportingRuntimes(t *testing.T) {
 			},
 			isMMS:       false,
 			isMultinode: false,
-			expected:    []v1alpha1.SupportedRuntime{ /*{Name: clusterServingRuntimePrefix + xgboostRuntime, Spec: servingRuntimeSpecs[xgboostRuntime]}*/ },
+			expected:    []v1alpha1.SupportedRuntime{{Name: clusterServingRuntimePrefix + xgboostRuntime, Spec: servingRuntimeSpecs[xgboostRuntime]}},
 		},
 		"RuntimeV1ProtocolNotFound": {
 			spec: &ModelSpec{
@@ -487,7 +486,7 @@ func TestGetSupportingRuntimes(t *testing.T) {
 		t.Errorf("unable to add scheme : %v", err)
 	}
 
-	mockClient := fake.NewClientBuilder().WithLists(runtimes /*, clusterRuntimes*/).WithScheme(s).Build()
+	mockClient := fake.NewClientBuilder().WithLists(runtimes, clusterRuntimes).WithScheme(s).Build()
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
 			res, _ := scenario.spec.GetSupportingRuntimes(t.Context(), mockClient, namespace, scenario.isMMS, scenario.isMultinode)

--- a/pkg/controller/v1beta1/inferenceservice/pod_watch_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/pod_watch_test.go
@@ -652,139 +652,139 @@ var _ = Describe("ServingRuntime Watch", func() {
 		}
 	})
 
-	// Describe("clusterServingRuntimeFunc", func() {
-	//	It("should only reconcile ISVCs that use the specific ClusterServingRuntime", func() {
-	//		// Create ISVC using clusterRuntime1
-	//		isvc1 := &v1beta1.InferenceService{
-	//			ObjectMeta: metav1.ObjectMeta{
-	//				Name:      "isvc-cluster-runtime-1",
-	//				Namespace: testNamespace,
-	//			},
-	//			Spec: v1beta1.InferenceServiceSpec{
-	//				Predictor: v1beta1.PredictorSpec{
-	//					SKLearn: &v1beta1.SKLearnSpec{},
-	//				},
-	//			},
-	//		}
-	//		Expect(k8sClient.Create(context.Background(), isvc1)).To(Succeed())
-	//
-	//		// Set the ClusterServingRuntimeName in status
-	//		isvc1.Status.ClusterServingRuntimeName = "cluster-runtime-1"
-	//		Expect(k8sClient.Status().Update(context.Background(), isvc1)).To(Succeed())
-	//
-	//		// Create ISVC using clusterRuntime2
-	//		isvc2 := &v1beta1.InferenceService{
-	//			ObjectMeta: metav1.ObjectMeta{
-	//				Name:      "isvc-cluster-runtime-2",
-	//				Namespace: testNamespace,
-	//			},
-	//			Spec: v1beta1.InferenceServiceSpec{
-	//				Predictor: v1beta1.PredictorSpec{
-	//					SKLearn: &v1beta1.SKLearnSpec{},
-	//				},
-	//			},
-	//		}
-	//		Expect(k8sClient.Create(context.Background(), isvc2)).To(Succeed())
-	//
-	//		// Set the ClusterServingRuntimeName in status
-	//		isvc2.Status.ClusterServingRuntimeName = "cluster-runtime-2"
-	//		Expect(k8sClient.Status().Update(context.Background(), isvc2)).To(Succeed())
-	//
-	//		// Create a ClusterServingRuntime object (only need metadata for the mapper)
-	//		csr := &v1alpha1.ClusterServingRuntime{
-	//			ObjectMeta: metav1.ObjectMeta{
-	//				Name: "cluster-runtime-1",
-	//			},
-	//		}
-	//
-	//		// Wait for the cache to sync and verify the mapper returns the correct request.
-	//		// The cached client may not immediately reflect status updates.
-	//		Eventually(func() []reconcile.Request {
-	//			return reconciler.clusterServingRuntimeFunc(context.Background(), csr)
-	//		}).Should(HaveLen(1))
-	//
-	//		requests := reconciler.clusterServingRuntimeFunc(context.Background(), csr)
-	//		Expect(requests[0].Name).To(Equal("isvc-cluster-runtime-1"))
-	//		Expect(requests[0].Namespace).To(Equal(testNamespace))
-	//	})
-	//
-	//	It("should not reconcile ISVCs that use a different ClusterServingRuntime", func() {
-	//		// Create ISVC using a different runtime
-	//		isvc := &v1beta1.InferenceService{
-	//			ObjectMeta: metav1.ObjectMeta{
-	//				Name:      "isvc-different-runtime",
-	//				Namespace: testNamespace,
-	//			},
-	//			Spec: v1beta1.InferenceServiceSpec{
-	//				Predictor: v1beta1.PredictorSpec{
-	//					SKLearn: &v1beta1.SKLearnSpec{},
-	//				},
-	//			},
-	//		}
-	//		Expect(k8sClient.Create(context.Background(), isvc)).To(Succeed())
-	//
-	//		// Set the ClusterServingRuntimeName in status to a different runtime
-	//		isvc.Status.ClusterServingRuntimeName = "cluster-runtime-other"
-	//		Expect(k8sClient.Status().Update(context.Background(), isvc)).To(Succeed())
-	//
-	//		// Create a ClusterServingRuntime object with a unique name not used by any ISVC
-	//		csr := &v1alpha1.ClusterServingRuntime{
-	//			ObjectMeta: metav1.ObjectMeta{
-	//				Name: "cluster-runtime-unused",
-	//			},
-	//		}
-	//
-	//		// Call the mapper function
-	//		requests := reconciler.clusterServingRuntimeFunc(context.Background(), csr)
-	//
-	//		// Should return empty since no ISVC uses cluster-runtime-unused
-	//		Expect(requests).To(BeEmpty())
-	//	})
-	//
-	//	It("should not reconcile ISVCs with auto-update disabled when ready", func() {
-	//		// Create ISVC with auto-update disabled
-	//		isvc := &v1beta1.InferenceService{
-	//			ObjectMeta: metav1.ObjectMeta{
-	//				Name:      "isvc-auto-update-disabled",
-	//				Namespace: testNamespace,
-	//				Annotations: map[string]string{
-	//					constants.DisableAutoUpdateAnnotationKey: "true",
-	//				},
-	//			},
-	//			Spec: v1beta1.InferenceServiceSpec{
-	//				Predictor: v1beta1.PredictorSpec{
-	//					SKLearn: &v1beta1.SKLearnSpec{},
-	//				},
-	//			},
-	//		}
-	//		Expect(k8sClient.Create(context.Background(), isvc)).To(Succeed())
-	//
-	//		// Set the ClusterServingRuntimeName and make it ready
-	//		isvc.Status.ClusterServingRuntimeName = "cluster-runtime-auto-update"
-	//		isvc.Status.SetCondition(v1beta1.PredictorReady, &knativeapis.Condition{
-	//			Type:   v1beta1.PredictorReady,
-	//			Status: corev1.ConditionTrue,
-	//		})
-	//		isvc.Status.SetCondition(v1beta1.IngressReady, &knativeapis.Condition{
-	//			Type:   v1beta1.IngressReady,
-	//			Status: corev1.ConditionTrue,
-	//		})
-	//		Expect(k8sClient.Status().Update(context.Background(), isvc)).To(Succeed())
-	//
-	//		// Create a ClusterServingRuntime object
-	//		csr := &v1alpha1.ClusterServingRuntime{
-	//			ObjectMeta: metav1.ObjectMeta{
-	//				Name: "cluster-runtime-auto-update",
-	//			},
-	//		}
-	//
-	//		// Call the mapper function
-	//		requests := reconciler.clusterServingRuntimeFunc(context.Background(), csr)
-	//
-	//		// Should not reconcile the ISVC because auto-update is disabled and it's ready
-	//		Expect(requests).To(BeEmpty())
-	//	})
-	// })
+	Describe("clusterServingRuntimeFunc", func() {
+		It("should only reconcile ISVCs that use the specific ClusterServingRuntime", func() {
+			// Create ISVC using clusterRuntime1
+			isvc1 := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "isvc-cluster-runtime-1",
+					Namespace: testNamespace,
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						SKLearn: &v1beta1.SKLearnSpec{},
+					},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), isvc1)).To(Succeed())
+
+			// Set the ClusterServingRuntimeName in status
+			isvc1.Status.ClusterServingRuntimeName = "cluster-runtime-1"
+			Expect(k8sClient.Status().Update(context.Background(), isvc1)).To(Succeed())
+
+			// Create ISVC using clusterRuntime2
+			isvc2 := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "isvc-cluster-runtime-2",
+					Namespace: testNamespace,
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						SKLearn: &v1beta1.SKLearnSpec{},
+					},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), isvc2)).To(Succeed())
+
+			// Set the ClusterServingRuntimeName in status
+			isvc2.Status.ClusterServingRuntimeName = "cluster-runtime-2"
+			Expect(k8sClient.Status().Update(context.Background(), isvc2)).To(Succeed())
+
+			// Create a ClusterServingRuntime object (only need metadata for the mapper)
+			csr := &v1alpha1.ClusterServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-runtime-1",
+				},
+			}
+
+			// Wait for the cache to sync and verify the mapper returns the correct request.
+			// The cached client may not immediately reflect status updates.
+			Eventually(func() []reconcile.Request {
+				return reconciler.clusterServingRuntimeFunc(context.Background(), csr)
+			}).Should(HaveLen(1))
+
+			requests := reconciler.clusterServingRuntimeFunc(context.Background(), csr)
+			Expect(requests[0].Name).To(Equal("isvc-cluster-runtime-1"))
+			Expect(requests[0].Namespace).To(Equal(testNamespace))
+		})
+
+		It("should not reconcile ISVCs that use a different ClusterServingRuntime", func() {
+			// Create ISVC using a different runtime
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "isvc-different-runtime",
+					Namespace: testNamespace,
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						SKLearn: &v1beta1.SKLearnSpec{},
+					},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), isvc)).To(Succeed())
+
+			// Set the ClusterServingRuntimeName in status to a different runtime
+			isvc.Status.ClusterServingRuntimeName = "cluster-runtime-other"
+			Expect(k8sClient.Status().Update(context.Background(), isvc)).To(Succeed())
+
+			// Create a ClusterServingRuntime object with a unique name not used by any ISVC
+			csr := &v1alpha1.ClusterServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-runtime-unused",
+				},
+			}
+
+			// Call the mapper function
+			requests := reconciler.clusterServingRuntimeFunc(context.Background(), csr)
+
+			// Should return empty since no ISVC uses cluster-runtime-unused
+			Expect(requests).To(BeEmpty())
+		})
+
+		It("should not reconcile ISVCs with auto-update disabled when ready", func() {
+			// Create ISVC with auto-update disabled
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "isvc-auto-update-disabled",
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						constants.DisableAutoUpdateAnnotationKey: "true",
+					},
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						SKLearn: &v1beta1.SKLearnSpec{},
+					},
+				},
+			}
+			Expect(k8sClient.Create(context.Background(), isvc)).To(Succeed())
+
+			// Set the ClusterServingRuntimeName and make it ready
+			isvc.Status.ClusterServingRuntimeName = "cluster-runtime-auto-update"
+			isvc.Status.SetCondition(v1beta1.PredictorReady, &knativeapis.Condition{
+				Type:   v1beta1.PredictorReady,
+				Status: corev1.ConditionTrue,
+			})
+			isvc.Status.SetCondition(v1beta1.IngressReady, &knativeapis.Condition{
+				Type:   v1beta1.IngressReady,
+				Status: corev1.ConditionTrue,
+			})
+			Expect(k8sClient.Status().Update(context.Background(), isvc)).To(Succeed())
+
+			// Create a ClusterServingRuntime object
+			csr := &v1alpha1.ClusterServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster-runtime-auto-update",
+				},
+			}
+
+			// Call the mapper function
+			requests := reconciler.clusterServingRuntimeFunc(context.Background(), csr)
+
+			// Should not reconcile the ISVC because auto-update is disabled and it's ready
+			Expect(requests).To(BeEmpty())
+		})
+	})
 
 	Describe("servingRuntimeFunc", func() {
 		It("should only reconcile ISVCs that use the specific ServingRuntime", func() {

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils_test.go
@@ -1106,16 +1106,16 @@ func TestGetServingRuntime(t *testing.T) {
 		},
 	}
 
-	// clusterRuntimes := &v1alpha1.ClusterServingRuntimeList{
-	//	Items: []v1alpha1.ClusterServingRuntime{
-	//		{
-	//			ObjectMeta: metav1.ObjectMeta{
-	//				Name: sklearnRuntime,
-	//			},
-	//			Spec: servingRuntimeSpecs[sklearnRuntime],
-	//		},
-	//	},
-	//}
+	clusterRuntimes := &v1alpha1.ClusterServingRuntimeList{
+		Items: []v1alpha1.ClusterServingRuntime{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: sklearnRuntime,
+				},
+				Spec: servingRuntimeSpecs[sklearnRuntime],
+			},
+		},
+	}
 
 	scenarios := map[string]struct {
 		runtimeName string
@@ -1125,21 +1125,27 @@ func TestGetServingRuntime(t *testing.T) {
 			runtimeName: tfRuntime,
 			expected:    servingRuntimeSpecs[tfRuntime],
 		},
-		// "ClusterServingRuntime": {
-		//	runtimeName: sklearnRuntime,
-		//	expected:    servingRuntimeSpecs[sklearnRuntime],
-		// },
+		"ClusterServingRuntime": {
+			runtimeName: sklearnRuntime,
+			expected:    servingRuntimeSpecs[sklearnRuntime],
+		},
 	}
 
 	s := runtime.NewScheme()
 	_ = v1alpha1.AddToScheme(s)
 
-	mockClient := fake.NewClientBuilder().WithLists(runtimes /*, clusterRuntimes*/).WithScheme(s).Build()
+	mockClient := fake.NewClientBuilder().WithLists(runtimes, clusterRuntimes).WithScheme(s).Build()
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			res, _, _, _ := GetServingRuntime(t.Context(), mockClient, scenario.runtimeName, namespace)
+			res, _, _, isClusterServingRuntime := GetServingRuntime(t.Context(), mockClient, scenario.runtimeName, namespace)
 			if !g.Expect(res).To(gomega.Equal(&scenario.expected)) {
 				t.Errorf("got %v, want %v", res, &scenario.expected)
+			}
+			// Check if the returned runtime is a cluster serving runtime
+			if name == "ClusterServingRuntime" {
+				g.Expect(isClusterServingRuntime).To(gomega.BeTrue())
+			} else {
+				g.Expect(isClusterServingRuntime).To(gomega.BeFalse())
 			}
 		})
 	}

--- a/pkg/webhook/admission/servingruntime/servingruntime_webhook.go
+++ b/pkg/webhook/admission/servingruntime/servingruntime_webhook.go
@@ -85,12 +85,11 @@ func (sr *ServingRuntimeValidator) Handle(ctx context.Context, req admission.Req
 	if servingRuntime.Spec.IsDisabled() {
 		return admission.Allowed("")
 	}
+	if err := validateModelFormatPrioritySame(&servingRuntime.Spec); err != nil {
+		return admission.Denied(fmt.Sprintf(ProrityIsNotSameServingRuntimeError, err.Error(), servingRuntime.Name))
+	}
 	existingRuntimeSpec := v1alpha1.ServingRuntimeSpec{}
 	for i := range ExistingRuntimes.Items {
-		if err := validateModelFormatPrioritySame(&servingRuntime.Spec); err != nil {
-			return admission.Denied(fmt.Sprintf(ProrityIsNotSameServingRuntimeError, err.Error(), servingRuntime.Name))
-		}
-
 		if err := validateServingRuntimePriority(&servingRuntime.Spec, &ExistingRuntimes.Items[i].Spec, servingRuntime.Name, ExistingRuntimes.Items[i].Name); err != nil {
 			return admission.Denied(fmt.Sprintf(InvalidPriorityServingRuntimeError, err.Error(), ExistingRuntimes.Items[i].Name, servingRuntime.Name, servingRuntime.Namespace))
 		}
@@ -128,11 +127,11 @@ func (csr *ClusterServingRuntimeValidator) Handle(ctx context.Context, req admis
 	if clusterServingRuntime.Spec.IsDisabled() {
 		return admission.Allowed("")
 	}
+	if err := validateModelFormatPrioritySame(&clusterServingRuntime.Spec); err != nil {
+		return admission.Denied(fmt.Sprintf(ProrityIsNotSameClusterServingRuntimeError, err.Error(), clusterServingRuntime.Name))
+	}
 	existingRuntimeSpec := v1alpha1.ServingRuntimeSpec{}
 	for i := range ExistingRuntimes.Items {
-		if err := validateModelFormatPrioritySame(&clusterServingRuntime.Spec); err != nil {
-			return admission.Denied(fmt.Sprintf(ProrityIsNotSameClusterServingRuntimeError, err.Error(), clusterServingRuntime.Name))
-		}
 		if err := validateServingRuntimePriority(&clusterServingRuntime.Spec, &ExistingRuntimes.Items[i].Spec, clusterServingRuntime.Name, ExistingRuntimes.Items[i].Name); err != nil {
 			return admission.Denied(fmt.Sprintf(InvalidPriorityClusterServingRuntimeError, err.Error(), ExistingRuntimes.Items[i].Name, clusterServingRuntime.Name))
 		}

--- a/pkg/webhook/admission/servingruntime/servingruntime_webhook_test.go
+++ b/pkg/webhook/admission/servingruntime/servingruntime_webhook_test.go
@@ -1886,6 +1886,181 @@ func TestServingRuntimeValidator_Handle(t *testing.T) {
 			if tt.wantAllowed {
 				g.Expect(resp.Allowed).To(gomega.BeTrue())
 			}
+			if tt.wantDenied {
+				g.Expect(resp.Allowed).To(gomega.BeFalse())
+			}
+			if tt.wantStatusCode != 0 {
+				g.Expect(int(resp.Result.Code)).To(gomega.Equal(tt.wantStatusCode))
+			}
+		})
+	}
+}
+
+func TestClusterServingRuntimeValidator_Handle(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	tests := []struct {
+		name           string
+		setupObjs      []client.Object
+		runtime        *v1alpha1.ClusterServingRuntime
+		decoderErr     error
+		listErr        error
+		wantAllowed    bool
+		wantDenied     bool
+		wantStatusCode int
+	}{
+		{
+			name: "allow when cluster runtime is disabled",
+			runtime: &v1alpha1.ClusterServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{Name: "csr1"},
+				Spec: v1alpha1.ServingRuntimeSpec{
+					Disabled: proto.Bool(true),
+				},
+			},
+			wantAllowed: true,
+		},
+		{
+			name: "deny when model format priorities are not the same",
+			runtime: &v1alpha1.ClusterServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{Name: "csr2"},
+				Spec: v1alpha1.ServingRuntimeSpec{
+					SupportedModelFormats: []v1alpha1.SupportedModelFormat{
+						{Name: "onnx", AutoSelect: proto.Bool(true), Priority: proto.Int32(1)},
+						{Name: "onnx", AutoSelect: proto.Bool(true), Priority: proto.Int32(2)},
+					},
+				},
+			},
+			wantDenied: true,
+		},
+		{
+			name: "deny when cluster runtime priorities conflict with existing",
+			setupObjs: []client.Object{
+				&v1alpha1.ClusterServingRuntime{
+					ObjectMeta: metav1.ObjectMeta{Name: "csr3"},
+					Spec: v1alpha1.ServingRuntimeSpec{
+						MultiModel:       proto.Bool(true),
+						ProtocolVersions: []constants.InferenceServiceProtocol{constants.ProtocolV1},
+						SupportedModelFormats: []v1alpha1.SupportedModelFormat{
+							{Name: "onnx", AutoSelect: proto.Bool(true), Priority: proto.Int32(1)},
+						},
+					},
+				},
+			},
+			runtime: &v1alpha1.ClusterServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{Name: "csr4"},
+				Spec: v1alpha1.ServingRuntimeSpec{
+					MultiModel:       proto.Bool(true),
+					ProtocolVersions: []constants.InferenceServiceProtocol{constants.ProtocolV1},
+					SupportedModelFormats: []v1alpha1.SupportedModelFormat{
+						{Name: "onnx", AutoSelect: proto.Bool(true), Priority: proto.Int32(1)},
+					},
+				},
+			},
+			wantDenied: true,
+		},
+		{
+			name: "deny when multinode spec is invalid (removing workerSpec)",
+			setupObjs: []client.Object{
+				&v1alpha1.ClusterServingRuntime{
+					ObjectMeta: metav1.ObjectMeta{Name: "csr5"},
+					Spec: v1alpha1.ServingRuntimeSpec{
+						WorkerSpec: &v1alpha1.WorkerSpec{
+							ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+								Containers: []corev1.Container{{Name: "worker"}},
+							},
+						},
+					},
+				},
+			},
+			runtime: &v1alpha1.ClusterServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{Name: "csr5"},
+				Spec:       v1alpha1.ServingRuntimeSpec{},
+			},
+			wantDenied: true,
+		},
+		{
+			name: "deny when blocked env var is set",
+			runtime: &v1alpha1.ClusterServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{Name: "csr-blocked-env"},
+				Spec: v1alpha1.ServingRuntimeSpec{
+					ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  constants.InferenceServiceContainerName,
+								Image: "kserve/sklearnserver:latest",
+								Env: []corev1.EnvVar{
+									{Name: "PYTHONPATH", Value: "/custom"},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantDenied: true,
+		},
+		{
+			name: "allow valid cluster runtime",
+			setupObjs: []client.Object{
+				&v1alpha1.ClusterServingRuntime{
+					ObjectMeta: metav1.ObjectMeta{Name: "csr6"},
+					Spec: v1alpha1.ServingRuntimeSpec{
+						MultiModel:       proto.Bool(true),
+						ProtocolVersions: []constants.InferenceServiceProtocol{constants.ProtocolV1},
+						SupportedModelFormats: []v1alpha1.SupportedModelFormat{
+							{Name: "onnx", AutoSelect: proto.Bool(true), Priority: proto.Int32(1)},
+						},
+					},
+				},
+			},
+			runtime: &v1alpha1.ClusterServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{Name: "csr7"},
+				Spec: v1alpha1.ServingRuntimeSpec{
+					MultiModel:       proto.Bool(true),
+					ProtocolVersions: []constants.InferenceServiceProtocol{constants.ProtocolV1},
+					SupportedModelFormats: []v1alpha1.SupportedModelFormat{
+						{Name: "onnx", AutoSelect: proto.Bool(true), Priority: proto.Int32(2)},
+					},
+				},
+			},
+			wantAllowed: true,
+		},
+		{
+			name:           "error decoding request",
+			runtime:        &v1alpha1.ClusterServingRuntime{},
+			decoderErr:     errors.New("decode error"),
+			wantStatusCode: http.StatusBadRequest,
+		},
+		{
+			name: "error listing cluster runtimes",
+			runtime: &v1alpha1.ClusterServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{Name: "csr8"},
+			},
+			listErr:        errors.New("list error"),
+			wantStatusCode: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := &fakeClient{
+				objs:    tt.setupObjs,
+				listErr: tt.listErr,
+			}
+			fakeDecoder := &fakeDecoder{
+				obj: tt.runtime,
+				err: tt.decoderErr,
+			}
+			validator := &ClusterServingRuntimeValidator{
+				Client:  fakeClient,
+				Decoder: fakeDecoder,
+			}
+			resp := validator.Handle(t.Context(), admission.Request{})
+			if tt.wantAllowed {
+				g.Expect(resp.Allowed).To(gomega.BeTrue())
+			}
+			if tt.wantDenied {
+				g.Expect(resp.Allowed).To(gomega.BeFalse())
+			}
 			if tt.wantStatusCode != 0 {
 				g.Expect(int(resp.Result.Code)).To(gomega.Equal(tt.wantStatusCode))
 			}
@@ -1903,17 +2078,22 @@ func (f *fakeClient) List(ctx context.Context, list client.ObjectList, opts ...c
 	if f.listErr != nil {
 		return f.listErr
 	}
-	if l, ok := list.(*v1alpha1.ServingRuntimeList); ok {
+	switch l := list.(type) {
+	case *v1alpha1.ServingRuntimeList:
 		for _, obj := range f.objs {
 			if sr, ok := obj.(*v1alpha1.ServingRuntime); ok {
 				l.Items = append(l.Items, *sr)
 			}
 		}
+	case *v1alpha1.ClusterServingRuntimeList:
+		for _, obj := range f.objs {
+			if csr, ok := obj.(*v1alpha1.ClusterServingRuntime); ok {
+				l.Items = append(l.Items, *csr)
+			}
+		}
 	}
 	return nil
 }
-
-// ...
 
 type fakeDecoder struct {
 	admission.Decoder
@@ -1925,8 +2105,11 @@ func (f *fakeDecoder) Decode(_ admission.Request, into runtime.Object) error {
 	if f.err != nil {
 		return f.err
 	}
-	if v, ok := into.(*v1alpha1.ServingRuntime); ok {
+	switch v := into.(type) {
+	case *v1alpha1.ServingRuntime:
 		*v = *(f.obj.(*v1alpha1.ServingRuntime))
+	case *v1alpha1.ClusterServingRuntime:
+		*v = *(f.obj.(*v1alpha1.ClusterServingRuntime))
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Re-enables the `ClusterServingRuntime` CRD and validating webhook in the ODH/RHOAI kustomize overlays. They were previously removed via `$patch: delete`, which blocks ClusterServingRuntime install and the runtimes team's CLI/GitOps CSR work (e.g. odh-model-controller#862, [RHOAIENG-71865](https://redhat.atlassian.net/browse/RHOAIENG-71865)).

Also fixes ServingRuntime/ClusterServingRuntime validators so model-format priority consistency is checked even when no existing runtimes are listed, and adds unit coverage for `ClusterServingRuntimeValidator`.

**Which issue(s) this PR fixes**:
Fixes https://redhat.atlassian.net/browse/RHOAIENG-76590

**Feature/Issue validation/testing**:

- [x] `go test ./pkg/webhook/admission/servingruntime/`
- [x] `kustomize build config/overlays/odh-crds` includes `clusterservingruntimes.serving.kserve.io`
- [x] `kustomize build config/overlays/odh` includes ValidatingWebhookConfiguration `clusterservingruntime.serving.kserve.io` with OpenShift CA inject annotation

**Special notes for your reviewer**:

- Default CSR *instances* are not added here; those land via odh-model-controller (opendatahub-io/odh-model-controller#862).
- OpenShift CA injection for the re-enabled webhook uses the existing `openshift-ca-patch.yaml` selector on ValidatingWebhookConfigurations.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note
Enable ClusterServingRuntime CRD and validating webhook in ODH/RHOAI installs
```

Made with [Cursor](https://cursor.com)

[RHOAIENG-71865]: https://redhat.atlassian.net/browse/RHOAIENG-71865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Updated deployment configuration so legacy removal of cluster-scoped serving runtime resources (including the related CRD and validating webhook) is no longer applied.
  * CI/E2E setup now installs **ClusterServingRuntimes** as cluster-scoped resources (no longer rewritten to namespaced ServingRuntimes).

* **Bug Fixes**
  * Improved serving runtime admission validation so model-format priority conflicts are detected earlier and consistently for both serving and cluster runtimes.

* **Tests**
  * Expanded admission and controller test coverage for cluster-scoped serving runtime scenarios and adjusted supporting test fixtures accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->