### PR TITLE
Fix kserve-module hardcoded image for disconnected deployments

### DIFF
--- a/kserve-module/config/kustomization.yaml
+++ b/kserve-module/config/kustomization.yaml
@@ -10,5 +10,3 @@ resources:
 
 images:
 - name: kserve-module-controller
-  newName: quay.io/opendatahub/odh-kserve-module-operator
-  newTag: odh-stable

--- a/kserve-module/tests/scripts/setup-cluster.sh
+++ b/kserve-module/tests/scripts/setup-cluster.sh
@@ -342,7 +342,7 @@ deploy_kserve_module() {
 
   if [[ -n "${KSERVE_MODULE_IMG}" ]]; then
     log_info "Using custom image: ${KSERVE_MODULE_IMG}"
-    output=$(echo "$output" | sed "s|image: .*odh-kserve-module-operator.*|image: ${KSERVE_MODULE_IMG}|g")
+    output=$(echo "$output" | sed "s|image: kserve-module-controller|image: ${KSERVE_MODULE_IMG}|g")
   fi
 
   echo "$output" | ${KUBECTL} apply --server-side=true --force-conflicts -f -


### PR DESCRIPTION
## Summary
Fix disconnected readiness blocker by removing hardcoded kserve-module-operator image reference and updating e2e test injection.

## Changes

### 1. Remove hardcoded kserve-module-operator image
**File**: `kserve-module/config/kustomization.yaml`
- Remove `newName` and `newTag` from kustomization
- Allows ODH operator to inject image reference from params.env via `RELATED_IMAGE_ODH_KSERVE_MODULE_OPERATOR_IMAGE`
- Required for disconnected/air-gapped deployments

### 2. Fix e2e test image injection
**File**: `kserve-module/tests/scripts/setup-cluster.sh`
- Update sed pattern from `image: .*odh-kserve-module-operator.*` to `image: kserve-module-controller`
- Matches new placeholder-only image reference after removing hardcoded values

## Why
In disconnected environments, images must be injected by the operator from params.env. Hardcoded image references prevent this and cause deployment failures.

## Related PRs
- Latency predictor fix: #1834 (separate PR)
- Build configs: https://github.com/opendatahub-io/ODH-Build-Config/pull/3508
- Operator: https://github.com/opendatahub-io/opendatahub-operator/pull/3906

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the custom controller image override from the deployment configuration.
  * Updated cluster setup to apply custom image substitutions to the controller image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->