### PR TITLE
feat(kserve-module): switch ODH manifest refs on release branches 

### DIFF
--- a/kserve-module/hack/get_kserve_manifests.sh
+++ b/kserve-module/hack/get_kserve_manifests.sh
@@ -14,9 +14,15 @@ DST_MANIFESTS_DIR="${1:-${MODULE_DIR}/opt/manifests}"
 #   "tag"                 - immutable reference
 #   "branch@commit-sha"  - tracks branch but pinned to specific commit
 declare -A ODH_COMPONENT_MANIFESTS=(
-    ["kserve"]="opendatahub-io:kserve:release-v0.17:config"
+    ["kserve"]="opendatahub-io:kserve:master:config"
     ["modelcontroller"]="opendatahub-io:odh-model-controller:incubating:config"
-    ["wva"]="opendatahub-io:workload-variant-autoscaler:main@46a9982943a4353ce709f3bea968547bbdabc43f:config"
+    ["wva"]="opendatahub-io:workload-variant-autoscaler:main:config"
+)
+
+declare -A ODH_RELEASE_COMPONENT_MANIFESTS=(
+    ["kserve"]="opendatahub-io:kserve:release-v0.17:config"
+    ["modelcontroller"]="opendatahub-io:odh-model-controller:main:config"
+    ["wva"]="opendatahub-io:workload-variant-autoscaler:main:config"
 )
 
 # RHOAI Component Manifests
@@ -26,6 +32,7 @@ declare -A RHOAI_COMPONENT_MANIFESTS=(
     ["wva"]="red-hat-data-services:workload-variant-autoscaler:rhoai-3.5@46a9982943a4353ce709f3bea968547bbdabc43f:config"
 )
 
+
 # Select manifests based on platform type
 if [ "${ODH_PLATFORM_TYPE:-OpenDataHub}" = "OpenDataHub" ]; then
     echo "Cloning manifests for ODH"
@@ -33,6 +40,14 @@ if [ "${ODH_PLATFORM_TYPE:-OpenDataHub}" = "OpenDataHub" ]; then
     for key in "${!ODH_COMPONENT_MANIFESTS[@]}"; do
         COMPONENT_MANIFESTS["$key"]="${ODH_COMPONENT_MANIFESTS[$key]}"
     done
+    # Release branches ship a `release` marker file → use ODH_RELEASE_COMPONENT_MANIFESTS.
+    # main has no marker, so behavior is unchanged there.
+    if [ -f "${SCRIPT_DIR}/release" ]; then
+        echo "Release marker found: using ODH_RELEASE_COMPONENT_MANIFESTS"
+        for key in "${!ODH_RELEASE_COMPONENT_MANIFESTS[@]}"; do
+            COMPONENT_MANIFESTS["$key"]="${ODH_RELEASE_COMPONENT_MANIFESTS[$key]}"
+        done
+    fi
 else
     echo "Cloning manifests for RHOAI"
     declare -A COMPONENT_MANIFESTS=()


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the gather script grabs the same manifests for master and release branch. However, it needs to pull different manifests per branch (fast/stable). For this, we will use a marker file in kserve-module/hack/release. If this file exist, gather script will pull the manifests from the release branch per repo

However, actually only odh-model-controller will be impacted by this change because kserve will always copy the local config folder and wva is using the branch for release. omc use incubating and main branch.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated manifest retrieval to use the latest standard KServe and WVA sources.
  * Added support for release-specific manifest selections when a local release marker is present.
  * Preserved existing RHOAI manifest behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->