### PR TITLE
fix: mount CA bundle ConfigMap in localmodel download jobs

### DIFF
--- a/pkg/controller/v1alpha1/localmodelnode/cabundle_test.go
+++ b/pkg/controller/v1alpha1/localmodelnode/cabundle_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package localmodelnode
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/kserve/kserve/pkg/constants"
+	"github.com/kserve/kserve/pkg/credentials"
+	"github.com/kserve/kserve/pkg/credentials/s3"
+)
+
+func TestMountCaBundleVolume_WithEnvVar(t *testing.T) {
+	reconciler := &LocalModelNodeReconciler{Log: ctrl.Log.WithName("test")}
+	container := &corev1.Container{
+		Env: []corev1.EnvVar{
+			{Name: s3.AWSCABundleConfigMap, Value: "my-ca-bundle"},
+		},
+	}
+	volumes := []corev1.Volume{}
+
+	reconciler.mountCaBundleVolume(container, &volumes)
+
+	if len(volumes) != 1 {
+		t.Fatalf("expected 1 volume, got %d", len(volumes))
+	}
+	if volumes[0].Name != CaBundleVolumeName {
+		t.Errorf("expected volume name %q, got %q", CaBundleVolumeName, volumes[0].Name)
+	}
+	if volumes[0].ConfigMap.Name != "my-ca-bundle" {
+		t.Errorf("expected configmap name %q, got %q", "my-ca-bundle", volumes[0].ConfigMap.Name)
+	}
+
+	foundMount := false
+	for _, vm := range container.VolumeMounts {
+		if vm.Name == CaBundleVolumeName {
+			foundMount = true
+			if vm.MountPath != constants.DefaultCaBundleVolumeMountPath {
+				t.Errorf("expected mount path %q, got %q", constants.DefaultCaBundleVolumeMountPath, vm.MountPath)
+			}
+			if !vm.ReadOnly {
+				t.Error("expected volume mount to be read-only")
+			}
+		}
+	}
+	if !foundMount {
+		t.Error("CA bundle volume mount not found on container")
+	}
+
+	envMap := map[string]string{}
+	for _, e := range container.Env {
+		envMap[e.Name] = e.Value
+	}
+	if envMap[constants.CaBundleConfigMapNameEnvVarKey] != "my-ca-bundle" {
+		t.Errorf("expected %s=%q, got %q", constants.CaBundleConfigMapNameEnvVarKey, "my-ca-bundle", envMap[constants.CaBundleConfigMapNameEnvVarKey])
+	}
+	if envMap[constants.CaBundleVolumeMountPathEnvVarKey] != constants.DefaultCaBundleVolumeMountPath {
+		t.Errorf("expected %s=%q, got %q", constants.CaBundleVolumeMountPathEnvVarKey, constants.DefaultCaBundleVolumeMountPath, envMap[constants.CaBundleVolumeMountPathEnvVarKey])
+	}
+}
+
+func TestMountCaBundleVolume_WithoutEnvVar(t *testing.T) {
+	reconciler := &LocalModelNodeReconciler{Log: ctrl.Log.WithName("test")}
+	container := &corev1.Container{
+		Env: []corev1.EnvVar{
+			{Name: "UNRELATED", Value: "value"},
+		},
+	}
+	volumes := []corev1.Volume{}
+
+	reconciler.mountCaBundleVolume(container, &volumes)
+
+	if len(volumes) != 0 {
+		t.Fatalf("expected 0 volumes when no CA bundle env, got %d", len(volumes))
+	}
+	if len(container.VolumeMounts) != 0 {
+		t.Fatalf("expected 0 volume mounts when no CA bundle env, got %d", len(container.VolumeMounts))
+	}
+}
+
+func TestMountCaBundleVolume_EmptyValue(t *testing.T) {
+	reconciler := &LocalModelNodeReconciler{Log: ctrl.Log.WithName("test")}
+	container := &corev1.Container{
+		Env: []corev1.EnvVar{
+			{Name: s3.AWSCABundleConfigMap, Value: ""},
+		},
+	}
+	volumes := []corev1.Volume{}
+
+	reconciler.mountCaBundleVolume(container, &volumes)
+
+	if len(volumes) != 0 {
+		t.Fatalf("expected 0 volumes for empty configmap name, got %d", len(volumes))
+	}
+}
+
+func TestErrStorageKeyNotFound_IsTyped(t *testing.T) {
+	err := fmt.Errorf("specified storage key foo not found: %w", credentials.ErrStorageKeyNotFound)
+	if !errors.Is(err, credentials.ErrStorageKeyNotFound) {
+		t.Error("expected errors.Is to match ErrStorageKeyNotFound")
+	}
+}
+
+func TestErrStorageConfigSecretNotFound_IsTyped(t *testing.T) {
+	err := fmt.Errorf("can't read storage secret bar: %w", credentials.ErrStorageConfigSecretNotFound)
+	if !errors.Is(err, credentials.ErrStorageConfigSecretNotFound) {
+		t.Error("expected errors.Is to match ErrStorageConfigSecretNotFound")
+	}
+}

