### PR TITLE
Pin ODH manifest gathering to odh-v3.5 release tags

### DIFF
--- a/kserve-module/hack/get_kserve_manifests.sh
+++ b/kserve-module/hack/get_kserve_manifests.sh
@@ -14,9 +14,9 @@ DST_MANIFESTS_DIR="${1:-${MODULE_DIR}/opt/manifests}"
 #   "tag"                 - immutable reference
 #   "branch@commit-sha"  - tracks branch but pinned to specific commit
 declare -A ODH_COMPONENT_MANIFESTS=(
-    ["kserve"]="opendatahub-io:kserve:release-v0.17:config"
-    ["modelcontroller"]="opendatahub-io:odh-model-controller:main:config"
-    ["wva"]="opendatahub-io:workload-variant-autoscaler:odh-v3.5@e303a3af23f4bed3fee0f6b94b8f56db0c43e44d:config"
+    ["kserve"]="opendatahub-io:kserve:odh-v3.5:config"
+    ["modelcontroller"]="opendatahub-io:odh-model-controller:odh-v3.5:config"
+    ["wva"]="opendatahub-io:workload-variant-autoscaler:odh-v3.5:config"
 )
 
 # RHOAI Component Manifests


### PR DESCRIPTION
## Summary
- Pin `ODH_COMPONENT_MANIFESTS` in `get_kserve_manifests.sh` to `odh-v3.5` tags for kserve, odh-model-controller, and wva
- Replaces `release-v0.17` and `main` branch refs that caused image/manifest skew (newer controller code + stale 3.5 RBAC)

## Context
Related to [RHOAIENG-82376](https://redhat.atlassian.net/browse/RHOAIENG-82376) — `odh-model-controller` CrashLoopBackOff when gathered manifests from `main` lack `apiservers` RBAC required by `odh-stable` controller images.

## Verification
- [x] Confirmed `odh-v3.5` tags exist on kserve, omc, and wva
- [x] Ran `kserve-module/hack/get_kserve_manifests.sh /tmp/kserve-manifests-test`
- [x] Gathered `modelcontroller` uses `odh-v3.5` image tag and has no `apiservers` RBAC (consistent with 3.5 release)

## Test plan
- [ ] Review manifest pin changes
- [ ] After merge: re-run ODH release workflow for kserve `odh-v3.5` and verify kserve-module bundle

[RHOAIENG-82376]: https://redhat.atlassian.net/browse/RHOAIENG-82376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