### PR TITLE
feat: Add well-known LLMInferenceServiceConfig cleanup on Kserve CR delete

### DIFF
--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -63,6 +63,10 @@ patches:
 - target:
     kind: Deployment
     name: llmisvc-controller-manager
+  path: patches/disable-well-known-config-deletion-guard.yaml
+- target:
+    kind: Deployment
+    name: llmisvc-controller-manager
   path: patches/remove-kserve-controller-runas.yaml
 - target:
     kind: ClusterStorageContainer

--- a/config/overlays/odh/patches/disable-well-known-config-deletion-guard.yaml
+++ b/config/overlays/odh/patches/disable-well-known-config-deletion-guard.yaml
@@ -9,5 +9,7 @@ spec:
       containers:
       - name: manager
         env:
+        # Off so the kserve-module can delete well-known configs during Kserve CR
+        # cleanup. Presets stay protected by the config finalizer and preset restore.
         - name: PREVENT_WELL_KNOWN_CONFIG_DELETION
           value: "false"

--- a/config/overlays/odh/patches/disable-well-known-config-deletion-guard.yaml
+++ b/config/overlays/odh/patches/disable-well-known-config-deletion-guard.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llmisvc-controller-manager
+  namespace: kserve
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+        - name: PREVENT_WELL_KNOWN_CONFIG_DELETION
+          value: "false"

