### PR TITLE
ci(e2e): add kserve-module deploy path to openshift-ci setup

### DIFF
--- a/test/scripts/openshift-ci/deploy.kserve-manual.sh
+++ b/test/scripts/openshift-ci/deploy.kserve-manual.sh
@@ -41,9 +41,6 @@ source "${SCRIPT_DIR}/common.sh"
 make -C "${PROJECT_ROOT}" yq
 export PATH="${PROJECT_ROOT}/bin:${PATH}"
 
-# Cluster-level autoscaler is not managed by an operator in manual mode
-"${SCRIPT_DIR}/deploy.cma.sh"
-
 PARAMS_ENV="${PROJECT_ROOT}/config/overlays/odh/params.env"
 
 # When QUAY_REPO is set, prefer locally-built images (tagged :${GITHUB_SHA:-master})

--- a/test/scripts/openshift-ci/infra/verify-autoscaling-health.sh
+++ b/test/scripts/openshift-ci/infra/verify-autoscaling-health.sh
@@ -27,7 +27,7 @@
 set -euo pipefail
 
 : "${KEDA_NAMESPACE:=openshift-keda}"
-WVA_NAMESPACE="wva-system"
+: "${WVA_NAMESPACE:=wva-system}"
 WVA_DEPLOY="workload-variant-autoscaler-controller-manager"
 
 retry() {

--- a/test/scripts/openshift-ci/setup-kserve.sh
+++ b/test/scripts/openshift-ci/setup-kserve.sh
@@ -42,7 +42,13 @@ source "${SCRIPT_DIR}/version.sh"
 case "${OPERATOR_TYPE}" in
   rhods|rhoai)     : "${KSERVE_NAMESPACE:=redhat-ods-applications}" ;;
   odh|opendatahub) : "${KSERVE_NAMESPACE:=opendatahub}" ;;
-  "")              : "${KSERVE_NAMESPACE:=kserve}" ;;
+  "")
+    if [[ -n "${KSERVE_MODULE_CONTROLLER_IMAGE:-}" ]]; then
+      : "${KSERVE_NAMESPACE:=opendatahub}"
+    else
+      : "${KSERVE_NAMESPACE:=kserve}"
+    fi
+    ;;
   *)               echo "Unknown OPERATOR_TYPE '${OPERATOR_TYPE}'"; exit 1 ;;
 esac
 export KSERVE_NAMESPACE
@@ -53,16 +59,9 @@ export KSERVE_NAMESPACE
 make -C "${PROJECT_ROOT}" yq
 export PATH="${PROJECT_ROOT}/bin:${PATH}"
 
-# Ensure the target namespace exists before the install scripts apply resources.
-oc new-project "${KSERVE_NAMESPACE}" || true
-
-# --- Dispatch to the selected install method ---
-case "${OPERATOR_TYPE}" in
-  odh|opendatahub|rhoai|rhods) "${SCRIPT_DIR}/deploy.odh.sh" ;;
-  "")                          "${SCRIPT_DIR}/deploy.kserve-manual.sh" "${1:-}" ;;
-esac
-
-# --- Common post-install steps (apply to all install methods) ---
+# Dependencies: cert-manager, LeaderWorkerSet, Gateway API, Kuadrant.
+# Cluster-level autoscaler is not managed by an operator in manual mode
+"${SCRIPT_DIR}/deploy.cma.sh"
 
 # On OCP 4.20 and earlier, InferencePool lives in the x-k8s.io API group.
 # OCP 4.21+ ships the GA API group (inference.networking.k8s.io).
@@ -76,6 +75,7 @@ if [[ -z "${INFERENCE_POOL_GROUP:-}" ]]; then
     echo "OCP $server_version (${ocp_major_minor}): skipping setting INFERENCE_POOL_GROUP env variable."
   fi
 fi
+
 
 # LLMISvc dependencies: cert-manager, LeaderWorkerSet, Gateway API, Kuadrant.
 # These are core cluster infrastructure required for LLMInferenceService to function.
@@ -100,7 +100,18 @@ fi
 # by the ODH overlay (config/overlays/odh/patches/inferenceservice-config-patch.yaml).
 if [[ "${1:-}" =~ "autoscaling_keda" ]]; then
   echo "Setting up KEDA autoscaling infrastructure for LLMISVC..."
