### PR TITLE
fix(llmisvc): add support on /dev/shm size for CPU kv cache offloading

### DIFF
--- a/docs/samples/llmisvc/kv-cache-offloading/README.md
+++ b/docs/samples/llmisvc/kv-cache-offloading/README.md
@@ -4,6 +4,12 @@ KV cache offloading extends GPU memory by cascading evicted KV cache blocks to
 cheaper tiers: GPU → CPU RAM → disk. This allows serving longer contexts or
 more concurrent requests without increasing GPU count.
 
+## Sizing
+
+Set `kvCacheOffloading.cpu` to how much CPU RAM the KV cache may use before blocks
+are evicted to the next tier. Size `template.resources` for the model server itself;
+this CPU tier is added on top of those resources automatically when needed.
+
 ## How to choose a secondary disk tier
 
 ### I have a Ceph cluster (e.g. ODF on OpenShift)

--- a/docs/samples/llmisvc/kv-cache-offloading/llm-inference-service-kv-cache-offloading.yaml
+++ b/docs/samples/llmisvc/kv-cache-offloading/llm-inference-service-kv-cache-offloading.yaml
@@ -24,7 +24,8 @@ spec:
             nvidia.com/gpu: "1"
   workload:
     kvCacheOffloading:
-      # Primary tier: CPU RAM. GPU overflows here first.
+      # Primary tier: CPU RAM. When the GPU KV cache fills up, evicted blocks
+      # spill here first, then on to the disk tiers below.
       cpu: "10Gi"
       evictionPolicy: lru
       # Secondary tiers: disk. GPU -> CPU -> disk cascade.

