### PR TITLE
fix: support both full JWK and raw key formats in JWE decryption

### DIFF
--- a/python/storage/kserve_storage/confidential/jwe_decryptor.py
+++ b/python/storage/kserve_storage/confidential/jwe_decryptor.py
@@ -104,13 +104,20 @@ class JWEDecryptor:
         # memory.  For very large models this may be a concern; consider splitting
         # large files before encryption or increasing container memory limits.
         key_bytes = self._resolver.resolve_key(rid)
-        key_str = key_bytes.decode("utf-8")
-        # Try to import as a full JWK JSON object
         try:
-            symmetric_key = jwk.JWK.from_json(key_str)
-        except (ValueError, jwk.InvalidJWKValue):
-            # Not a JWK object - treat as raw key value
-            symmetric_key = jwk.JWK(kty="oct", k=key_str)
+            # the kubernetes secret likely returns a utf-8 encoded value.
+            # so try to decode utf-8.
+            key_str = key_bytes.decode("utf-8")
+            try:
+                # if kubernetes secret was created from the full encryption key file,
+                # the value should be the full json.
+                symmetric_key = jwk.JWK.from_json(key_str)
+            except (ValueError, jwk.InvalidJWKValue):
+                # Not a JWK object - treat as raw key value
+                symmetric_key = jwk.JWK(kty="oct", k=key_str)
+        except UnicodeDecodeError:
+            # if we fail to decode, then the key is likely raw-bytes and should be encoded.
+            symmetric_key = jwk.JWK(kty="oct", k=jwe.base64url_encode(key_bytes))
 
         jwe_token = jwe.JWE()
         jwe_token.deserialize(path.read_text())

--- a/python/storage/kserve_storage/confidential/jwe_decryptor.py
+++ b/python/storage/kserve_storage/confidential/jwe_decryptor.py
@@ -104,7 +104,13 @@ class JWEDecryptor:
         # memory.  For very large models this may be a concern; consider splitting
         # large files before encryption or increasing container memory limits.
         key_bytes = self._resolver.resolve_key(rid)
-        symmetric_key = jwk.JWK(kty="oct", k=jwk.base64url_encode(key_bytes))
+        key_str = key_bytes.decode("utf-8")
+        # Try to import as a full JWK JSON object
+        try:
+            symmetric_key = jwk.JWK.from_json(key_str)
+        except (ValueError, jwk.InvalidJWKValue):
+            # Not a JWK object - treat as raw key value
+            symmetric_key = jwk.JWK(kty="oct", k=key_str)
 
         jwe_token = jwe.JWE()
         jwe_token.deserialize(path.read_text())

--- a/python/storage/test/test_confidential.py
+++ b/python/storage/test/test_confidential.py
@@ -17,14 +17,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from jwcrypto import jwe, jwk
-
 from kserve_storage.confidential import (
     CDHSecretResolver,
     JWEDecryptor,
     SecretResolutionError,
     SecretResolver,
 )
-
 
 # --- Helpers ---
 
@@ -33,7 +31,7 @@ class StubSecretResolver(SecretResolver):
     """A test resolver that returns a fixed key."""
 
     def __init__(self, key: bytes):
-        self._key = key
+        self._key = jwk.base64url_encode(key).encode("utf-8")
 
     def resolve_key(self, resource_id: str) -> bytes:
         return self._key
@@ -179,6 +177,57 @@ class TestJWEDecryptorRoundTrip:
         decryptor = JWEDecryptor(resolver)
         with pytest.raises(ValueError, match="No resource_id"):
             decryptor.decrypt_file(encrypted_file)
