### PR TITLE
ci(e2e): install odh-model-controller via overlays/odh instead of base

### DIFF
--- a/test/scripts/openshift-ci/kustomization.yaml
+++ b/test/scripts/openshift-ci/kustomization.yaml
@@ -2,6 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - github.com/opendatahub-io/odh-model-controller/config/base?ref=incubating
+  - github.com/opendatahub-io/odh-model-controller/config/overlays/odh?ref=incubating
 
 namespace: kserve


### PR DESCRIPTION
openshift-ci manual install used odh-model-controller `config/base`, which misses the OpenShift RBAC (distro role) and model-serving-api. Switch to `config/overlays/odh`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to use the Open Data Hub overlay while preserving the existing release reference and namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->