### PR TITLE
fix(kserve-module): enqueue preset updates that drop the well-known annotation

### DIFF
--- a/kserve-module/pkg/kservemodule/dynamic_watch_int_test.go
+++ b/kserve-module/pkg/kservemodule/dynamic_watch_int_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
@@ -186,5 +187,114 @@ var _ = Describe("Dynamic Watch Integration", Ordered, func() {
 			}).WithContext(ctx).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
 		})
 	})
-})
 
+	// TestPresetWatchFilter covers what the predicate accepts, driving the
+	// filter the controller uses. This spec covers the wiring around it: that
+	// the dynamic watch registers for the preset GVK and that its events reach
+	// the reconciler.
+	//
+	// This context uses the mock deployer, so nothing applies resources and a
+	// restored preset is not observable here; a reconcile having run is the
+	// signal. The fixture pushes periodic requeues out to ten minutes so that
+	// signal is unambiguous rather than a race against the clock.
+	Context("LLMInferenceServiceConfig preset watch", Ordered, func() {
+		var presetCRD *apiextensionsv1.CustomResourceDefinition
+		var deployer *fixture.MockDeployer
+
+		presetGVK := schema.GroupVersionKind{
+			Group: "serving.kserve.io", Version: "v1alpha2", Kind: "LLMInferenceServiceConfig",
+		}
+		const wellKnownAnnotation = "serving.kserve.io/well-known-config"
+
+		// The fixture pushes periodic requeues out to ten minutes, so a reconcile
+		// arriving in this window came from the watch. The window is generous
+		// because it no longer races anything - it only bounds how long a loaded
+		// runner is given.
+		const eventDrivenReconcileWindow = 60 * time.Second
+
+		shippedPreset := func() *unstructured.Unstructured {
+			preset := &unstructured.Unstructured{}
+			preset.SetGroupVersionKind(presetGVK)
+			preset.SetName("v1-2-3-kserve-config-llm-decode")
+			preset.SetNamespace("opendatahub")
+			preset.SetAnnotations(map[string]string{wellKnownAnnotation: "true"})
+
+			return preset
+		}
+
+		BeforeAll(func(ctx SpecContext) {
+			var ok bool
+			deployer, ok = testEnv.Reconciler.Deployer.(*fixture.MockDeployer)
+			Expect(ok).To(BeTrue(), "this context counts Deploy calls to detect reconciles")
+
+			// Dependencies the Subscription context deletes in its AfterAll. A
+			// critical failure returns before the deployer runs, which would
+			// leave nothing to count.
+			for _, name := range []string{"rhcl-operator", "openshift-cert-manager-operator"} {
+				fixture.CreateSubscription(ctx, testEnv.Client, name, "openshift-operators")
+			}
+
+			presetCRD = fixture.CreateCRD(ctx, testEnv.Client,
+				presetGVK.Group, presetGVK.Version, presetGVK.Kind, apiextensionsv1.NamespaceScoped)
+
+			triggerReconcile(ctx, kserve, "dw-preset-crd-created")
+			Eventually(func(g Gomega) {
+				g.Expect(testEnv.Client.Get(ctx, client.ObjectKeyFromObject(kserve), kserve)).To(Succeed())
+				g.Expect(kserve.Status.ObservedGeneration).To(Equal(kserve.Generation))
+			}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
+
+			// Wait for registerDynamicWatches to claim the GVK.
+			Eventually(func(g Gomega) {
+				list := &unstructured.UnstructuredList{}
+				list.SetGroupVersionKind(presetGVK)
+				g.Expect(testEnv.Reconciler.Client.List(ctx, list)).To(Succeed())
+			}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
+		})
+
+		AfterAll(func(ctx SpecContext) {
+			if presetCRD != nil {
+				client.IgnoreNotFound(testEnv.Client.Delete(ctx, presetCRD))
+			}
+		})
+
+		It("reconciles when a preset loses the annotation that marks it as ours", func(ctx SpecContext) {
+			preset := shippedPreset()
+
+			// Sampled before the create, not after: the reconcile it triggers can
+			// land first, and a baseline taken afterwards would already include it.
+			// The wait would then be for a second reconcile that never comes, since
+			// periodic requeues are ten minutes out.
+			start := deployer.CallCount()
+
+			Expect(testEnv.Client.Create(ctx, preset)).To(Succeed())
+			DeferCleanup(func(ctx SpecContext) {
+				client.IgnoreNotFound(testEnv.Client.Delete(ctx, shippedPreset()))
+			})
+
+			// Wait for the create to be picked up before editing, so the count
+			// below moves for the update rather than for work already queued.
+			Eventually(deployer.CallCount).
+				WithContext(ctx).WithTimeout(60*time.Second).WithPolling(100*time.Millisecond).
+				Should(BeNumerically(">", start), "reconciles must reach the deployer for this spec to mean anything")
+			mark := deployer.CallCount()
+
+			// Stripping the annotation must not change whether the event is
+			// delivered: the filter is scoped by namespace, which the edit
+			// leaves alone.
+			Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				live := &unstructured.Unstructured{}
+				live.SetGroupVersionKind(presetGVK)
+				if err := testEnv.Client.Get(ctx, client.ObjectKeyFromObject(preset), live); err != nil {
+					return err
+				}
+				live.SetAnnotations(nil)
+
+				return testEnv.Client.Update(ctx, live)
+			})).To(Succeed())
+
+			Eventually(deployer.CallCount).
+				WithContext(ctx).WithTimeout(eventDrivenReconcileWindow).WithPolling(100*time.Millisecond).
+				Should(BeNumerically(">", mark), "the update should have enqueued a reconcile; periodic requeues are ten minutes out")
+		})
+	})
+})

