### PR TITLE
[RHOAIENG-79440] Add named e2e suite targets to Makefile

### DIFF
--- a/Makefile.ocp.mk
+++ b/Makefile.ocp.mk
@@ -7,6 +7,9 @@
 # non-surgically; it will destroy workloads it did not create.
 
 E2E_MARKER ?= predictor
+E2E_PARALLELISM ?= 6
+E2E_PROFILE ?=
+SETUP_E2E ?= false
 QUAY_REPO ?=
 GITHUB_SHA ?= master
 
@@ -78,13 +81,29 @@ deploy-e2e-ocp: ## Set up E2E test environment on OpenShift. Use OPERATOR_TYPE=o
 	GITHUB_SHA="$(GITHUB_SHA)" \
 	./test/scripts/openshift-ci/setup-e2e-tests.sh "$(E2E_MARKER)"
 
-run-e2e-ocp: ## Run E2E tests (assumes deploy-e2e-ocp already ran).
-	SETUP_E2E=false \
+run-e2e-ocp: ## Run E2E tests. Set SETUP_E2E=false to skip cluster setup (assumes deploy-e2e-ocp already ran).
+	SETUP_E2E="$(SETUP_E2E)" \
 	OPERATOR_TYPE="$(strip $(OPERATOR_TYPE))" \
 	KSERVE_NAMESPACE="$(strip $(KSERVE_NAMESPACE))" \
 	RUNNING_LOCAL="$(strip $(RUNNING_LOCAL))" \
 	PYTEST_ARGS="$(PYTEST_ARGS)" \
-	./test/scripts/openshift-ci/run-e2e-tests.sh "$(E2E_MARKER)"
+	./test/scripts/openshift-ci/run-e2e-tests.sh "$(E2E_MARKER)" "$(E2E_PARALLELISM)" "$(E2E_PROFILE)"
+
+e2e-graph-ocp: ## Run graph E2E suite.
+	$(MAKE) run-e2e-ocp E2E_MARKER="graph" E2E_PARALLELISM="$(E2E_PARALLELISM)" E2E_PROFILE=raw SETUP_E2E=true
+
+e2e-raw-ocp: ## Run raw E2E suite (includes rawcipn phase).
+	$(MAKE) run-e2e-ocp E2E_MARKER="raw" E2E_PARALLELISM="$(E2E_PARALLELISM)" SETUP_E2E=true
+	oc patch configmaps -n $(KSERVE_NAMESPACE) inferenceservice-config \
+	  --patch '{"data":{"service":"{\"serviceClusterIPNone\": true}"}}'
+	sleep 5
+	$(MAKE) run-e2e-ocp E2E_MARKER="rawcipn" E2E_PARALLELISM=1 E2E_PROFILE=raw SETUP_E2E=false
+
+e2e-predictor-ocp: ## Run predictor E2E suite.
+	$(MAKE) run-e2e-ocp E2E_MARKER="predictor or kserve_on_openshift" E2E_PARALLELISM="$(E2E_PARALLELISM)" SETUP_E2E=true
+
+e2e-llmisvc-ocp: ## Run LLMISvc E2E suite.
+	$(MAKE) run-e2e-ocp E2E_MARKER="llmisvc_core and cluster_cpu and not pvc_storage" E2E_PARALLELISM=2 E2E_PROFILE=llm-d SETUP_E2E=true
 
 reset-e2e-ocp: ## Reset the test namespace for a fresh E2E rerun.
 	./test/scripts/openshift-ci/setup-ci-namespace.sh

--- a/Makefile.ocp.mk
+++ b/Makefile.ocp.mk
@@ -93,14 +93,14 @@ e2e-graph-ocp: ## Run graph E2E suite.
 	$(MAKE) run-e2e-ocp E2E_MARKER="graph" E2E_PARALLELISM="$(E2E_PARALLELISM)" E2E_PROFILE=raw SETUP_E2E=true
 
 e2e-raw-ocp: ## Run raw E2E suite (includes rawcipn phase).
