### PR TITLE
[RHOAIENG-75957] Enable SecureServing on metrics endpoints

### DIFF
--- a/cmd/llmisvc/main.go
+++ b/cmd/llmisvc/main.go
@@ -85,6 +85,7 @@ type Options struct {
 	enableHTTP2           bool
 	probeAddr             string
 	metricsSecure         bool
+	metricsCertPath       string
 	migrationTimeout      time.Duration
 	migrationPollInterval time.Duration
 	tlsMinVersion         string
@@ -114,7 +115,8 @@ func GetOptions() Options {
 		"Enable leader election for kserve controller manager. "+
 			"Enabling this will ensure there is only one active kserve controller manager.")
 	flag.StringVar(&opts.probeAddr, "health-probe-addr", opts.probeAddr, "The address the probe endpoint binds to.")
-	flag.BoolVar(&opts.metricsSecure, "metrics-secure", opts.metricsSecure, "Whether to serve metric via HTTPS.")
+	flag.BoolVar(&opts.metricsSecure, "metrics-secure", opts.metricsSecure, "Whether to serve metrics via HTTPS.")
+	flag.StringVar(&opts.metricsCertPath, "metrics-cert-path", opts.metricsCertPath, "Directory containing tls.crt and tls.key for the metrics server. If empty, self-signed certificates are generated.")
 	flag.BoolVar(&opts.enableHTTP2, "enable-http2", false, "Deprecated: CVE-2023-44487 is fixed in Go 1.21.3+. Use --tls-min-version and --tls-cipher-suites instead.")
 	flag.StringVar(&opts.tlsMinVersion, "tls-min-version", opts.tlsMinVersion, "Minimum TLS version (VersionTLS12, VersionTLS13). Defaults to VersionTLS12.")
 	flag.StringVar(&opts.tlsCipherSuites, "tls-cipher-suites", opts.tlsCipherSuites, "Comma-separated list of TLS cipher suites (Go names). If empty, Go defaults are used.")
@@ -196,6 +198,9 @@ func main() {
 
 	if options.metricsSecure {
 		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
+	}
+	if options.metricsCertPath != "" {
+		metricsServerOptions.CertDir = options.metricsCertPath
 	}
 
 	llmSvcCacheSelector, _ := metav1.LabelSelectorAsSelector(&llmisvc.ChildResourcesLabelSelector)

--- a/cmd/localmodel/main.go
+++ b/cmd/localmodel/main.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -54,6 +55,8 @@ type Options struct {
 	webhookPort          int
 	enableLeaderElection bool
 	probeAddr            string
+	metricsSecure        bool
+	metricsCertPath      string
 	tlsMinVersion        string
 	tlsCipherSuites      string
 	zapOpts              zap.Options
@@ -79,6 +82,8 @@ func GetOptions() Options {
 		"Enable leader election for kserve controller manager. "+
 			"Enabling this will ensure there is only one active kserve controller manager.")
 	flag.StringVar(&opts.probeAddr, "health-probe-addr", opts.probeAddr, "The address the probe endpoint binds to.")
+	flag.BoolVar(&opts.metricsSecure, "metrics-secure", opts.metricsSecure, "Whether to serve metrics via HTTPS.")
+	flag.StringVar(&opts.metricsCertPath, "metrics-cert-path", opts.metricsCertPath, "Directory containing tls.crt and tls.key for the metrics server. If empty, self-signed certificates are generated.")
 	flag.StringVar(&opts.tlsMinVersion, "tls-min-version", opts.tlsMinVersion, "Minimum TLS version (VersionTLS12, VersionTLS13). Defaults to VersionTLS12.")
 	flag.StringVar(&opts.tlsCipherSuites, "tls-cipher-suites", opts.tlsCipherSuites, "Comma-separated list of TLS cipher suites (Go names). If empty, Go defaults are used.")
 	opts.zapOpts.BindFlags(flag.CommandLine)
@@ -113,11 +118,20 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	setupLog.Info("Setting up manager")
+	metricsServerOptions := metricsserver.Options{
+		BindAddress:   options.metricsAddr,
+		SecureServing: options.metricsSecure,
+		TLSOpts:       tlsResult,
+	}
+	if options.metricsSecure {
+		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
+	}
+	if options.metricsCertPath != "" {
+		metricsServerOptions.CertDir = options.metricsCertPath
+	}
+
 	mgr, err := manager.New(cfg, manager.Options{
-		Metrics: metricsserver.Options{
-			BindAddress: options.metricsAddr,
-			TLSOpts:     tlsResult,
-		},
+		Metrics: metricsServerOptions,
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port:    options.webhookPort,
 			TLSOpts: tlsResult,

--- a/cmd/localmodelnode/main.go
+++ b/cmd/localmodelnode/main.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -50,6 +51,8 @@ type Options struct {
 	webhookPort          int
 	enableLeaderElection bool
 	probeAddr            string
+	metricsSecure        bool
+	metricsCertPath      string
 	tlsMinVersion        string
 	tlsCipherSuites      string
 	zapOpts              zap.Options
@@ -69,9 +72,12 @@ func DefaultOptions() Options {
 // GetOptions parses the program flags and returns them as Options.
 func GetOptions() Options {
 	opts := DefaultOptions()
+	flag.StringVar(&opts.metricsAddr, "metrics-addr", opts.metricsAddr, "The address the metric endpoint binds to.")
 	flag.BoolVar(&opts.enableLeaderElection, "leader-elect", opts.enableLeaderElection,
 		"Enable leader election for kserve controller manager. "+
 			"Enabling this will ensure there is only one active kserve controller manager.")
+	flag.BoolVar(&opts.metricsSecure, "metrics-secure", opts.metricsSecure, "Whether to serve metrics via HTTPS.")
+	flag.StringVar(&opts.metricsCertPath, "metrics-cert-path", opts.metricsCertPath, "Directory containing tls.crt and tls.key for the metrics server. If empty, self-signed certificates are generated.")
 	flag.StringVar(&opts.tlsMinVersion, "tls-min-version", opts.tlsMinVersion, "Minimum TLS version (VersionTLS12, VersionTLS13). Defaults to VersionTLS12.")
 	flag.StringVar(&opts.tlsCipherSuites, "tls-cipher-suites", opts.tlsCipherSuites, "Comma-separated list of TLS cipher suites (Go names). If empty, Go defaults are used.")
 	opts.zapOpts.BindFlags(flag.CommandLine)
@@ -106,11 +112,20 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	setupLog.Info("Setting up manager")
+	metricsServerOptions := metricsserver.Options{
+		BindAddress:   options.metricsAddr,
+		SecureServing: options.metricsSecure,
+		TLSOpts:       tlsResult,
+	}
+	if options.metricsSecure {
+		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
+	}
+	if options.metricsCertPath != "" {
+		metricsServerOptions.CertDir = options.metricsCertPath
+	}
+
 	mgr, err := manager.New(cfg, manager.Options{
-		Metrics: metricsserver.Options{
-			BindAddress: options.metricsAddr,
-			TLSOpts:     tlsResult,
-		},
+		Metrics: metricsServerOptions,
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port:    options.webhookPort,
 			TLSOpts: tlsResult,

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -63,6 +64,8 @@ type Options struct {
 	webhookPort          int
 	enableLeaderElection bool
 	probeAddr            string
+	metricsSecure        bool
+	metricsCertPath      string
 	tlsMinVersion        string
 	tlsCipherSuites      string
 	zapOpts              zap.Options
@@ -88,6 +91,8 @@ func GetOptions() Options {
 		"Enable leader election for kserve controller manager. "+
 			"Enabling this will ensure there is only one active kserve controller manager.")
 	flag.StringVar(&opts.probeAddr, "health-probe-addr", opts.probeAddr, "The address the probe endpoint binds to.")
+	flag.BoolVar(&opts.metricsSecure, "metrics-secure", opts.metricsSecure, "Whether to serve metrics via HTTPS.")
+	flag.StringVar(&opts.metricsCertPath, "metrics-cert-path", opts.metricsCertPath, "Directory containing tls.crt and tls.key for the metrics server. If empty, self-signed certificates are generated.")
 	flag.StringVar(&opts.tlsMinVersion, "tls-min-version", opts.tlsMinVersion, "Minimum TLS version (VersionTLS12, VersionTLS13). Defaults to VersionTLS12.")
 	flag.StringVar(&opts.tlsCipherSuites, "tls-cipher-suites", opts.tlsCipherSuites, "Comma-separated list of TLS cipher suites (Go names). If empty, Go defaults are used.")
 	opts.zapOpts.BindFlags(flag.CommandLine)
@@ -135,11 +140,20 @@ func main() {
 		os.Exit(1)
 	}
 
+	metricsServerOptions := metricsserver.Options{
+		BindAddress:   options.metricsAddr,
+		SecureServing: options.metricsSecure,
+		TLSOpts:       tlsResult,
+	}
+	if options.metricsSecure {
+		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
+	}
+	if options.metricsCertPath != "" {
+		metricsServerOptions.CertDir = options.metricsCertPath
+	}
+
 	mgr, err := manager.New(cfg, manager.Options{
-		Metrics: metricsserver.Options{
-			BindAddress: options.metricsAddr,
-			TLSOpts:     tlsResult,
-		},
+		Metrics: metricsServerOptions,
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port:    options.webhookPort,
 			TLSOpts: tlsResult,

--- a/config/overlays/odh-modelcache/kustomization.yaml
+++ b/config/overlays/odh-modelcache/kustomization.yaml
@@ -66,6 +66,12 @@ patches:
   target:
     kind: DaemonSet
     name: kserve-localmodelnode-agent
+# SecureServing patches
+- path: patches/secure-metrics-localmodel-patch.yaml
+- target:
+    kind: DaemonSet
+    name: kserve-localmodelnode-agent
+  path: patches/secure-metrics-localmodelnode-patch.yaml
 # ClusterRole SCC use for agent
 - target:
     kind: ClusterRole

--- a/config/overlays/odh-modelcache/patches/secure-metrics-localmodel-patch.yaml
+++ b/config/overlays/odh-modelcache/patches/secure-metrics-localmodel-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kserve-localmodel-controller-manager
+  namespace: kserve
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - "--metrics-addr=:8443"
+        - "--metrics-secure"
+        - "--leader-elect"
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP

--- a/config/overlays/odh-modelcache/patches/secure-metrics-localmodelnode-patch.yaml
+++ b/config/overlays/odh-modelcache/patches/secure-metrics-localmodelnode-patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kserve-localmodelnode-agent
+  namespace: kserve
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - "--metrics-addr=:8443"
+        - "--metrics-secure"
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP

--- a/config/overlays/odh-modelcache/rbac/localmodel/role.yaml
+++ b/config/overlays/odh-modelcache/rbac/localmodel/role.yaml
@@ -5,6 +5,18 @@ metadata:
   name: kserve-localmodel-distro-role
 rules:
 - apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - serving.kserve.io
   resources:
   - localmodelcaches/finalizers

--- a/config/overlays/odh-modelcache/rbac/localmodelnode/role.yaml
+++ b/config/overlays/odh-modelcache/rbac/localmodelnode/role.yaml
@@ -10,3 +10,15 @@ rules:
   - namespaces
   verbs:
   - get
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -34,6 +34,12 @@ patches:
 - path: patches/inferenceservice-config-patch.yaml
 - path: patches/set-resources-manager-patch.yaml
 - path: patches/remove-auth-proxy-patch.yaml
+- path: patches/secure-metrics-kserve-patch.yaml
+- path: patches/secure-metrics-service-patch.yaml
+- target:
+    kind: Deployment
+    name: llmisvc-controller-manager
+  path: patches/secure-metrics-llmisvc-patch.yaml
 - path: patches/config-scheduler-patch.yaml
 - target:
     kind: ValidatingWebhookConfiguration

--- a/config/overlays/odh/patches/secure-metrics-kserve-patch.yaml
+++ b/config/overlays/odh/patches/secure-metrics-kserve-patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kserve-controller-manager
+  namespace: kserve
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - "--metrics-addr=:8443"
+        - "--metrics-secure"
+        - "--leader-elect"
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP

--- a/config/overlays/odh/patches/secure-metrics-llmisvc-patch.yaml
+++ b/config/overlays/odh/patches/secure-metrics-llmisvc-patch.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llmisvc-controller-manager
+  namespace: kserve
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - "--metrics-addr=:8443"
+        - "--metrics-secure"
+        - "--leader-elect"

--- a/config/overlays/odh/patches/secure-metrics-service-patch.yaml
+++ b/config/overlays/odh/patches/secure-metrics-service-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kserve-controller-manager-metrics-service
+  namespace: kserve
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: metrics

--- a/config/overlays/odh/rbac/inferenceservice/role.yaml
+++ b/config/overlays/odh/rbac/inferenceservice/role.yaml
@@ -5,6 +5,18 @@ metadata:
   name: kserve-inferenceservice-distro-role
 rules:
 - apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/pkg/agent/storage/s3_integration_test.go
+++ b/pkg/agent/storage/s3_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 /*
 Copyright 2026 The KServe Authors.
 
@@ -13,8 +15,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-//go:build integration
 
 // Integration tests for S3Provider using a local S3-compatible server.
 //

--- a/pkg/controller/v1alpha1/localmodel/distro/controller_rbac_odh.go
+++ b/pkg/controller/v1alpha1/localmodel/distro/controller_rbac_odh.go
@@ -20,5 +20,7 @@ package distro
 // Processed by a separate controller-gen invocation (see Makefile.overrides.mk)
 // to generate a dedicated ClusterRole included only in distro overlays.
 
+//+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
+//+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 //+kubebuilder:rbac:groups=serving.kserve.io,resources=localmodelcaches/finalizers,verbs=update
 //+kubebuilder:rbac:groups=serving.kserve.io,resources=localmodelnamespacecaches/finalizers,verbs=update

--- a/pkg/controller/v1alpha1/localmodelnode/distro/controller_rbac_odh.go
+++ b/pkg/controller/v1alpha1/localmodelnode/distro/controller_rbac_odh.go
@@ -20,4 +20,6 @@ package distro
 // Processed by a separate controller-gen invocation (see Makefile.overrides.mk)
 // to generate a dedicated ClusterRole included only in distro overlays.
 
+//+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
+//+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 //+kubebuilder:rbac:groups=core,resources=namespaces,verbs=get

--- a/pkg/controller/v1beta1/inferenceservice/distro/controller_rbac_odh.go
+++ b/pkg/controller/v1beta1/inferenceservice/distro/controller_rbac_odh.go
@@ -20,5 +20,7 @@ package distro
 // Processed by a separate controller-gen invocation (see Makefile.overrides.mk)
 // to generate a dedicated ClusterRole included only in distro overlays.
 
+//+kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
+//+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create;update;delete
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=openshift-ai-inferenceservice-image-volume-scc,verbs=use

--- a/test/e2e/predictor/test_secure_metrics.py
+++ b/test/e2e/predictor/test_secure_metrics.py
@@ -1,0 +1,209 @@
+# Copyright 2026 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""E2E tests for secure metrics on ODH controller deployments.
+
+Validates that controller metrics endpoints serve over HTTPS
+with authentication and authorization (SecureServing). ODH
+replaces the upstream kube-rbac-proxy sidecar with
+controller-runtime's built-in SecureServing, which requires
+--metrics-secure and tokenreview/SAR RBAC.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import uuid
+
+import pytest
+
+KSERVE_NAMESPACE = os.environ.get("KSERVE_NAMESPACE", "opendatahub")
+METRICS_PORT = 8443
+_METRICS_RBAC_NAME = "e2e-metrics-reader"
+_CURL_IMAGE = "curlimages/curl:8.11.1"
+_SA_TOKEN_PATH = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+MANAGER_ARGS_JSONPATH = "{.spec.template.spec.containers[?(@.name=='manager')].args}"
+
+
+def _run(cmd, check=True, timeout=60):
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    if check and result.returncode != 0:
+        raise RuntimeError(
+            f"Command failed: {cmd}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+    return result
+
+
+def _find_kubectl():
+    for name in ("oc", "kubectl"):
+        if shutil.which(name):
+            return name
+    raise RuntimeError("Neither 'oc' nor 'kubectl' found in PATH")
+
+
+@pytest.fixture(scope="module")
+def kubectl():
+    return _find_kubectl()
+
+
+def _get_pod_ip(kubectl, deployment_name):
+    result = _run(
+        [
+            kubectl,
+            "get",
+            "pods",
+            "-n",
+            KSERVE_NAMESPACE,
+            "-l",
+            f"control-plane={deployment_name}",
+            "-o",
+            "jsonpath={.items[0].status.podIP}",
+        ]
+    )
+    ip = result.stdout.strip()
+    if not ip:
+        raise RuntimeError(f"No pod IP for {deployment_name}")
+    return ip
+
+
+def _get_container_args(kubectl, resource, name):
+    result = _run(
+        [
+            kubectl,
+            "get",
+            resource,
+            name,
+            "-n",
+            KSERVE_NAMESPACE,
+            "-o",
+            f"jsonpath={MANAGER_ARGS_JSONPATH}",
+        ],
+        check=False,
+    )
+    return result.stdout.strip()
+
+
+def _curl_metrics(kubectl, target_ip, use_sa_token=False):
+    """Curl metrics endpoint from inside the cluster.
+
+    When use_sa_token is True, the runner pod reads its own mounted
+    service-account token at runtime instead of receiving the token
+    value as a command argument.
+    """
+    url = f"https://{target_ip}:{METRICS_PORT}/metrics"
+    if use_sa_token:
+        curl_cmd = (
+            f"TOKEN=$(cat {_SA_TOKEN_PATH}) && "
+            'curl -s -o /dev/null -w "%{http_code}" --max-time 5 -k '
+            f'-H "Authorization: Bearer $TOKEN" {url}'
+        )
+    else:
+        curl_cmd = f'curl -s -o /dev/null -w "%{{http_code}}" --max-time 5 -k {url}'
+
+    pod_name = f"curl-metrics-{uuid.uuid4().hex[:8]}"
+    result = _run(
+        [
+            kubectl,
+            "run",
+            pod_name,
+            "--rm",
+            "-i",
+            "--restart=Never",
+            "-n",
+            KSERVE_NAMESPACE,
+            f"--image={_CURL_IMAGE}",
+            "--",
+            "sh",
+            "-c",
+            curl_cmd,
+        ],
+        check=False,
+        timeout=30,
+    )
+    stdout = result.stdout.strip()
+    match = re.match(r"([1-5]\d{2})", stdout)
+    http_code = int(match.group(1)) if match else 0
+    return http_code, result.stdout, result.stderr
+
+
+def _create_metrics_rbac(kubectl):
+    name = f"{_METRICS_RBAC_NAME}-{uuid.uuid4().hex[:8]}"
+    _run(
+        [
+            kubectl,
+            "create",
+            "clusterrolebinding",
+            name,
+            "--clusterrole=kserve-metrics-reader-cluster-role",
+            f"--serviceaccount={KSERVE_NAMESPACE}:default",
+        ],
+    )
+    return name
+
+
+def _delete_metrics_rbac(kubectl, name):
+    _run(
+        [
+            kubectl,
+            "delete",
+            "clusterrolebinding",
+            name,
+            "--ignore-not-found",
+        ],
+        check=False,
+    )
+
+
+@pytest.fixture
+def metrics_reader_rbac(kubectl):
+    name = _create_metrics_rbac(kubectl)
+    yield
+    _delete_metrics_rbac(kubectl, name)
+
+
+def _assert_secure_args(args, name):
+    assert "--metrics-secure" in args, f"--metrics-secure missing in {name}: {args}"
+    assert ":8443" in args, f":8443 missing in {name}: {args}"
+    assert "127.0.0.1" not in args, f"metrics bound to localhost in {name}: {args}"
+
+
+@pytest.mark.kserve_on_openshift
+class TestSecureMetrics:
+    """Verify controller metrics use SecureServing."""
+
+    def test_kserve_controller_args(self, kubectl):
+        name = "kserve-controller-manager"
+        args = _get_container_args(kubectl, "deployment", name)
+        _assert_secure_args(args, name)
+
+    def test_llmisvc_controller_args(self, kubectl):
+        name = "llmisvc-controller-manager"
+        args = _get_container_args(kubectl, "deployment", name)
+        _assert_secure_args(args, name)
+
+    def test_rejects_unauthenticated(self, kubectl):
+        pod_ip = _get_pod_ip(kubectl, "kserve-controller-manager")
+        code, stdout, stderr = _curl_metrics(kubectl, pod_ip)
+        assert code in (401, 403), (
+            f"Expected 401/403, got {code}. stdout={stdout}, stderr={stderr}"
+        )
+
+    def test_accepts_authenticated(self, kubectl, metrics_reader_rbac):
+        pod_ip = _get_pod_ip(kubectl, "kserve-controller-manager")
+        code, stdout, stderr = _curl_metrics(kubectl, pod_ip, use_sa_token=True)
+        assert code == 200, (
+            f"Expected 200, got {code}. stdout={stdout}, stderr={stderr}"
+        )


### PR DESCRIPTION
## Summary

Replace the removed kube-rbac-proxy sidecar with controller-runtime's built-in SecureServing for metrics endpoints on all four controllers (kserve, llmisvc, localmodel, localmodelnode).

- **Go flag wiring** (`cmd/`): add `--metrics-secure` and `--metrics-cert-path` flags to manager, localmodel, and localmodelnode (matching existing llmisvc pattern). When enabled, wire `FilterProvider` with authn/authz and optionally set `CertDir` for externally provisioned certificates. Defaults to disabled for no behavior change without opt-in.
- **Kustomize patches** (`config/overlays/odh/`, `config/overlays/odh-modelcache/`): set `--metrics-addr=:8443` and `--metrics-secure` on all controller deployments, expose containerPort 8443 named `metrics`.
- **Service fix**: patch `auth_proxy_service` `targetPort` from `https` to `metrics` to match the new container port name after kube-rbac-proxy removal.
- **RBAC**: add `tokenreviews`/`subjectaccessreviews` permissions to all distro roles so `FilterProvider` can perform authn/authz on metrics requests.
- **E2E tests**: validate secure args on ~~all four~~ controllers, verify unauthenticated requests are rejected (401/403), and authenticated requests via mounted SA token succeed (200).
  - LocalModel skipped for now because we don't have an ODH+LocalModel suite

## Commits

1. **Distro overlay** (kustomize patches, RBAC, Service fix, e2e tests)
2. **Go changes** (`--metrics-secure`/`--metrics-cert-path` flag wiring in all four `cmd/` binaries)

## Test plan

- [ ] E2E: `test_secure_metrics.py` passes on OCP cluster (arg validation + authn/authz enforcement)
- [ ] Prometheus scraping works through `kserve-controller-manager-metrics-service` after `targetPort` fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added secure HTTPS metrics for KServe, LLM inference, local model, and node services.
  - Added configurable certificate locations and secure-serving options.
  - Metrics endpoints now support authentication and authorization, rejecting unauthenticated access.
  - Added a secure metrics service on port 8443.

- **Bug Fixes**
  - Updated permissions to support authenticated access reviews.

- **Tests**
  - Added end-to-end coverage for secure metrics configuration and access control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->