--- a/kserve-module/pkg/kservemodule/fixture/envtest.go
+++ b/kserve-module/pkg/kservemodule/fixture/envtest.go
@@ -76,6 +76,13 @@ func SetupTestEnv(ctx context.Context) *TestEnv {
 		Scheme:                mgr.GetScheme(),
 		ManifestsTemplatePath: workDir,
 		Deployer:              kservemodule.NewDeployer(),
+
+		// Periodic requeues are pushed far enough out that a reconcile observed
+		// shortly after an event came from a watch and not from the clock. Set
+		// here rather than per context: the manager is already running by the
+		// time a BeforeAll executes, so writing these later would race it.
+		RequeueInterval:           10 * time.Minute,
+		DependencyRequeueInterval: 10 * time.Minute,
 	}
 	reconciler.SetWorkDir(workDir)
 	reconciler.SetClusterType(cluster.ClusterTypeOpenShift)

--- a/kserve-module/pkg/kservemodule/fixture/mock_deployer.go
+++ b/kserve-module/pkg/kservemodule/fixture/mock_deployer.go
@@ -20,6 +20,16 @@ func (m *MockDeployer) Deploy(_ context.Context, input deploy.DeployInput) error
 	return m.DeployError
 }
 
+// CallCount reports how many times Deploy has run. Tests that assert an event
+// reached the reconciler poll this, so it has to take the lock the same way
+// Deploy does.
+func (m *MockDeployer) CallCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return len(m.Calls)
+}
+
 func (m *MockDeployer) LastCall() *deploy.DeployInput {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/kserve-module/pkg/kservemodule/helpers_test.go
+++ b/kserve-module/pkg/kservemodule/helpers_test.go
@@ -1,0 +1,21 @@
+package kservemodule
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// presetObject builds an LLMInferenceServiceConfig the way the module ships
+// them. Built from llmISVCConfigGVK so a version bump cannot leave the tests
+// asserting against an apiVersion nothing serves.
+func presetObject(namespace string, annotations map[string]any) *unstructured.Unstructured {
+	metadata := map[string]any{"name": "v1-2-3-kserve-config-llm-decode", "namespace": namespace}
+	if annotations != nil {
+		metadata["annotations"] = annotations
+	}
+
+	return &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": llmISVCConfigGVK.GroupVersion().String(),
+		"kind":       llmISVCConfigGVK.Kind,
+		"metadata":   metadata,
+	}}
+}

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -116,11 +116,18 @@ type KserveModuleReconciler struct {
 	Scheme                *runtime.Scheme
 	ManifestsTemplatePath string
 	Deployer              ResourceDeployer
-	workDir               string
-	initDone              bool
-	applicationsNamespace string
-	monitoringNamespace   string
-	clusterType           *cluster.ClusterType
+
+	// RequeueInterval is how long to wait before reconciling again while
+	// components are still coming up; DependencyRequeueInterval is the same for
+	// the critical-dependency path. Zero selects the default. Tests raise them
+	// so a reconcile arriving just after an event cannot be a periodic one.
+	RequeueInterval           time.Duration
+	DependencyRequeueInterval time.Duration
+	workDir                   string
+	initDone                  bool
+	applicationsNamespace     string
+	monitoringNamespace       string
+	clusterType               *cluster.ClusterType
 
 	controller     controller.Controller
 	cache          cache.Cache
@@ -178,7 +185,7 @@ func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		applyProvisioningCondition(condMgr, map[string]error{
 			"dependencies": fmt.Errorf("critical dependencies unavailable"),
 		})
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		return ctrl.Result{RequeueAfter: r.dependencyRequeueInterval()}, nil
 	}
 
 	componentErrors := r.reconcile(ctx, kserve)