-	$(MAKE) run-e2e-ocp E2E_MARKER="raw" E2E_PARALLELISM="$(E2E_PARALLELISM)" SETUP_E2E=true
+	$(MAKE) run-e2e-ocp E2E_MARKER="raw" E2E_PARALLELISM="$(E2E_PARALLELISM)" E2E_PROFILE=raw SETUP_E2E=true
 	oc patch configmaps -n $(KSERVE_NAMESPACE) inferenceservice-config \
 	  --patch '{"data":{"service":"{\"serviceClusterIPNone\": true}"}}'
 	sleep 5
 	$(MAKE) run-e2e-ocp E2E_MARKER="rawcipn" E2E_PARALLELISM=1 E2E_PROFILE=raw SETUP_E2E=false
 
 e2e-predictor-ocp: ## Run predictor E2E suite.
-	$(MAKE) run-e2e-ocp E2E_MARKER="predictor or kserve_on_openshift" E2E_PARALLELISM="$(E2E_PARALLELISM)" SETUP_E2E=true
+	$(MAKE) run-e2e-ocp E2E_MARKER="predictor or kserve_on_openshift" E2E_PARALLELISM="$(E2E_PARALLELISM)" E2E_PROFILE=raw SETUP_E2E=true
 
 e2e-llmisvc-ocp: ## Run LLMISvc E2E suite.
 	$(MAKE) run-e2e-ocp E2E_MARKER="llmisvc_core and cluster_cpu and not pvc_storage" E2E_PARALLELISM=2 E2E_PROFILE=llm-d SETUP_E2E=true

--- a/test/scripts/openshift-ci/run-e2e-tests.sh
+++ b/test/scripts/openshift-ci/run-e2e-tests.sh
@@ -93,6 +93,8 @@ if [ "$SETUP_E2E" = "true" ]; then
   popd
 fi
 
+export OPT_125M_MODEL_URI="${OPT_125M_MODEL_URI:-s3://example-models/facebook/opt-125m}"
+
 # Use certify go module to get the CA certs
 # For serverless it is configured here: infra/deploy.serverless.sh
 # For Raw: setup-e2e-tests.sh


### PR DESCRIPTION
## Summary
- Add canonical named e2e suite targets (`e2e-graph-ocp`, `e2e-raw-ocp`, `e2e-predictor-ocp`, `e2e-llmisvc-ocp`) to `Makefile.ocp.mk`
- Extend `run-e2e-ocp` with `E2E_PARALLELISM`, `E2E_PROFILE`, and `SETUP_E2E` args
- Raw suite includes rawcipn second phase (configmap patch + headless service retest)
- Prow values are source of truth for markers; CI systems override `E2E_PARALLELISM` only
- `SETUP_E2E` defaults to `false` for backward compat; named suites pass `true`
- Fix: export `OPT_125M_MODEL_URI` in `run-e2e-tests.sh` -- `setup-e2e-tests.sh` exports it but runs as a subprocess, so the var is lost. pytest falls back to `hf://` and downloads ~500MB from HuggingFace, timing out on slow clusters.

## Motivation
Prow and Konflux inline their own pytest invocations which have drifted (different markers, missing rawcipn phase). This PR creates a single source of truth in the Makefile.

## Involved repos
- **This PR**: opendatahub-io/kserve (Makefile targets)
- openshift/release (consume targets)
- opendatahub-io/odh-konflux-central (consume targets)

## Test plan
- Dry-run verified locally for all suite targets
- Prow rehearsal on openshift/release PR (after this merges)
- Konflux group-test pipeline run (after this merges)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable parallelism and profile selection for OpenShift end-to-end test runs.
  * Added dedicated commands for graph, raw, predictor, and LLM inference service E2E suites.
  * Enabled passing additional runtime options when launching OpenShift E2E tests.
* **Improvements**
  * Enhanced the raw OpenShift suite to run multiple phases with the necessary in-environment adjustment.
  * Introduced a default model URI for the 125M OPT E2E workflow when not already set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->