-  "${SCRIPT_DIR}/infra/deploy.wva.sh"
+
+  if [[ -n "${KSERVE_MODULE_CONTROLLER_IMAGE:-}" ]]; then
+    # kserve-module deploys WVA via Kserve CR patch
+    oc patch kserve/default-kserve --type=merge \
+      -p '{"spec":{"wva":{"managementState":"Managed"}}}'
+    oc wait kserve/default-kserve \
+      --for=jsonpath='{.status.conditions[?(@.type=="Ready")].status}'=True \
+      --timeout=300s
+  else
+    "${SCRIPT_DIR}/infra/deploy.wva.sh"
+  fi
+
   "${SCRIPT_DIR}/infra/deploy.keda-thanos-auth.sh"
 
   echo "Restarting llmisvc-controller-manager to pick up autoscaling config..."
@@ -108,9 +119,73 @@ if [[ "${1:-}" =~ "autoscaling_keda" ]]; then
   wait_for_pod_ready "${KSERVE_NAMESPACE}" "control-plane=llmisvc-controller-manager" 300s
 
   echo "Running KEDA autoscaling pipeline health check..."
-  KSERVE_NAMESPACE="${KSERVE_NAMESPACE}" "${SCRIPT_DIR}/infra/verify-autoscaling-health.sh"
+  if [[ -n "${KSERVE_MODULE_CONTROLLER_IMAGE:-}" ]]; then
+    KSERVE_NAMESPACE="${KSERVE_NAMESPACE}" WVA_NAMESPACE="${KSERVE_NAMESPACE}" \
+      "${SCRIPT_DIR}/infra/verify-autoscaling-health.sh"
+  else
+    KSERVE_NAMESPACE="${KSERVE_NAMESPACE}" "${SCRIPT_DIR}/infra/verify-autoscaling-health.sh"
+  fi
   echo "KEDA autoscaling infrastructure ready"
 fi
