### PR TITLE
fix(kserve-module): add apiservers RBAC for TLS profile watcher

### DIFF
--- a/kserve-module/config/rbac/role.yaml
+++ b/kserve-module/config/rbac/role.yaml
@@ -154,6 +154,14 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - apiservers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
   - clusterversions
   verbs:
   - get


### PR DESCRIPTION
## Summary

- Adds `get/list/watch` on `apiservers.config.openshift.io` to `kserve-module/config/rbac/role.yaml`
- Fixes CrashLoopBackOff of `odh-model-controller` caused by missing RBAC for the TLS profile watcher introduced in [odh-model-controller#863](https://github.com/opendatahub-io/odh-model-controller/pull/863)

## Root Cause

The odh-model-controller image includes a TLS profile watcher (`pkg/tls`) that reads `apiservers.config.openshift.io/cluster` at startup. If the ServiceAccount lacks permission, the error is treated as fatal (fail-closed) and the pod crashes:

```
unable to resolve TLS configuration: failed to read APIServer TLS profile:
apiservers.config.openshift.io "cluster" is forbidden
```

The `kserve-module` ClusterRole shipped by the operator did not include this rule.

## Test plan

- [ ] Deploy operator with updated kserve-module manifests
- [ ] Verify `odh-model-controller` ClusterRole includes `apiservers` get/list/watch
- [ ] Verify `odh-model-controller` pod starts without CrashLoop
- [ ] Verify DSC `KserveReady` condition becomes True

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permissions to view OpenShift API server resources, enabling the application to retrieve, list, and monitor their status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->