@@ -196,7 +203,7 @@ func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	if !condMgr.IsHappy() {
 		log.Info("not all components ready, requeueing")
-		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+		return ctrl.Result{RequeueAfter: r.requeueInterval()}, nil
 	}
 
 	return ctrl.Result{}, nil
@@ -271,6 +278,27 @@ func (r *KserveModuleReconciler) reconcile(ctx context.Context, kserve *platform
 	log.Info("deployed all resources", "owned", len(owned), "unowned", len(unowned))
 
 	return nil
+}
+
+const (
+	defaultRequeueInterval           = 15 * time.Second
+	defaultDependencyRequeueInterval = 30 * time.Second
+)
+
+func (r *KserveModuleReconciler) requeueInterval() time.Duration {
+	if r.RequeueInterval > 0 {
+		return r.RequeueInterval
+	}
+
+	return defaultRequeueInterval
+}
+
+func (r *KserveModuleReconciler) dependencyRequeueInterval() time.Duration {
+	if r.DependencyRequeueInterval > 0 {
+		return r.DependencyRequeueInterval
+	}
+
+	return defaultDependencyRequeueInterval
 }
 
 func splitByOwnership(resources []unstructured.Unstructured) (owned, unowned []unstructured.Unstructured) {

--- a/kserve-module/pkg/kservemodule/setup.go
+++ b/kserve-module/pkg/kservemodule/setup.go
@@ -52,7 +52,7 @@ var watchedSubscriptions = map[string]bool{
 type dynamicWatch struct {
 	groupKind  schema.GroupKind
 	gvk        schema.GroupVersionKind
-	filterFn   func(*unstructured.Unstructured) bool
+	filterFn   func(client.Object) bool
 	registered bool
 }
 
@@ -116,11 +116,7 @@ func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		b.Watches(subObj,
 			handler.EnqueueRequestsFromMapFunc(mapToKserve),
 			builder.WithPredicates(predicate.NewPredicateFuncs(func(o client.Object) bool {
-				u, ok := o.(*unstructured.Unstructured)
-				if !ok {
-					return false
-				}
-				return watchedSubscriptions[u.GetName()]
+				return watchedSubscriptions[o.GetName()]
 			})),
 		)
 	}
@@ -137,14 +133,20 @@ func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		{
 			// Presets are deliberately out of the ownerRef chain (see
 			// unownedGroupKinds), so nothing recreates them when they are deleted.
-			// Watching them turns that into a normal reconcile. Scoped to the
-			// applications namespace: a reconcile renders and applies everything,
-			// so copies a user made elsewhere must not trigger one.
+			// Watching them turns that into a normal reconcile. The predicate,
+			// not the cache, is what scopes this to the applications namespace:
+			// a reconcile renders and applies everything, so copies a user made
+			// elsewhere must not trigger one.
+			//
+			// Scoping stops at the namespace on purpose. Narrowing it further by
+			// the annotation that marks a preset as ours would filter on a field
+			// a user can remove, and removing it is precisely the edit that has
+			// to be reverted - the event would be dropped for carrying the change
+			// it was needed for. A reconcile applies this module's own resources,
+			// so the cost of the wider filter is a redundant pass.
 			groupKind: llmISVCConfigGVK.GroupKind(),
 			gvk:       llmISVCConfigGVK,
-			filterFn: func(u *unstructured.Unstructured) bool {
-				return isShippedPreset(u, r.getApplicationsNamespace())
-			},
+			filterFn:  presetWatchFilter(r.getApplicationsNamespace()),
 		},
 	}
 
