### PR TITLE
fix(xks): align cert-manager issuer/secret names with rhai-on-xks chart

### DIFF
--- a/config/overlays/odh-xks/cert-manager/llmisvc-webhook-server-certificate.yaml
+++ b/config/overlays/odh-xks/cert-manager/llmisvc-webhook-server-certificate.yaml
@@ -1,5 +1,5 @@
 # Certificate for the LLMInferenceService webhook server.
-# Issued by the OpenDataHub CA ClusterIssuer.
+# Issued by the RHAI CA ClusterIssuer (rhai-ca-issuer).
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:

--- a/config/overlays/odh-xks/params.env
+++ b/config/overlays/odh-xks/params.env
@@ -2,11 +2,11 @@
 # Namespace where KServe components are deployed
 NAMESPACE=opendatahub
 # Certificate issuer configuration
-ISSUER_REF_NAME=opendatahub-ca-issuer
+ISSUER_REF_NAME=rhai-ca-issuer
 ISSUER_REF_KIND=ClusterIssuer
 ISSUER_REF_GROUP=cert-manager.io
 # CA signing secret configuration
-CA_SECRET_NAME=opendatahub-ca
+CA_SECRET_NAME=rhai-ca
 CA_SECRET_NAMESPACE=cert-manager
 # Istio CA certificate path (mounted from CA bundle ConfigMap)
 ISTIO_CA_CERTIFICATE_PATH=/var/run/secrets/opendatahub/ca.crt


### PR DESCRIPTION
## Summary
- The xKS overlay `params.env` references `opendatahub-ca-issuer` and `opendatahub-ca` which do not exist on non-OCP clusters
- The `rhai-on-xks` Helm chart creates `rhai-ca-issuer` ClusterIssuer and `rhai-ca` CA secret instead
- This causes the `llmisvc-webhook-server` Certificate to remain in `False` (not ready) state, blocking the llmisvc-controller pod startup
- Update `params.env` to use the correct names (`rhai-ca-issuer`, `rhai-ca`)

## Test plan
- [x] Deployed `rhai-on-xks` chart on AKS — confirmed only `rhai-ca-issuer` ClusterIssuer and `rhai-ca` secret exist
- [ ] Validate llmisvc-webhook-server Certificate becomes Ready without manual patching after this change

Ref: [RHOAIENG-79510](https://redhat.atlassian.net/browse/RHOAIENG-79510)

Made with [Cursor](https://cursor.com)

[RHOAIENG-79510]: https://redhat.atlassian.net/browse/RHOAIENG-79510?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated XKS certificate configuration to consistently reference the RHAI certificate authority and issuer.
  * Corrected certificate documentation to reflect the RHAI CA issuer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->