### PR TITLE
[RHAI-121] Add imageParamMap entries for vLLM CPU P/Z (AIPCC migration)

### DIFF
--- a/kserve-module/pkg/kservemodule/images.go
+++ b/kserve-module/pkg/kservemodule/images.go
@@ -83,6 +83,12 @@ var modelControllerImageParamMap = map[string]string{
 	"vllm-cpu-x86-image-upstream-version":           "RELATED_IMAGE_RHAII_VLLM_CPU_IMAGE_UPSTREAM_VERSION",
 	"vllm-cpu-x86-image-fast-1-upstream-version":    "RELATED_IMAGE_RHAII_VLLM_CPU_FAST_1_IMAGE_UPSTREAM_VERSION",
 	"vllm-cpu-x86-image-fast-2-upstream-version":    "RELATED_IMAGE_RHAII_VLLM_CPU_FAST_2_IMAGE_UPSTREAM_VERSION",
+	"vllm-cpu-pz-image":                             "RELATED_IMAGE_RHAII_VLLM_CPU_PZ_IMAGE",
+	"vllm-cpu-pz-image-fast-1":                      "RELATED_IMAGE_RHAII_VLLM_CPU_PZ_FAST_1_IMAGE",
+	"vllm-cpu-pz-image-fast-2":                      "RELATED_IMAGE_RHAII_VLLM_CPU_PZ_FAST_2_IMAGE",
+	"vllm-cpu-pz-image-upstream-version":            "RELATED_IMAGE_RHAII_VLLM_CPU_PZ_IMAGE_UPSTREAM_VERSION",
+	"vllm-cpu-pz-image-fast-1-upstream-version":     "RELATED_IMAGE_RHAII_VLLM_CPU_PZ_FAST_1_IMAGE_UPSTREAM_VERSION",
+	"vllm-cpu-pz-image-fast-2-upstream-version":     "RELATED_IMAGE_RHAII_VLLM_CPU_PZ_FAST_2_IMAGE_UPSTREAM_VERSION",
 	"guardrails-detector-huggingface-runtime-image": "RELATED_IMAGE_ODH_GUARDRAILS_DETECTOR_HUGGINGFACE_RUNTIME_IMAGE",
 	"autogluon-image":                               "RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE",
 }


### PR DESCRIPTION
## Context

Part of [RHAI-121](https://issues.redhat.com/browse/RHAI-121) / [RHAISTRAT-2304](https://issues.redhat.com/browse/RHAISTRAT-2304) — migrating vLLM CPU Power/Z builds from RHOAI Konflux to RHAII on AIPCC base images.

## Changes

Adds 6 new entries to `modelControllerImageParamMap` in `images.go`:

- `vllm-cpu-pz-image` → `RELATED_IMAGE_RHAII_VLLM_CPU_PZ_IMAGE`
- `vllm-cpu-pz-image-fast-1` → `RELATED_IMAGE_RHAII_VLLM_CPU_PZ_FAST_1_IMAGE`
- `vllm-cpu-pz-image-fast-2` → `RELATED_IMAGE_RHAII_VLLM_CPU_PZ_FAST_2_IMAGE`
- Plus 3 corresponding `upstream-version` mappings

This is the mapping that `applyParams()` uses at reconcile time — it reads the env var value (digest from OLM) and writes it into the params.env ConfigMap entry.

Additive change only — existing entries are unchanged.

## Companion PRs

- **opendatahub-operator** — [#3996](https://github.com/opendatahub-io/opendatahub-operator/pull/3996) (RelatedImages declaration)
- **odh-model-controller** — params.env + kustomize wiring (TBD)
- **RHOAI-Build-Config** — `additional-images-patch.yaml` digest entry (blocked on RC image)

cc @edquarm @syedali @Raghul-M

[RHAI-121]: https://redhat.atlassian.net/browse/RHAI-121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAISTRAT-2304]: https://redhat.atlassian.net/browse/RHAISTRAT-2304?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for six CPU-optimized vLLM image variants, including standard, fast, and upstream-version options.
  * Enabled these image variants to be selected through the corresponding model controller configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->