--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -652,13 +652,6 @@ func ReplaceVariables(llmSvc *v1alpha2.LLMInferenceService, llmSvcCfg *v1alpha2.
 				if !ok || kv == nil {
 					return ""
 				}
-				extraConfig := map[string]any{
-					"spec_name":        "TieringOffloadingSpec",
-					"cpu_bytes_to_use": kv.CPU.Value(),
-				}
-				if kv.EvictionPolicy != "" {
-					extraConfig["eviction_policy"] = kv.EvictionPolicy
-				}
 				var secondaryTiers []map[string]any
 				for i, s := range kv.Secondary {
 					if s.FileSystem == nil {
@@ -670,7 +663,17 @@ func ReplaceVariables(llmSvc *v1alpha2.LLMInferenceService, llmSvcCfg *v1alpha2.
 					}
 					secondaryTiers = append(secondaryTiers, entry)
 				}
+				// CPUOffloadingSpec for CPU-only
+				// use  multi-tier TieringOffloadingSpec only when a secondary tier is configured.
+				extraConfig := map[string]any{
+					"spec_name":        "CPUOffloadingSpec",
+					"cpu_bytes_to_use": kv.CPU.Value(),
+				}
+				if kv.EvictionPolicy != "" {
+					extraConfig["eviction_policy"] = kv.EvictionPolicy
+				}
 				if len(secondaryTiers) > 0 {
+					extraConfig["spec_name"] = "TieringOffloadingSpec"
 					extraConfig["secondary_tiers"] = secondaryTiers
 				}
 				kvConfig := map[string]any{

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
@@ -2113,7 +2113,8 @@ func TestReplaceVariables(t *testing.T) {
 							Containers: []corev1.Container{
 								// Keys are alphabetical (json.Marshal on a map); quotes stay escaped as \"
 								// so the value is safe in the KV_TRANSFER_ARGS="..." bash assignment.
-								{Args: []string{`--kv-transfer-config '{\"kv_connector\":\"OffloadingConnector\",\"kv_connector_extra_config\":{\"cpu_bytes_to_use\":10737418240,\"spec_name\":\"TieringOffloadingSpec\"},\"kv_role\":\"kv_both\"}'`}},
+								// only single-tier CPUOffloadingSpec.
+								{Args: []string{`--kv-transfer-config '{\"kv_connector\":\"OffloadingConnector\",\"kv_connector_extra_config\":{\"cpu_bytes_to_use\":10737418240,\"spec_name\":\"CPUOffloadingSpec\"},\"kv_role\":\"kv_both\"}'`}},
 							},
 						},
 					},
@@ -2148,8 +2149,9 @@ func TestReplaceVariables(t *testing.T) {
 					WorkloadSpec: v1alpha2.WorkloadSpec{
 						Template: &corev1.PodSpec{
 							Containers: []corev1.Container{
-								// json.Marshal sorts map keys alphabetically: cpu_bytes_to_use < eviction_policy < spec_name
-								{Args: []string{`--kv-transfer-config '{\"kv_connector\":\"OffloadingConnector\",\"kv_connector_extra_config\":{\"cpu_bytes_to_use\":5368709120,\"eviction_policy\":\"arc\",\"spec_name\":\"TieringOffloadingSpec\"},\"kv_role\":\"kv_both\"}'`}},
+								// json.Marshal sorts map keys alphabetically: cpu_bytes_to_use < eviction_policy < spec_name.
+								// only single-tier CPUOffloadingSpec.
+								{Args: []string{`--kv-transfer-config '{\"kv_connector\":\"OffloadingConnector\",\"kv_connector_extra_config\":{\"cpu_bytes_to_use\":5368709120,\"eviction_policy\":\"arc\",\"spec_name\":\"CPUOffloadingSpec\"},\"kv_role\":\"kv_both\"}'`}},
 							},
 						},
 					},
@@ -2354,7 +2356,7 @@ printf '%s' "$2"`
 	g.Expect(parsed).To(HaveKey("kv_connector_extra_config"))
 	extra := parsed["kv_connector_extra_config"]
 	g.Expect(extra).To(And(
-		HaveKeyWithValue("spec_name", "TieringOffloadingSpec"),
+		HaveKeyWithValue("spec_name", "CPUOffloadingSpec"),
 		HaveKeyWithValue("eviction_policy", "lru"),
 	))
 }

--- a/pkg/controller/v1alpha2/llmisvc/workload_kvcache.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_kvcache.go
@@ -20,9 +20,71 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
+	"github.com/kserve/kserve/pkg/utils"
 )
+
+// sharedMemoryMountPath is where the base preset mounts the tmpfs shared-memory
+// volume that vLLM uses for both NCCL and CPU KV cache offload buffer.
+const sharedMemoryMountPath = "/dev/shm"
+
+func attachKVCacheOffloading(podSpec *corev1.PodSpec, kv *v1alpha2.KVCacheOffloadingSpec) {
+	const containerName = "main"
+	attachKVCachePrimaryTier(podSpec, kv.CPU, containerName)
+	attachKVCacheSecondaryTiers(podSpec, kv.Secondary, containerName)
+}
+
+// CPU kv cache offloading
+func attachKVCachePrimaryTier(podSpec *corev1.PodSpec, cpu resource.Quantity, containerName string) {
+	c := utils.GetContainerWithName(podSpec, containerName)
+	if c == nil {
+		return
+	}
+
+	required := *resource.NewQuantity(cpu.Value()*120/100, cpu.Format)
+
+	// in total, add 120% CPU kv cache offloading size + NCCL buffer (1Gi or 8Gi up to the preset)
+	bumpSharedMemoryVolume(podSpec, c, required)
+	bumpResourcesMemory(c, required)
+}
+
+func bumpSharedMemoryVolume(podSpec *corev1.PodSpec, c *corev1.Container, size resource.Quantity) {
+	var name string
+	for _, m := range c.VolumeMounts {
+		if m.MountPath == sharedMemoryMountPath {
+			name = m.Name
+			break
+		}
+	}
+	if name == "" {
+		return
+	}
+	for i := range podSpec.Volumes {
+		v := &podSpec.Volumes[i]
+		if v.Name != name {
+			continue
+		}
+		if v.EmptyDir != nil && v.EmptyDir.Medium == corev1.StorageMediumMemory && v.EmptyDir.SizeLimit != nil {
+			sizeLimit := v.EmptyDir.SizeLimit.DeepCopy()
+			sizeLimit.Add(size)
+			v.EmptyDir.SizeLimit = &sizeLimit
+		}
+		return
+	}
+}
+
+func bumpResourcesMemory(c *corev1.Container, size resource.Quantity) {
+	if req, ok := c.Resources.Requests[corev1.ResourceMemory]; ok {
+		req.Add(size)
+		c.Resources.Requests[corev1.ResourceMemory] = req
+	}
+	if lim, ok := c.Resources.Limits[corev1.ResourceMemory]; ok {
+		lim.Add(size)
+		c.Resources.Limits[corev1.ResourceMemory] = lim
+	}
+}
 
 // attachKVCacheSecondaryTiers injects a volume and container mount for each
 // secondary KV cache tier defined in the spec. It mirrors attachModelArtifacts

--- a/pkg/controller/v1alpha2/llmisvc/workload_kvcache_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_kvcache_test.go
@@ -29,29 +29,25 @@ import (
 
 func TestAttachKVCacheSecondaryTiers(t *testing.T) {
 	tests := []struct {
-		name          string
-		secondary     []v1alpha2.SecondaryTierSpec
-		containerName string
-		wantVolumes   []corev1.Volume
-		wantMounts    []corev1.VolumeMount
+		name        string
+		secondary   []v1alpha2.SecondaryTierSpec
+		wantVolumes []corev1.Volume
+		wantMounts  []corev1.VolumeMount
 	}{
 		{
-			name:          "empty secondary list produces no volumes",
-			secondary:     nil,
-			containerName: "main",
-			wantVolumes:   nil,
-			wantMounts:    nil,
+			name:        "empty secondary list produces no volumes",
+			secondary:   nil,
+			wantVolumes: nil,
+			wantMounts:  nil,
 		},
 		{
-			name:          "nil fileSystem entry is skipped",
-			secondary:     []v1alpha2.SecondaryTierSpec{{FileSystem: nil}},
-			containerName: "main",
-			wantVolumes:   nil,
-			wantMounts:    nil,
+			name:        "nil fileSystem entry is skipped",
+			secondary:   []v1alpha2.SecondaryTierSpec{{FileSystem: nil}},
+			wantVolumes: nil,
+			wantMounts:  nil,
 		},
 		{
-			name:          "emptyDir tier creates emptyDir volume with sizeLimit",
-			containerName: "main",
+			name: "emptyDir tier creates emptyDir volume with sizeLimit",
 			secondary: []v1alpha2.SecondaryTierSpec{
 				{FileSystem: &v1alpha2.FileSystemTierSpec{
 					EmptyDir: &v1alpha2.EmptyDirTierSpec{Size: resource.MustParse("100Gi")},
@@ -72,8 +68,7 @@ func TestAttachKVCacheSecondaryTiers(t *testing.T) {
 			},
 		},
 		{
-			name:          "pvc.spec tier creates ephemeral volume using full PVC spec",
-			containerName: "main",
+			name: "pvc.spec tier creates ephemeral volume using full PVC spec",
 			secondary: []v1alpha2.SecondaryTierSpec{
 				{FileSystem: &v1alpha2.FileSystemTierSpec{
 					PVC: &v1alpha2.PVCTierSpec{
@@ -114,8 +109,7 @@ func TestAttachKVCacheSecondaryTiers(t *testing.T) {
 			},
 		},
 		{
-			name:          "pvc.ref tier creates PVC volume with subPath",
-			containerName: "main",
+			name: "pvc.ref tier creates PVC volume with subPath",
 			secondary: []v1alpha2.SecondaryTierSpec{
 				{FileSystem: &v1alpha2.FileSystemTierSpec{
 					PVC: &v1alpha2.PVCTierSpec{
@@ -138,8 +132,7 @@ func TestAttachKVCacheSecondaryTiers(t *testing.T) {
 			},
 		},
 		{
-			name:          "multiple tiers get indexed names and default mountPaths",
-			containerName: "main",
+			name: "multiple tiers get indexed names and default mountPaths",
 			secondary: []v1alpha2.SecondaryTierSpec{
 				{FileSystem: &v1alpha2.FileSystemTierSpec{
 					EmptyDir: &v1alpha2.EmptyDirTierSpec{Size: resource.MustParse("100Gi")},
@@ -172,8 +165,7 @@ func TestAttachKVCacheSecondaryTiers(t *testing.T) {
 			},
 		},
 		{
-			name:          "mixed backends: pvc.ref at index 0 and pvc.spec at index 1",
-			containerName: "main",
+			name: "mixed backends: pvc.ref at index 0 and pvc.spec at index 1",
 			secondary: []v1alpha2.SecondaryTierSpec{
 				{FileSystem: &v1alpha2.FileSystemTierSpec{
 					PVC: &v1alpha2.PVCTierSpec{
@@ -236,7 +228,7 @@ func TestAttachKVCacheSecondaryTiers(t *testing.T) {
 					{Name: "main"},
 				},
 			}
-			attachKVCacheSecondaryTiers(podSpec, tt.secondary, tt.containerName)
+			attachKVCacheSecondaryTiers(podSpec, tt.secondary, "main")
 
 			if diff := cmp.Diff(tt.wantVolumes, podSpec.Volumes); diff != "" {
 				t.Errorf("volumes mismatch (-want +got):\n%s", diff)
@@ -244,6 +236,136 @@ func TestAttachKVCacheSecondaryTiers(t *testing.T) {
 			if diff := cmp.Diff(tt.wantMounts, podSpec.Containers[0].VolumeMounts); diff != "" {
 				t.Errorf("volumeMounts mismatch (-want +got):\n%s", diff)
 			}
+		})
+	}
+}
+
+// kvCachePodSpec builds a pod shaped like the base preset: a "main" container with a
+// /dev/shm mount backed by a memory-medium emptyDir, plus optional memory req/limit.
+// Any of shmSize/memReq/memLimit may be "" to omit that field.
+func kvCachePodSpec(shmSize, memReq, memLimit string) *corev1.PodSpec {
+	shm := &corev1.EmptyDirVolumeSource{Medium: corev1.StorageMediumMemory}
+	if shmSize != "" {
+		shm.SizeLimit = ptr.To(resource.MustParse(shmSize))
+	}
+	res := corev1.ResourceRequirements{}
+	if memReq != "" {
+		res.Requests = corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(memReq)}
+	}
+	if memLimit != "" {
+		res.Limits = corev1.ResourceList{corev1.ResourceMemory: resource.MustParse(memLimit)}
+	}
+	return &corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:         "main",
+			Resources:    res,
+			VolumeMounts: []corev1.VolumeMount{{Name: "dshm", MountPath: "/dev/shm"}},
+		}},
+		Volumes: []corev1.Volume{{
+			Name:         "dshm",
+			VolumeSource: corev1.VolumeSource{EmptyDir: shm},
+		}},
+	}
+}
+
+func TestAttachKVCachePrimaryTier(t *testing.T) {
+	// wantQty compares a quantity field, treating "" as "expected absent/nil".
+	wantQty := func(t *testing.T, label, want string, got *resource.Quantity) {
+		t.Helper()
+		if want == "" {
+			if got != nil {
+				t.Errorf("%s: expected absent, got %s", label, got.String())
+			}
+			return
+		}
+		if got == nil {
+			t.Errorf("%s: expected %s, got absent", label, want)
+			return
+		}
+		if w := resource.MustParse(want); got.Cmp(w) != 0 {
+			t.Errorf("%s: expected %s, got %s", label, want, got.String())
+		}
+	}
+
+	tests := []struct {
+		name         string
+		cpu          resource.Quantity
+		podSpec      *corev1.PodSpec
+		wantMount    bool
+		wantShm      string
+		wantMemReq   string
+		wantMemLimit string
+	}{
+		{
+			name:         "grows an explicitly-set /dev/shm by cpu*120% and bumps set memory req/limit",
+			cpu:          resource.MustParse("10Gi"),
+			podSpec:      kvCachePodSpec("1Gi", "32Gi", "64Gi"),
+			wantMount:    true,
+			wantShm:      "13Gi",
+			wantMemReq:   "44Gi",
+			wantMemLimit: "76Gi",
+		},
+		{
+			name:         "no /dev/shm mount: does not create a mount or volume",
+			cpu:          resource.MustParse("10Gi"),
+			podSpec:      &corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}},
+			wantMount:    false,
+			wantShm:      "",
+			wantMemReq:   "",
+			wantMemLimit: "",
+		},
+		{
+			name:         "resources memory limit set but request unset: bumps only the limit",
+			cpu:          resource.MustParse("10Gi"),
+			podSpec:      kvCachePodSpec("1Gi", "", "64Gi"),
+			wantMount:    true,
+			wantShm:      "13Gi",
+			wantMemReq:   "",
+			wantMemLimit: "76Gi",
+		},
+		{
+			name:         "no memory set on resources, leaves both request and limit unset",
+			cpu:          resource.MustParse("10Gi"),
+			podSpec:      kvCachePodSpec("1Gi", "", ""),
+			wantMount:    true,
+			wantShm:      "13Gi",
+			wantMemReq:   "",
+			wantMemLimit: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attachKVCachePrimaryTier(tt.podSpec, tt.cpu, "main")
+
+			hasMount := false
+			for _, m := range tt.podSpec.Containers[0].VolumeMounts {
+				if m.MountPath == "/dev/shm" {
+					hasMount = true
+				}
+			}
+			if hasMount != tt.wantMount {
+				t.Errorf("/dev/shm mount present = %v, want %v", hasMount, tt.wantMount)
+			}
+
+			var shm *resource.Quantity
+			for i := range tt.podSpec.Volumes {
+				if tt.podSpec.Volumes[i].Name == "dshm" && tt.podSpec.Volumes[i].EmptyDir != nil {
+					shm = tt.podSpec.Volumes[i].EmptyDir.SizeLimit
+				}
+			}
+			wantQty(t, "/dev/shm sizeLimit", tt.wantShm, shm)
+
+			c := tt.podSpec.Containers[0]
+			var memReq, memLimit *resource.Quantity
+			if q, ok := c.Resources.Requests[corev1.ResourceMemory]; ok {
+				memReq = &q
+			}
+			if q, ok := c.Resources.Limits[corev1.ResourceMemory]; ok {
+				memLimit = &q
+			}
+			wantQty(t, "memory request", tt.wantMemReq, memReq)
+			wantQty(t, "memory limit", tt.wantMemLimit, memLimit)
 		})
 	}
 }

--- a/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_multi_node.go
@@ -213,8 +213,9 @@ func (r *LLMISVCReconciler) expectedMainMultiNodeLWS(ctx context.Context, llmSvc
 		if err := r.attachModelArtifacts(ctx, serviceAccount, llmSvc, currLeaderSpec, &expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec, config, "main", constants.DefaultModelLocalMountPath, len(config.ResolvedLoRAAdapters) > 0); err != nil {
 			return nil, fmt.Errorf("failed to attach model artifacts to leader template: %w", err)
 		}
+
 		if llmSvc.Spec.KVCacheOffloading != nil {
-			attachKVCacheSecondaryTiers(&expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec, llmSvc.Spec.KVCacheOffloading.Secondary, "main")
+			attachKVCacheOffloading(&expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec, llmSvc.Spec.KVCacheOffloading)
 		}
 
 		if hasRoutingSidecar(expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec) {
@@ -242,7 +243,7 @@ func (r *LLMISVCReconciler) expectedMainMultiNodeLWS(ctx context.Context, llmSvc
 			return nil, fmt.Errorf("failed to attach model artifacts to worker template: %w", err)
 		}
 		if llmSvc.Spec.KVCacheOffloading != nil {
-			attachKVCacheSecondaryTiers(&expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec, llmSvc.Spec.KVCacheOffloading.Secondary, "main")
+			attachKVCacheOffloading(&expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec, llmSvc.Spec.KVCacheOffloading)
 		}
 
 		if hasRoutingSidecar(expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec) {
@@ -357,7 +358,7 @@ func (r *LLMISVCReconciler) expectedPrefillMultiNodeLWS(ctx context.Context, llm
 				return nil, fmt.Errorf("failed to attach model artifacts to prefill leader template: %w", err)
 			}
 			if llmSvc.Spec.Prefill.KVCacheOffloading != nil {
-				attachKVCacheSecondaryTiers(&expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec, llmSvc.Spec.Prefill.KVCacheOffloading.Secondary, "main")
+				attachKVCacheOffloading(&expected.Spec.LeaderWorkerTemplate.LeaderTemplate.Spec, llmSvc.Spec.Prefill.KVCacheOffloading)
 			}
 		}
 		if llmSvc.Spec.Prefill.Worker != nil {
@@ -369,7 +370,7 @@ func (r *LLMISVCReconciler) expectedPrefillMultiNodeLWS(ctx context.Context, llm
 				return nil, fmt.Errorf("failed to attach model artifacts to prefill worker template: %w", err)
 			}
 			if llmSvc.Spec.Prefill.KVCacheOffloading != nil {
-				attachKVCacheSecondaryTiers(&expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec, llmSvc.Spec.Prefill.KVCacheOffloading.Secondary, "main")
+				attachKVCacheOffloading(&expected.Spec.LeaderWorkerTemplate.WorkerTemplate.Spec, llmSvc.Spec.Prefill.KVCacheOffloading)
 			}
 		}
 

--- a/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
+++ b/pkg/controller/v1alpha2/llmisvc/workload_single_node.go
@@ -170,7 +170,7 @@ func (r *LLMISVCReconciler) expectedSingleNodeMainDeployment(ctx context.Context
 			return nil, fmt.Errorf("failed to attach model artifacts to main deployment: %w", err)
 		}
 		if llmSvc.Spec.KVCacheOffloading != nil {
-			attachKVCacheSecondaryTiers(&d.Spec.Template.Spec, llmSvc.Spec.KVCacheOffloading.Secondary, "main")
+			attachKVCacheOffloading(&d.Spec.Template.Spec, llmSvc.Spec.KVCacheOffloading)
 		}
 	}
 
@@ -273,7 +273,7 @@ func (r *LLMISVCReconciler) expectedPrefillMainDeployment(ctx context.Context, l
 			return nil, fmt.Errorf("failed to attach model artifacts to prefill deployment: %w", err)
 		}
 		if llmSvc.Spec.Prefill != nil && llmSvc.Spec.Prefill.KVCacheOffloading != nil {
-			attachKVCacheSecondaryTiers(&d.Spec.Template.Spec, llmSvc.Spec.Prefill.KVCacheOffloading.Secondary, "main")
+			attachKVCacheOffloading(&d.Spec.Template.Spec, llmSvc.Spec.Prefill.KVCacheOffloading)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When CPU KV cache offloading is enabled, vLLM's offloading connector uses the pod's /dev/shm (RAM-backed tmpfs) for the CPU cache buffer. The base presets only size /dev/shm for NCCL shared memory (1Gi for leader/single-node, 8Gi for data-parallel workers), which will never work for a CPU tier is requested. vLLM crashes on startup, and the container can be OOMKilled.

  This PR makes the controller account for the requested CPU tier automatically:
  - Grows the existing /dev/shm volume by the CPU tier size + 20% headroom, on top of the preset's NCCL baseline (so leaders keep 1Gi and workers keep 8Gi underneath).
  - Grows the main container's memory request and limit by the same amount, adjusting only the ones the user already set. If user did nto set it, meaning it can go as much as possible, we should not instead set one value and with smaller size
  - The controller only adjusts an existing /dev/shm; it never creates one, so user-provided llmisvcconfig stay under the user's control.
  - Fixes the KV-transfer connector spec name: CPU-only offloading now uses `CPUOffloadingSpec`, and `TieringOffloadingSpec` is used only when a secondary tier is configured.

**Feature/Issue validation/testing**:
- [x] Unit tests for the primary tier: growing an existing /dev/shm by cpu*120%, bumping only the memory request/limit that are set, and no-op when there is no /dev/shm mount.
  - [x] Unit tests for secondary tiers (emptyDir / pvc.spec / pvc.ref) unchanged and passing.
  - [x] make precommit (build, go vet, lint) clean.


**Special notes for your reviewer**:

- Sizing is additive on top of the preset baseline, deliberately not max — the preset's NCCL reservation and the CPU tier are independent needs.
  - No new pod-type branching: workers vs leaders differ only by their preset /dev/shm size, which the additive logic preserves automatically.
  - This PR does not change any image versions.

**Checklist**:
  - [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
  - [x] Has code been commented, particularly in hard-to-understand areas?
  - [x] Have you made corresponding changes to the documentation? (sample YAML + README under docs/samples/llmisvc/kv-cache-offloading/)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix CPU KV cache offloading for LLMInferenceService: the controller now sizes /dev/shm and the main container memory to fit the requested CPU tier (CPU size + 20% headroom on top of the NCCL baseline), preventing vLLM startup crashes and OOMKills.

```


cc @andresllh 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added CPU-based KV-cache offloading support for single-node and multi-node deployments.
  - Automatically adjusts shared memory and applicable memory resources for CPU offloading.
  - Added sizing guidance for configuring CPU-tier capacity.

- **Bug Fixes**
  - Improved configuration handling so CPU-only offloading uses the appropriate configuration type.
  - Clarified that evicted GPU cache data moves to CPU memory before disk tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->