### PR TITLE
feat(kserve-module): add deps-only/deploy-only toggle to cluster setup

### DIFF
--- a/kserve-module/docs/prerequisite/setup.cluster.md
+++ b/kserve-module/docs/prerequisite/setup.cluster.md
@@ -1,0 +1,60 @@
+# Cluster Setup
+
+Prepares a cluster for E2E testing by deploying the KServe manifests and the KServe Module Operator.
+
+* Required cli:
+```bash
+./hack/setup/cli/install-helm.sh
+```
+
+* Create KIND Cluster:
+```bash
+./hack/setup/dev/manage.kind-with-registry.sh
+```
+
+
+## All-in-One
+
+- install dependencies
+- kserve module operator with E2E_IMG
+
+
+```bash
+KSERVE_NAMESPACE=kserve \
+E2E_IMG=quay.io/jooholee/kserve-module-controller:20260806-1 \
+make e2e-setup-kserve-module
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KSERVE_NAMESPACE` | `opendatahub` | Target namespace |
+| `PLATFORM` | `xks` | Platform type - `xks` or `ocp` (automatically detect) |
+| `E2E_IMG` | (unset) | Controller image to use (falls back to the kustomize default if omitted) |
+| `SKIP_DEPS` | `false` | Skip dependency installation, deploy the operator only |
+| `SKIP_KM_DEPLOY` | `false` | Install dependencies only, skip the kserve-module deploy |
+
+## Dependencies only
+
+Install the platform dependencies without deploying the kserve-module operator:
+
+```bash
+SKIP_KM_DEPLOY=true PLATFORM=ocp make e2e-setup-kserve-module
+```
+
+## Deploy the kserve module operator only
+
+Deploy the kserve module operator when dependencies are already installed:
+
+```bash
+SKIP_DEPS=true PLATFORM=ocp make e2e-setup-kserve-module
+```
+
+## Cleanup
+
+```bash
+PLATFORM=ocp make e2e-cleanup-kserve-module
+```
+
+> See `kserve-module/tests/scripts/setup-cluster.sh` for the actual behavior.

--- a/kserve-module/tests/scripts/setup-cluster.sh
+++ b/kserve-module/tests/scripts/setup-cluster.sh
@@ -66,7 +66,10 @@ OCP_SUBSCRIPTIONS=(
 # Parse arguments
 # ---------------------------------------------------------------------------
 CLEANUP=false
-SKIP_DEPS=false
+# Skip dependency installation (deploy only). Env-overridable.
+SKIP_DEPS="${SKIP_DEPS:-false}"
+# Install dependencies only, skip the kserve-module deploy. Env-overridable.
+SKIP_KM_DEPLOY="${SKIP_KM_DEPLOY:-false}"
 
 parse_args() {
   while [[ $# -gt 0 ]]; do
@@ -78,9 +81,10 @@ parse_args() {
           exit 1
         fi
         KSERVE_MODULE_IMG="$2"; shift 2 ;;
-      --cleanup)    CLEANUP=true; shift ;;
-      --skip-deps)  SKIP_DEPS=true; shift ;;
-      -h|--help)    usage; exit 0 ;;
+      --cleanup)     CLEANUP=true; shift ;;
+      --skip-deps)      SKIP_DEPS=true; shift ;;
+      --skip-km-deploy) SKIP_KM_DEPLOY=true; shift ;;
+      -h|--help)        usage; exit 0 ;;
       *)            echo "Unknown option: $1"; usage; exit 1 ;;
     esac
   done
@@ -101,7 +105,10 @@ Options:
   --platform xks|ocp           Target platform (default: xks)
   --image IMAGE                 Controller image (e.g. quay.io/org/kserve-module:tag)
   --cleanup                     Uninstall kserve-module and all platform dependencies
-  --skip-deps                   Skip dependency installation (use when deps are already installed)
+  --skip-deps                   Skip dependency installation, deploy only
+                                (or set SKIP_DEPS=true)
+  --skip-km-deploy              Install dependencies only, skip the kserve-module deploy
+                                (or set SKIP_KM_DEPLOY=true)
   -h, --help                    Show this help
 
 Examples:
@@ -110,6 +117,9 @@ Examples:
 
   # Install on OCP with custom image
   $(basename "$0") --platform ocp --image quay.io/my-org/kserve-module:latest
+
+  # Install dependencies only (no module deploy)
+  $(basename "$0") --platform ocp --skip-km-deploy
 
   # Uninstall everything
   $(basename "$0") --cleanup --platform xks
@@ -401,7 +411,12 @@ main() {
     log_info "Skipping dependency installation (--skip-deps)"
   fi
 
-  deploy_kserve_module
+  if [[ "${SKIP_KM_DEPLOY}" != "true" ]]; then
+    deploy_kserve_module
+  else
+    log_info "Skipping kserve-module deploy (--skip-km-deploy / SKIP_KM_DEPLOY=true) — dependencies only"
+    return
+  fi
 
   echo ""
   log_success "Setup complete!"


### PR DESCRIPTION
Adds a deps-only / deploy-only toggle to setup-cluster.sh.

- SKIP_KM_DEPLOY=true (or --skip-km-deploy): install dependencies only, skip the module deploy
- SKIP_DEPS=true (or --skip-deps): deploy only, when deps are already installed

Both are env-overridable so they work through the make target too. Documented in docs/prerequisite/setup.cluster.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fix:  https://redhat.atlassian.net/browse/RHOAIENG-76063

## Summary by CodeRabbit

- **New Features**
  - Added options to run cluster setup with dependencies only or skip the KServe Module deployment.
  - Added configurable environment variables and a `--skip-km-deploy` command-line option.
  - Improved setup command help text and usage examples.

- **Documentation**
  - Added comprehensive cluster setup guidance for end-to-end testing, including prerequisites, deployment workflows, configuration, cleanup, and setup script usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->