### PR TITLE
test(kserve-module): assert defaultCleanup preserves CRDs on component disable

### DIFF
--- a/kserve-module/pkg/kservemodule/fixture/envtest.go
+++ b/kserve-module/pkg/kservemodule/fixture/envtest.go
@@ -121,6 +121,8 @@ metadata:
 data:
   enabled: "true"
 `
+	// WVA carries a CRD next to the Deployment so the CRD-preservation test
+	// can check defaultCleanup skips it when WVA is Removed.
 	wvaManifest := `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -138,6 +140,24 @@ spec:
       containers:
       - name: manager
         image: ghcr.io/llm-d/llm-d-workload-variant-autoscaler:latest
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: wvatestresources.test.kserve.io
+spec:
+  group: test.kserve.io
+  scope: Namespaced
+  names:
+    plural: wvatestresources
+    kind: WVATestResource
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
 `
 	observabilityManifest := `apiVersion: perses.dev/v1alpha2
 kind: PersesDashboard

--- a/kserve-module/pkg/kservemodule/reconciler_int_test.go
+++ b/kserve-module/pkg/kservemodule/reconciler_int_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -178,6 +179,8 @@ var _ = Describe("KserveModule Reconciler", func() {
 	Context("WVA ManagementState lifecycle", Ordered, func() {
 		var cr *platformv1alpha1.Kserve
 		wvaKey := client.ObjectKey{Name: "workload-variant-autoscaler-controller-manager", Namespace: "opendatahub"}
+		// Applied from the WVA rendered set (see fixture.WriteMinimalManifests).
+		wvaCRDKey := client.ObjectKey{Name: "wvatestresources.test.kserve.io"}
 
 		BeforeAll(func(ctx SpecContext) {
 			// Real: assert the WVA Deployment is really applied/deleted. Set before
@@ -220,11 +223,25 @@ var _ = Describe("KserveModule Reconciler", func() {
 				g.Expect(testEnv.Client.Get(ctx, wvaKey, &appsv1.Deployment{})).To(Succeed(),
 					"WVA Deployment should be applied to the cluster when Managed")
 			}).WithContext(ctx).Should(Succeed())
+
+			// The CRD must not carry an ownerReference to the namespaced Kserve CR: that would
+			// make GC cascade-delete it when the CR is removed. envtest has no GC, so assert
+			// the ref's absence rather than the deletion.
+			Eventually(func(g Gomega) {
+				crd := &apiextensionsv1.CustomResourceDefinition{}
+				g.Expect(testEnv.Client.Get(ctx, wvaCRDKey, crd)).To(Succeed(),
+					"WVA CRD should be applied to the cluster when Managed")
+				for _, ref := range crd.GetOwnerReferences() {
+					g.Expect(ref.Kind).NotTo(Equal("Kserve"),
+						"WVA CRD must not be owned by the Kserve CR (would cause GC cascade-delete on CR removal)")
+				}
+			}).WithContext(ctx).Should(Succeed())
 		})
 
-		It("deletes the WVA Deployment when ManagementState changes to Removed", func(ctx SpecContext) {
-			// Precondition: WVA Deployment exists from the previous (Managed) spec.
+		It("deletes the WVA Deployment but preserves the CRD when ManagementState changes to Removed", func(ctx SpecContext) {
+			// Precondition: WVA Deployment and CRD exist from the previous (Managed) spec.
 			Expect(testEnv.Client.Get(ctx, wvaKey, &appsv1.Deployment{})).To(Succeed())
+			Expect(testEnv.Client.Get(ctx, wvaCRDKey, &apiextensionsv1.CustomResourceDefinition{})).To(Succeed())
 
 			err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				if err := testEnv.Client.Get(ctx, client.ObjectKeyFromObject(cr), cr); err != nil {
@@ -240,6 +257,12 @@ var _ = Describe("KserveModule Reconciler", func() {
 				g.Expect(k8serr.IsNotFound(err)).To(BeTrue(),
 					"WVA Deployment should be deleted by defaultCleanup when Removed")
 			}).WithContext(ctx).Should(Succeed())
+
+			// defaultCleanup skips CRDs, so it must survive the same Removed reconcile.
+			Consistently(func(g Gomega) {
+				g.Expect(testEnv.Client.Get(ctx, wvaCRDKey, &apiextensionsv1.CustomResourceDefinition{})).To(Succeed(),
+					"WVA CRD must be preserved by defaultCleanup when Removed")
+			}).WithContext(ctx).WithTimeout(3 * time.Second).Should(Succeed())
 		})
 	})
 


### PR DESCRIPTION
[RHOAIENG-82794](https://redhat.atlassian.net/browse/RHOAIENG-82794)

defaultCleanup skips CustomResourceDefinition (resource_manager.go:106) but nothing tested it.

Added a CRD to the WVA fixture manifest and extended the "WVA ManagementState lifecycle" integration context:
- Managed: the CRD is applied and carries no ownerReference to the Kserve CR (a namespaced->cluster-scoped owner would trigger GC cascade-delete)
- Removed: the Deployment is deleted but the CRD survives (defaultCleanup skip)

Ticket asked for a fake-client unit test, but the unexported defaultCleanup forces an internal test package that can't import the fixture harness (import cycle). Went integration instead — reuses the existing envtest harness and asserts the CRD actually survives a real cleanup.

Test-only, no production code.

[RHOAIENG-82794]: https://redhat.atlassian.net/browse/RHOAIENG-82794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded integration test coverage for custom resource definitions.
  * Verified custom resource definitions are applied without ownership links and remain preserved when managed resources are removed.
  * Added validation that deployments are deleted correctly while custom resource definitions remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->