### PR TITLE
chore: sync upstream/master to odh/master

### DIFF
--- a/.github/workflows/precommit-check.yml
+++ b/.github/workflows/precommit-check.yml
@@ -40,6 +40,12 @@ jobs:
           go mod download
           cd qpext && go mod download
 
+      - name: Cache openapi-generator JAR
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: hack/python-sdk/openapi-generator-cli-*.jar
+          key: openapi-generator-${{ hashFiles('hack/python-sdk/client-gen.sh') }}
+
       - name: Check
         shell: bash
         run: |

--- a/charts/_common/common-patches/configmap-patch.yaml
+++ b/charts/_common/common-patches/configmap-patch.yaml
@@ -101,10 +101,10 @@ data:
   storageInitializer: |-
     {
         "image" : "{{ .Values.kserve.storage.image }}:{{ .Values.kserve.storage.tag | default .Values.kserve.version }}",
-        "memoryRequest": "100Mi",
-        "memoryLimit": "1Gi",
-        "cpuRequest": "100m",
-        "cpuLimit": "1",
+        "memoryRequest": "{{ .Values.kserve.storage.resources.requests.memory }}",
+        "memoryLimit": "{{ .Values.kserve.storage.resources.limits.memory }}",
+        "cpuRequest": "{{ .Values.kserve.storage.resources.requests.cpu }}",
+        "cpuLimit": "{{ .Values.kserve.storage.resources.limits.cpu }}",
         "caBundleConfigMapName": "{{ .Values.kserve.storage.caBundleConfigMapName }}",
         "caBundleVolumeMountPath": "{{ .Values.kserve.storage.caBundleVolumeMountPath }}",
         "enableModelcar": {{ .Values.kserve.storage.enableModelcar }},

--- a/charts/kserve-llmisvc-resources/files/common/configmap-patch.yaml
+++ b/charts/kserve-llmisvc-resources/files/common/configmap-patch.yaml
@@ -101,10 +101,10 @@ data:
   storageInitializer: |-
     {
         "image" : "{{ .Values.kserve.storage.image }}:{{ .Values.kserve.storage.tag | default .Values.kserve.version }}",
-        "memoryRequest": "100Mi",
-        "memoryLimit": "1Gi",
-        "cpuRequest": "100m",
-        "cpuLimit": "1",
+        "memoryRequest": "{{ .Values.kserve.storage.resources.requests.memory }}",
+        "memoryLimit": "{{ .Values.kserve.storage.resources.limits.memory }}",
+        "cpuRequest": "{{ .Values.kserve.storage.resources.requests.cpu }}",
+        "cpuLimit": "{{ .Values.kserve.storage.resources.limits.cpu }}",
         "caBundleConfigMapName": "{{ .Values.kserve.storage.caBundleConfigMapName }}",
         "caBundleVolumeMountPath": "{{ .Values.kserve.storage.caBundleVolumeMountPath }}",
         "enableModelcar": {{ .Values.kserve.storage.enableModelcar }},

--- a/charts/kserve-resources/files/common/configmap-patch.yaml
+++ b/charts/kserve-resources/files/common/configmap-patch.yaml
@@ -101,10 +101,10 @@ data:
   storageInitializer: |-
     {
         "image" : "{{ .Values.kserve.storage.image }}:{{ .Values.kserve.storage.tag | default .Values.kserve.version }}",
-        "memoryRequest": "100Mi",
-        "memoryLimit": "1Gi",
-        "cpuRequest": "100m",
-        "cpuLimit": "1",
+        "memoryRequest": "{{ .Values.kserve.storage.resources.requests.memory }}",
+        "memoryLimit": "{{ .Values.kserve.storage.resources.limits.memory }}",
+        "cpuRequest": "{{ .Values.kserve.storage.resources.requests.cpu }}",
+        "cpuLimit": "{{ .Values.kserve.storage.resources.limits.cpu }}",
         "caBundleConfigMapName": "{{ .Values.kserve.storage.caBundleConfigMapName }}",
         "caBundleVolumeMountPath": "{{ .Values.kserve.storage.caBundleVolumeMountPath }}",
         "enableModelcar": {{ .Values.kserve.storage.enableModelcar }},

--- a/charts/kserve-resources/files/kserve/resources.yaml
+++ b/charts/kserve-resources/files/kserve/resources.yaml
@@ -100,19 +100,6 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - mutatingwebhookconfigurations
-  - validatingwebhookconfigurations
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - apps
   resources:
   - deployments

--- a/cmd/router/main_test.go
+++ b/cmd/router/main_test.go
@@ -18,8 +18,10 @@ package main
 
 import (
 	"bytes"
+	"context"
 	crand "crypto/rand"
 	"encoding/json"
+	"errors"
 	"io"
 	"math/big"
 	"net/http"
@@ -32,6 +34,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"knative.dev/pkg/apis"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha1"
@@ -926,7 +929,7 @@ func TestServerTimeout(t *testing.T) {
 		{
 			name:                "timeout",
 			serverTimeout:       Int64Ptr(1),
-			serviceStepDuration: 500 * time.Millisecond,
+			serviceStepDuration: 1 * time.Second,
 			expectError:         true,
 		},
 		{
@@ -940,6 +943,7 @@ func TestServerTimeout(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			drainSleepDuration = 0 * time.Millisecond // instant shutdown
+			isShuttingDown = false
 
 			// Setup and start dummy models
 			model1 := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -1018,20 +1022,35 @@ func TestServerTimeout(t *testing.T) {
 				time.Sleep(100 * time.Millisecond)        // wait for server to release port before next subtest
 			})
 
-			// Call the InferenceGraph
+			// Retry until the server is up instead of a fixed sleep.
 			client := &http.Client{}
-			time.Sleep(1 * time.Second) // prevent race condition
-			req, _ := http.NewRequest(http.MethodPost, "http://localhost:"+strconv.Itoa(constants.RouterPort), bytes.NewBuffer(nil))
-			resp, err := client.Do(req)
-			if resp != nil {
-				defer resp.Body.Close()
-			}
+			url := "http://localhost:" + strconv.Itoa(constants.RouterPort)
+			var statusCode int
+			var lastErr error
+			err = wait.PollUntilContextTimeout(t.Context(), 50*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+				req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewBuffer(nil))
+				if err != nil {
+					return false, err
+				}
+				resp, reqErr := client.Do(req)
+				if resp != nil {
+					defer resp.Body.Close()
+					statusCode = resp.StatusCode
+				}
+				lastErr = reqErr
+				if reqErr != nil && errors.Is(reqErr, syscall.ECONNREFUSED) {
+					return false, nil
+				}
+				return true, nil
+			})
+			require.NoError(t, err, "server did not become ready")
 
 			if testCase.expectError {
-				assert.Contains(t, err.Error(), "EOF")
+				require.Error(t, lastErr)
+				assert.Contains(t, lastErr.Error(), "EOF")
 			} else {
-				require.NoError(t, err)
-				assert.Equal(t, http.StatusOK, resp.StatusCode)
+				require.NoError(t, lastErr)
+				assert.Equal(t, http.StatusOK, statusCode)
 			}
 		})
 	}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -42,19 +42,6 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - mutatingwebhookconfigurations
-  - validatingwebhookconfigurations
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - apps
   resources:
   - deployments

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -55071,19 +55071,6 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - mutatingwebhookconfigurations
-  - validatingwebhookconfigurations
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - apps
   resources:
   - deployments

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -54657,19 +54657,6 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - admissionregistration.k8s.io
-  resources:
-  - mutatingwebhookconfigurations
-  - validatingwebhookconfigurations
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - apps
   resources:
   - deployments

--- a/pkg/apis/serving/v1alpha1/llm_inference_service_validation.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_validation.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/utils"
+	kservevalidation "github.com/kserve/kserve/pkg/validation"
 )
 
 // +kubebuilder:webhook:path=/validate-serving-kserve-io-v1alpha1-llminferenceservice,mutating=false,failurePolicy=fail,sideEffects=None,groups=serving.kserve.io,resources=llminferenceservices,verbs=create;update,versions=v1alpha1,name=llminferenceservice.kserve-webhook-server.v1alpha1.validator,admissionReviewVersions=v1
@@ -93,6 +94,8 @@ func (l *LLMInferenceServiceValidator) validate(ctx context.Context, prev *LLMIn
 	allErrs = append(allErrs, l.validateParallelismConstraints(llmSvc)...)
 	allErrs = append(allErrs, l.validateSchedulerConfig(llmSvc)...)
 	allErrs = append(allErrs, l.validateScaling(llmSvc)...)
+	allErrs = append(allErrs, l.validateLoRAAdapters(llmSvc)...)
+	allErrs = append(allErrs, kservevalidation.ValidateManagedDRAAnnotations(llmSvc.GetAnnotations())...)
 	allErrs = append(allErrs, l.validateImmutable(prev, llmSvc)...)
 
 	if len(allErrs) == 0 {
@@ -373,6 +376,16 @@ func (l *LLMInferenceServiceValidator) validateWorkloadScaling(basePath *field.P
 	// the scaling rules live in exactly one place.
 	w := convertWorkloadSpecToV1Alpha2(workload)
 	return v1alpha2.ValidateWorkloadScaling(basePath, &w)
+}
+
+func (l *LLMInferenceServiceValidator) validateLoRAAdapters(llmSvc *LLMInferenceService) field.ErrorList {
+	if llmSvc.Spec.Model.LoRA == nil {
+		return nil
+	}
+	// Convert to the hub (v1alpha2) type and delegate to its exported validator so
+	// the LoRA rules live in exactly one place.
+	hub := convertLoRASpecToV1Alpha2(llmSvc.Spec.Model.LoRA)
+	return v1alpha2.ValidateLoRAAdapters(hub, ptr.Deref(llmSvc.Spec.Model.Name, llmSvc.Name), field.NewPath("spec", "model", "lora"))
 }
 
 // immutable returns a *Error indicating "unsupported mutation".

--- a/pkg/apis/serving/v1alpha1/llm_inference_service_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_validation_test.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/apis"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/kserve/kserve/pkg/constants"
 )
 
 func newBaseLLMInferenceService() *LLMInferenceService {
@@ -831,6 +833,180 @@ func TestValidateTrafficFields_V1Alpha1(t *testing.T) {
 				}
 			} else {
 				assert.Empty(t, errs)
+			}
+		})
+	}
+}
+
+func TestValidateLoRAAdapters_V1Alpha1(t *testing.T) {
+	validator := &LLMInferenceServiceValidator{}
+
+	makeAdapter := func(name, uri string) LLMModelSpec {
+		return LLMModelSpec{URI: apis.URL{Scheme: "hf", Host: uri}, Name: ptr.To(name)}
+	}
+
+	makeSvc := func(modelName string, loraSpec *LoRASpec) *LLMInferenceService {
+		svc := newBaseLLMInferenceService()
+		svc.Spec.Model.Name = ptr.To(modelName)
+		svc.Spec.Model.LoRA = loraSpec
+		return svc
+	}
+
+	tests := []struct {
+		name           string
+		svc            *LLMInferenceService
+		wantErrCount   int
+		wantErrStrings []string
+	}{
+		{
+			name:         "no lora",
+			svc:          makeSvc("base", nil),
+			wantErrCount: 0,
+		},
+		{
+			name: "valid single adapter",
+			svc: makeSvc("base", &LoRASpec{
+				Adapters: []LLMModelSpec{makeAdapter("adapter-1", "adapter-1")},
+			}),
+			wantErrCount: 0,
+		},
+		{
+			name: "adapter name missing",
+			svc: makeSvc("base", &LoRASpec{
+				Adapters: []LLMModelSpec{{URI: apis.URL{Scheme: "hf", Host: "adapter-1"}}},
+			}),
+			wantErrCount:   1,
+			wantErrStrings: []string{"spec.model.lora.adapters[0].name"},
+		},
+		{
+			name: "path traversal rejected",
+			svc: makeSvc("base", &LoRASpec{
+				Adapters: []LLMModelSpec{makeAdapter("..", "adapter-dotdot")},
+			}),
+			wantErrCount:   1,
+			wantErrStrings: []string{"path traversal"},
+		},
+		{
+			name: "duplicate adapter names",
+			svc: makeSvc("base", &LoRASpec{
+				Adapters: []LLMModelSpec{
+					makeAdapter("dup", "adapter-1"),
+					makeAdapter("dup", "adapter-2"),
+				},
+			}),
+			wantErrCount:   1,
+			wantErrStrings: []string{"duplicate"},
+		},
+		{
+			name: "adapter name same as base model",
+			svc: makeSvc("base-model", &LoRASpec{
+				Adapters: []LLMModelSpec{makeAdapter("base-model", "adapter-1")},
+			}),
+			wantErrCount:   1,
+			wantErrStrings: []string{"adapter name must differ from base model name"},
+		},
+		{
+			name: "maxRank zero invalid",
+			svc: makeSvc("base", &LoRASpec{
+				MaxRank:  ptr.To(int32(0)),
+				Adapters: []LLMModelSpec{makeAdapter("a", "a")},
+			}),
+			wantErrCount:   1,
+			wantErrStrings: []string{"maxRank"},
+		},
+		{
+			name: "all lora params valid",
+			svc: makeSvc("base", &LoRASpec{
+				MaxRank:        ptr.To(int32(128)),
+				MaxAdapters:    ptr.To(int32(4)),
+				MaxCpuAdapters: ptr.To(int32(8)),
+				Adapters: []LLMModelSpec{
+					makeAdapter("adapter-1", "adapter-1"),
+					makeAdapter("adapter-2", "adapter-2"),
+				},
+			}),
+			wantErrCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validator.validateLoRAAdapters(tt.svc)
+			assert.Len(t, errs, tt.wantErrCount, "expected %d errors, got %d: %v", tt.wantErrCount, len(errs), errs)
+			for _, wantStr := range tt.wantErrStrings {
+				found := false
+				for _, e := range errs {
+					if strings.Contains(e.Error(), wantStr) {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "expected error containing %q, got: %v", wantStr, errs)
+			}
+		})
+	}
+}
+
+func TestValidateManagedDRAAnnotations_V1Alpha1(t *testing.T) {
+	validator := &LLMInferenceServiceValidator{}
+
+	tests := []struct {
+		name         string
+		annotations  map[string]string
+		wantErrCount int
+		wantErrField string
+	}{
+		{
+			name:         "no DRA annotations",
+			annotations:  nil,
+			wantErrCount: 0,
+		},
+		{
+			name: "valid: device class only",
+			annotations: map[string]string{
+				constants.ManagedDRADeviceClassAnnotationKey: "gpu.nvidia.com",
+			},
+			wantErrCount: 0,
+		},
+		{
+			name: "invalid: device count without device class",
+			annotations: map[string]string{
+				constants.ManagedDRADeviceCountAnnotationKey: "2",
+			},
+			wantErrCount: 1,
+			wantErrField: constants.ManagedDRADeviceClassAnnotationKey,
+		},
+		{
+			name: "invalid: empty device class",
+			annotations: map[string]string{
+				constants.ManagedDRADeviceClassAnnotationKey: "   ",
+			},
+			wantErrCount: 1,
+			wantErrField: constants.ManagedDRADeviceClassAnnotationKey,
+		},
+		{
+			name: "invalid: non-numeric device count",
+			annotations: map[string]string{
+				constants.ManagedDRADeviceClassAnnotationKey: "gpu.nvidia.com",
+				constants.ManagedDRADeviceCountAnnotationKey: "abc",
+			},
+			wantErrCount: 1,
+			wantErrField: constants.ManagedDRADeviceCountAnnotationKey,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := newBaseLLMInferenceService()
+			svc.Annotations = tt.annotations
+
+			// Exercise the full validate() path to ensure DRA validation is wired in.
+			err := validator.validate(t.Context(), nil, svc)
+			if tt.wantErrCount == 0 {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrField)
 			}
 		})
 	}

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_types_func.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_types_func.go
@@ -17,14 +17,10 @@ limitations under the License.
 package v1alpha2
 
 import (
-	"fmt"
-	"strconv"
-	"strings"
-
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/kmeta"
 
-	"github.com/kserve/kserve/pkg/constants"
+	kservevalidation "github.com/kserve/kserve/pkg/validation"
 )
 
 func (s *SchedulerSpec) InferencePoolName(llmSvc *LLMInferenceService) string {
@@ -162,8 +158,7 @@ func (s *LLMInferenceService) HasManagedDRA() bool {
 	if s == nil {
 		return false
 	}
-	_, ok := s.Annotations[constants.ManagedDRADeviceClassAnnotationKey]
-	return ok
+	return kservevalidation.HasManagedDRA(s.Annotations)
 }
 
 // ManagedDRADeviceClass returns the trimmed device-class annotation value and
@@ -172,11 +167,7 @@ func (s *LLMInferenceService) ManagedDRADeviceClass() (string, bool) {
 	if s == nil {
 		return "", false
 	}
-	raw, ok := s.Annotations[constants.ManagedDRADeviceClassAnnotationKey]
-	if !ok {
-		return "", false
-	}
-	return strings.TrimSpace(raw), true
+	return kservevalidation.ManagedDRADeviceClass(s.Annotations)
 }
 
 // ManagedDRADeviceCount returns the requested device count, defaulting to 1.
@@ -184,18 +175,7 @@ func (s *LLMInferenceService) ManagedDRADeviceCount() (int, error) {
 	if s == nil {
 		return 1, nil
 	}
-	raw, ok := s.Annotations[constants.ManagedDRADeviceCountAnnotationKey]
-	if !ok || strings.TrimSpace(raw) == "" {
-		return 1, nil
-	}
-	count, err := strconv.Atoi(strings.TrimSpace(raw))
-	if err != nil {
-		return 0, fmt.Errorf("invalid %s value %q: %w", constants.ManagedDRADeviceCountAnnotationKey, raw, err)
-	}
-	if count < 1 {
-		return 0, fmt.Errorf("invalid %s value %q: must be >= 1", constants.ManagedDRADeviceCountAnnotationKey, raw)
-	}
-	return count, nil
+	return kservevalidation.ManagedDRADeviceCount(s.Annotations)
 }
 
 // ManagedDRACelSelectors returns the newline-separated CEL expressions, with
@@ -204,18 +184,7 @@ func (s *LLMInferenceService) ManagedDRACelSelectors() []string {
 	if s == nil {
 		return nil
 	}
-	raw, ok := s.Annotations[constants.ManagedDRACelSelectorAnnotationKey]
-	if !ok || strings.TrimSpace(raw) == "" {
-		return nil
-	}
-	parts := strings.Split(raw, "\n")
-	selectors := make([]string, 0, len(parts))
-	for _, p := range parts {
-		if v := strings.TrimSpace(p); v != "" {
-			selectors = append(selectors, v)
-		}
-	}
-	return selectors
+	return kservevalidation.ManagedDRACelSelectors(s.Annotations)
 }
 
 // ManagedDRAContainerName returns the trimmed container-name annotation value
@@ -224,9 +193,5 @@ func (s *LLMInferenceService) ManagedDRAContainerName() (string, bool) {
 	if s == nil {
 		return "", false
 	}
-	raw, ok := s.Annotations[constants.ManagedDRAContainerNameAnnotationKey]
-	if !ok {
-		return "", false
-	}
-	return strings.TrimSpace(raw), true
+	return kservevalidation.ManagedDRAContainerName(s.Annotations)
 }

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_validation.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_validation.go
@@ -22,13 +22,11 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
-	"strings"
 
 	"k8s.io/utils/ptr"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -36,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
-	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/utils"
 	kservevalidation "github.com/kserve/kserve/pkg/validation"
 )