+
+# --- Common post-install steps (apply to all install methods) ---
+
+# Ensure the target namespace exists before the install scripts apply resources.
+oc new-project "${KSERVE_NAMESPACE}" || true
+
+# --- Dispatch to the selected install method ---
+case "${OPERATOR_TYPE}" in
+  odh|opendatahub|rhoai|rhods) "${SCRIPT_DIR}/deploy.odh.sh" ;;
+  "")
+    if [[ -n "${KSERVE_MODULE_CONTROLLER_IMAGE:-}" ]]; then
+      "${PROJECT_ROOT}/kserve-module/tests/scripts/setup-cluster.sh" \
+        --platform ocp \
+        --skip-deps \
+        --image "${KSERVE_MODULE_CONTROLLER_IMAGE}"
+
+      # Override operand images on kserve-module controller via RELATED_IMAGE_* env vars
+      _env_overrides=()
+      [[ -n "${KSERVE_CONTROLLER_IMAGE:-}" ]] && \
+        _env_overrides+=("RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE=${KSERVE_CONTROLLER_IMAGE}")
+      [[ -n "${LLMISVC_CONTROLLER_IMAGE:-}" ]] && \
+        _env_overrides+=("RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE=${LLMISVC_CONTROLLER_IMAGE}")
+      [[ -n "${KSERVE_AGENT_IMAGE:-}" ]] && \
+        _env_overrides+=("RELATED_IMAGE_ODH_KSERVE_AGENT_IMAGE=${KSERVE_AGENT_IMAGE}")
+      [[ -n "${KSERVE_ROUTER_IMAGE:-}" ]] && \
+        _env_overrides+=("RELATED_IMAGE_ODH_KSERVE_ROUTER_IMAGE=${KSERVE_ROUTER_IMAGE}")
+      [[ -n "${STORAGE_INITIALIZER_IMAGE:-}" ]] && \
+        _env_overrides+=("RELATED_IMAGE_ODH_KSERVE_STORAGE_INITIALIZER_IMAGE=${STORAGE_INITIALIZER_IMAGE}")
+
+      if [[ ${#_env_overrides[@]} -gt 0 ]]; then
+        echo "Overriding operand images on kserve-module-controller-manager..."
+        oc set env deployment/kserve-module-controller-manager \
+          "${_env_overrides[@]}" \
+          -n "${KSERVE_NAMESPACE}"
+        oc rollout status deployment/kserve-module-controller-manager \
+          -n "${KSERVE_NAMESPACE}" --timeout=120s
+      fi
+
+      # Create Kserve CR to trigger reconciliation (deploys operands + ConfigMap)
+      echo "Creating Kserve CR..."
+      oc apply -f - <<'KSERVE_CR'
+apiVersion: components.platform.opendatahub.io/v1alpha1
+kind: Kserve
+metadata:
+  name: default-kserve
+spec:
+  managementState: Managed
+KSERVE_CR
+      sleep 5
+      echo "Waiting for Kserve CR to become Ready..."
+      oc wait kserve/default-kserve \
+        --for=jsonpath='{.status.conditions[?(@.type=="Ready")].status}'=True \
+        --timeout=300s
+    else
+      "${SCRIPT_DIR}/deploy.kserve-manual.sh" "${1:-}"
+    fi
+    ;;
+esac
+
 
 # Early CA cert extraction for raw deployments. This reads from cluster-wide namespaces
 # (not KSERVE_NAMESPACE) so it can run immediately after the install.
@@ -135,6 +210,12 @@ fi
 # Patch inferenceservice-config with the cluster ingress domain and restart the controller.
 echo "Patching ingress domain..."
 export OPENSHIFT_INGRESS_DOMAIN
+
+if [[ -n "${KSERVE_MODULE_CONTROLLER_IMAGE:-}" ]]; then
+  oc annotate configmap inferenceservice-config -n "${KSERVE_NAMESPACE}" \
+    opendatahub.io/managed=false --overwrite
+fi
+
 OPENSHIFT_INGRESS_DOMAIN=$(oc get ingresses.config cluster -o jsonpath='{.spec.domain}')
 INGRESS_DATA=$(oc get configmap inferenceservice-config -n "${KSERVE_NAMESPACE}" \
   -o jsonpath='{.data.ingress}' | \
@@ -148,7 +229,7 @@ oc wait --for=condition=ready pod -l control-plane=kserve-controller-manager \
   -n "${KSERVE_NAMESPACE}" --timeout=300s
 
 # Install or wait for ODH Model Controller depending on install method.
-if [[ -z "${OPERATOR_TYPE}" ]]; then
+if [[ -z "${OPERATOR_TYPE}" && -z "${KSERVE_MODULE_CONTROLLER_IMAGE:-}" ]]; then
   # Manual: install odh-model-controller directly via kustomize.
   # TODO: can be moved to odh-test overlays
   echo "Installing ODH Model Controller manually..."


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds kserve-module as an alternative KServe install method in openshift-ci `setup-kserve.sh`. When `KSERVE_MODULE_CONTROLLER_IMAGE` env var is set, the script deploys via `kserve-module/tests/scripts/setup-cluster.sh` instead of the manual kustomize path (`deploy.kserve-manual.sh`).

Changes:
- Dispatch to `setup-cluster.sh --platform ocp --skip-deps` when `KSERVE_MODULE_CONTROLLER_IMAGE` is set
- Inject `RELATED_IMAGE_*` env vars on kserve-module-controller-manager for operand image overrides
- Create Kserve CR and wait for Ready=True before post-install steps
- Default `KSERVE_NAMESPACE` to `opendatahub` for kserve-module path
- Annotate `inferenceservice-config` with `opendatahub.io/managed=false` to prevent SSA rollback of ingress domain patch
- WVA activation via Kserve CR patch in `autoscaling_keda` path (instead of `deploy.wva.sh`)
- Make `WVA_NAMESPACE` configurable in `verify-autoscaling-health.sh`
- Move `deploy.cma.sh` call to `setup-kserve.sh` (shared dependency across install methods)
- Skip manual ODH MC install when kserve-module is active

**Which issue(s) this PR fixes**:
https://redhat.atlassian.net/browse/RHOAIENG-79316

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring KServe with an optional module controller image.
  * Added readiness checks and managed-state configuration for KServe autoscaling.
  * Added conditional setup for KServe modules and autoscaling infrastructure.

* **Bug Fixes**
  * Preserved custom `WVA_NAMESPACE` values during autoscaling health checks.
  * Improved installation behavior across supported KServe deployment modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->