### PR TITLE
fix(e2e): poll for resource deletion instead of immediate assert for kserve-module

### DIFF
--- a/kserve-module/tests/e2e/test_lifecycle.py
+++ b/kserve-module/tests/e2e/test_lifecycle.py
@@ -307,7 +307,13 @@ class TestDeletionRecovery:
         assert uid_before, f"{cm_name} should exist before deletion"
 
         run([kubectl, "delete", "configmap", cm_name, "-n", NAMESPACE])
-        assert not resource_exists(kubectl, "configmap", cm_name, namespace=NAMESPACE)
+
+        def assert_cm_deleted():
+            assert not resource_exists(kubectl, "configmap", cm_name, namespace=NAMESPACE), (
+                f"{cm_name} should be deleted"
+            )
+
+        wait_for(assert_cm_deleted, timeout=TIMEOUT_120S, interval=5)
 
         def assert_recreated_with_new_uid():
             uid_after = get_jsonpath(

--- a/kserve-module/tests/e2e/test_modelcache.py
+++ b/kserve-module/tests/e2e/test_modelcache.py
@@ -16,6 +16,7 @@ from conftest import (
     generation_matches,
     trigger_reconcile,
     is_cr_ready,
+    wait_for,
     KSERVE_CR_NAME,
     NAMESPACE,
     PV_NAME,
@@ -273,27 +274,24 @@ class TestModelCacheRecovery:
 
     def test_deleted_lmng_is_recreated(self, kubectl, model_cache_enabled):
         """Deleting the LocalModelNodeGroup triggers recreation on next reconcile."""
-        import time
-
         assert resource_exists(kubectl, LMNG_RESOURCE, LMNG_NAME), (
             f"{LMNG_NAME} should exist before deletion"
         )
 
         run([kubectl, "delete", LMNG_RESOURCE, LMNG_NAME])
-        assert not resource_exists(kubectl, LMNG_RESOURCE, LMNG_NAME), (
-            f"{LMNG_NAME} should be deleted"
-        )
+
+        def assert_lmng_deleted():
+            assert not resource_exists(kubectl, LMNG_RESOURCE, LMNG_NAME), (
+                f"{LMNG_NAME} should be deleted"
+            )
+
+        wait_for(assert_lmng_deleted, timeout=TIMEOUT_120S, interval=5)
 
         trigger_reconcile(kubectl)
 
-        # Poll for LMNG recreation — the controller watch on LMNG triggers
-        # reconcile, but the resource creation happens during postRender.
-        deadline = time.time() + TIMEOUT_120S
-        while time.time() < deadline:
-            if resource_exists(kubectl, LMNG_RESOURCE, LMNG_NAME):
-                break
-            time.sleep(5)
+        def assert_lmng_recreated():
+            assert resource_exists(kubectl, LMNG_RESOURCE, LMNG_NAME), (
+                f"{LMNG_NAME} should be recreated after reconcile"
+            )
 
-        assert resource_exists(kubectl, LMNG_RESOURCE, LMNG_NAME), (
-            f"{LMNG_NAME} should be recreated after reconcile"
-        )
+        wait_for(assert_lmng_recreated, timeout=TIMEOUT_120S, interval=5)


### PR DESCRIPTION
**What this PR does / why we need it**:

`kubectl delete` is async — the resource may still exist when the next assertion runs. `test_deleted_lmng_is_recreated` fails intermittently because it asserts deletion immediately without polling.

Wraps deletion checks with `wait_for()` to poll until the resource is gone, matching the pattern already used for recreation checks in the same test suite.

Fixed:
- `test_modelcache.py::test_deleted_lmng_is_recreated` — LMNG deletion + recreation assertions
- `test_lifecycle.py::test_configmap_recovered_after_deletion` — ConfigMap deletion assertion

**Which issue(s) this PR fixes**:
Fixes flaky `test_deleted_lmng_is_recreated`

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end validation for recovery after ConfigMap deletion by waiting for confirmed deletion.
  * Improved LocalModelNodeGroup recovery checks by waiting for deletion and recreation to complete.
  * Reduced test flakiness by replacing immediate assertions and manual polling with reliable wait conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->