### PR TITLE
feat(kserve-module): add EnableAuditLogging to KserveSpec and ConfigMap reconciliation

### DIFF
--- a/kserve-module/config/crd/components.platform.opendatahub.io_kserves.yaml
+++ b/kserve-module/config/crd/components.platform.opendatahub.io_kserves.yaml
@@ -46,6 +46,12 @@ spec:
             type: object
           spec:
             properties:
+              enableAuditLogging:
+                description: |-
+                  Enables audit logging for KServe inference requests.
+                  When enabled, the audit logging flag is set in the inferenceservice-config
+                  ConfigMap's openshiftConfig section. Disabled by default.
+                type: boolean
               enableLLMInferenceServiceConsoleDashboards:
                 description: |-
                   Enables OpenShift Developer Console dashboards for LLMInferenceService.

--- a/kserve-module/pkg/apis/v1alpha1/types.go
+++ b/kserve-module/pkg/apis/v1alpha1/types.go
@@ -71,6 +71,12 @@ type KserveSpec struct {
 	// Enabled by default.
 	EnableLLMInferenceServiceConsoleDashboards *bool `json:"enableLLMInferenceServiceConsoleDashboards,omitempty"`
 
+	// Enables audit logging for KServe inference requests.
+	// When enabled, the audit logging flag is set in the inferenceservice-config
+	// ConfigMap's openshiftConfig section. Disabled by default.
+	// +optional
+	EnableAuditLogging *bool `json:"enableAuditLogging,omitempty"`
+
 	ModelCache *ModelCacheSpec `json:"modelCache,omitempty"`
 }
 