+
+    def test_decrypt_file_with_full_jwk_json(self, tmp_path):
+        """Test decryption when resolver returns a full JWK JSON object."""
+        plaintext = b"model weights data here"
+        key_bytes = os.urandom(32)
+        token = _encrypt_jwe(plaintext, key_bytes)
+
+        encrypted_file = tmp_path / "model.bin.jwe"
+        encrypted_file.write_text(token)
+
+        # Create a full JWK JSON object
+        full_jwk = jwk.JWK(kty="oct", k=jwk.base64url_encode(key_bytes))
+        jwk_json = full_jwk.export()  # Returns JSON string
+
+        # Resolver returns the full JWK JSON as bytes
+        resolver = StubSecretResolver(jwk_json)
+        decryptor = JWEDecryptor(resolver, resource_id="kbs:///repo/type/tag")
+        output = decryptor.decrypt_file(encrypted_file)
+
+        assert output == tmp_path / "model.bin"
+        assert output.read_bytes() == plaintext
+        assert not encrypted_file.exists()
+
+    def test_decrypt_file_with_full_jwk_json_with_metadata(self, tmp_path):
+        """Test decryption when resolver returns a JWK with algorithm and key_ops."""
+        plaintext = b"model weights data here"
+        key_bytes = os.urandom(32)
+        token = _encrypt_jwe(plaintext, key_bytes)
+
+        encrypted_file = tmp_path / "model.bin.jwe"
+        encrypted_file.write_text(token)
+
+        # Create a JWK with additional metadata (as KBS might store it)
+        import json
+
+        jwk_dict = {
+            "alg": "A256GCM",
+            "k": jwk.base64url_encode(key_bytes),
+            "key_ops": ["encrypt", "decrypt"],
+            "kty": "oct",
+        }
+        jwk_json = json.dumps(jwk_dict)
+
+        # Resolver returns the full JWK JSON as bytes
+        resolver = StubSecretResolver(jwk_json)
+        decryptor = JWEDecryptor(resolver, resource_id="kbs:///repo/type/tag")
+        output = decryptor.decrypt_file(encrypted_file)
+
+        assert output == tmp_path / "model.bin"
+        assert output.read_bytes() == plaintext
+        assert not encrypted_file.exists()
 
 
 class TestJWEDecryptorDirectory:

--- a/python/storage/test/test_confidential.py
+++ b/python/storage/test/test_confidential.py
@@ -31,7 +31,7 @@ class StubSecretResolver(SecretResolver):
     """A test resolver that returns a fixed key."""
 
     def __init__(self, key: bytes):
-        self._key = jwk.base64url_encode(key).encode("utf-8")
+        self._key = key
 
     def resolve_key(self, resource_id: str) -> bytes:
         return self._key
@@ -144,7 +144,8 @@ class TestJWEDecryptorRoundTrip:
         encrypted_file = tmp_path / "model.bin.jwe"
         encrypted_file.write_text(token)
 
-        resolver = StubSecretResolver(key_bytes)
+        kbs_key = jwk.base64url_encode(key_bytes).encode("utf-8")
+        resolver = StubSecretResolver(kbs_key)
         decryptor = JWEDecryptor(resolver, resource_id="kbs:///repo/type/tag")
         output = decryptor.decrypt_file(encrypted_file)
 
@@ -189,7 +190,7 @@ class TestJWEDecryptorRoundTrip:
 
         # Create a full JWK JSON object
         full_jwk = jwk.JWK(kty="oct", k=jwk.base64url_encode(key_bytes))
-        jwk_json = full_jwk.export()  # Returns JSON string
+        jwk_json = full_jwk.export().encode("utf-8")
 
         # Resolver returns the full JWK JSON as bytes
         resolver = StubSecretResolver(jwk_json)
@@ -218,7 +219,7 @@ class TestJWEDecryptorRoundTrip:
             "key_ops": ["encrypt", "decrypt"],
             "kty": "oct",
         }
-        jwk_json = json.dumps(jwk_dict)
+        jwk_json = json.dumps(jwk_dict).encode("utf-8")
 
         # Resolver returns the full JWK JSON as bytes
         resolver = StubSecretResolver(jwk_json)


### PR DESCRIPTION
## Summary

- Support both full JWK JSON objects and raw symmetric key values from KBS
- Fix "Expected key of length 256, got 344" error when using properly formatted keys

fixes: https://redhat.atlassian.net/browse/RHAI-567

## Details

The KBS secret resolver can return either:
1. A full JWK JSON object with metadata (`{"alg":"A256GCM","k":"...","kty":"oct"}`)
2. A raw base64url-encoded symmetric key value (`Ljylvmp3Q6G5SHu6hk65WZx9XKTaK8D9Q80fJBCPvGs`)

Previously, the code always called `jwk.base64url_encode(key_bytes)`, which:
- Failed for raw keys (double-encoding caused length mismatch)
- Would also fail for full JWK objects

Now we:
1. Decode the bytes response to UTF-8 string
2. Try parsing as full JWK JSON first (`JWK.from_json()`)
3. Fall back to raw key format if JSON parsing fails (`JWK(kty="oct", k=key_str)`)
4. Fall back to non-decoded format if decoding fails.

## Test plan

- [ ] Deploy InferenceService with JWE-encrypted model using raw key format
- [ ] Verify decryption succeeds
- [ ] Deploy InferenceService with JWE-encrypted model using full JWK format  
- [ ] Verify decryption succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)