### PR TITLE
test: trigger build failure for Build Buddy POC

### DIFF
--- a/.tekton/kserve-controller-push.yaml
+++ b/.tekton/kserve-controller-push.yaml
@@ -25,7 +25,7 @@ spec:
   - name: output-image
     value: quay.io/opendatahub/kserve-controller:odh-stable
   - name: dockerfile
-    value: Dockerfile
+    value: Dockerfile.nonexistent
   - name: path-context
     value: .
   - name: build-args


### PR DESCRIPTION
## Summary
- Sets dockerfile path to a nonexistent file to trigger a build failure
- Tests the new report-build-failure task (Slack notification + Jira issue creation)
- Will be reverted immediately after test

## Test plan
- [ ] Merge triggers push pipeline which fails at buildah step
- [ ] report-build-failure task fires in finally block
- [ ] Slack notification appears in #build-buddy-poc
- [ ] Jira issue created in RHOAIENG