--- a/kserve-module/pkg/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/kserve-module/pkg/apis/v1alpha1/zz_generated.deepcopy.go
@@ -90,6 +90,11 @@ func (in *KserveSpec) DeepCopyInto(out *KserveSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableAuditLogging != nil {
+		in, out := &in.EnableAuditLogging, &out.EnableAuditLogging
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ModelCache != nil {
 		in, out := &in.ModelCache, &out.ModelCache
 		*out = new(ModelCacheSpec)

--- a/kserve-module/pkg/kservemodule/configmap.go
+++ b/kserve-module/pkg/kservemodule/configmap.go
@@ -111,6 +111,14 @@ func updateInferenceCM(cm *corev1.ConfigMap, kserve *platformv1alpha1.Kserve) er
 		return err
 	}
 
+	if kserve.Spec.EnableAuditLogging != nil {
+		if err := updateCMJSONKey(cm, openshiftConfigKeyName, func(data map[string]any) {
+			data["enableAuditLogging"] = *kserve.Spec.EnableAuditLogging
+		}); err != nil {
+			return err
+		}
+	}
+
 	if agentImage := os.Getenv(kserveImageParamMap["kserve-agent"]); agentImage != "" {
 		if err := updateCMJSONKey(cm, openshiftConfigKeyName, func(data map[string]any) {
 			data["modelcachePermissionFixImage"] = agentImage

--- a/kserve-module/pkg/kservemodule/configmap_test.go
+++ b/kserve-module/pkg/kservemodule/configmap_test.go
@@ -142,6 +142,82 @@ func TestCustomizeKserveConfigMap_EnableTLS_NilPreservesExisting(t *testing.T) {
 	g.Expect(resultCM.Data[ingressConfigKeyName]).Should(ContainSubstring(`"enableLLMInferenceServiceTLS": true`))
 }
 
+func TestCustomizeKserveConfigMap_EnableAuditLogging_Nil(t *testing.T) {
+	g := NewWithT(t)
+
+	resources := buildTestResourcesWithOpenshiftConfig(t)
+
+	result, err := customizeKserveConfigMap(resources, buildTestKserveWithAudit(platformv1alpha1.KserveRawHeadless, nil, nil, nil))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	_, cm, err := getIndexedResource[corev1.ConfigMap](result, configMapGVK, kserveConfigMapName)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(cm.Data[openshiftConfigKeyName]).ShouldNot(ContainSubstring("enableAuditLogging"))
+}
+
+func TestCustomizeKserveConfigMap_EnableAuditLogging_True(t *testing.T) {
+	g := NewWithT(t)
+
+	resources := buildTestResourcesWithOpenshiftConfig(t)
+
+	result, err := customizeKserveConfigMap(resources, buildTestKserveWithAudit(platformv1alpha1.KserveRawHeadless, nil, nil, ptr.To(true)))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	_, cm, err := getIndexedResource[corev1.ConfigMap](result, configMapGVK, kserveConfigMapName)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(cm.Data[openshiftConfigKeyName]).Should(ContainSubstring(`"enableAuditLogging": true`))
+}
+
+func TestCustomizeKserveConfigMap_EnableAuditLogging_False(t *testing.T) {
+	g := NewWithT(t)
+
+	resources := buildTestResourcesWithOpenshiftConfig(t)
+
+	result, err := customizeKserveConfigMap(resources, buildTestKserveWithAudit(platformv1alpha1.KserveRawHeadless, nil, nil, ptr.To(false)))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	_, cm, err := getIndexedResource[corev1.ConfigMap](result, configMapGVK, kserveConfigMapName)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(cm.Data[openshiftConfigKeyName]).Should(ContainSubstring(`"enableAuditLogging": false`))
+}
+
+func TestCustomizeKserveConfigMap_EnableAuditLogging_NilPreservesExisting(t *testing.T) {
+	g := NewWithT(t)
+
+	cm := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: kserveConfigMapName, Namespace: "opendatahub"},
+		Data: map[string]string{
+			ingressConfigKeyName:   `{"ingressDomain": "example.com"}`,
+			serviceConfigKeyName:   `{"serviceType": "ClusterIP"}`,
+			openshiftConfigKeyName: `{"enableAuditLogging": true}`,
+		},
+	}
+	cmU, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cm)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	deploy := &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
+		ObjectMeta: metav1.ObjectMeta{Name: kserveControllerDeployment, Namespace: "opendatahub"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+			},
+		},
+	}
+	deployU, err := runtime.DefaultUnstructuredConverter.ToUnstructured(deploy)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	resources := []unstructured.Unstructured{{Object: cmU}, {Object: deployU}}
+
+	result, err := customizeKserveConfigMap(resources, buildTestKserveWithAudit(platformv1alpha1.KserveRawHeadless, nil, nil, nil))
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	_, resultCM, err := getIndexedResource[corev1.ConfigMap](result, configMapGVK, kserveConfigMapName)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(resultCM.Data[openshiftConfigKeyName]).Should(ContainSubstring(`"enableAuditLogging": true`))
+}
+
 func TestCustomizeKserveConfigMap_OAuthProxy_FullOverride(t *testing.T) {
 	g := NewWithT(t)
 
@@ -332,13 +408,49 @@ func buildTestResourcesWithOAuthProxy(t *testing.T) []unstructured.Unstructured 
 }
 
 func buildTestKserve(rawSvc platformv1alpha1.RawServiceConfig, enableTLS *bool, oauthProxy *platformv1alpha1.OAuthProxyConfig) *platformv1alpha1.Kserve {
+	return buildTestKserveWithAudit(rawSvc, enableTLS, oauthProxy, nil)
+}
+
+func buildTestKserveWithAudit(rawSvc platformv1alpha1.RawServiceConfig, enableTLS *bool, oauthProxy *platformv1alpha1.OAuthProxyConfig, enableAudit *bool) *platformv1alpha1.Kserve {
 	return &platformv1alpha1.Kserve{
 		Spec: platformv1alpha1.KserveSpec{
 			RawDeploymentServiceConfig:  rawSvc,
 			EnableLLMInferenceServiceTLS: enableTLS,
 			OAuthProxy:                  oauthProxy,
+			EnableAuditLogging:          enableAudit,
 		},
 	}
+}
+
+func buildTestResourcesWithOpenshiftConfig(t *testing.T) []unstructured.Unstructured {
+	t.Helper()
+	g := NewWithT(t)
+
+	cm := &corev1.ConfigMap{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{Name: kserveConfigMapName, Namespace: "opendatahub"},
+		Data: map[string]string{
+			ingressConfigKeyName:   `{"ingressDomain": "example.com"}`,
+			serviceConfigKeyName:   `{"serviceType": "ClusterIP"}`,
+			openshiftConfigKeyName: `{}`,
+		},
+	}
+	cmU, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cm)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	deploy := &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "apps/v1", Kind: "Deployment"},
+		ObjectMeta: metav1.ObjectMeta{Name: kserveControllerDeployment, Namespace: "opendatahub"},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+			},
+		},
+	}
+	deployU, err := runtime.DefaultUnstructuredConverter.ToUnstructured(deploy)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	return []unstructured.Unstructured{{Object: cmU}, {Object: deployU}}
 }
 
 func buildTestResources(t *testing.T) []unstructured.Unstructured {

--- a/kserve-module/pkg/kservemodule/fixture/kserve_builder.go
+++ b/kserve-module/pkg/kservemodule/fixture/kserve_builder.go
@@ -63,6 +63,12 @@ func WithEnableLLMInferenceServiceConsoleDashboards(val *bool) KserveOption {
 	}
 }
 
