### PR TITLE
fix(kserve-module): apply image params to base overlay on XKS

### DIFF
--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -306,8 +306,10 @@ func (r *KserveModuleReconciler) reconcileComponent(ctx context.Context,
 		sourcePath = comp.sourcePathXKS
 	}
 
+	// Image params live in the base overlay (e.g. overlays/odh/params.env), not
+	// the XKS overlay whose params.env only carries cert-manager keys.
 	if err := applyParams(
-		filepath.Join(manifestDir, comp.dirName(), sourcePath),
+		filepath.Join(manifestDir, comp.dirName(), comp.sourcePath),
 		comp.imageMap,
 	); err != nil {
 		return nil, fmt.Errorf("applying %s image params: %w", comp.name, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
applyParams() reads odh-xks/params.env on XKS, which has no image keys — only cert-manager params. Image keys are in odh/params.env (base overlay), so RELATED_IMAGE env vars silently do nothing.

Fix: use comp.sourcePath (base) instead of resolved sourcePath for image param step. Matches odh-operator Init() pattern.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://redhat.atlassian.net/browse/RHOAIENG-79035


**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Kubernetes rendering to apply image configuration from the base deployment settings.
  * Prevented image-related parameters from being incorrectly read from the XKS overlay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->