@@ -154,20 +156,10 @@ func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 		obj := &unstructured.Unstructured{}
 		obj.SetGroupVersionKind(dw.gvk)
-		if dw.filterFn != nil {
-			b.Watches(obj,
-				handler.EnqueueRequestsFromMapFunc(mapToKserve),
-				builder.WithPredicates(predicate.NewPredicateFuncs(func(o client.Object) bool {
-					u, ok := o.(*unstructured.Unstructured)
-					if !ok {
-						return false
-					}
-					return dw.filterFn(u)
-				})),
-			)
-		} else {
-			b.Watches(obj, handler.EnqueueRequestsFromMapFunc(mapToKserve))
-		}
+		b.Watches(obj,
+			handler.EnqueueRequestsFromMapFunc(mapToKserve),
+			builder.WithPredicates(dw.predicates()...),
+		)
 		dw.registered = true
 	}
 
@@ -209,18 +201,7 @@ func (r *KserveModuleReconciler) registerDynamicWatches(ctx context.Context) {
 		obj := &unstructured.Unstructured{}
 		obj.SetGroupVersionKind(dw.gvk)
 
-		var preds []predicate.Predicate
-		if dw.filterFn != nil {
-			preds = append(preds, predicate.NewPredicateFuncs(func(o client.Object) bool {
-				u, ok := o.(*unstructured.Unstructured)
-				if !ok {
-					return false
-				}
-				return dw.filterFn(u)
-			}))
-		}
-
-		if err := r.controller.Watch(source.Kind[client.Object](r.cache, obj, handler.EnqueueRequestsFromMapFunc(mapToKserve), preds...)); err != nil {
+		if err := r.controller.Watch(source.Kind[client.Object](r.cache, obj, handler.EnqueueRequestsFromMapFunc(mapToKserve), dw.predicates()...)); err != nil {
 			ctrl.LoggerFrom(ctx).Error(err, "failed to register dynamic watch", "gvk", dw.gvk)
 			continue
 		}
@@ -228,6 +209,27 @@ func (r *KserveModuleReconciler) registerDynamicWatches(ctx context.Context) {
 		dw.registered = true
 		ctrl.LoggerFrom(ctx).Info("registered dynamic watch", "gvk", dw.gvk)
 	}
+}
+
+// presetWatchFilter accepts events for objects in the applications namespace.
+//
+// Named rather than inlined so tests drive the filter the controller uses.
+// Asserting against a copy declared in the test would let the annotation creep
+// back into this one with everything still green.
+func presetWatchFilter(applicationsNS string) func(client.Object) bool {
+	return func(o client.Object) bool {
+		return o.GetNamespace() == applicationsNS
+	}
+}
+
+// predicates scopes the watch to the objects the filter accepts. A watch
+// without a filter registers none and sees every event for its kind.
+func (dw *dynamicWatch) predicates() []predicate.Predicate {
+	if dw.filterFn == nil {
+		return nil
+	}
+
+	return []predicate.Predicate{predicate.NewPredicateFuncs(dw.filterFn)}
 }
 
 func mapToKserve(_ context.Context, _ client.Object) []ctrl.Request {

--- a/kserve-module/pkg/kservemodule/setup_test.go
+++ b/kserve-module/pkg/kservemodule/setup_test.go
@@ -1,0 +1,50 @@
+package kservemodule
+
+import (
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	. "github.com/onsi/gomega"
+)
+
+// The preset watch is scoped by namespace and nothing else. Narrowing it by the
+// well-known annotation would filter on a field a user can remove, and removing
+// it is the edit that has to be reverted: the event would be dropped for
+// carrying the very change it was needed for.
+//
+// Driving presetWatchFilter rather than a copy declared here is what makes this
+// a regression test - the annotation creeping back into the filter fails it.
+func TestPresetWatchFilter_SurvivesAnnotationRemoval(t *testing.T) {
+	g := NewWithT(t)
+	pred := predicate.NewPredicateFuncs(presetWatchFilter("opendatahub"))
+
+	wellKnown := map[string]any{wellKnownAnnotationKey: wellKnownAnnotationValue}
+	shipped := presetObject("opendatahub", wellKnown)
+	stripped := presetObject("opendatahub", nil)
+	elsewhere := presetObject("user-models", wellKnown)
+
+	g.Expect(pred.Update(event.UpdateEvent{ObjectOld: shipped, ObjectNew: stripped})).
+		Should(BeTrue(), "stripping the annotation must still enqueue a reconcile")
+	g.Expect(pred.Update(event.UpdateEvent{ObjectOld: shipped, ObjectNew: shipped})).
+		Should(BeTrue(), "an edit that keeps the annotation must enqueue a reconcile")
+	g.Expect(pred.Create(event.CreateEvent{Object: shipped})).Should(BeTrue(), "create event")
+	g.Expect(pred.Delete(event.DeleteEvent{Object: shipped})).Should(BeTrue(), "delete event")
+
+	g.Expect(pred.Create(event.CreateEvent{Object: elsewhere})).
+		Should(BeFalse(), "a copy outside the applications namespace must not enqueue a reconcile")
+	g.Expect(pred.Delete(event.DeleteEvent{Object: elsewhere})).
+		Should(BeFalse(), "deleting a copy elsewhere must not enqueue a reconcile")
+}
+
+// A watch with no filter registers no predicate at all, so it sees every event
+// for its kind.
+func TestDynamicWatchPredicates_NoFilterRegistersNone(t *testing.T) {
+	NewWithT(t).Expect((&dynamicWatch{}).predicates()).Should(BeNil())
+}
+
+func TestDynamicWatchPredicates_FilterRegistersOne(t *testing.T) {
+	dw := &dynamicWatch{filterFn: presetWatchFilter("opendatahub")}
+	NewWithT(t).Expect(dw.predicates()).Should(HaveLen(1))
+}

--- a/kserve-module/pkg/kservemodule/versioning.go
+++ b/kserve-module/pkg/kservemodule/versioning.go
@@ -7,21 +7,20 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // isWellKnownConfig reports whether the object is an LLMInferenceServiceConfig
 // preset shipped by this module, as opposed to one authored by a user.
-func isWellKnownConfig(obj *unstructured.Unstructured) bool {
-	if obj.GroupVersionKind().GroupKind() != llmISVCConfigGVK.GroupKind() {
+//
+// Takes client.Object rather than *unstructured.Unstructured so watch
+// predicates need no type assertion: a wrong concrete type would otherwise be
+// dropped silently, which disables a watch rather than skipping one event.
+func isWellKnownConfig(obj client.Object) bool {
+	if obj.GetObjectKind().GroupVersionKind().GroupKind() != llmISVCConfigGVK.GroupKind() {
 		return false
 	}
 	return obj.GetAnnotations()[wellKnownAnnotationKey] == wellKnownAnnotationValue
-}
-
-// isShippedPreset reports whether the object is a preset this module applies,
-// as opposed to a copy a user made in their own namespace.
-func isShippedPreset(obj *unstructured.Unstructured, applicationsNS string) bool {
-	return obj.GetNamespace() == applicationsNS && isWellKnownConfig(obj)
 }
 
 // wellKnownPresetNames returns the names of the presets in a rendered resource

--- a/kserve-module/pkg/kservemodule/versioning_test.go
+++ b/kserve-module/pkg/kservemodule/versioning_test.go
@@ -35,48 +35,6 @@ func buildLLMISVCDeployment(t *testing.T) []unstructured.Unstructured {
 	return []unstructured.Unstructured{{Object: u}}
 }
 
-// The preset watch filters on this, so a false here means a deleted preset is
-// never recreated, and a false positive means user copies drive reconciles.
-func TestIsShippedPreset(t *testing.T) {
-	preset := func(namespace string, annotations map[string]any) *unstructured.Unstructured {
-		metadata := map[string]any{"name": "v1-2-3-kserve-config-llm-decode", "namespace": namespace}
-		if annotations != nil {
-			metadata["annotations"] = annotations
-		}
-		return &unstructured.Unstructured{Object: map[string]any{
-			"apiVersion": "serving.kserve.io/v1alpha2",
-			"kind":       "LLMInferenceServiceConfig",
-			"metadata":   metadata,
-		}}
-	}
-	wellKnown := map[string]any{wellKnownAnnotationKey: wellKnownAnnotationValue}
-
-	testCases := map[string]struct {
-		obj      *unstructured.Unstructured
-		expected bool
-	}{
-		"shipped preset":                            {obj: preset("opendatahub", wellKnown), expected: true},
-		"user copy in another namespace":            {obj: preset("user-models", wellKnown), expected: false},
-		"user config in the applications namespace": {obj: preset("opendatahub", nil), expected: false},
-		"other kind carrying the annotation": {
-			obj: &unstructured.Unstructured{Object: map[string]any{
-				"apiVersion": "v1",
-				"kind":       "ConfigMap",
-				"metadata": map[string]any{
-					"name": "not-a-preset", "namespace": "opendatahub", "annotations": wellKnown,
-				},
-			}},
-			expected: false,
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			NewWithT(t).Expect(isShippedPreset(tc.obj, "opendatahub")).Should(Equal(tc.expected))
-		})
-	}
-}
-
 func TestWellKnownPresetNames_SkipsUserConfigsAndOtherKinds(t *testing.T) {
 	g := NewWithT(t)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-up to #1872, which added a watch so a deleted `LLMInferenceServiceConfig` preset gets reapplied. T

Watch predicates built with `NewPredicateFuncs` evaluate updates against the new object only. A shipped preset is identified by its namespace plus the well-known annotation, so stripping that annotation makes the new object stop matching and the event is dropped before it ever reaches the reconciler. The preset stays as the user left it, and Kserve keeps reporting ready over it - the same class of silent drift #1872 set out to close, reached by editing rather than deleting.

Updates now pass when either side of the change matches, so an object leaving the shipped set is as visible as one joining it.

**Which issue(s) this PR fixes**:


**Feature/Issue validation/testing**:

- [x] Unit tests covering annotation removal and addition, in-place edits, untouched user configs, and copies in other namespaces
- [x] Full kserve-module suite green: `make test-kserve-module` - unit tests plus 25/25 envtest specs

**Special notes for your reviewer**:

Addresses https://github.com/opendatahub-io/kserve/pull/1872#discussion_r3774984440

One thing deliberately left out: both the watch and the preset presence check go through unstructured, so the cluster-scoped cache holds every `LLMInferenceServiceConfig` in every namespace in full - user-authored ones included - to answer a question about names.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event monitoring so configuration changes—including removed or changed preset annotations—reliably trigger reconciliation.
  * Improved handling of configuration updates across supported object types and namespaces.
  * Added configurable reconciliation timing for dependency failures and components that are not yet ready.

* **Tests**
  * Expanded coverage for dynamic watch registration, event filtering, preset updates, and reconciliation behavior.
  * Improved test reliability by reducing unnecessary periodic reconciliation during test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->