+func WithEnableAuditLogging(val *bool) KserveOption {
+	return func(k *platformv1alpha1.Kserve) {
+		k.Spec.EnableAuditLogging = val
+	}
+}
+
 func WithAnnotation(key, value string) KserveOption {
 	return func(k *platformv1alpha1.Kserve) {
 		if k.Annotations == nil {


### PR DESCRIPTION
## Summary

- Adds `enableAuditLogging` optional boolean to `KserveSpec` in the kserve-module-operator
- When set, the module operator writes the flag into `inferenceservice-config` ConfigMap's `openshiftConfig` section
- Pairs with [opendatahub-operator#3928](https://github.com/opendatahub-io/opendatahub-operator/pull/3928) which adds the field to DSC CR `KserveCommonSpec` — the rhods-operator projects it into the kserve module CR, and this PR makes the kserve-module-operator consume it

## Changes

| File | Change |
|------|--------|
| `kserve-module/pkg/apis/v1alpha1/types.go` | New `EnableAuditLogging *bool` field on `KserveSpec` |
| `kserve-module/pkg/apis/v1alpha1/zz_generated.deepcopy.go` | Regenerated |
| `kserve-module/config/crd/components.platform.opendatahub.io_kserves.yaml` | Regenerated CRD |
| `kserve-module/pkg/kservemodule/configmap.go` | Reconciliation: writes `enableAuditLogging` to `openshiftConfig` key |
| `kserve-module/pkg/kservemodule/configmap_test.go` | 4 tests: nil, true, false, nil-preserves-existing |
| `kserve-module/pkg/kservemodule/fixture/kserve_builder.go` | `WithEnableAuditLogging` builder option |

## Testing

- [x] `make generate-kserve-module manifests-kserve-module` — codegen clean
- [x] `make test-kserve-module` — all 216 tests pass (unit + envtest)
- [x] New tests: `TestCustomizeKserveConfigMap_EnableAuditLogging_{Nil,True,False,NilPreservesExisting}`

## End-to-end flow

```
DSC CR (enableAuditLogging: true)
  → rhods-operator BuildModuleCR() → Kserve module CR (spec.enableAuditLogging: true)
    → kserve-module-operator updateInferenceCM() → inferenceservice-config ConfigMap (openshiftConfig.enableAuditLogging: true)
```

## Jira

[RHOAIENG-78541](https://redhat.atlassian.net/browse/RHOAIENG-78541)

**Companion PR:** [opendatahub-operator#3928](https://github.com/opendatahub-io/opendatahub-operator/pull/3928)

[RHOAIENG-78541]: https://redhat.atlassian.net/browse/RHOAIENG-78541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