### PR TITLE
test: point kserve-controller to build-buddy pipeline branch

### DIFF
--- a/.tekton/kserve-controller-push.yaml
+++ b/.tekton/kserve-controller-push.yaml
@@ -41,7 +41,7 @@ spec:
     - name: url
       value: https://github.com/opendatahub-io/odh-konflux-central.git
     - name: revision
-      value: main
+      value: build-buddy
     - name: pathInRepo
       value: pipeline/multi-arch-container-build.yaml
   taskRunSpecs:


### PR DESCRIPTION
## Summary
- Points kserve-controller-push pipelineRef to `build-buddy` branch of odh-konflux-central
- Tests the new `report-build-failure` task which replaces `send-slack-notification`
- Temporary change for Build Buddy POC testing

## Test plan
- [ ] Merge triggers push pipeline using updated pipeline template
- [ ] Slack notification appears in #build-buddy-poc channel
- [ ] If build fails, Jira issue created in RHOAIENG project