### PR TITLE
fix(llmisvc): re-enqueue group peers when status model names change

### DIFF
--- a/pkg/controller/v1alpha2/llmisvc/router_group_handler.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group_handler.go
@@ -176,5 +176,13 @@ func trafficFieldsChanged(old, new *v1alpha2.LLMInferenceService) bool {
 		return true
 	}
 
+	// Model names resolved from status.Addresses drive divergence detection
+	// for peer members. Without this, a member whose spec.model changes gets
+	// reconciled (updating its own addresses), but peers that already
+	// reconciled against the stale addresses are never re-enqueued.
+	if !slices.Equal(resolvedModelNames(old), resolvedModelNames(new)) {
+		return true
+	}
+
 	return false
 }

--- a/pkg/controller/v1alpha2/llmisvc/router_group_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/router_group_test.go
@@ -559,6 +559,42 @@ func TestTrafficFieldsChanged(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "status addresses model names changed",
+			old: func() *v1alpha2.LLMInferenceService {
+				s := memberSvc("v1", "g", 9, false, now)
+				s.Status.Addresses = []v1alpha2.SourcedAddress{{
+					Models: []v1alpha2.ModelSourcedAddressStatus{{Name: "model-beta"}},
+				}}
+				return &s
+			}(),
+			new: func() *v1alpha2.LLMInferenceService {
+				s := memberSvc("v1", "g", 9, false, now)
+				s.Status.Addresses = []v1alpha2.SourcedAddress{{
+					Models: []v1alpha2.ModelSourcedAddressStatus{{Name: "model-alpha"}},
+				}}
+				return &s
+			}(),
+			want: true,
+		},
+		{
+			name: "status addresses model names unchanged",
+			old: func() *v1alpha2.LLMInferenceService {
+				s := memberSvc("v1", "g", 9, false, now)
+				s.Status.Addresses = []v1alpha2.SourcedAddress{{
+					Models: []v1alpha2.ModelSourcedAddressStatus{{Name: "model-alpha"}},
+				}}
+				return &s
+			}(),
+			new: func() *v1alpha2.LLMInferenceService {
+				s := memberSvc("v1", "g", 9, false, now)
+				s.Status.Addresses = []v1alpha2.SourcedAddress{{
+					Models: []v1alpha2.ModelSourcedAddressStatus{{Name: "model-alpha"}},
+				}}
+				return &s
+			}(),
+			want: false,
+		},
+		{
 			name: "non-traffic change on grouped member",
 			old:  func() *v1alpha2.LLMInferenceService { s := memberSvc("v1", "g", 9, false, now); return &s }(),
 			new:  func() *v1alpha2.LLMInferenceService { s := memberSvc("v1", "g", 9, false, now); return &s }(),


### PR DESCRIPTION
## Summary
- Fix race in group divergence detection: when a member's `spec.model.name` is patched, peers that reconcile first read stale model names from `Status.Addresses`, keep `GroupDegraded=True`, and are never re-enqueued because `trafficFieldsChanged` didn't check status address model names.
- Add `resolvedModelNames` comparison to `trafficFieldsChanged` predicate so status model name updates trigger peer re-reconciliation.

## Test plan
- [x] Unit test: `TestTrafficFieldsChanged` - two new cases (changed/unchanged model names)
- [ ] E2E: `test_model_name_divergence_resolves` should stop flaking

## Notes
Upstream fix - should be submitted to kserve/kserve after midstream CI validates.