### PR TITLE
fix(CVE-2026-59885): bump pyasn1 to >= 0.6.4

### DIFF
--- a/python/aiffairness/poetry.lock
+++ b/python/aiffairness/poetry.lock
@@ -1332,7 +1332,7 @@ pandas = ">=2.2.0,<2.3.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2260,13 +2260,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/artexplainer/poetry.lock
+++ b/python/artexplainer/poetry.lock
@@ -1118,7 +1118,7 @@ pandas = ">=2.2.0,<2.3.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2162,13 +2162,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/custom_model/poetry.lock
+++ b/python/custom_model/poetry.lock
@@ -1075,7 +1075,7 @@ pandas = ">=2.2.0,<2.3.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2035,13 +2035,13 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/custom_tokenizer/poetry.lock
+++ b/python/custom_tokenizer/poetry.lock
@@ -917,7 +917,7 @@ pandas = ">=2.2.0,<2.3.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -1671,13 +1671,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/custom_transformer/poetry.lock
+++ b/python/custom_transformer/poetry.lock
@@ -989,7 +989,7 @@ pandas = ">=2.2.0,<2.3.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -1945,13 +1945,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/huggingfaceserver/poetry.lock
+++ b/python/huggingfaceserver/poetry.lock
@@ -2433,7 +2433,7 @@ pandas = ">=2.2.0,<2.3.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -4256,13 +4256,13 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/kserve/poetry.lock
+++ b/python/kserve/poetry.lock
@@ -4273,13 +4273,13 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]
@@ -6887,4 +6887,4 @@ storage = ["azure-identity", "azure-storage-blob", "azure-storage-file-share", "
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "12f26f4d673c238cd6c25ac108949e6d329de15817d6ac47f1d8f17265365c3a"
+content-hash = "b3209a45f8eb71e35d511dbf69c7d17ad591e40737cfc08042958b5e030c67a1"

--- a/python/kserve/pyproject.toml
+++ b/python/kserve/pyproject.toml
@@ -69,8 +69,9 @@ aiohttp = ">=3.14.0,<4.0.0"
 # Pinning because it is a transitive dependency.
 PyJWT = ">=2.12.0"
 # CVE-2026-30922 pyasn1 Vulnerable to Denial of Service via Unbounded Recursion.
+# CVE-2026-59885 pyasn1 Denial of Service via crafted ASN.1 OBJECT IDENTIFIER.
 # Pinning because it is a transitive dependency.
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 # CVE-2026-28684 python-dotenv: Arbitrary file overwrite via symbolic link following
 # Pinning because it is a transitive dependency.
 python-dotenv = ">=1.2.2"

--- a/python/lgbserver/poetry.lock
+++ b/python/lgbserver/poetry.lock
@@ -1609,7 +1609,7 @@ pandas = ">=2.2.0,<2.3.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2443,13 +2443,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/paddleserver/poetry.lock
+++ b/python/paddleserver/poetry.lock
@@ -1620,7 +1620,7 @@ pandas = ">=2.2.0,<2.3.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2612,13 +2612,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/pmmlserver/poetry.lock
+++ b/python/pmmlserver/poetry.lock
@@ -1664,7 +1664,7 @@ pandas = ">=2.2.0,<2.3.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2483,13 +2483,13 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/sklearnserver/poetry.lock
+++ b/python/sklearnserver/poetry.lock
@@ -1609,7 +1609,7 @@ pandas = ">=2.2.0,<2.3.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2417,13 +2417,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/storage/poetry.lock
+++ b/python/storage/poetry.lock
@@ -826,13 +826,13 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]
@@ -1069,4 +1069,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "8083cf20ad6a926402d398384351c06d8ef15738ff11fc6ec4e0065d92b3ef1e"
+content-hash = "def7f0982a86c86dac3bf2c3d2930aa095610ae351999278509b6d60651567cd"

--- a/python/storage/pyproject.toml
+++ b/python/storage/pyproject.toml
@@ -36,8 +36,9 @@ PyJWT = {version = ">=2.13.0"}
 # Pinning because it is a transitive dependency.
 cryptography = {version = ">=46.0.5"}
 # CVE-2026-30922 pyasn1 Vulnerable to Denial of Service via Unbounded Recursion.
+# CVE-2026-59885 pyasn1 Denial of Service via crafted ASN.1 OBJECT IDENTIFIER.
 # Pinning because it is a transitive dependency.
-pyasn1 = {version = ">=0.6.3"}
+pyasn1 = {version = ">=0.6.4"}
 
 
 #[tool.poetry-version-plugin]

--- a/python/test_resources/graph/error_404_isvc/poetry.lock
+++ b/python/test_resources/graph/error_404_isvc/poetry.lock
@@ -906,7 +906,7 @@ pandas = ">=2.2.0,<2.3.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -1595,13 +1595,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/test_resources/graph/success_200_isvc/poetry.lock
+++ b/python/test_resources/graph/success_200_isvc/poetry.lock
@@ -906,7 +906,7 @@ pandas = ">=2.2.0,<2.3.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -1595,13 +1595,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/xgbserver/poetry.lock
+++ b/python/xgbserver/poetry.lock
@@ -1609,7 +1609,7 @@ pandas = ">=2.2.0,<2.3.0"
 prometheus-client = "^0.20.0"
 protobuf = "^4.25.4"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2428,13 +2428,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps `pyasn1` from `>= 0.6.3` to `>= 0.6.4` in `python/storage/pyproject.toml` and `python/kserve/pyproject.toml` to address CVE-2026-59885 (pyasn1 Denial of Service via crafted ASN.1 OBJECT IDENTIFIER).

**Which issue(s) this PR fixes**:
Ref: [RHOAIENG-78418](https://redhat.atlassian.net/browse/RHOAIENG-78418)

**Type of changes**
- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:
Dependency version bump only — no functional changes.

```release-note
NONE
```

[RHOAIENG-78418]: https://redhat.atlassian.net/browse/RHOAIENG-78418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