### PR TITLE
fix(kserve-module): clean up legacy LLMInference webhooks on upgrade

### DIFF
--- a/kserve-module/pkg/kservemodule/upgrade.go
+++ b/kserve-module/pkg/kservemodule/upgrade.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -103,6 +104,23 @@ var legacySelectorDaemonSets = []legacySelectorWorkload{
 	{name: "kserve-localmodelnode-agent", legacyLabelKey: "app.opendatahub.io/kserve"},
 }
 
+// legacyKServeWebhookService is the shared webhook Service name used before llmisvc
+// got its own endpoint (llmisvc-webhook-server-service).
+const legacyKServeWebhookService = "kserve-webhook-server-service"
+
+// legacyLLMInferenceValidatingWebhooks are ValidatingWebhookConfiguration names for
+// LLMInferenceService / LLMInferenceServiceConfig that may still point at the old service.
+var legacyLLMInferenceValidatingWebhooks = []string{
+	"llminferenceservice.serving.kserve.io",
+	"llminferenceserviceconfig.serving.kserve.io",
+}
+
+// legacyLLMInferenceMutatingWebhooks are MutatingWebhookConfiguration names with the
+// same legacy-service migration concern.
+var legacyLLMInferenceMutatingWebhooks = []string{
+	"llminferenceservice.serving.kserve.io",
+}
+
 // deleteLegacySelectorWorkloads checks each Deployment and DaemonSet for legacy selector
 // labels and deletes those that carry them. The reconciler will recreate them with the correct selectors.
 func deleteLegacySelectorWorkloads(ctx context.Context, cli client.Client, namespace string) error {
@@ -164,6 +182,81 @@ func deleteLegacySelectorWorkloads(ctx context.Context, cli client.Client, names
 	return errors.Join(errs...)
 }
 
+// deleteLegacyLLMInferenceWebhooks deletes LLMInferenceService webhook configs whose
+// webhooks still reference kserve-webhook-server-service. If any webhook entry in a
+// config points at the legacy service, the entire configuration is deleted so the
+// reconciler can recreate it with llmisvc-webhook-server-service.
+func deleteLegacyLLMInferenceWebhooks(ctx context.Context, cli client.Client) error {
+	log := ctrl.LoggerFrom(ctx)
+	var errs []error
+
+	for _, name := range legacyLLMInferenceValidatingWebhooks {
+		vwc := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+		if err := cli.Get(ctx, types.NamespacedName{Name: name}, vwc); err != nil {
+			if k8serr.IsNotFound(err) {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("failed to get ValidatingWebhookConfiguration %s: %w", name, err))
+			continue
+		}
+
+		if !validatingWebhookRefsLegacyService(vwc.Webhooks) {
+			continue
+		}
+
+		log.Info("Deleting ValidatingWebhookConfiguration with legacy webhook service",
+			"name", name, "legacyService", legacyKServeWebhookService)
+
+		if err := cli.Delete(ctx, vwc); err != nil && !k8serr.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("failed to delete ValidatingWebhookConfiguration %s: %w", name, err))
+		}
+	}
+
+	for _, name := range legacyLLMInferenceMutatingWebhooks {
+		mwc := &admissionregistrationv1.MutatingWebhookConfiguration{}
+		if err := cli.Get(ctx, types.NamespacedName{Name: name}, mwc); err != nil {
+			if k8serr.IsNotFound(err) {
+				continue
+			}
+			errs = append(errs, fmt.Errorf("failed to get MutatingWebhookConfiguration %s: %w", name, err))
+			continue
+		}
+
+		if !mutatingWebhookRefsLegacyService(mwc.Webhooks) {
+			continue
+		}
+
+		log.Info("Deleting MutatingWebhookConfiguration with legacy webhook service",
+			"name", name, "legacyService", legacyKServeWebhookService)
+
+		if err := cli.Delete(ctx, mwc); err != nil && !k8serr.IsNotFound(err) {
+			errs = append(errs, fmt.Errorf("failed to delete MutatingWebhookConfiguration %s: %w", name, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func validatingWebhookRefsLegacyService(webhooks []admissionregistrationv1.ValidatingWebhook) bool {
+	for i := range webhooks {
+		if webhooks[i].ClientConfig.Service != nil &&
+			webhooks[i].ClientConfig.Service.Name == legacyKServeWebhookService {
+			return true
+		}
+	}
+	return false
+}
+
+func mutatingWebhookRefsLegacyService(webhooks []admissionregistrationv1.MutatingWebhook) bool {
+	for i := range webhooks {
+		if webhooks[i].ClientConfig.Service != nil &&
+			webhooks[i].ClientConfig.Service.Name == legacyKServeWebhookService {
+			return true
+		}
+	}
+	return false
+}
+
 // knownConditionTypes lists all condition types managed by kserve-module.
 // Conditions not in this set (e.g. from the in-tree ODH operator) are removed on upgrade.
 // TODO(3.6): remove removeStaleConditions and knownConditionTypes — only needed for 3.5 migration from in-tree operator.
@@ -212,13 +305,18 @@ func removeStaleConditions(ctx context.Context, cli client.Client, crName string
 
 // runUpgradeTasks performs one-time migration tasks on startup:
 //  1. Deletes Deployments and DaemonSets carrying legacy selector labels from the in-tree ODH operator.
-//  2. Removes stale conditions left by the in-tree ODH operator.
-//  3. Migrates HardwareProfile annotations on InferenceServices.
+//  2. Deletes LLMInferenceService webhook configs still pointing at kserve-webhook-server-service.
+//  3. Removes stale conditions left by the in-tree ODH operator.
+//  4. Migrates HardwareProfile annotations on InferenceServices.
 func runUpgradeTasks(ctx context.Context, cli client.Client, applicationNS string) error {
 	log := ctrl.LoggerFrom(ctx)
 
 	if err := deleteLegacySelectorWorkloads(ctx, cli, applicationNS); err != nil {
 		log.Error(err, "legacy selector deployment cleanup encountered errors")
+	}
+
+	if err := deleteLegacyLLMInferenceWebhooks(ctx, cli); err != nil {
+		log.Error(err, "legacy llmisvc webhook cleanup encountered errors")
 	}
 
 	if err := removeStaleConditions(ctx, cli, platformv1alpha1.KserveInstanceName); err != nil {

--- a/kserve-module/pkg/kservemodule/upgrade_test.go
+++ b/kserve-module/pkg/kservemodule/upgrade_test.go
@@ -3,10 +3,12 @@ package kservemodule
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
 	. "github.com/onsi/gomega"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -33,12 +35,14 @@ var (
 	testClusterScope   = testRESTScope{name: apimeta.RESTScopeNameRoot}
 )
 
-// makeUpgradeTestScheme returns a scheme with corev1, appsv1, and apiextensionsv1 registered.
+// makeUpgradeTestScheme returns a scheme with corev1, appsv1, apiextensionsv1,
+// and admissionregistrationv1 registered.
 func makeUpgradeTestScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
 	_ = corev1.AddToScheme(s)
 	_ = appsv1.AddToScheme(s)
 	_ = apiextensionsv1.AddToScheme(s)
+	_ = admissionregistrationv1.AddToScheme(s)
 	return s
 }
 
@@ -53,6 +57,9 @@ func makeUpgradeTestRESTMapper() apimeta.RESTMapper {
 
 	// Typed GVKs
 	rm.Add(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, testNamespaceScope)
+	rm.Add(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "DaemonSet"}, testNamespaceScope)
+	rm.Add(schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "ValidatingWebhookConfiguration"}, testClusterScope)
+	rm.Add(schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1", Kind: "MutatingWebhookConfiguration"}, testClusterScope)
 
 	// Unstructured GVKs from upgrade.go
 	rm.Add(inferenceServiceGVK, testNamespaceScope)
@@ -1187,5 +1194,111 @@ func TestDeleteLegacySelectorWorkloads(t *testing.T) {
 		got := &appsv1.Deployment{}
 		g.Expect(k8serr.IsNotFound(cli.Get(ctx, client.ObjectKeyFromObject(dep2), got))).
 			To(BeTrue(), "llmisvc-controller-manager should be deleted despite kserve error")
+	})
+}
+
+// ─── Legacy LLMInference Webhook Cleanup ────────────────────────────────────
+
+func makeWebhookService(name string) *admissionregistrationv1.ServiceReference {
+	return &admissionregistrationv1.ServiceReference{Name: name, Namespace: "opendatahub"}
+}
+
+func makeValidatingWebhookConfig(name string, serviceNames ...string) *admissionregistrationv1.ValidatingWebhookConfiguration {
+	webhooks := make([]admissionregistrationv1.ValidatingWebhook, 0, len(serviceNames))
+	for i, svc := range serviceNames {
+		webhooks = append(webhooks, admissionregistrationv1.ValidatingWebhook{
+			Name:         fmt.Sprintf("%s-%d", name, i),
+			ClientConfig: admissionregistrationv1.WebhookClientConfig{Service: makeWebhookService(svc)},
+		})
+	}
+	return &admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Webhooks:   webhooks,
+	}
+}
+
+func makeMutatingWebhookConfig(name string, serviceNames ...string) *admissionregistrationv1.MutatingWebhookConfiguration {
+	webhooks := make([]admissionregistrationv1.MutatingWebhook, 0, len(serviceNames))
+	for i, svc := range serviceNames {
+		webhooks = append(webhooks, admissionregistrationv1.MutatingWebhook{
+			Name:         fmt.Sprintf("%s-%d", name, i),
+			ClientConfig: admissionregistrationv1.WebhookClientConfig{Service: makeWebhookService(svc)},
+		})
+	}
+	return &admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Webhooks:   webhooks,
+	}
+}
+
+func TestDeleteLegacyLLMInferenceWebhooks(t *testing.T) {
+	ctx := context.Background()
+	const newService = "llmisvc-webhook-server-service"
+
+	t.Run("DeletesWhenAnyWebhookEntryRefsLegacyService", func(t *testing.T) {
+		g := NewWithT(t)
+
+		// Mixed entries: first/new, middle/legacy, last/new — any one legacy forces full delete.
+		vwc := makeValidatingWebhookConfig(
+			"llminferenceserviceconfig.serving.kserve.io",
+			newService,
+			legacyKServeWebhookService,
+			newService,
+		)
+		cli := makeISVCFakeClient(vwc)
+
+		g.Expect(deleteLegacyLLMInferenceWebhooks(ctx, cli)).To(Succeed())
+
+		got := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+		err := cli.Get(ctx, client.ObjectKey{Name: vwc.Name}, got)
+		g.Expect(k8serr.IsNotFound(err)).To(BeTrue(), "config should be deleted when any entry is legacy")
+	})
+
+	t.Run("DeletesAllLegacyLLMInferenceWebhookConfigs", func(t *testing.T) {
+		g := NewWithT(t)
+
+		objects := []client.Object{
+			makeValidatingWebhookConfig("llminferenceservice.serving.kserve.io", legacyKServeWebhookService, legacyKServeWebhookService),
+			makeValidatingWebhookConfig("llminferenceserviceconfig.serving.kserve.io", legacyKServeWebhookService, legacyKServeWebhookService),
+			makeMutatingWebhookConfig("llminferenceservice.serving.kserve.io", legacyKServeWebhookService, legacyKServeWebhookService),
+		}
+		cli := makeISVCFakeClient(objects...)
+
+		g.Expect(deleteLegacyLLMInferenceWebhooks(ctx, cli)).To(Succeed())
+
+		for _, name := range []string{"llminferenceservice.serving.kserve.io", "llminferenceserviceconfig.serving.kserve.io"} {
+			vwc := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+			g.Expect(k8serr.IsNotFound(cli.Get(ctx, client.ObjectKey{Name: name}, vwc))).
+				To(BeTrue(), "ValidatingWebhookConfiguration %s should be deleted", name)
+		}
+		mwc := &admissionregistrationv1.MutatingWebhookConfiguration{}
+		g.Expect(k8serr.IsNotFound(cli.Get(ctx, client.ObjectKey{Name: "llminferenceservice.serving.kserve.io"}, mwc))).
+			To(BeTrue(), "MutatingWebhookConfiguration should be deleted")
+	})
+
+	t.Run("SkipsWhenAllWebhookEntriesUseNewService", func(t *testing.T) {
+		g := NewWithT(t)
+
+		vwc := makeValidatingWebhookConfig(
+			"llminferenceserviceconfig.serving.kserve.io",
+			newService,
+			newService,
+			newService,
+		)
+		mwc := makeMutatingWebhookConfig("llminferenceservice.serving.kserve.io", newService, newService)
+		cli := makeISVCFakeClient(vwc, mwc)
+
+		g.Expect(deleteLegacyLLMInferenceWebhooks(ctx, cli)).To(Succeed())
+
+		gotVWC := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+		g.Expect(cli.Get(ctx, client.ObjectKey{Name: vwc.Name}, gotVWC)).To(Succeed())
+		gotMWC := &admissionregistrationv1.MutatingWebhookConfiguration{}
+		g.Expect(cli.Get(ctx, client.ObjectKey{Name: mwc.Name}, gotMWC)).To(Succeed())
+	})
+
+	t.Run("SkipsMissingWebhookConfigs", func(t *testing.T) {
+		g := NewWithT(t)
+		cli := makeISVCFakeClient()
+		g.Expect(deleteLegacyLLMInferenceWebhooks(ctx, cli)).To(Succeed())
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
On 2.x the LLMInferenceService/Config validating+mutating webhooks lived in the main kserve webhook config and pointed at kserve-webhook-server-service. In 3.x that validation moved to llmisvc-controller-manager.

**Problem:** 
The webhook config object name (llminferenceservice[config].serving.kserve.io) is unchanged across the split. The 3.x reconciler SSA-applies the new entries (v1alpha1/v1alpha2 → llmisvc-webhook-server-service), but webhooks is a list-map merged by name, so the old .validator entry from 2.x survives — nothing owns it, nothing prunes it. Admission  then hits the dead kserve service and 404s:
```
  failed calling webhook "llminferenceserviceconfig.kserve-webhook-server.validator":
  the server could not find the requested resource
```
→ KserveReady=False after 2.x→3.x upgrade.

  Fix: add a one-time upgrade task (deleteLegacyLLMInferenceWebhooks, alongside deleteLegacySelectorWorkloads) that deletes any LLMInference webhook config still referencing kserve-webhook-server-service. The reconciler recreates them clean against llmisvc-webhook-server-service.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://redhat.atlassian.net/browse/RHOAIENG-80109


**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

Tests: unit coverage for the delete logic (mixed entries, all-legacy incl. mutating, new-only skip, missing skip).

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed legacy LLM inference service webhook configurations during startup upgrades.
  * Cleaned up outdated validating and mutating webhook configurations that reference the former webhook service.
  * Preserved configurations that already use the current webhook service.
  * Improved upgrade handling when webhook configurations are missing or partially configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->