--- a/pkg/controller/v1alpha1/localmodelnode/controller.go
+++ b/pkg/controller/v1alpha1/localmodelnode/controller.go
@@ -56,6 +56,7 @@ import (
 	"github.com/kserve/kserve/pkg/constants"
 	"github.com/kserve/kserve/pkg/controller/v1alpha1/utils"
 	"github.com/kserve/kserve/pkg/credentials"
+	"github.com/kserve/kserve/pkg/credentials/s3"
 	pkgtypes "github.com/kserve/kserve/pkg/types"
 )
 
@@ -76,6 +77,7 @@ type LocalModelNodeReconciler struct {
 const (
 	DownloadContainerName = "kserve-localmodel-download"
 	PvcSourceMountName    = "kserve-pvc-source"
+	CaBundleVolumeName    = "cabundle-cert"
 )
 
 var (
@@ -179,6 +181,9 @@ func (c *LocalModelNodeReconciler) launchJob(ctx context.Context, localModelNode
 		}
 	}
 
+	// Mount CA bundle ConfigMap as volume if AWS_CA_BUNDLE_CONFIGMAP env was injected
+	c.mountCaBundleVolume(container, &volumes)
+
 	// Note: statusKey (namespace/modelName) cannot be used as a label value since labels
 	// cannot contain '/'. We store namespace separately and reconstruct statusKey when needed.
 	jobLabels := map[string]string{
@@ -260,8 +265,8 @@ func (c *LocalModelNodeReconciler) injectCredentials(ctx context.Context, contai
 			params = *modelInfo.Storage.Parameters
 		}
 		c.Log.Info("Injecting storage spec credentials", "storageKey", *modelInfo.Storage.StorageKey)
-		return c.CredentialBuilder.CreateStorageSpecSecretEnvs(
-			ctx, jobNs, nil, *modelInfo.Storage.StorageKey, params, container)
+		return c.CredentialBuilder.CreateStorageSpecSecretEnvsWithSecretFallback(
+			ctx, jobNs, nil, *modelInfo.Storage.StorageKey, params, container, volumes)
 	}
 
 	// Use service account credentials
@@ -272,6 +277,66 @@ func (c *LocalModelNodeReconciler) injectCredentials(ctx context.Context, contai
 	c.Log.Info("Injecting service account credentials", "serviceAccountName", serviceAccountName)
 	return c.CredentialBuilder.CreateSecretVolumeAndEnv(
 		ctx, jobNs, nil, serviceAccountName, container, volumes)
+}
+
+// mountCaBundleVolume checks if the container has AWS_CA_BUNDLE_CONFIGMAP env var set and,
+// if so, mounts the referenced ConfigMap as a volume so the storage initializer can read the
+// CA certificates. This mirrors the behavior of the storage-initializer webhook injector.
+func (c *LocalModelNodeReconciler) mountCaBundleVolume(container *corev1.Container, volumes *[]corev1.Volume) {
+	var caBundleConfigMapName string
+	for _, envVar := range container.Env {
+		if envVar.Name == s3.AWSCABundleConfigMap {
+			caBundleConfigMapName = envVar.Value
+			break
+		}
+	}
+	if caBundleConfigMapName == "" {
+		return
+	}
+
+	mountPath := constants.DefaultCaBundleVolumeMountPath
+
+	caBundleVolume := corev1.Volume{
+		Name: CaBundleVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: caBundleConfigMapName,
+				},
+			},
+		},
+	}
+	caBundleVolumeMount := corev1.VolumeMount{
+		Name:      CaBundleVolumeName,
+		MountPath: mountPath,
+		ReadOnly:  true,
+	}
+
+	*volumes = append(*volumes, caBundleVolume)
+	container.VolumeMounts = append(container.VolumeMounts, caBundleVolumeMount)
+
+	if !envVarExists(container.Env, constants.CaBundleConfigMapNameEnvVarKey) {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  constants.CaBundleConfigMapNameEnvVarKey,
+			Value: caBundleConfigMapName,
+		})
+	}
+	if !envVarExists(container.Env, constants.CaBundleVolumeMountPathEnvVarKey) {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  constants.CaBundleVolumeMountPathEnvVarKey,
+			Value: mountPath,
+		})
+	}
+	c.Log.Info("Mounted CA bundle ConfigMap volume", "configMap", caBundleConfigMapName, "mountPath", mountPath)
+}
+
+func envVarExists(envs []corev1.EnvVar, name string) bool {
+	for _, e := range envs {
+		if e.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 // Fetches container spec for model download container, use the default KServe image if not found

--- a/pkg/credentials/service_account_credentials.go
+++ b/pkg/credentials/service_account_credentials.go
@@ -117,11 +117,12 @@ func (c *CredentialBuilder) CreateStorageSpecSecretEnvs(ctx context.Context, nam
 	secret, err := c.clientset.CoreV1().Secrets(namespace).Get(ctx, storageSecretName, metav1.GetOptions{})
 
 	var storageData []byte
-	if err == nil {
+	switch {
+	case err == nil:
 		if storageKey != "" {
 			if storageData = secret.Data[storageKey]; storageData == nil {
-				return fmt.Errorf("specified storage key %s not found in storage secret %s",
-					storageKey, storageSecretName)
+				return fmt.Errorf("specified storage key %s not found in storage secret %s: %w",
+					storageKey, storageSecretName, ErrStorageKeyNotFound)
 			}
 		} else {
 			if stype == "" {
@@ -129,34 +130,41 @@ func (c *CredentialBuilder) CreateStorageSpecSecretEnvs(ctx context.Context, nam
 			} else {
 				storageKey = fmt.Sprintf("%s_%s", DefaultStorageSecretKey, stype)
 			}
-			// It's ok for the entry not to be found in the default/fallback cases
 			storageData = secret.Data[storageKey]
 		}
-	} else if storageKey != "" || !apierr.IsNotFound(err) { // Don't fail if not found and no storage key was specified
-		return fmt.Errorf("can't read storage secret %s: %w", storageSecretName, err)
+	case apierr.IsNotFound(err):
+		if storageKey != "" {
+			return fmt.Errorf("can't read storage secret %s: %w", storageSecretName, ErrStorageConfigSecretNotFound)
+		}
+	default:
+		if storageKey != "" {
+			return fmt.Errorf("can't read storage secret %s: %w", storageSecretName, err)
+		}
 	}
 
 	if storageData != nil {
+		var storageDataJson map[string]string
+		if err := json.Unmarshal(storageData, &storageDataJson); err != nil {
+			return fmt.Errorf("invalid json encountered in key %s of storage secret %s: %w",
+				storageKey, storageSecretName, err)
+		}
+
 		if stype == "" {
-			var storageDataJson map[string]string
-			if err := json.Unmarshal(storageData, &storageDataJson); err != nil {
-				return fmt.Errorf("invalid json encountered in key %s of storage secret %s: %w",
-					storageKey, storageSecretName, err)
-			}
 			if storageType, ok := storageDataJson["type"]; ok {
 				stype = storageType
 				if !utils.Includes(SupportedStorageSpecTypes, stype) {
 					return fmt.Errorf(UnsupportedStorageSpecType, strings.Join(SupportedStorageSpecTypes, ", "), stype)
 				}
 			}
-			// Get bucket from storage-config if not provided in override params
-			if _, ok := storageDataJson["bucket"]; ok && bucket == "" {
-				bucket = storageDataJson["bucket"]
-			}
-			if cabundle_configmap, ok := storageDataJson["cabundle_configmap"]; ok {
+		}
+		if _, ok := storageDataJson["bucket"]; ok && bucket == "" {
+			bucket = storageDataJson["bucket"]
+		}
+		if cabundleConfigmap, ok := storageDataJson["cabundle_configmap"]; ok && cabundleConfigmap != "" {
+			if !envVarExists(container.Env, s3.AWSCABundleConfigMap) {
 				container.Env = append(container.Env, corev1.EnvVar{
 					Name:  s3.AWSCABundleConfigMap,
-					Value: cabundle_configmap,
+					Value: cabundleConfigmap,
 				})
 			}
 		}
@@ -205,6 +213,60 @@ func (c *CredentialBuilder) CreateStorageSpecSecretEnvs(ctx context.Context, nam
 		}
 	}
 
+	return nil
+}
+
+// ErrStorageKeyNotFound indicates the requested key was not found in the storage-config secret.
+var ErrStorageKeyNotFound = errors.New("storage key not found")
+
+// ErrStorageConfigSecretNotFound indicates the storage-config secret itself does not exist.
+var ErrStorageConfigSecretNotFound = errors.New("storage-config secret not found")
+
+func shouldFallbackToDirectSecret(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, ErrStorageKeyNotFound) || errors.Is(err, ErrStorageConfigSecretNotFound)
+}
+
+func envVarExists(envs []corev1.EnvVar, name string) bool {
+	for _, e := range envs {
+		if e.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// MountSecretCredential mounts a Kubernetes secret as storage credentials on a container.
+// This is the same path used by InferenceService storage-initializer injection for ODH S3
+// connection secrets (serving.kserve.io/s3-* annotations).
+func (c *CredentialBuilder) MountSecretCredential(ctx context.Context, secretName string, namespace string,
+	container *corev1.Container, volumes *[]corev1.Volume,
+) error {
+	return c.mountSecretCredential(ctx, secretName, namespace, container, volumes)
+}
+
+// CreateStorageSpecSecretEnvsWithSecretFallback resolves storage credentials for local model
+// download jobs. It first looks up storageKey inside the storage-config secret (upstream
+// KServe behavior). When that entry is missing, it falls back to treating storageKey as a
+// standalone secret name with S3/GCS/HF annotations.
+func (c *CredentialBuilder) CreateStorageSpecSecretEnvsWithSecretFallback(
+	ctx context.Context, namespace string, annotations map[string]string, storageKey string,
+	overrideParams map[string]string, container *corev1.Container, volumes *[]corev1.Volume,
+) error {
+	err := c.CreateStorageSpecSecretEnvs(ctx, namespace, annotations, storageKey, overrideParams, container)
+	if err == nil {
+		return nil
+	}
+	if !shouldFallbackToDirectSecret(err) {
+		return err
+	}
+	log.Info("storage-config lookup failed, falling back to direct secret mount",
+		"storageKey", storageKey, "error", err)
+	if mountErr := c.mountSecretCredential(ctx, storageKey, namespace, container, volumes); mountErr != nil {
+		return fmt.Errorf("storage spec credentials: %w; direct secret mount: %w", err, mountErr)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Fixes SSL validation failures in model cache download jobs on disconnected clusters
- Moves `cabundle_configmap` parsing outside the `if stype == ""` block so it applies regardless of override params
- Adds `mountCaBundleVolume()` to mount the referenced ConfigMap as a volume in download job pods

## Root Cause
The `LocalModelNode` agent creates download jobs but never mounts the CA bundle ConfigMap referenced by `cabundle_configmap` in `storage-config`. Two issues:
1. `cabundle_configmap` was only parsed when `stype == ""`, skipped when override params set `type=s3`
2. The ConfigMap was never mounted as a volume in the job pod template

## Test Plan
- [x] Verified fix compiles cleanly (`go build ./...`)
- [x] Unit tests pass (no new regressions)
- [x] Deployed patched controller + agent on connected cluster with MinIO (self-signed cert)
- [x] Confirmed CA bundle is mounted: `Global ca bundle file(/etc/ssl/custom-certs/cabundle.crt) combined with the default trust store`
- [x] Confirmed S3 download succeeds: `Found S3 object: test-dir/1/mnist-8.onnx (26454 bytes)`
- [x] Old behavior unchanged: without `cabundle_configmap` in storage-config, no volume is added

Fixes: [RHOAIENG-83466](https://redhat.atlassian.net/browse/RHOAIENG-83466)

[RHOAIENG-83466]: https://redhat.atlassian.net/browse/RHOAIENG-83466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Download jobs can use a configured custom CA bundle for secure storage access.
  * Storage credentials support fallback mounting when referenced secrets or keys are unavailable.
  * Storage configuration can combine explicit overrides with values from storage metadata.

* **Bug Fixes**
  * Prevented duplicate CA-bundle environment settings.
  * Improved handling and reporting of missing storage credentials and configuration secrets.

* **Tests**
  * Added coverage for CA-bundle scenarios and typed storage credential errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->