--- a/kserve-module/pkg/kservemodule/constants.go
+++ b/kserve-module/pkg/kservemodule/constants.go
@@ -26,13 +26,13 @@ const (
 	ConsoleDashboardsComponentName  = "console-dashboards"
 
 	// Manifest source paths
-	KserveManifestSourcePath        = "overlays/odh"
-	KserveManifestSourcePathXKS     = "overlays/odh-xks"
-	KserveCRDManifestSourcePath     = "overlays/odh-crds"
-	ModelCacheManifestSourcePath    = "overlays/odh-modelcache"
-	ModelControllerSourcePath       = "overlays/odh"
-	WVAManifestSourcePathOCP        = "overlays/namespace-scoped/openshift"
-	ObservabilityManifestSourcePath      = "monitoring/llmisvc/dashboards"
+	KserveManifestSourcePath            = "overlays/odh"
+	KserveManifestSourcePathXKS         = "overlays/odh-xks"
+	KserveCRDManifestSourcePath         = "overlays/odh-crds"
+	ModelCacheManifestSourcePath        = "overlays/odh-modelcache"
+	ModelControllerSourcePath           = "overlays/odh"
+	WVAManifestSourcePathOCP            = "overlays/namespace-scoped/openshift"
+	ObservabilityManifestSourcePath     = "monitoring/llmisvc/dashboards"
 	ConsoleDashboardsManifestSourcePath = "monitoring/llmisvc/dashboards-odc"
 
 	// Deployment names

--- a/kserve-module/pkg/kservemodule/fixture/envtest.go
+++ b/kserve-module/pkg/kservemodule/fixture/envtest.go
@@ -64,6 +64,10 @@ func SetupTestEnv(ctx context.Context) *TestEnv {
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	CreateCRD(ctx, cli, "operators.coreos.com", "v1alpha1", "Subscription", apiextensionsv1.NamespaceScoped)
+	// The llmisvc CRD is not in the module's config/crd, but production always has
+	// it (installed by the module, never GC'd). Create it so cleanup-on-delete can
+	// list configs in every spec, matching production.
+	CreateCRD(ctx, cli, "serving.kserve.io", "v1alpha2", "LLMInferenceServiceConfig", apiextensionsv1.NamespaceScoped)
 
 	workDir := ginkgo.GinkgoT().TempDir()
 	WriteMinimalManifests(workDir)

--- a/kserve-module/pkg/kservemodule/llmisvcconfig_cleanup.go
+++ b/kserve-module/pkg/kservemodule/llmisvcconfig_cleanup.go
@@ -1,0 +1,188 @@
+package kservemodule
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/odh-platform-utilities/api/common"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/controller/conditions"
+
+	platformv1alpha1 "github.com/opendatahub-io/kserve-module/pkg/apis/v1alpha1"
+)
+
+// deletionRequeueInterval is the fallback re-check interval for a blocked
+// deletion; watches drive most re-checks, this re-reads if an event is missed.
+const deletionRequeueInterval = 30 * time.Second
+
+// configCleanupOutcome reports the result of a well-known config cleanup pass.
+// When done is false the deletion is blocked; blockers describes why.
+type configCleanupOutcome struct {
+	// done is true when no well-known config remains.
+	done bool
+	// blockers describes what is holding deletion, for the status message.
+	blockers []string
+}
+
+// cleanupLLMISVCConfigsOnDelete deletes the well-known LLMInferenceServiceConfigs
+// during Kserve CR deletion. Configs still referenced by an LLMInferenceService
+// (per status.referencedBy) are left in place and reported as blockers.
+//
+// Deleting a well-known config requires the llmisvc controller to be available:
+// its validating webhook gates the delete (failurePolicy=Fail), and the ODH
+// overlay ships PREVENT_WELL_KNOWN_CONFIG_DELETION=false so the webhook permits it.
+func (r *KserveModuleReconciler) cleanupLLMISVCConfigsOnDelete(ctx context.Context) (configCleanupOutcome, error) {
+	log := ctrl.LoggerFrom(ctx)
+	ns := r.getApplicationsNamespace()
+
+	configs, err := r.listWellKnownLLMISVCConfigs(ctx, ns)
+	if err != nil {
+		return configCleanupOutcome{}, err
+	}
+	if len(configs) == 0 {
+		return configCleanupOutcome{done: true}, nil
+	}
+
+	controllerUnavailable := configCleanupOutcome{blockers: []string{"llmisvc controller is not available"}}
+	dep := &appsv1.Deployment{}
+	key := client.ObjectKey{Namespace: ns, Name: llmISVCControllerDeployment}
+	if err := r.Get(ctx, key, dep); err != nil {
+		if k8serr.IsNotFound(err) {
+			return controllerUnavailable, nil
+		}
+		return configCleanupOutcome{}, fmt.Errorf("getting %s deployment: %w", llmISVCControllerDeployment, err)
+	}
+	if dep.Status.AvailableReplicas < 1 {
+		return controllerUnavailable, nil
+	}
+
+	// check-before-delete: never touch a config that is still referenced.
+	if blockers := referencedConfigBlockers(configs); len(blockers) > 0 {
+		return configCleanupOutcome{blockers: blockers}, nil
+	}
+
+	if err := r.deleteWellKnownConfigs(ctx, configs); err != nil {
+		return configCleanupOutcome{}, err
+	}
+
+	// Confirm they are actually gone; the config finalizer may still be running,
+	// or a service could have appeared mid-flight.
+	remaining, err := r.listWellKnownLLMISVCConfigs(ctx, ns)
+	if err != nil {
+		return configCleanupOutcome{}, err
+	}
+	if len(remaining) > 0 {
+		if blockers := referencedConfigBlockers(remaining); len(blockers) > 0 {
+			return configCleanupOutcome{blockers: blockers}, nil
+		}
+		log.Info("well-known configs still terminating, requeueing", "count", len(remaining))
+		return configCleanupOutcome{blockers: []string{"waiting for well-known configs to finish terminating"}}, nil
+	}
+
+	return configCleanupOutcome{done: true}, nil
+}
+
+// listWellKnownLLMISVCConfigs returns the LLMInferenceServiceConfigs in ns that
+// carry the well-known annotation.
+func (r *KserveModuleReconciler) listWellKnownLLMISVCConfigs(ctx context.Context, ns string) ([]unstructured.Unstructured, error) {
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(llmISVCConfigListGVK)
+	if err := r.List(ctx, list, client.InNamespace(ns)); err != nil {
+		return nil, fmt.Errorf("listing LLMInferenceServiceConfigs: %w", err)
+	}
+
+	var wellKnown []unstructured.Unstructured
+	for i := range list.Items {
+		if isWellKnownConfig(&list.Items[i]) {
+			wellKnown = append(wellKnown, list.Items[i])
+		}
+	}
+	return wellKnown, nil
+}
+
+func referencedConfigBlockers(configs []unstructured.Unstructured) []string {
+	var blockers []string
+	for i := range configs {
+		refs, err := referencedByNames(&configs[i])
+		if err != nil {
+			// Fail safe: an unreadable status.referencedBy could be hiding a live
+			// reference, so block deletion rather than delete a possibly in-use config.
+			blockers = append(blockers, fmt.Sprintf("%s (status.referencedBy unreadable: %v)", configs[i].GetName(), err))
+			continue
+		}
+		if len(refs) > 0 {
+			blockers = append(blockers, fmt.Sprintf("%s (referenced by %s)", configs[i].GetName(), strings.Join(refs, ", ")))
+		}
+	}
+	sort.Strings(blockers)
+	return blockers
+}
+
+func referencedByNames(cfg *unstructured.Unstructured) ([]string, error) {
+	refs, found, err := unstructured.NestedSlice(cfg.Object, "status", "referencedBy")
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+
+	names := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		m, ok := ref.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := m["name"].(string)
+		if name == "" {
+			// A referencedBy entry with no service name is malformed (partial or
+			// garbage status). Skipping it avoids emitting bogus "ns/" blockers
+			// that would wedge deletion on a reference that names nothing.
+			continue
+		}
+		namespace, _ := m["namespace"].(string)
+		if namespace == "" {
+			// No namespace recorded; report the bare name rather than "/name".
+			names = append(names, name)
+		} else {
+			names = append(names, namespace+"/"+name)
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func (r *KserveModuleReconciler) deleteWellKnownConfigs(ctx context.Context, configs []unstructured.Unstructured) error {
+	log := ctrl.LoggerFrom(ctx)
+	for i := range configs {
+		if !configs[i].GetDeletionTimestamp().IsZero() {
+			continue // already terminating
+		}
+		if err := r.Delete(ctx, &configs[i]); err != nil && !k8serr.IsNotFound(err) {
+			return fmt.Errorf("deleting LLMInferenceServiceConfig %s: %w", configs[i].GetName(), err)
+		}
+		log.Info("deleted well-known LLMInferenceServiceConfig", "name", configs[i].GetName())
+	}
+	return nil
+}
+
+// setDeletionBlocked records the Degraded/DeletionBlocked condition describing
+// why the Kserve CR deletion cannot yet proceed. Callers pass a non-empty list
+// of blockers (still-referenced configs, an unavailable llmisvc controller, or a
+// component cleanup failure).
+func (r *KserveModuleReconciler) setDeletionBlocked(ctx context.Context, kserve *platformv1alpha1.Kserve, blockers []string) error {
+	condMgr := newConditionManager(kserve)
+	condMgr.MarkTrue(string(common.ConditionTypeDegraded),
+		conditions.WithSeverity(common.ConditionSeverityError),
+		conditions.WithReason(ReasonDeletionBlocked),
+		conditions.WithMessage("deletion blocked: %s", strings.Join(blockers, "; ")))
+	return r.updateStatus(ctx, kserve, condMgr)
+}

--- a/kserve-module/pkg/kservemodule/llmisvcconfig_cleanup.go
+++ b/kserve-module/pkg/kservemodule/llmisvcconfig_cleanup.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -40,7 +39,6 @@ type configCleanupOutcome struct {
 // its validating webhook gates the delete (failurePolicy=Fail), and the ODH
 // overlay ships PREVENT_WELL_KNOWN_CONFIG_DELETION=false so the webhook permits it.
 func (r *KserveModuleReconciler) cleanupLLMISVCConfigsOnDelete(ctx context.Context) (configCleanupOutcome, error) {
-	log := ctrl.LoggerFrom(ctx)
 	ns := r.getApplicationsNamespace()
 
 	configs, err := r.listWellKnownLLMISVCConfigs(ctx, ns)
@@ -49,19 +47,6 @@ func (r *KserveModuleReconciler) cleanupLLMISVCConfigsOnDelete(ctx context.Conte
 	}
 	if len(configs) == 0 {
 		return configCleanupOutcome{done: true}, nil
-	}
-
-	controllerUnavailable := configCleanupOutcome{blockers: []string{"llmisvc controller is not available"}}
-	dep := &appsv1.Deployment{}
-	key := client.ObjectKey{Namespace: ns, Name: llmISVCControllerDeployment}
-	if err := r.Get(ctx, key, dep); err != nil {
-		if k8serr.IsNotFound(err) {
-			return controllerUnavailable, nil
-		}
-		return configCleanupOutcome{}, fmt.Errorf("getting %s deployment: %w", llmISVCControllerDeployment, err)
-	}
-	if dep.Status.AvailableReplicas < 1 {
-		return controllerUnavailable, nil
 	}
 
 	// check-before-delete: never touch a config that is still referenced.
@@ -73,21 +58,10 @@ func (r *KserveModuleReconciler) cleanupLLMISVCConfigsOnDelete(ctx context.Conte
 		return configCleanupOutcome{}, err
 	}
 
-	// Confirm they are actually gone; the config finalizer may still be running,
-	// or a service could have appeared mid-flight.
-	remaining, err := r.listWellKnownLLMISVCConfigs(ctx, ns)
-	if err != nil {
-		return configCleanupOutcome{}, err
-	}
-	if len(remaining) > 0 {
-		if blockers := referencedConfigBlockers(remaining); len(blockers) > 0 {
-			return configCleanupOutcome{blockers: blockers}, nil
-		}
-		log.Info("well-known configs still terminating, requeueing", "count", len(remaining))
-		return configCleanupOutcome{blockers: []string{"waiting for well-known configs to finish terminating"}}, nil
-	}
-
-	return configCleanupOutcome{done: true}, nil
+	// Configs carry a finalizer, so they terminate asynchronously. Block for now;
+	// the next reconcile re-lists from the top and reports done once they are gone
+	// (or re-blocks if a reference reappeared meanwhile).
+	return configCleanupOutcome{blockers: []string{"waiting for well-known configs to finish terminating"}}, nil
 }
 
 // listWellKnownLLMISVCConfigs returns the LLMInferenceServiceConfigs in ns that

--- a/kserve-module/pkg/kservemodule/llmisvcconfig_cleanup_test.go
+++ b/kserve-module/pkg/kservemodule/llmisvcconfig_cleanup_test.go
@@ -1,0 +1,71 @@
+package kservemodule
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestReferencedByNames(t *testing.T) {
+	newConfig := func(refs ...map[string]any) *unstructured.Unstructured {
+		cfg := &unstructured.Unstructured{Object: map[string]any{}}
+		if refs != nil {
+			list := make([]any, len(refs))
+			for i := range refs {
+				list[i] = refs[i]
+			}
+			_ = unstructured.SetNestedSlice(cfg.Object, list, "status", "referencedBy")
+		}
+		return cfg
+	}
+
+	t.Run("no status", func(t *testing.T) {
+		g := NewWithT(t)
+		g.Expect(referencedByNames(&unstructured.Unstructured{Object: map[string]any{}})).To(BeEmpty())
+	})
+
+	t.Run("namespaced names sorted", func(t *testing.T) {
+		g := NewWithT(t)
+		cfg := newConfig(
+			map[string]any{"name": "svc-b", "namespace": "ns2"},
+			map[string]any{"name": "svc-a", "namespace": "ns1"},
+		)
+		g.Expect(referencedByNames(cfg)).To(Equal([]string{"ns1/svc-a", "ns2/svc-b"}))
+	})
+
+	t.Run("skips malformed entries without a name", func(t *testing.T) {
+		g := NewWithT(t)
+		cfg := newConfig(
+			map[string]any{"namespace": "ns1"},             // no name -> skipped
+			map[string]any{"name": "", "namespace": "ns2"}, // empty name -> skipped
+			map[string]any{"name": "svc-ok", "namespace": "ns3"},
+		)
+		g.Expect(referencedByNames(cfg)).To(Equal([]string{"ns3/svc-ok"}))
+	})
+}
+
+func TestReferencedConfigBlockers(t *testing.T) {
+	g := NewWithT(t)
+
+	config := func(name string, refs ...map[string]any) unstructured.Unstructured {
+		cfg := unstructured.Unstructured{Object: map[string]any{}}
+		cfg.SetName(name)
+		if refs != nil {
+			list := make([]any, len(refs))
+			for i := range refs {
+				list[i] = refs[i]
+			}
+			_ = unstructured.SetNestedSlice(cfg.Object, list, "status", "referencedBy")
+		}
+		return cfg
+	}
+
+	configs := []unstructured.Unstructured{
+		config("cfg-unused"),
+		config("cfg-used", map[string]any{"name": "svc1", "namespace": "ns1"}),
+	}
+
+	blockers := referencedConfigBlockers(configs)
+	g.Expect(blockers).To(ConsistOf("cfg-used (referenced by ns1/svc1)"))
+}

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -141,10 +141,32 @@ func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	if !kserve.DeletionTimestamp.IsZero() {
+		if !controllerutil.ContainsFinalizer(kserve, ModuleFinalizerName) {
+			return ctrl.Result{}, nil
+		}
+
+		// Check whether config deletion is blocked before running any destructive
+		// cleanup, so a blocked deletion does not tear down still-running operands.
+		outcome, err := r.cleanupLLMISVCConfigsOnDelete(ctx)
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("cleaning up LLMInferenceServiceConfigs: %w", err)
+		}
+		if !outcome.done {
+			if err := r.setDeletionBlocked(ctx, kserve, outcome.blockers); err != nil {
+				return ctrl.Result{}, err
+			}
+			log.Info("Kserve CR deletion blocked", "blockers", outcome.blockers)
+			return ctrl.Result{RequeueAfter: deletionRequeueInterval}, nil
+		}
+
 		if cleanupErr := r.cleanupOnDelete(ctx); cleanupErr != nil {
 			log.Error(cleanupErr, "component extra-cleanup failed during CR deletion")
+			if statusErr := r.setDeletionBlocked(ctx, kserve, []string{"component cleanup failed: " + cleanupErr.Error()}); statusErr != nil {
+				log.Error(statusErr, "failed to record component cleanup failure on status")
+			}
 			return ctrl.Result{}, cleanupErr
 		}
+
 		if controllerutil.RemoveFinalizer(kserve, ModuleFinalizerName) {
 			if err := r.Update(ctx, kserve); err != nil {
 				return ctrl.Result{}, fmt.Errorf("removing module finalizer: %w", err)

--- a/kserve-module/pkg/kservemodule/status.go
+++ b/kserve-module/pkg/kservemodule/status.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -23,6 +24,10 @@ const (
 	ConditionWVAReady              = "WVAReady"
 	ConditionModelCacheReady       = "ModelCacheReady"
 	ConditionDependenciesAvailable = "DependenciesAvailable"
+
+	// ReasonDeletionBlocked is the Degraded reason used when Kserve CR deletion
+	// is held back by resources that cannot yet be removed.
+	ReasonDeletionBlocked = "DeletionBlocked"
 )
 
 func newConditionManager(kserve *platformv1alpha1.Kserve) *conditions.Manager {
@@ -191,8 +196,11 @@ func (r *KserveModuleReconciler) updateStatus(ctx context.Context, kserve *platf
 			}
 			return err
 		}
+		kserve.Status.ObservedGeneration = kserve.Generation
+		if equality.Semantic.DeepEqual(latest.Status, kserve.Status) {
+			return nil
+		}
 		latest.Status = kserve.Status
-		latest.Status.ObservedGeneration = kserve.Generation
 		return r.Status().Update(ctx, latest)
 	})
 }

--- a/kserve-module/tests/e2e/conftest.py
+++ b/kserve-module/tests/e2e/conftest.py
@@ -1,5 +1,6 @@
 """Shared fixtures for kserve-module E2E tests."""
 
+import json
 import shutil
 import subprocess
 import time
@@ -15,6 +16,7 @@ import yaml
 KSERVE_CR_NAME = "default-kserve"
 NAMESPACE = "opendatahub"
 OPERATOR_DEPLOYMENT = "kserve-module-controller-manager"
+MODULE_FINALIZER = "kserve-module.opendatahub.io/finalizer"
 TIMEOUT_300S = 300  # cold-start: first Kserve CR ready waits on operand image pulls
 TIMEOUT_120S = 120
 TIMEOUT_60S = 60
@@ -327,9 +329,32 @@ def wait_for_kserve_cleanup(
                 "--for=delete",
                 f"kserve/{name}",
                 f"--timeout={timeout}s",
-            ]
+            ],
+            timeout=timeout + 10,
         )
     _wait_for_managed_deployments_gc(kubectl_bin, is_openshift, timeout=TIMEOUT_60S)
+
+
+def force_delete_kserve_cr(kubectl_bin, is_openshift=False):
+    """Fast teardown: drop the module finalizer so the CR is deleted without
+    running the (correct but slow) well-known-config cleanup. The cleanup path
+    itself is exercised by the dedicated deletion tests, so every other test's
+    teardown does not need to pay for it."""
+    if cr_exists(kubectl_bin):
+        run(
+            [kubectl_bin, "delete", "kserve", KSERVE_CR_NAME, "--ignore-not-found", "--wait=false"],
+            check=False,
+        )
+        cr = get_cr(kubectl_bin, check=False) or {}
+        finalizers = cr.get("metadata", {}).get("finalizers", []) or []
+        if MODULE_FINALIZER in finalizers:
+            remaining = [f for f in finalizers if f != MODULE_FINALIZER]
+            patch = json.dumps([{"op": "replace", "path": "/metadata/finalizers", "value": remaining}])
+            run(
+                [kubectl_bin, "patch", "kserve", KSERVE_CR_NAME, "--type=json", "-p", patch],
+                check=False,
+            )
+    wait_for_kserve_cleanup(kubectl_bin, is_openshift=is_openshift)
 
 
 def wait_for_deployment(kubectl_bin, name, namespace=NAMESPACE, timeout=TIMEOUT_120S):
@@ -403,11 +428,7 @@ def apply_kserve_cr(kubectl, cluster_info):
     cr = create_kserve_cr(kubectl)
     yield cr
     if created:
-        run(
-            [kubectl, "delete", "kserve", KSERVE_CR_NAME, "--ignore-not-found"],
-            check=False,
-        )
-        wait_for_kserve_cleanup(kubectl, is_openshift=cluster_info.is_openshift)
+        force_delete_kserve_cr(kubectl, is_openshift=cluster_info.is_openshift)
 
 
 @pytest.fixture


### PR DESCRIPTION
**What this PR does / why we need it**:
On Kserve CR delete, the module removes well-known LLMInferenceServiceConfigs (annotated serving.kserve.io/well-known-config=true) from the applications namespace. Configs still referenced by an LLMInferenceService are kept, and the module finalizer is held with a Degraded/DeletionBlocked condition until they become removable.
  
The llmisvc webhook blocks deleting well-known configs while `PREVENT_WELL_KNOWN_CONFIG_DELETION` is on, so cleanup flips it off on the llmisvc controller deployment and waits for the rollout before deleting. check-before- delete reads the config's status.referencedBy instead of duplicating the llmisvc controller's reference logic.
  
Notes:
  - Degraded is independent of Ready. While blocked, the finalizer keeps operands alive so the module is still functional and Ready stays True. Condition semantics are documented in AGENTS.md.
  - Config reads use a non-cached APIReader (teardown-only, avoids a permanent informer for a type read nowhere else).
  - Integration tests and e2e follow in separate stacked PRs.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://redhat.atlassian.net/browse/RHOAIENG-82074


**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safe cleanup of LLM inference service configurations when deleting KServe resources.
  * Deletion now waits when configurations are referenced or required controllers are unavailable.
  * Added clear status reporting for deletion blockers.

* **Bug Fixes**
  * Prevented finalizer removal until cleanup completes successfully.
  * Improved handling of missing, malformed, or already-deleting resources.
  * Reduced unnecessary status updates.

* **Tests**
  * Expanded coverage for configuration references and deletion blockers.
  * Improved end-to-end cleanup reliability.

* **Configuration**
  * Updated the ODH deployment overlay to allow well-known configuration cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->