@@ -418,14 +415,18 @@ func (l *LLMInferenceServiceValidator) validateSchedulerConfig(svc *LLMInference
 }
 
 func (l *LLMInferenceServiceValidator) validateLoRAAdapters(llmSvc *LLMInferenceService) field.ErrorList {
+	return ValidateLoRAAdapters(llmSvc.Spec.Model.LoRA, ptr.Deref(llmSvc.Spec.Model.Name, llmSvc.Name), field.NewPath("spec", "model", "lora"))
+}
+
+// ValidateLoRAAdapters validates a LoRA spec: numeric bounds, adapter name
+// uniqueness, path traversal, and base-model collision. It is exported so
+// v1alpha1 can convert its spoke type and call the same logic.
+func ValidateLoRAAdapters(loraSpec *LoRASpec, baseModelName string, loraPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 
-	if llmSvc.Spec.Model.LoRA == nil {
+	if loraSpec == nil {
 		return allErrs
 	}
-
-	loraPath := field.NewPath("spec").Child("model", "lora")
-	loraSpec := llmSvc.Spec.Model.LoRA
 
 	if loraSpec.MaxRank != nil && *loraSpec.MaxRank < 1 {
 		allErrs = append(allErrs, field.Invalid(loraPath.Child("maxRank"), *loraSpec.MaxRank, "maxRank must be at least 1"))
@@ -437,15 +438,14 @@ func (l *LLMInferenceServiceValidator) validateLoRAAdapters(llmSvc *LLMInference
 		allErrs = append(allErrs, field.Invalid(loraPath.Child("maxCpuAdapters"), *loraSpec.MaxCpuAdapters, "maxCpuAdapters must be at least 1"))
 	}
 
-	if len(llmSvc.Spec.Model.LoRA.Adapters) == 0 {
+	if len(loraSpec.Adapters) == 0 {
 		return allErrs
 	}
 
 	adaptersPath := loraPath.Child("adapters")
-	baseModelName := ptr.Deref(llmSvc.Spec.Model.Name, llmSvc.Name)
-	seen := make(map[string]int, len(llmSvc.Spec.Model.LoRA.Adapters))
+	seen := make(map[string]int, len(loraSpec.Adapters))
 
-	for i, adapter := range llmSvc.Spec.Model.LoRA.Adapters {
+	for i, adapter := range loraSpec.Adapters {
 		namePath := adaptersPath.Index(i).Child("name")
 
 		if adapter.Name == nil || *adapter.Name == "" {
@@ -678,84 +678,7 @@ func immutableField(path *field.Path, value interface{}, detail string) *field.E
 // validateManagedDRAAnnotations performs admission-time validation of the
 // serving.kserve.io/exp-dra-* annotations to catch user mistakes early.
 func (l *LLMInferenceServiceValidator) validateManagedDRAAnnotations(llmSvc *LLMInferenceService) field.ErrorList {
-	var allErrs field.ErrorList
-	annotations := llmSvc.GetAnnotations()
-	if len(annotations) == 0 {
-		return allErrs
-	}
-
-	annotationsPath := field.NewPath("metadata").Child("annotations")
-
-	hasDeviceClass := llmSvc.HasManagedDRA()
-	_, hasDeviceCount := annotations[constants.ManagedDRADeviceCountAnnotationKey]
-	_, hasCelSelector := annotations[constants.ManagedDRACelSelectorAnnotationKey]
-	_, hasContainerName := annotations[constants.ManagedDRAContainerNameAnnotationKey]
-
-	// Require device-class if any other DRA annotation is set.
-	if !hasDeviceClass && (hasDeviceCount || hasCelSelector || hasContainerName) {
-		allErrs = append(allErrs, field.Required(
-			annotationsPath.Key(constants.ManagedDRADeviceClassAnnotationKey),
-			fmt.Sprintf("%s is required to enable managed DRA when %s, %s, or %s is set",
-				constants.ManagedDRADeviceClassAnnotationKey,
-				constants.ManagedDRADeviceCountAnnotationKey,
-				constants.ManagedDRACelSelectorAnnotationKey,
-				constants.ManagedDRAContainerNameAnnotationKey),
-		))
-	}
-
-	if trimmed, present := llmSvc.ManagedDRADeviceClass(); present {
-		raw := annotations[constants.ManagedDRADeviceClassAnnotationKey]
-		if trimmed == "" {
-			allErrs = append(allErrs, field.Invalid(
-				annotationsPath.Key(constants.ManagedDRADeviceClassAnnotationKey),
-				raw,
-				"device class must not be empty",
-			))
-		} else if errs := validation.IsDNS1123Subdomain(trimmed); len(errs) > 0 {
-			allErrs = append(allErrs, field.Invalid(
-				annotationsPath.Key(constants.ManagedDRADeviceClassAnnotationKey),
-				raw,
-				"device class must be a DNS subdomain: "+strings.Join(errs, "; "),
-			))
-		}
-	}
-
-	if hasDeviceCount {
-		if _, err := llmSvc.ManagedDRADeviceCount(); err != nil {
-			allErrs = append(allErrs, field.Invalid(
-				annotationsPath.Key(constants.ManagedDRADeviceCountAnnotationKey),
-				annotations[constants.ManagedDRADeviceCountAnnotationKey],
-				err.Error(),
-			))
-		}
-	}
-
-	if hasCelSelector && len(llmSvc.ManagedDRACelSelectors()) == 0 {
-		allErrs = append(allErrs, field.Invalid(
-			annotationsPath.Key(constants.ManagedDRACelSelectorAnnotationKey),
-			annotations[constants.ManagedDRACelSelectorAnnotationKey],
-			"cel selector must contain at least one non-empty CEL expression",
-		))
-	}
-
-	if trimmed, present := llmSvc.ManagedDRAContainerName(); present {
-		raw := annotations[constants.ManagedDRAContainerNameAnnotationKey]
-		if trimmed == "" {
-			allErrs = append(allErrs, field.Invalid(
-				annotationsPath.Key(constants.ManagedDRAContainerNameAnnotationKey),
-				raw,
-				"container name must not be empty",
-			))
-		} else if errs := validation.IsDNS1123Label(trimmed); len(errs) > 0 {
-			allErrs = append(allErrs, field.Invalid(
-				annotationsPath.Key(constants.ManagedDRAContainerNameAnnotationKey),
-				raw,
-				"container name must be a DNS label: "+strings.Join(errs, "; "),
-			))
-		}
-	}
-
-	return allErrs
+	return kservevalidation.ValidateManagedDRAAnnotations(llmSvc.GetAnnotations())
 }
 
 // validateKVCacheOffloading validates KVCacheOffloading secondary tier specs.

--- a/pkg/controller/v1alpha2/llmisvc/controller.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller.go
@@ -150,6 +150,8 @@ type LLMISVCReconciler struct {
 //+kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=leaderworkerset.x-k8s.io,resources=leaderworkersets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
+// Secret access stays cluster-scoped so Owns() can watch TLS cert secrets in workload namespaces.
+// Keep create/update/patch/delete so reconcile and force-stop can manage TLS secrets.
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes;gateways;gatewayclasses,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/controller/v1alpha2/llmisvc/controller_latency_predictor_int_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_latency_predictor_int_test.go
@@ -73,6 +73,48 @@ var _ = Describe("LLMInferenceService Controller — Latency Predictor", func() 
 		})
 	})
 
+	Context("When predicted-latency-producer plugin is declared via template.containers[].args", func() {
+		It("should inject training and prediction sidecar containers into the scheduler deployment", func(ctx SpecContext) {
+			svcName := "test-llm-lp-sidecars-template-args"
+			testNs := NewTestNamespace(ctx, envTest)
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithSchedulerConfigTemplateArgs(`plugins:
+- type: predicted-latency-producer
+- type: latency-scorer
+- type: weighted-random-picker
+`),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			Eventually(func(g Gomega, ctx context.Context) {
+				deployments := &appsv1.DeploymentList{}
+				g.Expect(envTest.Client.List(ctx, deployments, &client.ListOptions{
+					Namespace:     testNs.Name,
+					LabelSelector: labels.SelectorFromSet(llmisvc.SchedulerLabels(llmSvc)),
+				})).To(Succeed())
+				g.Expect(deployments.Items).To(HaveLen(1))
+
+				dep := deployments.Items[0]
+				containerNames := make([]string, len(dep.Spec.Template.Spec.Containers))
+				for i, c := range dep.Spec.Template.Spec.Containers {
+					containerNames[i] = c.Name
+				}
+				g.Expect(containerNames).To(ContainElement("training-server"))
+				g.Expect(containerNames).To(ContainElement("prediction-server"))
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
 	Context("When predicted-latency-producer plugin is NOT in the scheduler config", func() {
 		It("should not inject sidecar containers", func(ctx SpecContext) {
 			svcName := "test-llm-no-lp"

--- a/pkg/controller/v1alpha2/llmisvc/fixture/llmisvc_builders.go
+++ b/pkg/controller/v1alpha2/llmisvc/fixture/llmisvc_builders.go
@@ -570,6 +570,23 @@ func WithSchedulerConfigInline(configYAML string) LLMInferenceServiceOption {
 	}
 }
 
+// WithSchedulerConfigTemplateArgs sets the scheduler config as a --config-text
+// argument on the "main" container of the scheduler pod template, instead of
+// spec.router.scheduler.config.inline.
+func WithSchedulerConfigTemplateArgs(configYAML string) LLMInferenceServiceOption {
+	return func(llmSvc *v1alpha2.LLMInferenceService) {
+		ensureSchedulerSpec(&llmSvc.Spec)
+		llmSvc.Spec.Router.Scheduler.Template = &corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Args: []string{"--config-text", configYAML},
+				},
+			},
+		}
+	}
+}
+
 // WithSchedulerConfigRef sets a ConfigMap reference for scheduler config.
 // If key is empty, it defaults to "epp" at runtime.
 func WithSchedulerConfigRef(configMapName, key string) LLMInferenceServiceOption {

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -24,6 +24,7 @@ import (
 	"path"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/coreos/go-semver/semver"
@@ -1305,15 +1306,29 @@ var deprecatedMetricFlagNames = map[string]bool{
 	"cache-info-metric":                true,
 }
 
-// modelServerMetricsSchemeFlag is the deprecated EPP CLI flag (without leading
-// dashes) removed in llm-d-router 0.10, superseded by the metrics-data-source
-// data layer plugin's scheme parameter in EndpointPickerConfig.
-const modelServerMetricsSchemeFlag = "model-server-metrics-scheme"
+// Deprecated EPP CLI flags (without leading dashes) removed in llm-d-router 0.10.
+// --model-server-metrics-scheme, --model-server-metrics-path, and --model-server-metrics-https-insecure-skip-verify
+// are superseded in EndpointPickerConfig's metrics-data-source plugin, by scheme, path, and insecureSkipVerify parameters
+// --model-server-metrics-port has no plugin parameter: the scrape port is always the InferencePool target port,
+// so the flag is only stripped, never re-injected.
+const (
+	modelServerMetricsSchemeFlag             = "model-server-metrics-scheme"
+	modelServerMetricsPathFlag               = "model-server-metrics-path"
+	modelServerMetricsPortFlag               = "model-server-metrics-port"
+	modelServerMetricsInsecureSkipVerifyFlag = "model-server-metrics-https-insecure-skip-verify"
+)
 
-// metricsDataSourceSchemeMinVersion is the first llm-d-router version that
-// removes --model-server-metrics-scheme; from this version the scrape scheme
+var deprecatedModelServerMetricFlagNames = map[string]bool{
+	modelServerMetricsSchemeFlag:             true,
+	modelServerMetricsPathFlag:               true,
+	modelServerMetricsPortFlag:               true,
+	modelServerMetricsInsecureSkipVerifyFlag: true,
+}
+
+// metricsDataSourceMinVersion is the first llm-d-router version that removes
+// the --model-server-metrics-* flags; from this version their surviving equivalents
 // must be supplied via the metrics-data-source plugin parameters.
-var metricsDataSourceSchemeMinVersion = semver.New("0.10.0")
+var metricsDataSourceMinVersion = semver.New("0.10.0")
 
 // hasDeprecatedMetricFlags reports whether any container in the pod spec
 // carries one of the 5 deprecated metric CLI flags, without modifying args.
@@ -1353,8 +1368,9 @@ func hasDeprecatedMetricFlags(d *appsv1.Deployment) bool {
 //  5. withCoreMetricsExtractorPlugin – inject core-metrics-extractor with extracted flag values
 //  6. withMigrateCoreMetricsExtractor – rename model-server-protocol-metrics → core-metrics-extractor
 //     (v0.8.0 only, runs after injection so freshly injected plugins are also renamed)
-//  7. withMetricsDataSourceScheme – move --model-server-metrics-scheme into the
-//     metrics-data-source plugin parameters (v0.10.0+, flag removed upstream)
+//  7. withMetricsDataSourceParams – move --model-server-metrics-{scheme,path,
+//     https-insecure-skip-verify} into the metrics-data-source plugin parameters
+//     and strip --model-server-metrics-port (v0.10.0+, flags removed in llm-d-router)
 func schedulerTransform(ctx context.Context, d *appsv1.Deployment, llmSvc *v1alpha2.LLMInferenceService, enableTLS bool) error {
 	version, ok := d.Spec.Template.Annotations["app.kubernetes.io/version"]
 	if !ok || version == "" {
@@ -1412,21 +1428,38 @@ func schedulerTransform(ctx context.Context, d *appsv1.Deployment, llmSvc *v1alp
 		}
 	}
 
-	// llm-d-router v0.10.0 removes "--model-server-metrics-scheme"
-	// the function had been moved into metrics-data-source plugin parameters.
-	if v.Compare(*metricsDataSourceSchemeMinVersion) >= 0 {
-		if !writable {
-			if hasModelServerMetricsSchemeFlag(d) {
+	// llm-d-router v0.10.0 removes the --model-server-metrics-* flags. Stripping
+	// them from Command/Args never touches the config, so it is always safe;
+	// extractModelServerMetricsFlags does that and returns only the
+	// re-injectable values (scheme, path, insecureSkipVerify). --model-server-metrics-port
+	// has no plugin parameter, so it is dropped in place and never appears here.
+	// Re-injecting the surviving values requires a writable inline config-text;
+	// abort only in that case so their values are not silently lost.
+	// Extraction runs before the writable check so --model-server-metrics-port is
+	// always stripped; on the error path d is discarded, so the early mutation is safe.
+	if v.Compare(*metricsDataSourceMinVersion) >= 0 {
+		if params := extractModelServerMetricsFlags(ctx, d); len(params) > 0 {
+			if !writable {
+				flags := make([]string, 0, len(params))
+				for name := range params {
+					flags = append(flags, "--"+name)
+				}
+				sort.Strings(flags)
 				return fmt.Errorf(
-					"scheduler deployment %s/%s sets --%s but has no inline "+
-						"--config-text; automatic migration to the metrics-data-source "+
-						"plugin is not possible — convert to --config-text or remove the "+
-						"flag manually",
-					d.GetNamespace(), d.GetName(), modelServerMetricsSchemeFlag,
+					"scheduler deployment %s/%s sets deprecated %s "+
+						"but has no inline --config-text; automatic migration to the "+
+						"metrics-data-source plugin is not possible — convert to --config-text "+
+						"or remove the flags manually",
+					d.GetNamespace(), d.GetName(), strings.Join(flags, ", "),
 				)
 			}
-		} else if scheme := extractModelServerMetricsScheme(d); scheme != "" {
-			opts = append(opts, withMetricsDataSourceScheme(scheme))
+			parameters, err := metricsDataSourceParameters(params)
+			if err != nil {
+				return err
+			}
+			if len(parameters) > 0 {
+				opts = append(opts, withMetricsDataSourceParams(parameters))
+			}
 		}
 	}
 
@@ -1808,43 +1841,35 @@ func extractDeprecatedMetricFlags(d *appsv1.Deployment) map[string]string {
 	return allExtracted
 }
 
-// extractModelServerMetricsScheme strips the deprecated --model-server-metrics-scheme
-// flag from every container's Command and Args and returns its value (empty if
-// absent). The scheduler preset carries the flag on Command, but a user-supplied
-// SchedulerSpec.Template may place it on Args instead; both work on the old image
-// (kube concatenates Command+Args) but are rejected by llm-d-router v0.10.0, so
-// both lists must be scrubbed.
-func extractModelServerMetricsScheme(d *appsv1.Deployment) string {
-	names := map[string]bool{modelServerMetricsSchemeFlag: true}
-	scheme := ""
+// extractModelServerMetricsFlags strips the deprecated --model-server-metrics-*
+// flags from every container's Command and Args and returns the re-injectable
+// values keyed by flag name. The scheduler preset carries the flags on Command,
+// but a user-supplied SchedulerSpec.Template may place them on Args instead;
+// both work on the old image (kube concatenates Command+Args) but are rejected
+// by llm-d-router v0.10.0, so both lists must be scrubbed. --model-server-metrics-port
+// has no plugin parameter: it is stripped and logged, never returned.
+func extractModelServerMetricsFlags(ctx context.Context, d *appsv1.Deployment) map[string]string {
+	params := map[string]string{}
 	for ci := range d.Spec.Template.Spec.Containers {
 		c := &d.Spec.Template.Spec.Containers[ci]
-		if filtered, extracted := filterArgs(c.Command, names); len(extracted) > 0 {
+		if filtered, extracted := filterArgs(c.Command, deprecatedModelServerMetricFlagNames); len(extracted) > 0 {
 			c.Command = filtered
-			scheme = extracted[modelServerMetricsSchemeFlag]
+			maps.Copy(params, extracted)
 		}
-		if filtered, extracted := filterArgs(c.Args, names); len(extracted) > 0 {
+		if filtered, extracted := filterArgs(c.Args, deprecatedModelServerMetricFlagNames); len(extracted) > 0 {
 			c.Args = filtered
-			scheme = extracted[modelServerMetricsSchemeFlag]
+			maps.Copy(params, extracted)
 		}
 	}
-	return scheme
-}
-
-// hasModelServerMetricsSchemeFlag reports whether any container carries the
-// --model-server-metrics-scheme flag on Command or Args, without modifying it.
-func hasModelServerMetricsSchemeFlag(d *appsv1.Deployment) bool {
-	names := map[string]bool{modelServerMetricsSchemeFlag: true}
-	for ci := range d.Spec.Template.Spec.Containers {
-		c := &d.Spec.Template.Spec.Containers[ci]
-		if _, extracted := filterArgs(c.Command, names); len(extracted) > 0 {
-			return true
-		}
-		if _, extracted := filterArgs(c.Args, names); len(extracted) > 0 {
-			return true
-		}
+	// remove port flag to keep other 3 flags if were set
+	if port, ok := params[modelServerMetricsPortFlag]; ok {
+		log.FromContext(ctx).Info(
+			"Dropped --model-server-metrics-port; llm-d-router v0.10.0 scrapes metrics "+
+				"on the InferencePool target port", "droppedPort", port,
+		)
+		delete(params, modelServerMetricsPortFlag)
 	}
-	return false
+	return params
 }
 
 // filterArgs removes matching flags from args and returns their values.
@@ -1929,13 +1954,39 @@ func withCoreMetricsExtractorPlugin(extracted map[string]string) mutateScheduler
 	}
 }
 
-// withMetricsDataSourceScheme returns a mutateSchedulerConfigFunc that injects a
-// metrics-data-source plugin carrying the scheme previously passed via the
-// --model-server-metrics-scheme CLI flag. EPP data layer defaulting wires the
-// declared source to core-metrics-extractor automatically, so only the plugin
-// entry is needed. Callers pass a non-empty scheme; no-op if a metrics-data-source
-// plugin is already declared.
-func withMetricsDataSourceScheme(scheme string) mutateSchedulerConfigFunc {
+// metricsDataSourceParameters converts the extracted --model-server-metrics-*
+// flag values into metrics-data-source plugin parameters, validating them.
+// A bare --model-server-metrics-https-insecure-skip-verify (empty value) means true;
+// any other value must parse as a boolean, matching the router's flag parsing.
+// Empty scheme/path values are dropped; the returned map may be empty.
+func metricsDataSourceParameters(extracted map[string]string) (map[string]interface{}, error) {
+	parameters := map[string]interface{}{}
+	if scheme := extracted[modelServerMetricsSchemeFlag]; scheme != "" {
+		parameters["scheme"] = scheme
+	}
+	if p := extracted[modelServerMetricsPathFlag]; p != "" {
+		parameters["path"] = p
+	}
+	if v, ok := extracted[modelServerMetricsInsecureSkipVerifyFlag]; ok {
+		if v == "" {
+			parameters["insecureSkipVerify"] = true
+		} else {
+			b, err := strconv.ParseBool(v)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value %q for --%s: %w", v, modelServerMetricsInsecureSkipVerifyFlag, err)
+			}
+			parameters["insecureSkipVerify"] = b
+		}
+	}
+	return parameters, nil
+}
+
+// withMetricsDataSourceParams returns a mutateSchedulerConfigFunc that injects a
+// metrics-data-source plugin carrying the given parameters (scheme, path, and
+// insecureSkipVerify) previously passed via the --model-server-metrics-* CLI flags.
+// Callers pass a non-empty, already-validated parameter map (see
+// metricsDataSourceParameters). No-op if a metrics-data-source plugin is already declared.
+func withMetricsDataSourceParams(parameters map[string]interface{}) mutateSchedulerConfigFunc {
 	return func(_ context.Context, u *unstructured.Unstructured) error {
 		val, _, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
 		if err != nil {
@@ -1950,10 +2001,8 @@ func withMetricsDataSourceScheme(scheme string) mutateSchedulerConfigFunc {
 		}
 
 		pluginEntry := map[string]interface{}{
-			"type": metricsDataSourcePlugin,
-			"parameters": map[string]interface{}{
-				"scheme": scheme,
-			},
+			"type":       metricsDataSourcePlugin,
+			"parameters": parameters,
 		}
 
 		plugins = append(plugins, pluginEntry)

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_latency_predictor.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_latency_predictor.go
@@ -27,18 +27,21 @@ const (
 	predictedLatencyProducerPlugin = "predicted-latency-producer"
 )
 
-// hasLatencyProducerInSpec checks the LLMInferenceService spec's inline config.
-// NOTE: This only checks Config.Inline, not Config.Ref (ConfigMap-based config).
-// The ConfigMap Ref is resolved later in expectedSchedulerDeployment, after
+// hasLatencyProducerInSpec checks the LLMInferenceService spec's scheduler config,
+// supplied via either Config.Inline or a --config-text pair in
+// Template.Containers[].Args (see inlineSchedulerConfigBytes).
+// NOTE: This does not check Config.Ref (ConfigMap-based config). The ConfigMap
+// Ref is resolved later in expectedSchedulerDeployment, after
 // combineBaseRefsConfig has already run. If the plugin is specified via Ref,
 // the well-known config will not be auto-injected. This is a known limitation;
 // all llm-d guides and examples use Config.Inline.
 func hasLatencyProducerInSpec(spec v1alpha2.LLMInferenceServiceSpec) bool {
-	if spec.Router == nil || spec.Router.Scheduler == nil || spec.Router.Scheduler.Config == nil || spec.Router.Scheduler.Config.Inline == nil {
+	raw, ok := inlineSchedulerConfigBytes(spec)
+	if !ok {
 		return false
 	}
 	u := unstructured.Unstructured{}
-	if err := yaml.Unmarshal(spec.Router.Scheduler.Config.Inline.Raw, &u.Object); err != nil {
+	if err := yaml.Unmarshal(raw, &u.Object); err != nil {
 		return false
 	}
 	return hasPluginType(u.Object, predictedLatencyProducerPlugin)

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_latency_predictor_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_latency_predictor_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
@@ -81,6 +82,81 @@ func TestHasLatencyProducerInSpec(t *testing.T) {
 				Router: &v1alpha2.RouterSpec{
 					Scheduler: &v1alpha2.SchedulerSpec{
 						Config: &v1alpha2.SchedulerConfigSpec{},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "plugin supplied via template args, no config.inline set",
+			spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{"--config-text", latencyProducerConfig},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "no plugin via template args",
+			spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{"--config-text", noLatencyConfig},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "config.inline takes priority over template args when both are present",
+			spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Config: &v1alpha2.SchedulerConfigSpec{
+							Inline: &runtime.RawExtension{Raw: []byte(noLatencyConfig)},
+						},
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{"--config-text", latencyProducerConfig},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "config-file flag in template args is not treated as inline plugin source",
+			spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{"--config-file", "/etc/epp/config.yaml"},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -2358,27 +2358,95 @@ plugins:
 	}
 }
 
-func TestWithMetricsDataSourceScheme(t *testing.T) {
+func TestMetricsDataSourceParameters(t *testing.T) {
+	tests := []struct {
+		name         string
+		extracted    map[string]string
+		expectErr    bool
+		errSubstring string
+		expected     map[string]interface{}
+	}{
+		{
+			name: "converts scheme, path and insecureSkipVerify",
+			extracted: map[string]string{
+				modelServerMetricsSchemeFlag:             "https",
+				modelServerMetricsPathFlag:               "/custom/metrics",
+				modelServerMetricsInsecureSkipVerifyFlag: "false",
+			},
+			expected: map[string]interface{}{
+				"scheme":             "https",
+				"path":               "/custom/metrics",
+				"insecureSkipVerify": false,
+			},
+		},
+		{
+			name:      "bare insecureSkipVerify flag means true",
+			extracted: map[string]string{modelServerMetricsInsecureSkipVerifyFlag: ""},
+			expected:  map[string]interface{}{"insecureSkipVerify": true},
+		},
+		{
+			name: "empty scheme and path values are dropped",
+			extracted: map[string]string{
+				modelServerMetricsSchemeFlag: "",
+				modelServerMetricsPathFlag:   "",
+			},
+			expected: map[string]interface{}{},
+		},
+		{
+			name:      "no flags returns empty parameters",
+			extracted: map[string]string{},
+			expected:  map[string]interface{}{},
+		},
+		{
+			name:         "invalid insecureSkipVerify value returns error",
+			extracted:    map[string]string{modelServerMetricsInsecureSkipVerifyFlag: "notabool"},
+			expectErr:    true,
+			errSubstring: "invalid value",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			parameters, err := metricsDataSourceParameters(tt.extracted)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.errSubstring))
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(parameters).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestWithMetricsDataSourceParams(t *testing.T) {
 	tests := []struct {
 		name       string
 		configYAML string
-		scheme     string
+		parameters map[string]interface{}
 		validate   func(g Gomega, obj map[string]interface{})
 	}{
 		{
-			name: "injects plugin with scheme",
+			name: "injects plugin with the given parameters",
 			configYAML: `
 plugins:
 - type: queue-scorer
 `,
-			scheme: "https",
+			parameters: map[string]interface{}{
+				"scheme":             "https",
+				"path":               "/custom/metrics",
+				"insecureSkipVerify": false,
+			},
 			validate: func(g Gomega, obj map[string]interface{}) {
 				plugins := obj["plugins"].([]interface{})
 				g.Expect(plugins).To(HaveLen(2))
 				pluginMap := plugins[1].(map[string]interface{})
 				g.Expect(pluginMap["type"]).To(Equal(metricsDataSourcePlugin))
 				params := pluginMap["parameters"].(map[string]interface{})
-				g.Expect(params["scheme"]).To(Equal("https"))
+				g.Expect(params).To(HaveKeyWithValue("scheme", "https"))
+				g.Expect(params).To(HaveKeyWithValue("path", "/custom/metrics"))
+				g.Expect(params).To(HaveKeyWithValue("insecureSkipVerify", false))
 			},
 		},
 		{
@@ -2389,7 +2457,7 @@ plugins:
   parameters:
     scheme: http
 `,
-			scheme: "https",
+			parameters: map[string]interface{}{"scheme": "https"},
 			validate: func(g Gomega, obj map[string]interface{}) {
 				plugins := obj["plugins"].([]interface{})
 				g.Expect(plugins).To(HaveLen(1))
@@ -2406,27 +2474,31 @@ plugins:
 			var obj map[string]interface{}
 			g.Expect(yaml.Unmarshal([]byte(tt.configYAML), &obj)).To(Succeed())
 			u := unstructured.Unstructured{Object: obj}
-			fn := withMetricsDataSourceScheme(tt.scheme)
+			fn := withMetricsDataSourceParams(tt.parameters)
 			g.Expect(fn(context.Background(), &u)).To(Succeed())
 			tt.validate(g, u.Object)
 		})
 	}
 }
 
-func TestExtractModelServerMetricsScheme(t *testing.T) {
+func TestExtractModelServerMetricsFlags(t *testing.T) {
 	tests := []struct {
 		name            string
 		command         []string
 		args            []string
 		expectedCommand []string
 		expectedArgs    []string
-		expectedScheme  string
+		expectedParams  map[string]string
 	}{
 		{
-			name:            "extracts from command with equals form",
-			command:         []string{"/app/epp", "--model-server-metrics-scheme=https", "--grpc-port=9002"},
+			name:            "extracts scheme, path and insecureSkipVerify from command",
+			command:         []string{"/app/epp", "--model-server-metrics-scheme=https", "--model-server-metrics-path=/custom/metrics", "--model-server-metrics-https-insecure-skip-verify=false", "--grpc-port=9002"},
 			expectedCommand: []string{"/app/epp", "--grpc-port=9002"},
-			expectedScheme:  "https",
+			expectedParams: map[string]string{
+				modelServerMetricsSchemeFlag:             "https",
+				modelServerMetricsPathFlag:               "/custom/metrics",
+				modelServerMetricsInsecureSkipVerifyFlag: "false",
+			},
 		},
 		{
 			name:            "extracts from args with equals form",
@@ -2434,13 +2506,19 @@ func TestExtractModelServerMetricsScheme(t *testing.T) {
 			args:            []string{"--model-server-metrics-scheme=https", "--grpc-port=9002"},
 			expectedCommand: []string{"/app/epp"},
 			expectedArgs:    []string{"--grpc-port=9002"},
-			expectedScheme:  "https",
+			expectedParams:  map[string]string{modelServerMetricsSchemeFlag: "https"},
 		},
 		{
-			name:            "no flag returns empty scheme",
+			name:            "strips port without returning it",
+			command:         []string{"/app/epp", "--model-server-metrics-port=8000", "--grpc-port=9002"},
+			expectedCommand: []string{"/app/epp", "--grpc-port=9002"},
+			expectedParams:  map[string]string{},
+		},
+		{
+			name:            "no flag returns empty params",
 			command:         []string{"/app/epp", "--grpc-port=9002"},
 			expectedCommand: []string{"/app/epp", "--grpc-port=9002"},
-			expectedScheme:  "",
+			expectedParams:  map[string]string{},
 		},
 	}
 
@@ -2458,8 +2536,8 @@ func TestExtractModelServerMetricsScheme(t *testing.T) {
 					},
 				},
 			}
-			scheme := extractModelServerMetricsScheme(d)
-			g.Expect(scheme).To(Equal(tt.expectedScheme))
+			params := extractModelServerMetricsFlags(context.Background(), d)
+			g.Expect(params).To(Equal(tt.expectedParams))
 			if tt.expectedCommand != nil {
 				g.Expect(d.Spec.Template.Spec.Containers[0].Command).To(Equal(tt.expectedCommand))
 			}
@@ -2484,40 +2562,65 @@ plugins:
 		args         []string
 		expectErr    bool
 		errSubstring string
-		expectFlag   bool
-		expectPlugin bool
+		flag         string                 // the deprecated flag literal to check on Command/Args
+		expectFlag   bool                   // whether flag still survives on Command
+		expectParams map[string]interface{} // nil => no metrics-data-source plugin
 	}{
 		{
 			name:         "0.9.0 leaves flag and config untouched",
 			version:      "0.9.0",
 			command:      []string{"/app/epp", "--model-server-metrics-scheme=https"},
 			args:         []string{"--config-text", configYAML},
+			flag:         "--model-server-metrics-scheme=https",
 			expectFlag:   true,
-			expectPlugin: false,
+			expectParams: nil,
 		},
 		{
-			name:         "0.10.0 strips flag from command and injects plugin",
+			name:         "0.10.0 strips scheme from command and injects plugin",
 			version:      "0.10.0",
 			command:      []string{"/app/epp", "--model-server-metrics-scheme=https"},
 			args:         []string{"--config-text", configYAML},
-			expectFlag:   false,
-			expectPlugin: true,
+			flag:         "--model-server-metrics-scheme=https",
+			expectParams: map[string]interface{}{"scheme": "https"},
 		},
 		{
-			name:         "0.10.0 strips flag from args and injects plugin",
+			name:         "0.10.0 strips scheme from args and injects plugin",
 			version:      "0.10.0",
 			command:      []string{"/app/epp"},
 			args:         []string{"--model-server-metrics-scheme=https", "--config-text", configYAML},
-			expectFlag:   false,
-			expectPlugin: true,
+			flag:         "--model-server-metrics-scheme=https",
+			expectParams: map[string]interface{}{"scheme": "https"},
+		},
+		{
+			name:         "0.10.0 strips path and injects plugin",
+			version:      "0.10.0",
+			command:      []string{"/app/epp", "--model-server-metrics-path=/custom/metrics"},
+			args:         []string{"--config-text", configYAML},
+			flag:         "--model-server-metrics-path=/custom/metrics",
+			expectParams: map[string]interface{}{"path": "/custom/metrics"},
+		},
+		{
+			name:         "0.10.0 strips insecureSkipVerify and injects plugin",
+			version:      "0.10.0",
+			command:      []string{"/app/epp", "--model-server-metrics-https-insecure-skip-verify=false"},
+			args:         []string{"--config-text", configYAML},
+			flag:         "--model-server-metrics-https-insecure-skip-verify=false",
+			expectParams: map[string]interface{}{"insecureSkipVerify": false},
+		},
+		{
+			name:         "0.10.0 strips port without injecting a plugin",
+			version:      "0.10.0",
+			command:      []string{"/app/epp", "--model-server-metrics-port=8000"},
+			args:         []string{"--config-text", configYAML},
+			flag:         "--model-server-metrics-port=8000",
+			expectParams: nil,
 		},
 		{
 			name:         "0.10.0 without flag leaves config untouched",
 			version:      "0.10.0",
 			command:      []string{"/app/epp"},
 			args:         []string{"--config-text", configYAML},
-			expectFlag:   false,
-			expectPlugin: false,
+			expectParams: nil,
 		},
 		{
 			name:         "0.10.0 with flag but non-writable config-file returns error",
@@ -2526,6 +2629,43 @@ plugins:
 			args:         []string{"--config-file", "/etc/scheduler/config.yaml"},
 			expectErr:    true,
 			errSubstring: "no inline --config-text",
+		},
+		{
+			// multiple flags on a non-writable config: the error must list the
+			// actual flags that were set, in a deterministic (sorted) order.
+			name:    "0.10.0 non-writable config-file lists the set flags sorted",
+			version: "0.10.0",
+			command: []string{
+				"/app/epp",
+				"--model-server-metrics-scheme=https",
+				"--model-server-metrics-path=/metrics",
+				"--model-server-metrics-https-insecure-skip-verify=true",
+			},
+			args:      []string{"--config-file", "/etc/scheduler/config.yaml"},
+			expectErr: true,
+			errSubstring: "--model-server-metrics-https-insecure-skip-verify, " +
+				"--model-server-metrics-path, --model-server-metrics-scheme",
+		},
+		{
+			// an invalid boolean fails the reconcile up front (with a writable
+			// config-text), before any config mutation happens.
+			name:         "0.10.0 invalid insecureSkipVerify value returns error",
+			version:      "0.10.0",
+			command:      []string{"/app/epp", "--model-server-metrics-https-insecure-skip-verify=notabool"},
+			args:         []string{"--config-text", configYAML},
+			expectErr:    true,
+			errSubstring: "invalid value",
+		},
+		{
+			// port has no plugin parameter, so stripping it needs no config
+			// rewrite: a non-writable config-file must not block its removal.
+			name:         "0.10.0 strips port even with non-writable config-file",
+			version:      "0.10.0",
+			command:      []string{"/app/epp", "--model-server-metrics-port=8000"},
+			args:         []string{"--config-file", "/etc/scheduler/config.yaml"},
+			flag:         "--model-server-metrics-port=8000",
+			expectFlag:   false,
+			expectParams: nil,
 		},
 	}
 
@@ -2561,11 +2701,13 @@ plugins:
 			g.Expect(err).NotTo(HaveOccurred())
 
 			command := d.Spec.Template.Spec.Containers[0].Command
-			g.Expect(slices.Contains(command, "--model-server-metrics-scheme=https")).To(Equal(tt.expectFlag))
-
 			args := d.Spec.Template.Spec.Containers[0].Args
-			// The flag must never survive on Args either, regardless of where it started.
-			g.Expect(slices.Contains(args, "--model-server-metrics-scheme=https")).To(BeFalse())
+			if tt.flag != "" {
+				g.Expect(slices.Contains(command, tt.flag)).To(Equal(tt.expectFlag))
+				// The flag must never survive on Args, regardless of where it started.
+				g.Expect(slices.Contains(args, tt.flag)).To(BeFalse())
+			}
+
 			configText := ""
 			for i, a := range args {
 				if a == "--config-text" && i+1 < len(args) {
@@ -2584,11 +2726,13 @@ plugins:
 				}
 			}
 
-			if tt.expectPlugin {
+			if tt.expectParams != nil {
 				g.Expect(metricsPlugin).NotTo(BeNil(), "expected a metrics-data-source plugin to be injected")
 				params, ok := metricsPlugin["parameters"].(map[string]interface{})
 				g.Expect(ok).To(BeTrue(), "metrics-data-source plugin must carry parameters")
-				g.Expect(params).To(HaveKeyWithValue("scheme", "https"))
+				for k, v := range tt.expectParams {
+					g.Expect(params).To(HaveKeyWithValue(k, v))
+				}
 			} else {
 				g.Expect(metricsPlugin).To(BeNil(), "did not expect a metrics-data-source plugin")
 			}

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -1490,6 +1490,136 @@ plugins:
 	}
 }
 
+// TestSchedulerTransformDecomposesPrecisePrefixCacheFromTemplateArgs verifies
+// the >=0.9.0 decompose migration applies when the scheduler config is
+// supplied via spec.router.scheduler.template.containers[].args (a literal
+// "--config-text <yaml>" pair) instead of spec.router.scheduler.config.inline.
+func TestSchedulerTransformDecomposesPrecisePrefixCacheFromTemplateArgs(t *testing.T) {
+	legacyConfigYAML := `apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- parameters:
+    indexerConfig:
+      kvBlockIndexConfig:
+        enableMetrics: true
+      tokenProcessorConfig:
+        blockSize: 64
+        hashSeed: "42"
+      tokenizersPoolConfig:
+        hf:
+          tokenizersCacheDir: /mnt/tokenizers
+    kvEventsConfig:
+      topicFilter: kv
+      zmqEndpoint: tcp://*:5557
+  type: precise-prefix-cache-scorer
+- type: load-aware-scorer
+- type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: precise-prefix-cache-scorer
+    weight: 2.0
+  - pluginRef: load-aware-scorer
+    weight: 1.0
+  - pluginRef: max-score-picker
+`
+
+	g := NewGomegaWithT(t)
+
+	mainContainer := corev1.Container{
+		Name: "main",
+		Args: []string{
+			"--v=4",
+			"--secure-serving",
+			"--config-text",
+			legacyConfigYAML,
+		},
+	}
+
+	// The Deployment being reconciled: its pod template spec is a verbatim
+	// copy of llmSvc.Spec.Router.Scheduler.Template, exactly as
+	// expectedSchedulerDeployment builds it.
+	d := &appsv1.Deployment{
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"app.kubernetes.io/version": "0.10.0",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{mainContainer},
+				},
+			},
+		},
+	}
+
+	// The LLMInferenceService carries the config only via
+	// spec.router.scheduler.template.containers[].args; spec.router.scheduler.config
+	// is intentionally left unset.
+	llmSvc := &v1alpha2.LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "llmisvc-precise-prefix-scorer",
+			Namespace: "llmd-singlenode-precise-prefix-cache",
+		},
+		Spec: v1alpha2.LLMInferenceServiceSpec{
+			Router: &v1alpha2.RouterSpec{
+				Scheduler: &v1alpha2.SchedulerSpec{
+					Template: &corev1.PodSpec{
+						Containers: []corev1.Container{mainContainer},
+					},
+				},
+			},
+		},
+	}
+
+	g.Expect(hasPrecisePrefixCachePlugin(llmSvc.Spec)).To(BeTrue(),
+		"plugin detection must see the legacy plugin declared in template args, not just config.inline")
+	g.Expect(isTokenizerEnabled(llmSvc.Spec)).To(BeTrue())
+
+	g.Expect(schedulerTransform(context.Background(), d, llmSvc, false)).To(Succeed())
+
+	configText := d.Spec.Template.Spec.Containers[0].Args[3]
+
+	// The legacy monolithic plugin must be fully decomposed.
+	g.Expect(configText).NotTo(ContainSubstring(precisePrefixCacheScorerPlugin))
+	g.Expect(configText).To(ContainSubstring(tokenProducerPlugin))
+	g.Expect(configText).To(ContainSubstring(precisePrefixCacheProducerPlugin))
+	g.Expect(configText).To(ContainSubstring(prefixCacheScorerPlugin))
+	g.Expect(configText).To(ContainSubstring("prefixMatchInfoProducerName"))
+
+	// apiVersion must be migrated to the current llm-d.ai group.
+	g.Expect(configText).To(ContainSubstring("apiVersion: llm-d.ai/v1alpha1"))
+	g.Expect(configText).NotTo(ContainSubstring("inference.networking.x-k8s.io/v1alpha1"))
+
+	// tokenProcessorConfig must be promoted to the producer's top-level
+	// parameters, not left nested inside indexerConfig.
+	u := unstructured.Unstructured{}
+	g.Expect(yaml.Unmarshal([]byte(configText), &u)).To(Succeed())
+	val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(found).To(BeTrue())
+	plugins := val.([]interface{})
+
+	var producerPlugin map[string]interface{}
+	for _, p := range plugins {
+		pm := p.(map[string]interface{})
+		if pm["type"] == precisePrefixCacheProducerPlugin {
+			producerPlugin = pm
+		}
+	}
+	g.Expect(producerPlugin).NotTo(BeNil(), "expected a precise-prefix-cache-producer plugin in the decomposed pipeline")
+
+	params, _ := producerPlugin["parameters"].(map[string]interface{})
+	g.Expect(params).To(HaveKey("tokenProcessorConfig"), "tokenProcessorConfig must be promoted to top-level parameters")
+
+	if indexerConfig, ok := params["indexerConfig"].(map[string]interface{}); ok {
+		g.Expect(indexerConfig).NotTo(HaveKey("tokenProcessorConfig"), "tokenProcessorConfig must no longer be nested inside indexerConfig")
+		g.Expect(indexerConfig).NotTo(HaveKey("tokenizersPoolConfig"), "tokenizersPoolConfig is replaced by the standalone token-producer")
+	}
+}
+
 // TestSchedulerTransformMigratesLLMDAPIVersion verifies the version-gated
 // (>=0.9.0) EndpointPickerConfig apiVersion rewrite in isolation:
 //   - 0.9.0: inference.networking.x-k8s.io/v1alpha1 -> llm-d.ai/v1alpha1

--- a/pkg/controller/v1alpha2/llmisvc/tokenizer.go
+++ b/pkg/controller/v1alpha2/llmisvc/tokenizer.go
@@ -91,15 +91,42 @@ func isTokenizerEnabled(spec v1alpha2.LLMInferenceServiceSpec) bool {
 	return hasTokenProducerPlugin(spec) || hasPrecisePrefixCachePlugin(spec)
 }
 
+// inlineSchedulerConfigBytes returns the raw EndpointPickerConfig YAML/JSON for
+// this LLMInferenceService. The scheduler config can be supplied two ways:
+//
+//  1. spec.router.scheduler.config.inline — the dedicated, structured field.
+//  2. spec.router.scheduler.template.containers[].args — a user-authored pod
+//     template that embeds a literal "--config-text <yaml>" argument pair.
+//
+// Only "--config-text" (inline YAML) is supported for (2), not "--config-file"
+// (a path to a mounted file), since file contents aren't available at this point.
+func inlineSchedulerConfigBytes(spec v1alpha2.LLMInferenceServiceSpec) ([]byte, bool) {
+	if spec.Router == nil || spec.Router.Scheduler == nil {
+		return nil, false
+	}
+	if spec.Router.Scheduler.Config != nil && spec.Router.Scheduler.Config.Inline != nil {
+		return spec.Router.Scheduler.Config.Inline.Raw, true
+	}
+	if spec.Router.Scheduler.Template != nil {
+		if pair := configFlagFromContainers(spec.Router.Scheduler.Template.Containers); pair != nil {
+			if _, ok := inlineConfigTextFlags[pair[0]]; ok {
+				return []byte(pair[1]), true
+			}
+		}
+	}
+	return nil, false
+}
+
 // hasTokenProducerPlugin checks if the scheduler config contains the token-producer
 // plugin, which requires a standalone tokenizer deployment to serve tokenization
 // requests over HTTP (vLLM render endpoint).
 func hasTokenProducerPlugin(spec v1alpha2.LLMInferenceServiceSpec) bool {
-	if spec.Router == nil || spec.Router.Scheduler == nil || spec.Router.Scheduler.Config == nil || spec.Router.Scheduler.Config.Inline == nil {
+	raw, ok := inlineSchedulerConfigBytes(spec)
+	if !ok {
 		return false
 	}
 	u := unstructured.Unstructured{}
-	if err := yaml.Unmarshal(spec.Router.Scheduler.Config.Inline.Raw, &u.Object); err != nil {
+	if err := yaml.Unmarshal(raw, &u.Object); err != nil {
 		return false
 	}
 	return hasPluginType(u.Object, tokenProducerPlugin)
@@ -108,11 +135,12 @@ func hasTokenProducerPlugin(spec v1alpha2.LLMInferenceServiceSpec) bool {
 // hasPrecisePrefixCachePlugin checks if the scheduler config contains the legacy
 // precise-prefix-cache-scorer plugin (migration trigger).
 func hasPrecisePrefixCachePlugin(spec v1alpha2.LLMInferenceServiceSpec) bool {
-	if spec.Router == nil || spec.Router.Scheduler == nil || spec.Router.Scheduler.Config == nil || spec.Router.Scheduler.Config.Inline == nil {
+	raw, ok := inlineSchedulerConfigBytes(spec)
+	if !ok {
 		return false
 	}
 	u := unstructured.Unstructured{}
-	if err := yaml.Unmarshal(spec.Router.Scheduler.Config.Inline.Raw, &u.Object); err != nil {
+	if err := yaml.Unmarshal(raw, &u.Object); err != nil {
 		return false
 	}
 	return hasPluginType(u.Object, precisePrefixCacheScorerPlugin)

--- a/pkg/controller/v1alpha2/llmisvc/tokenizer_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/tokenizer_test.go
@@ -107,6 +107,99 @@ func TestIsTokenizerEnabled(t *testing.T) {
 			want: false,
 		},
 		{
+			// Config supplied via spec.router.scheduler.template.containers[].args
+			// (a literal "--config-text <yaml>" pair) rather than the dedicated
+			// spec.router.scheduler.config.inline field. Both are valid ways to
+			// configure the scheduler, and plugin detection must work for either.
+			name: "token-producer plugin present via template args, no config.inline set",
+			spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{
+										"--config-text",
+										`{"plugins":[{"type":"token-producer"}]}`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "legacy precise-prefix-cache-scorer present via template args, no config.inline set",
+			spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{
+										"--config-text",
+										`{"plugins":[{"type":"precise-prefix-cache-scorer"}]}`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "config.inline takes priority over template args when both are present",
+			spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Config: &v1alpha2.SchedulerConfigSpec{
+							Inline: &runtime.RawExtension{
+								Raw: []byte(`{"plugins":[{"type":"prefix-cache-scorer"}]}`),
+							},
+						},
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{
+										"--config-text",
+										`{"plugins":[{"type":"token-producer"}]}`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			// --config-file points at a mounted file whose contents aren't
+			// available at reconcile time, so it can't be inspected for
+			// plugin detection. This is a known, documented limitation.
+			name: "config-file flag in template args is not treated as inline plugin source",
+			spec: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "main",
+									Args: []string{"--config-file", "/etc/epp/config.yaml"},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
 			name: "nil scheduler",
 			spec: v1alpha2.LLMInferenceServiceSpec{
 				Router: &v1alpha2.RouterSpec{},

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -82,7 +82,6 @@ import (
 // +kubebuilder:rbac:groups=networking.istio.io,resources=virtualservices,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.istio.io,resources=virtualservices/finalizers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.istio.io,resources=virtualservices/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
@@ -263,13 +263,16 @@ func createRawPredictorHTTPRoute(ctx context.Context, client client.Client, isvc
 		})
 		return nil, nil
 	}
+	// The route name and hostname use a stable name (without predictor.name) so
+	// they don't change on canary promotion. Backend refs use the actual service name.
+	routeName := constants.PredictorServiceName(isvc.Name)
 	predictorName := constants.PredictorServiceName(isvc.Name, isvc.Spec.Predictor.Name)
 
 	// Add isvc name and namespace headers
 	filters := []gwapiv1.HTTPRouteFilter{addIsvcHeaders(isvc.Name, isvc.Namespace)}
 
 	// Add predictor host rules
-	predictorHost, err := GenerateDomainName(predictorName, isvc.ObjectMeta, ingressConfig)
+	predictorHost, err := GenerateDomainName(routeName, isvc.ObjectMeta, ingressConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate predictor ingress host: %w", err)
 	}
@@ -306,7 +309,7 @@ func createRawPredictorHTTPRoute(ctx context.Context, client client.Client, isvc
 	gatewaySlice := strings.Split(ingressConfig.KserveIngressGateway, "/")
 	httpRoute := gwapiv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        constants.PredictorServiceName(isvc.Name, isvc.Spec.Predictor.Name),
+			Name:        routeName,
 			Namespace:   isvc.Namespace,
 			Annotations: annotations,
 			Labels:      labels,
@@ -325,6 +328,9 @@ func createRawPredictorHTTPRoute(ctx context.Context, client client.Client, isvc
 				},
 			},
 		},
+	}
+	if len(isvc.Spec.Canary) > 0 {
+		applyCanaryWeights(isvc, &httpRoute)
 	}
 	return &httpRoute, nil
 }
@@ -669,13 +675,77 @@ func createRawTopLevelHTTPRoute(ctx context.Context, client client.Client, isvc 
 			},
 		},
 	}
+	if len(isvc.Spec.Canary) > 0 {
+		applyCanaryWeights(isvc, &httpRoute)
+	}
 	return &httpRoute, nil
 }
 
+// applyCanaryWeights modifies the HTTPRoute's backend refs to include weighted
+// backends for canary traffic splitting.
+func applyCanaryWeights(isvc *v1beta1.InferenceService, httpRoute *gwapiv1.HTTPRoute) {
+	var totalCanaryPercent int32
+	for _, canary := range isvc.Spec.Canary {
+		totalCanaryPercent += canary.TrafficPercent
+	}
+	stableWeight := int32(100) - totalCanaryPercent
+
+	for i := range httpRoute.Spec.Rules {
+		rule := &httpRoute.Spec.Rules[i]
+		if len(rule.BackendRefs) == 0 {
+			continue
+		}
+
+		template := rule.BackendRefs[0]
+		weightedBackends := make([]gwapiv1.HTTPBackendRef, 0, 1+len(isvc.Spec.Canary))
+
+		sw := stableWeight
+		stable := gwapiv1.HTTPBackendRef{
+			BackendRef: gwapiv1.BackendRef{
+				BackendObjectReference: template.BackendObjectReference,
+				Weight:                 &sw,
+			},
+		}
+		weightedBackends = append(weightedBackends, stable)
+
+		for _, canary := range isvc.Spec.Canary {
+			canaryServiceName := constants.PredictorServiceName(isvc.Name, canary.Predictor.Name)
+			cw := canary.TrafficPercent
+			backend := gwapiv1.HTTPBackendRef{
+				BackendRef: gwapiv1.BackendRef{
+					BackendObjectReference: gwapiv1.BackendObjectReference{
+						Kind:      template.Kind,
+						Name:      gwapiv1.ObjectName(canaryServiceName),
+						Namespace: template.Namespace,
+						Port:      template.Port,
+					},
+					Weight: &cw,
+				},
+			}
+			weightedBackends = append(weightedBackends, backend)
+		}
+
+		rule.BackendRefs = weightedBackends
+	}
+}
+
 func semanticHttpRouteEquals(desired, existing *gwapiv1.HTTPRoute) bool {
-	return equality.Semantic.DeepDerivative(desired.Spec, existing.Spec) &&
-		equality.Semantic.DeepDerivative(desired.Labels, existing.Labels) &&
-		equality.Semantic.DeepDerivative(desired.Annotations, existing.Annotations)
+	if !equality.Semantic.DeepDerivative(desired.Labels, existing.Labels) ||
+		!equality.Semantic.DeepDerivative(desired.Annotations, existing.Annotations) {
+		return false
+	}
+	// DeepDerivative treats missing fields as matching, so a single unweighted
+	// backend is seen as a subset of two weighted backends. Compare backend ref
+	// counts explicitly to detect canary addition/removal.
+	if len(desired.Spec.Rules) != len(existing.Spec.Rules) {
+		return false
+	}
+	for i := range desired.Spec.Rules {
+		if len(desired.Spec.Rules[i].BackendRefs) != len(existing.Spec.Rules[i].BackendRefs) {
+			return false
+		}
+	}
+	return equality.Semantic.DeepDerivative(desired.Spec, existing.Spec)
 }
 
 // isHTTPRouteReady checks if the HTTPRoute is ready. If not, returns the reason and message.
@@ -700,7 +770,7 @@ func (r *RawHTTPRouteReconciler) reconcilePredictorHTTPRoute(ctx context.Context
 	}
 
 	// reconcile httpRoute
-	httpRouteName := constants.PredictorServiceName(isvc.Name, isvc.Spec.Predictor.Name)
+	httpRouteName := constants.PredictorServiceName(isvc.Name)
 	existingHttpRoute := &gwapiv1.HTTPRoute{}
 	getExistingErr := r.client.Get(ctx, types.NamespacedName{
 		Namespace: isvc.Namespace,
@@ -955,7 +1025,7 @@ func (r *RawHTTPRouteReconciler) reconcileHTTPRouteStatus(ctx context.Context, i
 
 	checks := []httpRouteCheck{
 		{
-			name:      constants.PredictorServiceName(isvc.Name, isvc.Spec.Predictor.Name),
+			name:      constants.PredictorServiceName(isvc.Name),
 			component: "Predictor",
 		},
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
@@ -3461,3 +3461,179 @@ func TestCreateRawPredictorHTTPRouteDisableTimeout(t *testing.T) {
 		}
 	})
 }
+
+func TestApplyCanaryWeights(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	t.Run("single canary", func(t *testing.T) {
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-model", Namespace: "default"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Canary: []v1beta1.CanarySpec{
+					{
+						TrafficPercent: 20,
+						Predictor:      v1beta1.PredictorSpec{Name: "v2"},
+					},
+				},
+			},
+		}
+		httpRoute := &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{
+					{
+						BackendRefs: []gwapiv1.HTTPBackendRef{
+							{
+								BackendRef: gwapiv1.BackendRef{
+									BackendObjectReference: gwapiv1.BackendObjectReference{
+										Kind:      ptr.To(gwapiv1.Kind(constants.ServiceKind)),
+										Name:      "my-model-predictor",
+										Namespace: (*gwapiv1.Namespace)(ptr.To("default")),
+										Port:      ptr.To(int32(80)),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		applyCanaryWeights(isvc, httpRoute)
+
+		backends := httpRoute.Spec.Rules[0].BackendRefs
+		g.Expect(backends).To(HaveLen(2))
+		g.Expect(*backends[0].Weight).To(Equal(int32(80)))
+		g.Expect(string(backends[0].Name)).To(Equal("my-model-predictor"))
+		g.Expect(*backends[1].Weight).To(Equal(int32(20)))
+		g.Expect(string(backends[1].Name)).To(Equal("my-model-v2-predictor"))
+	})
+
+	t.Run("multiple canaries", func(t *testing.T) {
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-model", Namespace: "default"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Canary: []v1beta1.CanarySpec{
+					{TrafficPercent: 20, Predictor: v1beta1.PredictorSpec{Name: "v2"}},
+					{TrafficPercent: 30, Predictor: v1beta1.PredictorSpec{Name: "v3"}},
+				},
+			},
+		}
+		httpRoute := &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{
+					{
+						BackendRefs: []gwapiv1.HTTPBackendRef{
+							{BackendRef: gwapiv1.BackendRef{
+								BackendObjectReference: gwapiv1.BackendObjectReference{
+									Kind: ptr.To(gwapiv1.Kind(constants.ServiceKind)),
+									Name: "my-model-predictor",
+									Port: ptr.To(int32(80)),
+								},
+							}},
+						},
+					},
+				},
+			},
+		}
+
+		applyCanaryWeights(isvc, httpRoute)
+
+		backends := httpRoute.Spec.Rules[0].BackendRefs
+		g.Expect(backends).To(HaveLen(3))
+		g.Expect(*backends[0].Weight).To(Equal(int32(50)))
+		g.Expect(*backends[1].Weight).To(Equal(int32(20)))
+		g.Expect(string(backends[1].Name)).To(Equal("my-model-v2-predictor"))
+		g.Expect(*backends[2].Weight).To(Equal(int32(30)))
+		g.Expect(string(backends[2].Name)).To(Equal("my-model-v3-predictor"))
+	})
+
+	t.Run("dual-protocol rules", func(t *testing.T) {
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-model", Namespace: "default"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Canary: []v1beta1.CanarySpec{
+					{TrafficPercent: 25, Predictor: v1beta1.PredictorSpec{Name: "v2"}},
+				},
+			},
+		}
+		httpRoute := &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{
+					{BackendRefs: []gwapiv1.HTTPBackendRef{
+						{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{
+							Name: "my-model-predictor", Port: ptr.To(int32(9090)),
+						}}},
+					}},
+					{BackendRefs: []gwapiv1.HTTPBackendRef{
+						{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{
+							Name: "my-model-predictor", Port: ptr.To(int32(80)),
+						}}},
+					}},
+				},
+			},
+		}
+
+		applyCanaryWeights(isvc, httpRoute)
+
+		// Both rules should get canary backends
+		for _, rule := range httpRoute.Spec.Rules {
+			g.Expect(rule.BackendRefs).To(HaveLen(2))
+			g.Expect(*rule.BackendRefs[0].Weight).To(Equal(int32(75)))
+			g.Expect(*rule.BackendRefs[1].Weight).To(Equal(int32(25)))
+		}
+	})
+
+	t.Run("skips rules with no backends", func(t *testing.T) {
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-model"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Canary: []v1beta1.CanarySpec{
+					{TrafficPercent: 10, Predictor: v1beta1.PredictorSpec{Name: "v2"}},
+				},
+			},
+		}
+		httpRoute := &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{
+					{BackendRefs: nil},
+				},
+			},
+		}
+
+		applyCanaryWeights(isvc, httpRoute)
+		g.Expect(httpRoute.Spec.Rules[0].BackendRefs).To(BeNil())
+	})
+}
+
+func TestSemanticHttpRouteEquals_BackendRefCount(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	makeRoute := func(backendCount int) *gwapiv1.HTTPRoute {
+		backends := make([]gwapiv1.HTTPBackendRef, backendCount)
+		for i := range backends {
+			w := int32(100 / backendCount) //nolint:gosec // test-only, backendCount is always small
+			backends[i] = gwapiv1.HTTPBackendRef{
+				BackendRef: gwapiv1.BackendRef{
+					BackendObjectReference: gwapiv1.BackendObjectReference{
+						Name: gwapiv1.ObjectName("svc"),
+						Port: ptr.To(int32(80)),
+					},
+					Weight: &w,
+				},
+			}
+		}
+		return &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{{BackendRefs: backends}},
+			},
+		}
+	}
+
+	t.Run("different backend count is not equal", func(t *testing.T) {
+		g.Expect(semanticHttpRouteEquals(makeRoute(1), makeRoute(2))).To(BeFalse())
+	})
+
+	t.Run("same backend count is equal", func(t *testing.T) {
+		g.Expect(semanticHttpRouteEquals(makeRoute(2), makeRoute(2))).To(BeTrue())
+	})
+}

--- a/pkg/validation/managed_dra.go
+++ b/pkg/validation/managed_dra.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+// HasManagedDRA reports whether the annotations contain the managed DRA device class key.
+func HasManagedDRA(annotations map[string]string) bool {
+	_, ok := annotations[constants.ManagedDRADeviceClassAnnotationKey]
+	return ok
+}
+
+// ManagedDRADeviceClass returns the trimmed device class and whether it was present.
+func ManagedDRADeviceClass(annotations map[string]string) (string, bool) {
+	raw, ok := annotations[constants.ManagedDRADeviceClassAnnotationKey]
+	if !ok {
+		return "", false
+	}
+	return strings.TrimSpace(raw), true
+}
+
+// ManagedDRADeviceCount parses the device count annotation, defaulting to 1.
+func ManagedDRADeviceCount(annotations map[string]string) (int, error) {
+	raw, ok := annotations[constants.ManagedDRADeviceCountAnnotationKey]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return 1, nil
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s value %q: %w", constants.ManagedDRADeviceCountAnnotationKey, raw, err)
+	}
+	if count < 1 {
+		return 0, fmt.Errorf("invalid %s value %q: must be >= 1", constants.ManagedDRADeviceCountAnnotationKey, raw)
+	}
+	return count, nil
+}
+
+// ManagedDRACelSelectors splits the CEL selector annotation by newline, returning non-empty trimmed entries.
+func ManagedDRACelSelectors(annotations map[string]string) []string {
+	raw, ok := annotations[constants.ManagedDRACelSelectorAnnotationKey]
+	if !ok || strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, "\n")
+	selectors := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if v := strings.TrimSpace(p); v != "" {
+			selectors = append(selectors, v)
+		}
+	}
+	return selectors
+}
+
+// ManagedDRAContainerName returns the trimmed container name and whether it was present.
+func ManagedDRAContainerName(annotations map[string]string) (string, bool) {
+	raw, ok := annotations[constants.ManagedDRAContainerNameAnnotationKey]
+	if !ok {
+		return "", false
+	}
+	return strings.TrimSpace(raw), true
+}
+
+// ValidateManagedDRAAnnotations validates DRA-related annotations on any resource.
+func ValidateManagedDRAAnnotations(annotations map[string]string) field.ErrorList {
+	var allErrs field.ErrorList
+	if len(annotations) == 0 {
+		return allErrs
+	}
+
+	annotationsPath := field.NewPath("metadata").Child("annotations")
+
+	hasDeviceClass := HasManagedDRA(annotations)
+	_, hasDeviceCount := annotations[constants.ManagedDRADeviceCountAnnotationKey]
+	_, hasCelSelector := annotations[constants.ManagedDRACelSelectorAnnotationKey]
+	_, hasContainerName := annotations[constants.ManagedDRAContainerNameAnnotationKey]
+
+	// Require device-class if any other DRA annotation is set.
+	if !hasDeviceClass && (hasDeviceCount || hasCelSelector || hasContainerName) {
+		allErrs = append(allErrs, field.Required(
+			annotationsPath.Key(constants.ManagedDRADeviceClassAnnotationKey),
+			fmt.Sprintf("%s is required to enable managed DRA when %s, %s, or %s is set",
+				constants.ManagedDRADeviceClassAnnotationKey,
+				constants.ManagedDRADeviceCountAnnotationKey,
+				constants.ManagedDRACelSelectorAnnotationKey,
+				constants.ManagedDRAContainerNameAnnotationKey),
+		))
+	}
+
+	if trimmed, present := ManagedDRADeviceClass(annotations); present {
+		raw := annotations[constants.ManagedDRADeviceClassAnnotationKey]
+		if trimmed == "" {
+			allErrs = append(allErrs, field.Invalid(
+				annotationsPath.Key(constants.ManagedDRADeviceClassAnnotationKey),
+				raw,
+				"device class must not be empty",
+			))
+		} else if errs := validation.IsDNS1123Subdomain(trimmed); len(errs) > 0 {
+			allErrs = append(allErrs, field.Invalid(
+				annotationsPath.Key(constants.ManagedDRADeviceClassAnnotationKey),
+				raw,
+				"device class must be a DNS subdomain: "+strings.Join(errs, "; "),
+			))
+		}
+	}
+
+	if hasDeviceCount {
+		if _, err := ManagedDRADeviceCount(annotations); err != nil {
+			allErrs = append(allErrs, field.Invalid(
+				annotationsPath.Key(constants.ManagedDRADeviceCountAnnotationKey),
+				annotations[constants.ManagedDRADeviceCountAnnotationKey],
+				err.Error(),
+			))
+		}
+	}
+
+	if hasCelSelector && len(ManagedDRACelSelectors(annotations)) == 0 {
+		allErrs = append(allErrs, field.Invalid(
+			annotationsPath.Key(constants.ManagedDRACelSelectorAnnotationKey),
+			annotations[constants.ManagedDRACelSelectorAnnotationKey],
+			"cel selector must contain at least one non-empty CEL expression",
+		))
+	}
+
+	if trimmed, present := ManagedDRAContainerName(annotations); present {
+		raw := annotations[constants.ManagedDRAContainerNameAnnotationKey]
+		if trimmed == "" {
+			allErrs = append(allErrs, field.Invalid(
+				annotationsPath.Key(constants.ManagedDRAContainerNameAnnotationKey),
+				raw,
+				"container name must not be empty",
+			))
+		} else if errs := validation.IsDNS1123Label(trimmed); len(errs) > 0 {
+			allErrs = append(allErrs, field.Invalid(
+				annotationsPath.Key(constants.ManagedDRAContainerNameAnnotationKey),
+				raw,
+				"container name must be a DNS label: "+strings.Join(errs, "; "),
+			))
+		}
+	}
+
+	return allErrs
+}

--- a/pkg/validation/managed_dra_test.go
+++ b/pkg/validation/managed_dra_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kserve/kserve/pkg/constants"
+)
+
+func TestHasManagedDRA(t *testing.T) {
+	assert.False(t, HasManagedDRA(nil))
+	assert.False(t, HasManagedDRA(map[string]string{"foo": "bar"}))
+	assert.True(t, HasManagedDRA(map[string]string{constants.ManagedDRADeviceClassAnnotationKey: "gpu.nvidia.com"}))
+}
+
+func TestManagedDRADeviceCount(t *testing.T) {
+	t.Run("missing defaults to 1", func(t *testing.T) {
+		count, err := ManagedDRADeviceCount(nil)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+	})
+	t.Run("valid", func(t *testing.T) {
+		count, err := ManagedDRADeviceCount(map[string]string{constants.ManagedDRADeviceCountAnnotationKey: "4"})
+		require.NoError(t, err)
+		assert.Equal(t, 4, count)
+	})
+	t.Run("zero rejected", func(t *testing.T) {
+		_, err := ManagedDRADeviceCount(map[string]string{constants.ManagedDRADeviceCountAnnotationKey: "0"})
+		assert.Error(t, err)
+	})
+	t.Run("non-numeric rejected", func(t *testing.T) {
+		_, err := ManagedDRADeviceCount(map[string]string{constants.ManagedDRADeviceCountAnnotationKey: "abc"})
+		assert.Error(t, err)
+	})
+}
+
+func TestValidateManagedDRAAnnotations(t *testing.T) {
+	const (
+		deviceClassKey   = "serving.kserve.io/exp-dra-device-class"
+		deviceCountKey   = "serving.kserve.io/exp-dra-device-count"
+		celSelectorKey   = "serving.kserve.io/exp-dra-cel-selector"
+		containerNameKey = "serving.kserve.io/exp-dra-container-name"
+	)
+
+	tests := []struct {
+		name         string
+		annotations  map[string]string
+		wantErrCount int
+		wantErrField string
+	}{
+		{
+			name:         "no annotations",
+			annotations:  nil,
+			wantErrCount: 0,
+		},
+		{
+			name:         "valid: device class only",
+			annotations:  map[string]string{deviceClassKey: "gpu.nvidia.com"},
+			wantErrCount: 0,
+		},
+		{
+			name: "valid: full valid set",
+			annotations: map[string]string{
+				deviceClassKey:   "gpu.nvidia.com",
+				deviceCountKey:   "4",
+				celSelectorKey:   "device.attributes['gpu.nvidia.com']['type'] == 'A100'",
+				containerNameKey: "vllm",
+			},
+			wantErrCount: 0,
+		},
+		{
+			name:         "invalid: empty device class",
+			annotations:  map[string]string{deviceClassKey: "   "},
+			wantErrCount: 1,
+			wantErrField: deviceClassKey,
+		},
+		{
+			name:         "invalid: device count without device class",
+			annotations:  map[string]string{deviceCountKey: "2"},
+			wantErrCount: 1,
+			wantErrField: deviceClassKey,
+		},
+		{
+			name: "invalid: device count non-numeric",
+			annotations: map[string]string{
+				deviceClassKey: "gpu.nvidia.com",
+				deviceCountKey: "abc",
+			},
+			wantErrCount: 1,
+			wantErrField: deviceCountKey,
+		},
+		{
+			name: "invalid: empty cel selector",
+			annotations: map[string]string{
+				deviceClassKey: "gpu.nvidia.com",
+				celSelectorKey: "\n  \n",
+			},
+			wantErrCount: 1,
+			wantErrField: celSelectorKey,
+		},
+		{
+			name: "invalid: empty container name",
+			annotations: map[string]string{
+				deviceClassKey:   "gpu.nvidia.com",
+				containerNameKey: "   ",
+			},
+			wantErrCount: 1,
+			wantErrField: containerNameKey,
+		},
+		{
+			name: "invalid: multiple errors surfaced",
+			annotations: map[string]string{
+				deviceClassKey: "BAD CLASS",
+				deviceCountKey: "abc",
+			},
+			wantErrCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ValidateManagedDRAAnnotations(tt.annotations)
+			require.Len(t, errs, tt.wantErrCount, "errors: %v", errs)
+			if tt.wantErrField != "" {
+				found := false
+				for _, e := range errs {
+					if strings.Contains(e.Field, tt.wantErrField) {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "expected error on field %q, got: %v", tt.wantErrField, errs)
+			}
+		})
+	}
+}

--- a/test/e2e/common/utils.py
+++ b/test/e2e/common/utils.py
@@ -15,6 +15,7 @@
 import asyncio
 import json
 import os
+import time
 from concurrent import futures
 from typing import Union, List, Dict
 from urllib.parse import urlparse
@@ -22,6 +23,7 @@ from urllib.parse import urlparse
 import portforward
 import requests
 from kubernetes import client as k8s_client
+from kubernetes.stream import stream as k8s_stream
 from orjson import orjson
 
 from httpx import HTTPStatusError
@@ -670,14 +672,55 @@ def is_model_ready(
     return rest_client.is_model_ready(base_url, model_name, headers=headers)
 
 
-def extract_process_ids_from_logs(logs: str) -> set[int]:
-    process_ids = set()
-    for line in logs.splitlines():
-        tokens = line.strip().split()
-        if len(tokens) >= 5 and tokens[3] == "kserve.trace":
-            process_ids.add(int(tokens[2]))
-    logger.info("Extracted process ids: %s", process_ids)
-    return process_ids
+_WORKER_COUNT_SCRIPT = """\
+import glob, os
+count = 0
+for f in glob.glob("/proc/[0-9]*/cmdline"):
+    try:
+        data = open(f, "rb").read()
+        if b"spawn_main" not in data: continue
+        status = open(os.path.join(os.path.dirname(f), "status")).read()
+        ppid = status.split("PPid:\\t")[1].split()[0]
+        if ppid == "1": count += 1
+    except (OSError, IndexError): pass
+print(count)
+"""
+
+
+def get_container_worker_count(
+    core_api: k8s_client.CoreV1Api,
+    pod_name: str,
+    namespace: str,
+    container: str = INFERENCESERVICE_CONTAINER,
+    timeout: int = 30,
+    interval: int = 2,
+) -> int:
+    """Count multiprocessing worker processes inside a running container via /proc."""
+    cmd = ["python", "-c", _WORKER_COUNT_SCRIPT]
+    deadline = time.monotonic() + timeout
+    last_count = 0
+    while True:
+        resp = k8s_stream(
+            core_api.connect_get_namespaced_pod_exec,
+            pod_name,
+            namespace,
+            container=container,
+            command=cmd,
+            stderr=False,
+            stdout=True,
+            stdin=False,
+            tty=False,
+        )
+        try:
+            last_count = int(resp.strip())
+        except ValueError:
+            logger.warning("Unexpected worker-count output: %r", resp)
+            last_count = 0
+        if last_count > 0 or time.monotonic() >= deadline:
+            break
+        time.sleep(interval)
+    logger.info("Worker process count in %s/%s: %d", namespace, pod_name, last_count)
+    return last_count
 
 
 async def wait_for_pod_logs(

--- a/test/e2e/custom/test_custom_model_grpc.py
+++ b/test/e2e/custom/test_custom_model_grpc.py
@@ -144,7 +144,7 @@ async def test_predictor_grpc_with_transformer_grpc():
             V1Container(
                 name="kserve-container",
                 image="kserve/custom-image-transformer-grpc:"
-                + os.environ.get("GITHUB_SHA"),
+                + (os.environ.get("GITHUB_SHA") or "latest"),
                 resources=V1ResourceRequirements(
                     requests={"cpu": "50m", "memory": "128Mi"},
                     limits={"cpu": "100m", "memory": "1Gi"},
@@ -398,7 +398,8 @@ async def test_predictor_grpc_with_transformer_grpc_raw(network_layer):
         containers=[
             V1Container(
                 name="kserve-container",
-                image="kserve/custom-model-grpc:" + os.environ.get("GITHUB_SHA"),
+                image="kserve/custom-model-grpc:"
+                + (os.environ.get("GITHUB_SHA") or "latest"),
                 resources=V1ResourceRequirements(
                     requests={"cpu": "50m", "memory": "128Mi"},
                     limits={"cpu": "100m", "memory": "1Gi"},
@@ -418,7 +419,7 @@ async def test_predictor_grpc_with_transformer_grpc_raw(network_layer):
             V1Container(
                 name="kserve-container",
                 image="kserve/custom-image-transformer-grpc:"
-                + os.environ.get("GITHUB_SHA"),
+                + (os.environ.get("GITHUB_SHA") or "latest"),
                 resources=V1ResourceRequirements(
                     requests={"cpu": "50m", "memory": "128Mi"},
                     limits={"cpu": "100m", "memory": "1Gi"},

--- a/test/e2e/graph/test_inference_graph.py
+++ b/test/e2e/graph/test_inference_graph.py
@@ -39,7 +39,7 @@ from httpx import HTTPStatusError
 
 from ..common.utils import KSERVE_TEST_NAMESPACE, predict_ig
 
-img_version = os.environ.get("GITHUB_SHA", "latest")
+img_version = os.environ.get("GITHUB_SHA") or "latest"
 
 SUCCESS_ISVC_IMAGE = f"kserve/success-200-isvc:{img_version}"
 ERROR_ISVC_IMAGE = f"kserve/error-404-isvc:{img_version}"

--- a/test/e2e/llmisvc/fixtures.py
+++ b/test/e2e/llmisvc/fixtures.py
@@ -764,6 +764,58 @@ LLMINFERENCESERVICE_CONFIGS = {
             },
         },
     },
+    # Same plugin config as "scheduler-with-precise-prefix-cache-inline-config"
+    # above, but supplied as literal YAML via
+    # spec.router.scheduler.template.containers[].args (a "--config-text
+    # <yaml>" pair) instead of spec.router.scheduler.config.inline.
+    "scheduler-with-precise-prefix-cache-template-args-config": {
+        "router": {
+            "scheduler": {
+                "template": {
+                    "containers": [
+                        {
+                            "name": "main",
+                            "args": [
+                                "--config-text",
+                                (
+                                    "apiVersion: llm-d.ai/v1alpha1\n"
+                                    "kind: EndpointPickerConfig\n"
+                                    "plugins:\n"
+                                    "- type: single-profile-handler\n"
+                                    "- type: precise-prefix-cache-scorer\n"
+                                    "  parameters:\n"
+                                    "    tokenProcessorConfig:\n"
+                                    "      blockSize: 16\n"
+                                    '      hashSeed: "42"\n'
+                                    "    kvEventsConfig:\n"
+                                    "      zmqEndpoint: tcp://*:5557\n"
+                                    "    indexerConfig:\n"
+                                    "      tokenizersPoolConfig:\n"
+                                    "        modelName: facebook/opt-125m\n"
+                                    "      kvBlockIndexConfig:\n"
+                                    "        enableMetrics: true\n"
+                                    "        metricsLoggingInterval: 60000000000\n"
+                                    "- type: queue-scorer\n"
+                                    "- type: kv-cache-utilization-scorer\n"
+                                    "- type: max-score-picker\n"
+                                    "schedulingProfiles:\n"
+                                    "- name: default\n"
+                                    "  plugins:\n"
+                                    "  - pluginRef: queue-scorer\n"
+                                    "    weight: 2\n"
+                                    "  - pluginRef: kv-cache-utilization-scorer\n"
+                                    "    weight: 2\n"
+                                    "  - pluginRef: precise-prefix-cache-scorer\n"
+                                    "    weight: 3\n"
+                                    "  - pluginRef: max-score-picker\n"
+                                ),
+                            ],
+                        }
+                    ],
+                },
+            },
+        },
+    },
     # Clean-path: token-producer in inline config triggers standalone tokenizer
     # deployment automatically. The controller injects modelName and vllm.url
     # into the token-producer plugin parameters.

--- a/test/e2e/llmisvc/test_llm_canary_lifecycle.py
+++ b/test/e2e/llmisvc/test_llm_canary_lifecycle.py
@@ -37,13 +37,17 @@ import logging
 import os
 import requests
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
 import pytest
+from kserve.models import V1alpha2LLMInferenceService, V1alpha2LLMInferenceServiceConfig
 from kubernetes import client as k8s_client, config
 
+from .diagnostic import collect_diagnostics
 from .fixtures import DEFAULT_LLMISVC_ANNOTATIONS, LLMD_SIMULATOR_SECURITY_CONTEXT
+from .namespace import skip_deletion, skip_deletion_on_failure
 
 logger = logging.getLogger(__name__)
 
@@ -133,21 +137,16 @@ DIV_MODEL_V2 = "model-beta"
 
 def apply_divergence_member(api, name, model_name, weight, ns):
     """Deploy a member for divergence tests (service backend, no scheduler)."""
-    model_spec = {"name": model_name, "uri": MODEL_URI}
-    body = {
-        "apiVersion": f"{KSERVE_GROUP}/{KSERVE_VERSION}",
-        "kind": "LLMInferenceService",
-        "metadata": {
-            "name": name,
-            "namespace": ns,
-            **(
-                {"annotations": dict(DEFAULT_LLMISVC_ANNOTATIONS)}
-                if DEFAULT_LLMISVC_ANNOTATIONS
-                else {}
-            ),
-        },
-        "spec": {
-            "model": model_spec,
+    body = V1alpha2LLMInferenceService(
+        api_version=f"{KSERVE_GROUP}/{KSERVE_VERSION}",
+        kind="LLMInferenceService",
+        metadata=k8s_client.V1ObjectMeta(
+            name=name,
+            namespace=ns,
+            annotations=dict(DEFAULT_LLMISVC_ANNOTATIONS) or None,
+        ),
+        spec={
+            "model": {"name": model_name, "uri": MODEL_URI},
             "baseRefs": [{"name": INFERENCE_SIM.name}],
             "router": {
                 "route": {
@@ -157,7 +156,7 @@ def apply_divergence_member(api, name, model_name, weight, ns):
                 },
             },
         },
-    }
+    )
     try:
         api.create_namespaced_custom_object(
             KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, body
@@ -217,12 +216,12 @@ def get_api():
 
 
 def apply_config(api, name, ns, spec):
-    body = {
-        "apiVersion": f"{KSERVE_GROUP}/{KSERVE_VERSION}",
-        "kind": "LLMInferenceServiceConfig",
-        "metadata": {"name": name, "namespace": ns},
-        "spec": spec,
-    }
+    body = V1alpha2LLMInferenceServiceConfig(
+        api_version=f"{KSERVE_GROUP}/{KSERVE_VERSION}",
+        kind="LLMInferenceServiceConfig",
+        metadata=k8s_client.V1ObjectMeta(name=name, namespace=ns),
+        spec=spec,
+    )
     try:
         api.create_namespaced_custom_object(
             KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_CONFIG_PLURAL, body
@@ -253,20 +252,16 @@ def apply_member(api, member: MemberSpec, ns):
     if member.scheduler:
         spec["router"]["scheduler"] = {}
 
-    body = {
-        "apiVersion": f"{KSERVE_GROUP}/{KSERVE_VERSION}",
-        "kind": "LLMInferenceService",
-        "metadata": {
-            "name": member.name,
-            "namespace": ns,
-            **(
-                {"annotations": dict(DEFAULT_LLMISVC_ANNOTATIONS)}
-                if DEFAULT_LLMISVC_ANNOTATIONS
-                else {}
-            ),
-        },
-        "spec": spec,
-    }
+    body = V1alpha2LLMInferenceService(
+        api_version=f"{KSERVE_GROUP}/{KSERVE_VERSION}",
+        kind="LLMInferenceService",
+        metadata=k8s_client.V1ObjectMeta(
+            name=member.name,
+            namespace=ns,
+            annotations=dict(DEFAULT_LLMISVC_ANNOTATIONS) or None,
+        ),
+        spec=spec,
+    )
     try:
         api.create_namespaced_custom_object(
             KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, body
@@ -304,6 +299,42 @@ def delete_member(api, name, ns, wait=False):
                     return
             time.sleep(2)
         logger.warning(f"{name} still exists after 120s")
+
+
+def _maybe_delete_member(api, name, ns, test_failed):
+    """Conditionally delete a member, respecting skip-deletion env vars."""
+    try:
+        if skip_deletion():
+            logger.info("Skipping deletion of %s (SKIP_RESOURCE_DELETION)", name)
+            return
+        if test_failed and skip_deletion_on_failure():
+            logger.info(
+                "Skipping deletion of %s due to test failure (SKIP_DELETION_ON_FAILURE)",
+                name,
+            )
+            return
+        delete_member(api, name, ns)
+    except Exception as e:
+        logger.warning("Failed to cleanup member %s: %s", name, e)
+
+
+@contextmanager
+def member_lifecycle(api, members, ns):
+    """Collect diagnostics on failure, conditionally delete members on exit."""
+    test_failed = False
+    try:
+        yield
+    except BaseException:
+        test_failed = True
+        for name in members:
+            try:
+                collect_diagnostics(name, ns, log=logger.info)
+            except Exception:
+                logger.exception("Failed to collect diagnostics for %s", name)
+        raise
+    finally:
+        for name in members:
+            _maybe_delete_member(api, name, ns, test_failed)
 
 
 def wait_ready(api, name, ns, timeout=600):
@@ -616,7 +647,9 @@ class TestCanaryLifecycle:
     )
     def test_canary_service_backend(self, canary_env, traffic_driver):
         """Service backend - works with any gateway."""
-        self._run_canary_lifecycle(canary_env, traffic_driver)
+        scenario, api, ns = canary_env
+        with member_lifecycle(api, [scenario.v1.name, scenario.v2.name], ns):
+            self._run_canary_lifecycle(canary_env, traffic_driver)
 
     def test_model_name_divergence(self, test_namespace):
         """Members with different model.name form independent sub-groups.
@@ -628,38 +661,41 @@ class TestCanaryLifecycle:
         api = get_api()
         ns = test_namespace
 
-        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
-        apply_divergence_member(api, DIV_V1, DIV_MODEL_V1, 5, ns)
-        apply_divergence_member(api, DIV_V2, DIV_MODEL_V2, 5, ns)
+        with member_lifecycle(api, [DIV_V1, DIV_V2], ns):
+            apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+            apply_divergence_member(api, DIV_V1, DIV_MODEL_V1, 5, ns)
+            apply_divergence_member(api, DIV_V2, DIV_MODEL_V2, 5, ns)
 
-        wait_ready(api, DIV_V1, ns)
-        wait_ready(api, DIV_V2, ns)
+            wait_ready(api, DIV_V1, ns)
+            wait_ready(api, DIV_V2, ns)
 
-        # Both members should be GroupReady (each sub-group works)
-        for name in [DIV_V1, DIV_V2]:
-            c = wait_for_condition(api, name, ns, "GroupReady", status="True")
-            assert c["status"] == "True", f"{name}: GroupReady={c['status']}"
+            # Both members should be GroupReady (each sub-group works)
+            for name in [DIV_V1, DIV_V2]:
+                c = wait_for_condition(api, name, ns, "GroupReady", status="True")
+                assert c["status"] == "True", f"{name}: GroupReady={c['status']}"
 
-        # Both should be GroupDegraded with MemberDivergence
-        for name in [DIV_V1, DIV_V2]:
-            c = wait_for_condition(
-                api,
-                name,
-                ns,
-                "GroupDegraded",
-                status="True",
-                reason="MemberDivergence",
-            )
-            assert c["status"] == "True", f"{name}: GroupDegraded={c['status']}"
-            assert c["reason"] == "MemberDivergence", f"{name}: reason={c['reason']}"
+            # Both should be GroupDegraded with MemberDivergence
+            for name in [DIV_V1, DIV_V2]:
+                c = wait_for_condition(
+                    api,
+                    name,
+                    ns,
+                    "GroupDegraded",
+                    status="True",
+                    reason="MemberDivergence",
+                )
+                assert c["status"] == "True", f"{name}: GroupDegraded={c['status']}"
+                assert c["reason"] == "MemberDivergence", (
+                    f"{name}: reason={c['reason']}"
+                )
 
-        # Each member's sub-group should contain only itself
-        v1_members = get_group_members(api, DIV_V1, ns)
-        v2_members = get_group_members(api, DIV_V2, ns)
-        assert v1_members == [DIV_V1], f"v1 group members: {v1_members}"
-        assert v2_members == [DIV_V2], f"v2 group members: {v2_members}"
+            # Each member's sub-group should contain only itself
+            v1_members = get_group_members(api, DIV_V1, ns)
+            v2_members = get_group_members(api, DIV_V2, ns)
+            assert v1_members == [DIV_V1], f"v1 group members: {v1_members}"
+            assert v2_members == [DIV_V2], f"v2 group members: {v2_members}"
 
-        logger.info("Model name divergence verified")
+            logger.info("Model name divergence verified")
 
     def test_model_name_divergence_resolves(self, test_namespace):
         """Fixing a divergent model.name clears the degraded condition.
@@ -671,85 +707,91 @@ class TestCanaryLifecycle:
         api = get_api()
         ns = test_namespace
 
-        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
-        apply_divergence_member(api, DIV_V1, DIV_MODEL_V1, 5, ns)
-        apply_divergence_member(api, DIV_V2, DIV_MODEL_V2, 5, ns)
+        with member_lifecycle(api, [DIV_V1, DIV_V2], ns):
+            apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+            apply_divergence_member(api, DIV_V1, DIV_MODEL_V1, 5, ns)
+            apply_divergence_member(api, DIV_V2, DIV_MODEL_V2, 5, ns)
 
-        wait_ready(api, DIV_V1, ns)
-        wait_ready(api, DIV_V2, ns)
+            wait_ready(api, DIV_V1, ns)
+            wait_ready(api, DIV_V2, ns)
 
-        # Confirm divergence is detected first
-        wait_for_condition(
-            api,
-            DIV_V1,
-            ns,
-            "GroupDegraded",
-            status="True",
-            reason="MemberDivergence",
-        )
+            # Confirm divergence is detected first
+            wait_for_condition(
+                api,
+                DIV_V1,
+                ns,
+                "GroupDegraded",
+                status="True",
+                reason="MemberDivergence",
+            )
 
-        # Fix: patch v2's model name to match v1
-        patch_model_name(api, DIV_V2, DIV_MODEL_V1, ns)
-        logger.info(f"Patched {DIV_V2} model name to {DIV_MODEL_V1}")
+            # Fix: patch v2's model name to match v1
+            patch_model_name(api, DIV_V2, DIV_MODEL_V1, ns)
+            logger.info(f"Patched {DIV_V2} model name to {DIV_MODEL_V1}")
 
-        # Wait for ready again (model name change triggers reconcile)
-        wait_ready(api, DIV_V2, ns)
+            # Wait for ready again (model name change triggers reconcile)
+            wait_ready(api, DIV_V2, ns)
 
-        # GroupReady should still be True
-        for name in [DIV_V1, DIV_V2]:
-            c = wait_for_condition(api, name, ns, "GroupReady", status="True")
-            assert c["status"] == "True", f"{name}: GroupReady={c['status']}"
+            # GroupReady should still be True
+            for name in [DIV_V1, DIV_V2]:
+                c = wait_for_condition(api, name, ns, "GroupReady", status="True")
+                assert c["status"] == "True", f"{name}: GroupReady={c['status']}"
 
-        # GroupDegraded should be cleared (controller removes the condition
-        # via ClearCondition, so it becomes absent rather than status=False)
-        for name in [DIV_V1, DIV_V2]:
-            wait_for_condition_absent(api, name, ns, "GroupDegraded")
+            # GroupDegraded should be cleared (controller removes the condition
+            # via ClearCondition, so it becomes absent rather than status=False)
+            for name in [DIV_V1, DIV_V2]:
+                wait_for_condition_absent(api, name, ns, "GroupDegraded")
 
-        # Both members should now appear in each other's group.
-        # Wait for group membership to converge (may lag behind condition update).
-        for name in [DIV_V1, DIV_V2]:
-            wait_for_member_count(api, name, ns, 2)
-            members = get_group_members(api, name, ns)
-            assert DIV_V1 in members, f"{name} missing {DIV_V1}: {members}"
-            assert DIV_V2 in members, f"{name} missing {DIV_V2}: {members}"
+            # Both members should now appear in each other's group.
+            # Wait for group membership to converge (may lag behind condition update).
+            for name in [DIV_V1, DIV_V2]:
+                wait_for_member_count(api, name, ns, 2)
+                group_members = get_group_members(api, name, ns)
+                assert DIV_V1 in group_members, (
+                    f"{name} missing {DIV_V1}: {group_members}"
+                )
+                assert DIV_V2 in group_members, (
+                    f"{name} missing {DIV_V2}: {group_members}"
+                )
 
-        logger.info("Model name divergence resolution verified")
+            logger.info("Model name divergence resolution verified")
 
     def test_weight_without_group_rejected(self, test_namespace):
         """Webhook rejects LLMISVC with weight but no group. (spike step 11)"""
         api = get_api()
         ns = test_namespace
 
-        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+        with member_lifecycle(api, ["webhook-reject"], ns):
+            apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
 
-        body = {
-            "apiVersion": f"{KSERVE_GROUP}/{KSERVE_VERSION}",
-            "kind": "LLMInferenceService",
-            "metadata": {"name": "webhook-reject", "namespace": ns},
-            "spec": {
-                "model": {"name": MODEL, "uri": MODEL_URI},
-                "baseRefs": [{"name": INFERENCE_SIM.name}],
-                "router": {
-                    "route": {
-                        "weight": 5,
-                        "http": {},
+            body = V1alpha2LLMInferenceService(
+                api_version=f"{KSERVE_GROUP}/{KSERVE_VERSION}",
+                kind="LLMInferenceService",
+                metadata=k8s_client.V1ObjectMeta(name="webhook-reject", namespace=ns),
+                spec={
+                    "model": {"name": MODEL, "uri": MODEL_URI},
+                    "baseRefs": [{"name": INFERENCE_SIM.name}],
+                    "router": {
+                        "route": {
+                            "weight": 5,
+                            "http": {},
+                        },
                     },
                 },
-            },
-        }
-
-        with pytest.raises(k8s_client.ApiException) as exc_info:
-            api.create_namespaced_custom_object(
-                KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, body
             )
-        assert exc_info.value.status == 422, (
-            f"Expected 422 webhook rejection, got {exc_info.value.status}"
-        )
-        err_msg = json.loads(exc_info.value.body).get("message", "")
-        assert "weight requires group" in err_msg.lower(), (
-            f"Expected 'weight requires group' in error message: {err_msg}"
-        )
-        logger.info("Webhook rejection verified: weight without group")
+
+            with pytest.raises(k8s_client.ApiException) as exc_info:
+                api.create_namespaced_custom_object(
+                    KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, body
+                )
+            assert exc_info.value.status == 422, (
+                f"Expected 422 webhook rejection, got {exc_info.value.status}"
+            )
+            err_msg = json.loads(exc_info.value.body).get("message", "")
+            assert "weight requires group" in err_msg.lower(), (
+                f"Expected 'weight requires group' in error message: {err_msg}"
+            )
+            logger.info("Webhook rejection verified: weight without group")
 
     def _run_canary_lifecycle(self, canary_env, traffic_driver):
         scenario, api, ns = canary_env
@@ -872,72 +914,77 @@ class TestCanaryLifecycle:
         v1 = MemberSpec(name="stop-v1", weight=9, scheduler=False)
         v2 = MemberSpec(name="stop-v2", weight=1, scheduler=False)
 
-        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
-        apply_member(api, v1, ns)
-        apply_member(api, v2, ns)
+        with member_lifecycle(api, [v1.name, v2.name], ns):
+            apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+            apply_member(api, v1, ns)
+            apply_member(api, v2, ns)
 
-        wait_ready(api, v1.name, ns)
-        wait_ready(api, v2.name, ns)
+            wait_ready(api, v1.name, ns)
+            wait_ready(api, v2.name, ns)
 
-        gateway = get_gateway_base_url(api, v1.name, ns)
-        driver = traffic_driver(
-            url=f"{gateway}/v1/completions",
-            headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
-            payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
-            rate=2,
-            timeout=15.0,
-            warmup=True,
-        )
-
-        driver.mark("before_stop")
-        driver.collect(20)
-
-        patch_stop(api, v2.name, ns)
-        wait_for_member_stopped(api, v1.name, v2.name, ns, stopped=True)
-
-        wait_for_healthy_route(
-            f"{gateway}/v1/completions",
-            {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
-            {"model": MODEL, "prompt": "Hello", "max_tokens": 5},
-            expect_header=("x-inference-pod", v1.name),
-        )
-        driver.mark("settled")
-        driver.collect(30)
-
-        report = driver.stop()
-
-        settled = report.phase("settled")
-        settled.assert_no_errors(
-            "force-stop: traffic should flow to v1 after convergence"
-        )
-
-        def is_v2(r):
-            return r.headers.get("x-inference-pod", "").startswith(v2.name)
-
-        v2_after = settled.where(is_v2).count
-        assert v2_after == 0, f"v2 got {v2_after} requests after stop"
-
-        m = get_member_status(api, v1.name, v2.name, ns)
-        assert m is not None, "v2 should still be in group status"
-        assert m.get("stopped") is True, f"v2 stopped={m.get('stopped')}"
-        assert m.get("weight") == 1, f"v2 declared weight={m.get('weight')}, expected 1"
-
-        # Verify workload scaled down (deleted or scaled to zero)
-        apps = k8s_client.AppsV1Api()
-        deadline = time.monotonic() + 60
-        while time.monotonic() < deadline:
-            deps = apps.list_namespaced_deployment(
-                ns,
-                label_selector=f"app.kubernetes.io/part-of=llminferenceservice,app.kubernetes.io/instance={v2.name}",
+            gateway = get_gateway_base_url(api, v1.name, ns)
+            driver = traffic_driver(
+                url=f"{gateway}/v1/completions",
+                headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+                payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+                rate=2,
+                timeout=15.0,
+                warmup=True,
             )
-            if not deps.items or all(d.spec.replicas == 0 for d in deps.items):
-                break
-            time.sleep(2)
-        else:
-            replicas = [d.spec.replicas for d in deps.items]
-            raise AssertionError(f"v2 deployment not scaled down: replicas={replicas}")
 
-        logger.info("Force-stop verified")
+            driver.mark("before_stop")
+            driver.collect(20)
+
+            patch_stop(api, v2.name, ns)
+            wait_for_member_stopped(api, v1.name, v2.name, ns, stopped=True)
+
+            wait_for_healthy_route(
+                f"{gateway}/v1/completions",
+                {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+                {"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+                expect_header=("x-inference-pod", v1.name),
+            )
+            driver.mark("settled")
+            driver.collect(30)
+
+            report = driver.stop()
+
+            settled = report.phase("settled")
+            settled.assert_no_errors(
+                "force-stop: traffic should flow to v1 after convergence"
+            )
+
+            def is_v2(r):
+                return r.headers.get("x-inference-pod", "").startswith(v2.name)
+
+            v2_after = settled.where(is_v2).count
+            assert v2_after == 0, f"v2 got {v2_after} requests after stop"
+
+            m = get_member_status(api, v1.name, v2.name, ns)
+            assert m is not None, "v2 should still be in group status"
+            assert m.get("stopped") is True, f"v2 stopped={m.get('stopped')}"
+            assert m.get("weight") == 1, (
+                f"v2 declared weight={m.get('weight')}, expected 1"
+            )
+
+            # Verify workload scaled down (deleted or scaled to zero)
+            apps = k8s_client.AppsV1Api()
+            deadline = time.monotonic() + 60
+            while time.monotonic() < deadline:
+                deps = apps.list_namespaced_deployment(
+                    ns,
+                    label_selector=f"app.kubernetes.io/part-of=llminferenceservice,app.kubernetes.io/instance={v2.name}",
+                )
+                if not deps.items or all(d.spec.replicas == 0 for d in deps.items):
+                    break
+                time.sleep(2)
+            else:
+                replicas = [d.spec.replicas for d in deps.items]
+                raise AssertionError(
+                    f"v2 deployment not scaled down: replicas={replicas}"
+                )
+
+            logger.info("Force-stop verified")
 
     def test_decommission(self, test_namespace, traffic_driver):
         """Delete a member from the group - remaining member stays Ready,
@@ -948,47 +995,50 @@ class TestCanaryLifecycle:
         v1 = MemberSpec(name="decom-v1", weight=9, scheduler=False)
         v2 = MemberSpec(name="decom-v2", weight=1, scheduler=False)
 
-        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
-        apply_member(api, v1, ns)
-        apply_member(api, v2, ns)
+        with member_lifecycle(api, [v1.name, v2.name], ns):
+            apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+            apply_member(api, v1, ns)
+            apply_member(api, v2, ns)
 
-        wait_ready(api, v1.name, ns)
-        wait_ready(api, v2.name, ns)
+            wait_ready(api, v1.name, ns)
+            wait_ready(api, v2.name, ns)
 
-        gateway = get_gateway_base_url(api, v1.name, ns)
-        driver = traffic_driver(
-            url=f"{gateway}/v1/completions",
-            headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
-            payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
-            rate=2,
-            timeout=15.0,
-            warmup=True,
-        )
+            gateway = get_gateway_base_url(api, v1.name, ns)
+            driver = traffic_driver(
+                url=f"{gateway}/v1/completions",
+                headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+                payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+                rate=2,
+                timeout=15.0,
+                warmup=True,
+            )
 
-        driver.mark("before_delete")
-        driver.collect(20)
+            driver.mark("before_delete")
+            driver.collect(20)
 
-        driver.mark("delete")
-        delete_member(api, v2.name, ns, wait=True)
-        wait_for_member_count(api, v1.name, ns, 1)
+            driver.mark("delete")
+            delete_member(api, v2.name, ns, wait=True)
+            wait_for_member_count(api, v1.name, ns, 1)
 
-        driver.mark("settled")
-        driver.collect(30)
+            driver.mark("settled")
+            driver.collect(30)
 
-        report = driver.stop()
+            report = driver.stop()
 
-        # Intentionally strict: zero errors across the entire run including
-        # the delete-to-route-reprogramming window. This is the zero-downtime
-        # deletion claim. If it flakes, that's a real gateway routing gap
-        # worth investigating rather than masking with tolerance.
-        report.all.assert_no_errors("decommission: zero errors including transition")
+            # Intentionally strict: zero errors across the entire run including
+            # the delete-to-route-reprogramming window. This is the zero-downtime
+            # deletion claim. If it flakes, that's a real gateway routing gap
+            # worth investigating rather than masking with tolerance.
+            report.all.assert_no_errors(
+                "decommission: zero errors including transition"
+            )
 
-        members = get_group_members(api, v1.name, ns)
-        assert v2.name not in members, f"v2 still in group: {members}"
+            group_members = get_group_members(api, v1.name, ns)
+            assert v2.name not in group_members, f"v2 still in group: {group_members}"
 
-        wait_for_condition(api, v1.name, ns, "Ready", status="True")
+            wait_for_condition(api, v1.name, ns, "Ready", status="True")
 
-        logger.info("Decommission verified")
+            logger.info("Decommission verified")
 
     def test_leave_group(self, test_namespace):
         """Remove group+weight from a member - leaves the group. (spike step 14)"""
@@ -998,43 +1048,44 @@ class TestCanaryLifecycle:
         v1 = MemberSpec(name="leave-v1", weight=5, scheduler=False)
         v2 = MemberSpec(name="leave-v2", weight=5, scheduler=False)
 
-        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
-        apply_member(api, v1, ns)
-        apply_member(api, v2, ns)
+        with member_lifecycle(api, [v1.name, v2.name], ns):
+            apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+            apply_member(api, v1, ns)
+            apply_member(api, v2, ns)
 
-        wait_ready(api, v1.name, ns)
-        wait_ready(api, v2.name, ns)
-        wait_for_member_count(api, v1.name, ns, 2)
+            wait_ready(api, v1.name, ns)
+            wait_ready(api, v2.name, ns)
+            wait_for_member_count(api, v1.name, ns, 2)
 
-        # Remove group and weight from v2
-        api.patch_namespaced_custom_object(
-            KSERVE_GROUP,
-            KSERVE_VERSION,
-            ns,
-            KSERVE_PLURAL,
-            v2.name,
-            {"spec": {"router": {"route": {"group": None, "weight": None}}}},
-        )
-        logger.info(f"Removed group+weight from {v2.name}")
+            # Remove group and weight from v2
+            api.patch_namespaced_custom_object(
+                KSERVE_GROUP,
+                KSERVE_VERSION,
+                ns,
+                KSERVE_PLURAL,
+                v2.name,
+                {"spec": {"router": {"route": {"group": None, "weight": None}}}},
+            )
+            logger.info(f"Removed group+weight from {v2.name}")
 
-        wait_for_member_count(api, v1.name, ns, 1)
+            wait_for_member_count(api, v1.name, ns, 1)
 
-        members = get_group_members(api, v1.name, ns)
-        assert v2.name not in members, f"v2 still in group: {members}"
+            group_members = get_group_members(api, v1.name, ns)
+            assert v2.name not in group_members, f"v2 still in group: {group_members}"
 
-        # v1 should still be Ready
-        wait_for_condition(api, v1.name, ns, "Ready", status="True")
+            # v1 should still be Ready
+            wait_for_condition(api, v1.name, ns, "Ready", status="True")
 
-        # v2's routing-group label should be removed
-        obj = api.get_namespaced_custom_object(
-            KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, v2.name
-        )
-        labels = obj.get("metadata", {}).get("labels", {})
-        assert "serving.kserve.io/routing-group" not in labels, (
-            f"routing-group label still present: {labels}"
-        )
+            # v2's routing-group label should be removed
+            obj = api.get_namespaced_custom_object(
+                KSERVE_GROUP, KSERVE_VERSION, ns, KSERVE_PLURAL, v2.name
+            )
+            labels = obj.get("metadata", {}).get("labels", {})
+            assert "serving.kserve.io/routing-group" not in labels, (
+                f"routing-group label still present: {labels}"
+            )
 
-        logger.info("Leave group verified")
+            logger.info("Leave group verified")
 
     def test_three_member_group(self, test_namespace, traffic_driver):
         """Three members in a group all receive traffic. (spike step 15)"""
@@ -1045,47 +1096,50 @@ class TestCanaryLifecycle:
         v2 = MemberSpec(name="tri-v2", weight=3, scheduler=False)
         v3 = MemberSpec(name="tri-v3", weight=2, scheduler=False)
 
-        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
-        for m in [v1, v2, v3]:
-            apply_member(api, m, ns)
+        with member_lifecycle(api, [v1.name, v2.name, v3.name], ns):
+            apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+            for m in [v1, v2, v3]:
+                apply_member(api, m, ns)
 
-        for m in [v1, v2, v3]:
-            wait_ready(api, m.name, ns)
-        wait_for_member_count(api, v1.name, ns, 3)
+            for m in [v1, v2, v3]:
+                wait_ready(api, m.name, ns)
+            wait_for_member_count(api, v1.name, ns, 3)
 
-        gateway = get_gateway_base_url(api, v1.name, ns)
-        route_headers = {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"}
-        route_payload = {"model": MODEL, "prompt": "Hello", "max_tokens": 5}
+            gateway = get_gateway_base_url(api, v1.name, ns)
+            route_headers = {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"}
+            route_payload = {"model": MODEL, "prompt": "Hello", "max_tokens": 5}
 
-        wait_for_healthy_route(
-            f"{gateway}/v1/completions",
-            route_headers,
-            route_payload,
-        )
+            wait_for_healthy_route(
+                f"{gateway}/v1/completions",
+                route_headers,
+                route_payload,
+            )
 
-        driver = traffic_driver(
-            url=f"{gateway}/v1/completions",
-            headers=route_headers,
-            payload=route_payload,
-            rate=2,
-            timeout=15.0,
-            warmup=True,
-        )
+            driver = traffic_driver(
+                url=f"{gateway}/v1/completions",
+                headers=route_headers,
+                payload=route_payload,
+                rate=2,
+                timeout=15.0,
+                warmup=True,
+            )
 
-        driver.collect(60)
-        report = driver.stop()
+            driver.collect(60)
+            report = driver.stop()
 
-        report.all.assert_no_errors("three-member group")
+            report.all.assert_no_errors("three-member group")
 
-        for m in [v1, v2, v3]:
+            for m in [v1, v2, v3]:
 
-            def match(r, prefix=m.name):
-                return r.headers.get("x-inference-pod", "").startswith(prefix)
+                def match(r, prefix=m.name):
+                    return r.headers.get("x-inference-pod", "").startswith(prefix)
 
-            count = report.all.where(match).count
-            assert count > 0, f"{m.name} received no traffic ({report.all.count} total)"
+                count = report.all.where(match).count
+                assert count > 0, (
+                    f"{m.name} received no traffic ({report.all.count} total)"
+                )
 
-        logger.info("Three-member group verified")
+            logger.info("Three-member group verified")
 
     def test_late_join(self, test_namespace, traffic_driver):
         """A member joins an already-running group. (spike step 16)"""
@@ -1095,49 +1149,52 @@ class TestCanaryLifecycle:
         v1 = MemberSpec(name="late-v1", weight=9, scheduler=False)
         v2 = MemberSpec(name="late-v2", weight=1, scheduler=False)
 
-        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
-        apply_member(api, v1, ns)
+        with member_lifecycle(api, [v1.name, v2.name], ns):
+            apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+            apply_member(api, v1, ns)
 
-        wait_ready(api, v1.name, ns)
+            wait_ready(api, v1.name, ns)
 
-        gateway = get_gateway_base_url(api, v1.name, ns)
-        driver = traffic_driver(
-            url=f"{gateway}/v1/completions",
-            headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
-            payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
-            rate=2,
-            timeout=15.0,
-            warmup=True,
-        )
+            gateway = get_gateway_base_url(api, v1.name, ns)
+            driver = traffic_driver(
+                url=f"{gateway}/v1/completions",
+                headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+                payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+                rate=2,
+                timeout=15.0,
+                warmup=True,
+            )
 
-        driver.mark("v1_only")
-        driver.collect(20)
+            driver.mark("v1_only")
+            driver.collect(20)
 
-        # Late-join v2
-        apply_member(api, v2, ns)
-        wait_ready(api, v2.name, ns)
-        wait_for_member_count(api, v1.name, ns, 2)
-        wait_for_healthy_route(
-            f"{gateway}/v1/completions",
-            {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
-            {"model": MODEL, "prompt": "Hello", "max_tokens": 5},
-        )
+            # Late-join v2
+            apply_member(api, v2, ns)
+            wait_ready(api, v2.name, ns)
+            wait_for_member_count(api, v1.name, ns, 2)
+            wait_for_healthy_route(
+                f"{gateway}/v1/completions",
+                {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+                {"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+            )
 
-        driver.mark("both")
-        driver.collect(40)
+            driver.mark("both")
+            driver.collect(40)
 
-        report = driver.stop()
-        report.all.assert_no_errors("late-join")
+            report = driver.stop()
+            report.all.assert_no_errors("late-join")
 
-        both = report.phase("both")
+            both = report.phase("both")
 
-        def is_v2(r):
-            return r.headers.get("x-inference-pod", "").startswith(v2.name)
+            def is_v2(r):
+                return r.headers.get("x-inference-pod", "").startswith(v2.name)
 
-        v2_count = both.where(is_v2).count
-        assert v2_count > 0, f"v2 received no traffic after join ({both.count} total)"
+            v2_count = both.where(is_v2).count
+            assert v2_count > 0, (
+                f"v2 received no traffic after join ({both.count} total)"
+            )
 
-        logger.info("Late-join verified")
+            logger.info("Late-join verified")
 
     def test_delete_at_nonzero_weight(self, test_namespace, traffic_driver):
         """Delete a member with weight>0 - no route breakage. (spike step 17)"""
@@ -1147,39 +1204,40 @@ class TestCanaryLifecycle:
         v1 = MemberSpec(name="delw-v1", weight=5, scheduler=False)
         v2 = MemberSpec(name="delw-v2", weight=5, scheduler=False)
 
-        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
-        apply_member(api, v1, ns)
-        apply_member(api, v2, ns)
+        with member_lifecycle(api, [v1.name, v2.name], ns):
+            apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+            apply_member(api, v1, ns)
+            apply_member(api, v2, ns)
 
-        wait_ready(api, v1.name, ns)
-        wait_ready(api, v2.name, ns)
+            wait_ready(api, v1.name, ns)
+            wait_ready(api, v2.name, ns)
 
-        gateway = get_gateway_base_url(api, v1.name, ns)
-        driver = traffic_driver(
-            url=f"{gateway}/v1/completions",
-            headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
-            payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
-            rate=2,
-            timeout=15.0,
-            warmup=True,
-        )
+            gateway = get_gateway_base_url(api, v1.name, ns)
+            driver = traffic_driver(
+                url=f"{gateway}/v1/completions",
+                headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+                payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+                rate=2,
+                timeout=15.0,
+                warmup=True,
+            )
 
-        driver.collect(20)
-        driver.mark("delete")
+            driver.collect(20)
+            driver.mark("delete")
 
-        delete_member(api, v2.name, ns, wait=True)
-        wait_for_member_count(api, v1.name, ns, 1)
+            delete_member(api, v2.name, ns, wait=True)
+            wait_for_member_count(api, v1.name, ns, 1)
 
-        driver.mark("settled")
-        driver.collect(30)
+            driver.mark("settled")
+            driver.collect(30)
 
-        report = driver.stop()
+            report = driver.stop()
 
-        report.all.assert_no_errors(
-            "delete at weight>0: zero errors including transition"
-        )
+            report.all.assert_no_errors(
+                "delete at weight>0: zero errors including transition"
+            )
 
-        logger.info("Delete at nonzero weight verified")
+            logger.info("Delete at nonzero weight verified")
 
     def test_rollback(self, test_namespace, traffic_driver):
         """Promote v2 then rollback to v1 - traffic returns. (spike step 7)"""
@@ -1189,68 +1247,69 @@ class TestCanaryLifecycle:
         v1 = MemberSpec(name="roll-v1", weight=9, scheduler=False)
         v2 = MemberSpec(name="roll-v2", weight=1, scheduler=False)
 
-        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
-        apply_member(api, v1, ns)
-        apply_member(api, v2, ns)
+        with member_lifecycle(api, [v1.name, v2.name], ns):
+            apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+            apply_member(api, v1, ns)
+            apply_member(api, v2, ns)
 
-        wait_ready(api, v1.name, ns)
-        wait_ready(api, v2.name, ns)
+            wait_ready(api, v1.name, ns)
+            wait_ready(api, v2.name, ns)
 
-        gateway = get_gateway_base_url(api, v1.name, ns)
-        driver = traffic_driver(
-            url=f"{gateway}/v1/completions",
-            headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
-            payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
-            rate=2,
-            timeout=15.0,
-            warmup=True,
-        )
+            gateway = get_gateway_base_url(api, v1.name, ns)
+            driver = traffic_driver(
+                url=f"{gateway}/v1/completions",
+                headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+                payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+                rate=2,
+                timeout=15.0,
+                warmup=True,
+            )
 
-        route_headers = {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"}
-        route_payload = {"model": MODEL, "prompt": "Hello", "max_tokens": 5}
+            route_headers = {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"}
+            route_payload = {"model": MODEL, "prompt": "Hello", "max_tokens": 5}
 
-        # Promote v2
-        driver.mark("promote_mutation")
-        patch_weight(api, v1.name, 0, ns)
-        patch_weight(api, v2.name, 9, ns)
-        wait_for_group_weight(api, v2.name, v1.name, 0, ns)
-        wait_for_healthy_route(
-            f"{gateway}/v1/completions",
-            route_headers,
-            route_payload,
-            expect_header=("x-inference-pod", v2.name),
-        )
-        driver.mark("promoted")
-        driver.collect(30)
+            # Promote v2
+            driver.mark("promote_mutation")
+            patch_weight(api, v1.name, 0, ns)
+            patch_weight(api, v2.name, 9, ns)
+            wait_for_group_weight(api, v2.name, v1.name, 0, ns)
+            wait_for_healthy_route(
+                f"{gateway}/v1/completions",
+                route_headers,
+                route_payload,
+                expect_header=("x-inference-pod", v2.name),
+            )
+            driver.mark("promoted")
+            driver.collect(30)
 
-        # Rollback to v1
-        driver.mark("rollback_mutation")
-        patch_weight(api, v1.name, 9, ns)
-        patch_weight(api, v2.name, 0, ns)
-        wait_for_group_weight(api, v1.name, v2.name, 0, ns)
-        wait_for_healthy_route(
-            f"{gateway}/v1/completions",
-            route_headers,
-            route_payload,
-            expect_header=("x-inference-pod", v1.name),
-        )
-        driver.mark("settled")
-        driver.collect(30)
+            # Rollback to v1
+            driver.mark("rollback_mutation")
+            patch_weight(api, v1.name, 9, ns)
+            patch_weight(api, v2.name, 0, ns)
+            wait_for_group_weight(api, v1.name, v2.name, 0, ns)
+            wait_for_healthy_route(
+                f"{gateway}/v1/completions",
+                route_headers,
+                route_payload,
+                expect_header=("x-inference-pod", v1.name),
+            )
+            driver.mark("settled")
+            driver.collect(30)
 
-        report = driver.stop()
+            report = driver.stop()
 
-        for phase in ["promoted", "settled"]:
-            report.phase(phase).assert_no_errors(f"rollback: stable phase {phase}")
+            for phase in ["promoted", "settled"]:
+                report.phase(phase).assert_no_errors(f"rollback: stable phase {phase}")
 
-        settled = report.phase("settled")
+            settled = report.phase("settled")
 
-        def is_v2(r):
-            return r.headers.get("x-inference-pod", "").startswith(v2.name)
+            def is_v2(r):
+                return r.headers.get("x-inference-pod", "").startswith(v2.name)
 
-        v2_count = settled.where(is_v2).count
-        assert v2_count <= 3, f"v2 got {v2_count} requests after rollback"
+            v2_count = settled.where(is_v2).count
+            assert v2_count <= 3, f"v2 got {v2_count} requests after rollback"
 
-        logger.info("Rollback verified")
+            logger.info("Rollback verified")
 
     def test_force_stop_route_owner(self, test_namespace, traffic_driver):
         """Force-stop the route owner - traffic shifts to other member. (spike step 18)"""
@@ -1260,49 +1319,52 @@ class TestCanaryLifecycle:
         v1 = MemberSpec(name="owner-v1", weight=5, scheduler=False)
         v2 = MemberSpec(name="owner-v2", weight=5, scheduler=False)
 
-        apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
-        apply_member(api, v1, ns)
-        apply_member(api, v2, ns)
+        with member_lifecycle(api, [v1.name, v2.name], ns):
+            apply_config(api, INFERENCE_SIM.name, ns, INFERENCE_SIM.to_spec())
+            apply_member(api, v1, ns)
+            apply_member(api, v2, ns)
 
-        wait_ready(api, v1.name, ns)
-        wait_ready(api, v2.name, ns)
+            wait_ready(api, v1.name, ns)
+            wait_ready(api, v2.name, ns)
 
-        gateway = get_gateway_base_url(api, v1.name, ns)
-        driver = traffic_driver(
-            url=f"{gateway}/v1/completions",
-            headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
-            payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
-            rate=2,
-            timeout=15.0,
-            warmup=True,
-        )
+            gateway = get_gateway_base_url(api, v1.name, ns)
+            driver = traffic_driver(
+                url=f"{gateway}/v1/completions",
+                headers={"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+                payload={"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+                rate=2,
+                timeout=15.0,
+                warmup=True,
+            )
 
-        driver.collect(20)
-        driver.mark("before_stop")
+            driver.collect(20)
+            driver.mark("before_stop")
 
-        # v1 is the route owner (created first). Force-stop it.
-        patch_stop(api, v1.name, ns)
-        wait_for_member_stopped(api, v2.name, v1.name, ns, stopped=True)
+            # v1 is the route owner (created first). Force-stop it.
+            patch_stop(api, v1.name, ns)
+            wait_for_member_stopped(api, v2.name, v1.name, ns, stopped=True)
 
-        # Route ownership handoff: v1's route is deleted, v2 creates a new one.
-        wait_for_healthy_route(
-            f"{gateway}/v1/completions",
-            {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
-            {"model": MODEL, "prompt": "Hello", "max_tokens": 5},
-            expect_header=("x-inference-pod", v2.name),
-        )
-        driver.mark("settled")
-        driver.collect(30)
+            # Route ownership handoff: v1's route is deleted, v2 creates a new one.
+            wait_for_healthy_route(
+                f"{gateway}/v1/completions",
+                {"X-Gateway-Model-Name": f"publishers/{ns}/models/{MODEL}"},
+                {"model": MODEL, "prompt": "Hello", "max_tokens": 5},
+                expect_header=("x-inference-pod", v2.name),
+            )
+            driver.mark("settled")
+            driver.collect(30)
 
-        report = driver.stop()
+            report = driver.stop()
 
-        settled = report.phase("settled")
-        settled.assert_no_errors("force-stop route owner: traffic should shift to v2")
+            settled = report.phase("settled")
+            settled.assert_no_errors(
+                "force-stop route owner: traffic should shift to v2"
+            )
 
-        def is_v1(r):
-            return r.headers.get("x-inference-pod", "").startswith(v1.name)
+            def is_v1(r):
+                return r.headers.get("x-inference-pod", "").startswith(v1.name)
 
-        v1_after = settled.where(is_v1).count
-        assert v1_after == 0, f"v1 got {v1_after} requests after stop"
+            v1_after = settled.where(is_v1).count
+            assert v1_after == 0, f"v1 got {v1_after} requests after stop"
 
-        logger.info("Force-stop route owner verified")
+            logger.info("Force-stop route owner verified")

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -629,6 +629,25 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
                 pytest.mark.llmd_simulator,
             ],
         ),
+        # Same migration path, but with the legacy plugin config supplied via
+        # spec.router.scheduler.template.containers[].args instead of
+        # spec.router.scheduler.config.inline.
+        pytest.param(
+            TestCase(
+                base_refs=[
+                    "router-managed",
+                    "scheduler-with-precise-prefix-cache-template-args-config",
+                    "workload-llmd-simulator-kvcache",
+                ],
+                prompt="KServe is a",
+                service_name="tokenizer-migration-path-template-args-test",
+            ),
+            marks=[
+                pytest.mark.cluster_cpu,
+                pytest.mark.cluster_single_node,
+                pytest.mark.llmd_simulator,
+            ],
+        ),
         # Models endpoint coverage
         pytest.param(
             TestCase(

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -640,7 +640,7 @@ def chat_completions_payload(test_case: TestCase) -> Dict[str, Any]:
                     "workload-llmd-simulator-kvcache",
                 ],
                 prompt="KServe is a",
-                service_name="tokenizer-migration-path-template-args-test",
+                service_name="tokenizer-template-args-test",
             ),
             marks=[
                 pytest.mark.cluster_cpu,

--- a/test/e2e/llmisvc/test_llm_lora_adapters.py
+++ b/test/e2e/llmisvc/test_llm_lora_adapters.py
@@ -58,7 +58,7 @@ class LoRATestCase:
     expected_adapter_names: List[str]
     service_name: Optional[str] = None
     endpoint: str = "/v1/completions"
-    max_tokens: int = 100
+    max_tokens: int = 20
     wait_timeout: int = 900
     response_timeout: int = 60
 

--- a/test/e2e/predictor/test_canary_raw_deployment.py
+++ b/test/e2e/predictor/test_canary_raw_deployment.py
@@ -31,7 +31,8 @@ from kubernetes import client
 from kubernetes.client import V1ResourceRequirements
 from kubernetes.client.rest import ApiException
 
-from ..common.utils import KSERVE_TEST_NAMESPACE
+from ..common.http_retry import post_with_retry
+from ..common.utils import KSERVE_TEST_NAMESPACE, get_isvc_endpoint
 
 logger = logging.getLogger(__name__)
 
@@ -135,6 +136,26 @@ def _wait_for_condition(
     )
 
 
+def _get_httproute(name, namespace):
+    api = client.CustomObjectsApi()
+    return api.get_namespaced_custom_object(
+        "gateway.networking.k8s.io", "v1", namespace, "httproutes", name
+    )
+
+
+def _get_httproute_backend_refs(name, namespace):
+    """Return a list of (service_name, weight) tuples from the first rule's backendRefs."""
+    route = _get_httproute(name, namespace)
+    rules = route.get("spec", {}).get("rules", [])
+    if not rules:
+        return []
+    return [(ref["name"], ref.get("weight")) for ref in rules[0].get("backendRefs", [])]
+
+
+def _is_gatewayapi(network_layer):
+    return network_layer is not None and "gatewayapi" in network_layer
+
+
 def _get_pod_uids(apps_v1, deployment_name, namespace):
     core_v1 = client.CoreV1Api()
     dep = apps_v1.read_namespaced_deployment(deployment_name, namespace)
@@ -144,10 +165,90 @@ def _get_pod_uids(apps_v1, deployment_name, namespace):
     return {pod.metadata.uid for pod in pods.items}
 
 
+def _verify_traffic_split(
+    kserve,
+    service_name,
+    namespace,
+    expected_pcts,
+    network_layer,
+    num_requests=100,
+    tolerance=10,
+):
+    """
+    Verify traffic split by sending requests and counting responses by status code.
+
+    In this test setup:
+    - Stable predictor uses STABLE_MODEL_URI which returns 200 (successful)
+    - Canary predictor uses CANARY_MODEL_URI which returns 500 (bad model path)
+
+    Args:
+        kserve: KServeClient instance
+        service_name: Name of the InferenceService
+        namespace: Kubernetes namespace
+        expected_pcts: Dict mapping status code to expected percentage, e.g., {200: 80, 500: 20}
+        network_layer: Network layer type (e.g., "istio-gatewayapi")
+        num_requests: Total number of requests to send
+        tolerance: Allowed deviation in percentage points
+
+    Returns:
+        dict: {status_code: (count, percentage)}
+    """
+    isvc = kserve.get(service_name, namespace=namespace)
+    scheme, cluster_ip, host, path = get_isvc_endpoint(isvc, network_layer)
+
+    url = f"{scheme}://{cluster_ip}{path}/v1/models/{service_name}:predict"
+    headers = {"Host": host, "Content-Type": "application/json"}
+
+    # Simple prediction input for sklearn model
+    input_data = {"instances": [[1, 2, 3, 4]]}
+
+    status_counts = {}
+
+    logger.info(
+        f"Sending {num_requests} requests to verify traffic split: {expected_pcts}"
+    )
+
+    for i in range(num_requests):
+        try:
+            # Don't retry on 500 since we expect it from canary (bad model path)
+            # Only retry on network errors and 502/503/504 gateway errors
+            response = post_with_retry(
+                url,
+                headers=headers,
+                json_data=input_data,
+                retry_status_codes=(502, 503, 504),
+            )
+            status_counts[response.status_code] = (
+                status_counts.get(response.status_code, 0) + 1
+            )
+        except Exception as e:
+            logger.warning(f"Request {i + 1} failed: {e}")
+
+    total = sum(status_counts.values())
+    results = {}
+
+    logger.info("Traffic split results:")
+    for status_code, count in sorted(status_counts.items()):
+        pct = (count / total * 100) if total > 0 else 0
+        results[status_code] = (count, pct)
+        logger.info(f"  {status_code}: {count}/{total} ({pct:.1f}%)")
+
+    # Verify each expected status code is within tolerance
+    for status_code, expected_pct in expected_pcts.items():
+        assert status_code in results, (
+            f"Expected status code {status_code} not seen in responses"
+        )
+        _, actual_pct = results[status_code]
+        assert abs(actual_pct - expected_pct) <= tolerance, (
+            f"Status {status_code} traffic {actual_pct:.1f}% outside expected {expected_pct}% ±{tolerance}%"
+        )
+
+    return results
+
+
 @pytest.mark.predictor
 @pytest.mark.raw
-@pytest.mark.asyncio(scope="session")
-def test_canary_create():
+def test_canary_create(network_layer):
     service_name = "isvc-canary-create"
     kserve = _kserve_client()
     apps = _apps_v1()
@@ -187,14 +288,39 @@ def test_canary_create():
         canary_status = got.get("status", {}).get("canaryStatuses", [])
         assert len(canary_status) > 0, "canary status should be populated"
         assert canary_status[0]["name"] == "v2"
+
+        if _is_gatewayapi(network_layer):
+            backends = _get_httproute_backend_refs(
+                f"{service_name}-predictor", KSERVE_TEST_NAMESPACE
+            )
+            assert len(backends) == 2, (
+                f"Expected 2 backends (stable + canary), got {backends}"
+            )
+            names = {name for name, _ in backends}
+            assert f"{service_name}-predictor" in names
+            assert f"{service_name}-v2-predictor" in names
+            weights = {name: weight for name, weight in backends}
+            assert weights[f"{service_name}-predictor"] == 80
+            assert weights[f"{service_name}-v2-predictor"] == 20
+
+            # Verify actual traffic split by sending requests
+            # Stable (STABLE_MODEL_URI) returns 200, canary (CANARY_MODEL_URI) returns 500
+            _verify_traffic_split(
+                kserve,
+                service_name,
+                KSERVE_TEST_NAMESPACE,
+                expected_pcts={200: 80, 500: 20},
+                network_layer=network_layer,
+                num_requests=100,
+                tolerance=10,
+            )
     finally:
         _safe_delete(kserve, service_name)
 
 
 @pytest.mark.predictor
 @pytest.mark.raw
-@pytest.mark.asyncio(scope="session")
-def test_canary_promote():
+def test_canary_promote(network_layer):
     service_name = "isvc-canary-promote"
     kserve = _kserve_client()
     apps = _apps_v1()
@@ -249,14 +375,34 @@ def test_canary_promote():
         assert canary_pod_uids.issubset(post_promote_uids), (
             f"Canary pods were restarted during promotion: canary={canary_pod_uids}, post_promote={post_promote_uids}"
         )
+
+        if _is_gatewayapi(network_layer):
+            backends = _get_httproute_backend_refs(
+                f"{service_name}-predictor", KSERVE_TEST_NAMESPACE
+            )
+            assert len(backends) == 1, (
+                f"Expected 1 backend after promotion, got {backends}"
+            )
+            assert backends[0][0] == f"{service_name}-v2-predictor"
+
+            # Verify 100% traffic goes to promoted canary (v2)
+            # The promoted v2 uses CANARY_MODEL_URI which returns 500
+            _verify_traffic_split(
+                kserve,
+                service_name,
+                KSERVE_TEST_NAMESPACE,
+                expected_pcts={500: 100},
+                network_layer=network_layer,
+                num_requests=50,
+                tolerance=10,
+            )
     finally:
         _safe_delete(kserve, service_name)
 
 
 @pytest.mark.predictor
 @pytest.mark.raw
-@pytest.mark.asyncio(scope="session")
-def test_canary_rollback():
+def test_canary_rollback(network_layer):
     service_name = "isvc-canary-rollback"
     kserve = _kserve_client()
     apps = _apps_v1()
@@ -306,13 +452,33 @@ def test_canary_rollback():
         assert canary_condition is None, (
             "CanaryPredictorReady should be cleared after rollback"
         )
+
+        if _is_gatewayapi(network_layer):
+            backends = _get_httproute_backend_refs(
+                f"{service_name}-predictor", KSERVE_TEST_NAMESPACE
+            )
+            assert len(backends) == 1, (
+                f"Expected 1 backend after rollback, got {backends}"
+            )
+            assert backends[0][0] == f"{service_name}-predictor"
+
+            # Verify 100% traffic goes to stable after rollback
+            # Stable uses STABLE_MODEL_URI which returns 200
+            _verify_traffic_split(
+                kserve,
+                service_name,
+                KSERVE_TEST_NAMESPACE,
+                expected_pcts={200: 100},
+                network_layer=network_layer,
+                num_requests=50,
+                tolerance=10,
+            )
     finally:
         _safe_delete(kserve, service_name)
 
 
 @pytest.mark.predictor
 @pytest.mark.raw
-@pytest.mark.asyncio(scope="session")
 def test_canary_force_stop():
     service_name = "isvc-canary-stop"
     kserve = _kserve_client()
@@ -360,6 +526,3 @@ def test_canary_force_stop():
         _wait_for_condition(kserve, service_name, "CanaryPredictorReady", "Stopped")
     finally:
         _safe_delete(kserve, service_name)
-
-
-# TODO: Add testing for routing after HTTPRoute support is added to the raw deployment mode.

--- a/test/e2e/predictor/test_response_headers.py
+++ b/test/e2e/predictor/test_response_headers.py
@@ -61,7 +61,7 @@ def test_predictor_headers_v1():
             V1Container(
                 name="kserve-container",
                 image="kserve/custom-image-transformer-grpc:"
-                + os.environ.get("GITHUB_SHA"),
+                + (os.environ.get("GITHUB_SHA") or "latest"),
                 # Override the entrypoint to run the custom transformer rest server
                 command=["python", "-m", "custom_transformer.model"],
                 resources=V1ResourceRequirements(
@@ -146,7 +146,7 @@ def test_predictor_headers_v2():
             V1Container(
                 name="kserve-container",
                 image="kserve/custom-image-transformer-grpc:"
-                + os.environ.get("GITHUB_SHA"),
+                + (os.environ.get("GITHUB_SHA") or "latest"),
                 # Override the entrypoint to run the custom transformer rest server
                 command=["python", "-m", "custom_transformer.model"],
                 resources=V1ResourceRequirements(

--- a/test/e2e/predictor/test_sklearn.py
+++ b/test/e2e/predictor/test_sklearn.py
@@ -50,8 +50,7 @@ from ..common.utils import (
     KSERVE_TEST_NAMESPACE,
     predict_isvc,
     predict_grpc,
-    extract_process_ids_from_logs,
-    wait_for_pod_logs,
+    get_container_worker_count,
 )
 
 
@@ -179,6 +178,20 @@ async def test_sklearn_runtime_kserve(rest_v1_client, network_layer):
 
     kserve_client.create(isvc)
     kserve_client.wait_isvc_ready(service_name, namespace=KSERVE_TEST_NAMESPACE)
+
+    pods = kserve_client.core_api.list_namespaced_pod(
+        KSERVE_TEST_NAMESPACE,
+        label_selector="serving.kserve.io/inferenceservice={}".format(service_name),
+    )
+    worker_count = get_container_worker_count(
+        kserve_client.core_api,
+        pods.items[0].metadata.name,
+        KSERVE_TEST_NAMESPACE,
+    )
+    assert worker_count == 2, (
+        f"Expected 2 multiprocessing workers but found {worker_count}"
+    )
+
     tasks = [
         predict_isvc(
             rest_v1_client,
@@ -192,19 +205,6 @@ async def test_sklearn_runtime_kserve(rest_v1_client, network_layer):
     for res in responses:
         assert res["predictions"] == [19]
 
-    pods = kserve_client.core_api.list_namespaced_pod(
-        KSERVE_TEST_NAMESPACE,
-        label_selector="serving.kserve.io/inferenceservice={}".format(service_name),
-    )
-    logs = await wait_for_pod_logs(
-        kserve_client.core_api,
-        pods.items[0].metadata.name,
-        pods.items[0].metadata.namespace,
-        expected_substring="kserve.trace",
-        timeout_s=30,
-    )
-    process_ids = extract_process_ids_from_logs(logs)
-    assert len(process_ids) == 2
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
 
 


### PR DESCRIPTION
## What this PR does / why we need it

Sync upstream/master to odh/master. 13 commits, 6 conflicts resolved.

## Conflict Resolution Report

6 files had merge conflicts. 4 auto-resolved (generated code), 2 resolved by AI with human review.

### Resolution Table

| File | Resolution | Confidence | Rationale |
|------|-----------|------------|-----------|
| `charts/kserve-resources/files/kserve/resources.yaml` | source (auto) | -- | Generated file, regenerated by `make generate-chart-manifests` |
| `config/rbac/role.yaml` | source (auto) | -- | Generated file, regenerated by `make manifests` |
| `hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh` | source (auto) | -- | Generated file, regenerated by `make generate-quick-install-scripts` |
| `hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh` | source (auto) | -- | Generated file, regenerated by `make generate-quick-install-scripts` |
| `test/e2e/common/utils.py` | :green_circle: merged (high) | Both imports kept (ApiException for ODH's `wait_for_resource_deletion`, k8s_stream for upstream's `get_container_worker_count`). Both new functions preserved, old `extract_process_ids_from_logs` removed. Source: kserve/kserve#5893, Target: #1015 ([RHOAIENG-39707](https://redhat.atlassian.net/browse/RHOAIENG-39707)) |
| `test/e2e/graph/test_inference_graph.py` | :green_circle: merged (high) | Adopted upstream's cleaner `or`/f-string defaulting (kserve/kserve#5911) while preserving ODH env var overrides (`SUCCESS_200_ISVC_IMAGE`, `ERROR_404_ISVC_IMAGE`) from #563 |

### Build Verification

- `go build ./...`: :white_check_mark: passed
- `cd qpext && go build ./...`: :white_check_mark: passed
- `go build -tags distro ./...`: :white_check_mark: passed
- `go vet ./...`: :white_check_mark: passed
- `make generate tidy manifests generate-quick-install-scripts generate-chart-manifests`: :white_check_mark: passed
- `make e2e-collect`: :warning: skipped (pre-existing issue: pyarrow `<20.0.0` has no binary wheel for current Python, tries source build requiring cmake)

<details>
<summary>Commits synced (13)</summary>

- 860120c23 fix(llmisvc): detect latency-producer plugin from template args (#5937)
- acccb89da fix(llmisvc): close v1alpha1 validation gaps for LoRA and DRA annotations (#5938)
- 106d55640 ci: cache openapi-generator JAR to avoid Maven rate limiting (#5939)
- a53b39fe3 feat(llmisvc): migrate remaining --model-server-metrics-* flags for llm-d (#5930)
- 71eefc043 fix(llmisvc): detect scheduler plugins from template args (#5931)
- 85b090806 feat: add canary traffic splitting to RawDeployment HTTPRoutes (#5912)
- 61cc056ba fix(test): assert worker count via exec not log PIDs (#5893)
- ded99249a fix(rbac): harden controller manager ClusterRoles (#5785)
- 23ce982d2 fix: template storage resources in inferenceservice-config ConfigMap (#5697)
- c1cf19fb1 fix(router): resolve flaky TestServerTimeout nil pointer panic (#5887)
- 119d4b7bd fix(e2e): default GITHUB_SHA to 'latest' for test collection (#5911)
- 0a292320e refactor(e2e): failure diagnostics for canary lifecycle tests (#5919)
- 9c673d2ae fix(ci): reduce max_tokens for LoRA llmisvc tests (#5736)

</details>

[RHOAIENG-39707]: https://redhat.atlassian.net/browse/RHOAIENG-39707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable CPU and memory resources for storage initialization.
  * Improved canary traffic routing with stable routes and backend weighting.
  * Added validation for LoRA adapters and managed device allocation settings.
  * Added support for scheduler configuration supplied through container arguments, including legacy metrics migration.

* **Bug Fixes**
  * Removed unnecessary webhook configuration permissions.
  * Improved canary create, promote, rollback, and traffic-split behavior.
  * Made test image selection and router readiness handling more reliable.

* **Chores**
  * Added caching for OpenAPI generation in continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->