### PR TITLE
fix(kserve-module): align e2e setup cleanup namespace sed with deploy

### DIFF
--- a/kserve-module/tests/scripts/setup-cluster.sh
+++ b/kserve-module/tests/scripts/setup-cluster.sh
@@ -229,7 +229,7 @@ cleanup_kserve_module() {
 
   local config_dir="${PROJECT_ROOT}/kserve-module/config"
   ${KUBECTL} kustomize "$config_dir" | \
-    sed "s|namespace: kserve|namespace: ${KSERVE_NAMESPACE}|g" | \
+    sed "s|namespace: opendatahub|namespace: ${KSERVE_NAMESPACE}|g" | \
     ${KUBECTL} delete --ignore-not-found -f - 2>/dev/null || true
 
   log_success "kserve-module cleaned up"


### PR DESCRIPTION
setup-cluster.sh cleanup sed-replaced `namespace: kserve`, but the config base namespace is `opendatahub` (kserve-module/config/kustomization.yaml) and the deploy path seds `namespace: opendatahub`. So the cleanup substitution was a no-op when KSERVE_NAMESPACE is overridden, leaving resources in the wrong namespace on cleanup. Match the deploy pattern.

Found while running the kserve-module e2e on kind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected cleanup configuration to target the appropriate namespace when removing KServe resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->