### PR TITLE
fix(kserve-module): add ClusterServingRuntime RBAC permissions

### DIFF
--- a/kserve-module/config/rbac/role.yaml
+++ b/kserve-module/config/rbac/role.yaml
@@ -343,6 +343,7 @@ rules:
 - apiGroups:
   - serving.kserve.io
   resources:
+  - clusterservingruntimes
   - clusterstoragecontainers
   - llminferenceserviceconfigs
   - localmodelnodegroups

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -74,7 +74,7 @@ import (
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations;validatingwebhookconfigurations,verbs=create;delete;get;list;patch;update;watch
 
 // --- KServe cluster-scoped operand resources ---
-// +kubebuilder:rbac:groups=serving.kserve.io,resources=llminferenceserviceconfigs;clusterstoragecontainers,verbs=create;delete;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=serving.kserve.io,resources=clusterservingruntimes;llminferenceserviceconfigs;clusterstoragecontainers,verbs=create;delete;get;list;patch;update;watch
 
 // --- OpenShift-specific cluster-scoped resources ---
 // SCCs: required for InferenceService and LLMInferenceService workload pods


### PR DESCRIPTION
## Summary

Adds RBAC permissions for `clusterservingruntimes` in the `serving.kserve.io` API group to fix e2e test failures caused by odh-model-controller PR https://github.com/opendatahub-io/odh-model-controller/pull/862.

## Context

odh-model-controller recently added 3 new `ClusterServingRuntime` manifests:
- `csr-kserve-mlserver-v1`
- `csr-kserve-ovms-v1`
- `csr-kserve-vllm-v1`

These are included in `config/runtimes/kustomization.yaml` which flows through the modelcontroller component's `base` overlay that kserve-module deploys. The module controller lacked RBAC permissions to manage these resources, causing deployment failures in e2e tests.

## Changes

- Added `clusterservingruntimes` to the `serving.kserve.io` RBAC marker in `kserve-module/pkg/kservemodule/reconciler.go`
- Regenerated `kserve-module/config/rbac/role.yaml` to include the new resource

## Test plan

- [x] `make precommit` passes
- [ ] Deploy to test cluster and verify CSR manifests apply successfully
- [ ] Verify `oc get clusterservingruntimes` shows the 3 new resources
- [ ] Run e2e tests to confirm RBAC errors are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for managing ClusterServingRuntime resources, including creating, updating, deleting, retrieving, listing, and monitoring them.
* **Bug Fixes**
  * Updated access permissions to ensure the service can fully manage configured runtimes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->