### PR TITLE
[RHOAIENG-79772] Skip opt-125m download for non-llmisvc e2e

### DIFF
--- a/test/overlays/openshift-ci/seaweedfs-init-job-odh.yaml
+++ b/test/overlays/openshift-ci/seaweedfs-init-job-odh.yaml
@@ -12,14 +12,23 @@ spec:
         - python3
         - -c
         - |
-          from huggingface_hub import snapshot_download
-          snapshot_download(
-            "facebook/opt-125m",
-            local_dir="/shared/facebook/opt-125m",
-            ignore_patterns=["*.msgpack", "*.h5", "flax_model*", "tf_model*", "rust_model*"],
-          )
-          print("Model download complete")
+          import os
+          # Only the llmisvc suite needs facebook/opt-125m; skip the (slow) HuggingFace
+          # download for predictor/raw/graph. Gated by DOWNLOAD_OPT_125M (set from the
+          # e2e marker in setup-e2e-tests.sh).
+          if os.environ.get("DOWNLOAD_OPT_125M") != "true":
+              print("DOWNLOAD_OPT_125M != true; skipping opt-125m download")
+          else:
+              from huggingface_hub import snapshot_download
+              snapshot_download(
+                "facebook/opt-125m",
+                local_dir="/shared/facebook/opt-125m",
+                ignore_patterns=["*.msgpack", "*.h5", "flax_model*", "tf_model*", "rust_model*"],
+              )
+              print("Model download complete")
         env:
+        - name: DOWNLOAD_OPT_125M
+          value: "__DOWNLOAD_OPT_125M__"
         - name: HF_TOKEN
           valueFrom:
             secretKeyRef:
@@ -42,8 +51,15 @@ spec:
           aws s3 mb s3://example-models || true
           curl -L https://storage.googleapis.com/kfserving-examples/models/sklearn/1.0/model/model.joblib -o /tmp/sklearn-model.joblib
           aws s3 cp /tmp/sklearn-model.joblib s3://example-models/sklearn/model.joblib --no-verify-ssl
-          aws s3 sync /shared/facebook/opt-125m s3://example-models/facebook/opt-125m/ --no-verify-ssl
+          # opt-125m is only uploaded for the llmisvc suite (see DOWNLOAD_OPT_125M).
+          if [ "${DOWNLOAD_OPT_125M}" = "true" ]; then
+            aws s3 sync /shared/facebook/opt-125m s3://example-models/facebook/opt-125m/ --no-verify-ssl
+          else
+            echo "DOWNLOAD_OPT_125M != true; skipping opt-125m upload"
+          fi
         env:
+        - name: DOWNLOAD_OPT_125M
+          value: "__DOWNLOAD_OPT_125M__"
         - name: AWS_ACCESS_KEY_ID
           valueFrom:
             secretKeyRef:

--- a/test/scripts/openshift-ci/setup-e2e-tests.sh
+++ b/test/scripts/openshift-ci/setup-e2e-tests.sh
@@ -141,9 +141,18 @@ if oc wait --for=condition=complete job/s3-init -n ${KSERVE_NAMESPACE} --timeout
   echo "S3 init job already completed successfully"
 else
   echo "S3 init job not completed, re-creating..."
+  # facebook/opt-125m is only consumed by the llmisvc suite; skip the (slow) HuggingFace
+  # download + upload for predictor/raw/graph. The bucket creation and sklearn model
+  # upload below are needed by all S3-using suites and always run.
+  DOWNLOAD_OPT_125M=false
+  if [[ "${1:-}" =~ llminferenceservice|llmisvc ]]; then
+    DOWNLOAD_OPT_125M=true
+  fi
+  echo "DOWNLOAD_OPT_125M=${DOWNLOAD_OPT_125M} (marker: ${1:-})"
   sed "s/s3-service.kserve/s3-service.${KSERVE_NAMESPACE}/" \
     "$PROJECT_ROOT/test/overlays/openshift-ci/seaweedfs-init-job-odh.yaml" | \
     sed "s|kserve/storage-initializer:latest|${STORAGE_INITIALIZER_IMAGE}|" | \
+    sed "s/__DOWNLOAD_OPT_125M__/${DOWNLOAD_OPT_125M}/" | \
     oc replace --force -n ${KSERVE_NAMESPACE} -f -
 
   echo "Waiting for S3 init job to complete..."


### PR DESCRIPTION
**What this PR does / why we need it**:

The `s3-init` job in the OpenShift e2e setup unconditionally downloads
`facebook/opt-125m` from HuggingFace and syncs it to the local SeaweedFS
S3 backend for every e2e suite. Only the llmisvc suite consumes that
model; the predictor, raw, and graph suites do not.

This gates the opt-125m HuggingFace download (initContainer) and its S3
sync behind a `DOWNLOAD_OPT_125M` env flag, set to `true` only when the
e2e marker matches `llminferenceservice|llmisvc`. The SeaweedFS backend,
bucket creation, and sklearn model upload remain unconditional, since
predictor/raw tests (storagespec, logger) still need them.

**Feature/Issue validation/testing**:

- [x] `sed` substitution renders valid YAML for both `DOWNLOAD_OPT_125M=true`
  and `=false`; no leftover placeholder.
- [x] `bash -n` clean on `setup-e2e-tests.sh`.
- [ ] Prow e2e: predictor/raw/graph green without opt-125m; llmisvc still
  gets the model.

**Special notes for your reviewer**:

Non-llmisvc suites still use the SeaweedFS backend, buckets, and sklearn
model, so only the opt-125m-specific work is gated. Follow-ups (tracked in
JIRA): gate the CMA/KEDA operator install, skip SeaweedFS entirely for the
graph suite, and an upstream-first change gating opt-125m in the shared
`s3-local-backend` job via `ENABLE_LLMISVC`.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note
NONE
```

Involved repos:
- https://github.com/opendatahub-io/kserve
