### PR TITLE
refactor(kserve-module): move operand image overrides into setup-cluster.sh

### DIFF
--- a/kserve-module/tests/e2e/conftest.py
+++ b/kserve-module/tests/e2e/conftest.py
@@ -15,6 +15,7 @@ import yaml
 KSERVE_CR_NAME = "default-kserve"
 NAMESPACE = "opendatahub"
 OPERATOR_DEPLOYMENT = "kserve-module-controller-manager"
+TIMEOUT_300S = 300  # cold-start: first Kserve CR ready waits on operand image pulls
 TIMEOUT_120S = 120
 TIMEOUT_60S = 60
 
@@ -174,8 +175,8 @@ def create_kserve_cr(kubectl_bin, cr_dict=None):
             kubectl_bin,
             KSERVE_CR_NAME,
             is_cr_ready,
-            TIMEOUT_120S,
-            f"Kserve CR {KSERVE_CR_NAME} not ready within {TIMEOUT_120S}s",
+            TIMEOUT_300S,
+            f"Kserve CR {KSERVE_CR_NAME} not ready within {TIMEOUT_300S}s",
         )
     cr = yaml.safe_dump(cr_dict or KSERVE_CR_TEMPLATE)
     run([kubectl_bin, "create", "-f", "-"], input_text=cr)
@@ -183,8 +184,8 @@ def create_kserve_cr(kubectl_bin, cr_dict=None):
         kubectl_bin,
         KSERVE_CR_NAME,
         is_cr_ready,
-        TIMEOUT_120S,
-        f"Kserve CR {KSERVE_CR_NAME} not ready within {TIMEOUT_120S}s",
+        TIMEOUT_300S,
+        f"Kserve CR {KSERVE_CR_NAME} not ready within {TIMEOUT_300S}s",
     )
 
 

--- a/kserve-module/tests/scripts/setup-cluster.sh
+++ b/kserve-module/tests/scripts/setup-cluster.sh
@@ -111,6 +111,12 @@ Options:
                                 (or set SKIP_KM_DEPLOY=true)
   -h, --help                    Show this help
 
+Environment variables:
+  KSERVE_CONTROLLER_IMAGE, LLMISVC_CONTROLLER_IMAGE, KSERVE_AGENT_IMAGE,
+  KSERVE_ROUTER_IMAGE, STORAGE_INITIALIZER_IMAGE
+                                Override operand images (injected as RELATED_IMAGE_*
+                                on the kserve-module-controller-manager deployment)
+
 Examples:
   # Install on XKS cluster
   $(basename "$0") --platform xks
@@ -357,9 +363,30 @@ deploy_kserve_module() {
 
   echo "$output" | ${KUBECTL} apply --server-side=true --force-conflicts -f -
 
+  # Override operand images on kserve-module controller via RELATED_IMAGE_* env vars
+  _env_overrides=()
+  [[ -n "${KSERVE_CONTROLLER_IMAGE:-}" ]] && \
+    _env_overrides+=("RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE=${KSERVE_CONTROLLER_IMAGE}")
+  [[ -n "${LLMISVC_CONTROLLER_IMAGE:-}" ]] && \
+    _env_overrides+=("RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE=${LLMISVC_CONTROLLER_IMAGE}")
+  [[ -n "${KSERVE_AGENT_IMAGE:-}" ]] && \
+    _env_overrides+=("RELATED_IMAGE_ODH_KSERVE_AGENT_IMAGE=${KSERVE_AGENT_IMAGE}")
+  [[ -n "${KSERVE_ROUTER_IMAGE:-}" ]] && \
+    _env_overrides+=("RELATED_IMAGE_ODH_KSERVE_ROUTER_IMAGE=${KSERVE_ROUTER_IMAGE}")
+  [[ -n "${STORAGE_INITIALIZER_IMAGE:-}" ]] && \
+    _env_overrides+=("RELATED_IMAGE_ODH_KSERVE_STORAGE_INITIALIZER_IMAGE=${STORAGE_INITIALIZER_IMAGE}")
+
+  _env_overrides+=("APPLICATIONS_NAMESPACE=${KSERVE_NAMESPACE}")
+
+  log_info "Overriding operand images on kserve-module-controller-manager..."
   log_info "Waiting for controller rollout..."
+  ${KUBECTL} set env deployment/kserve-module-controller-manager \
+    "${_env_overrides[@]}" \
+    -n "${KSERVE_NAMESPACE}"
   ${KUBECTL} rollout status deployment/kserve-module-controller-manager \
     -n "${KSERVE_NAMESPACE}" --timeout=300s
+
+
   log_success "kserve-module deployed"
 }
 

--- a/test/scripts/openshift-ci/setup-kserve.sh
+++ b/test/scripts/openshift-ci/setup-kserve.sh
@@ -142,31 +142,7 @@ case "${OPERATOR_TYPE}" in
         --platform ocp \
         --skip-deps \
         --image "${KSERVE_MODULE_CONTROLLER_IMAGE}"
-
-      # Override operand images on kserve-module controller via RELATED_IMAGE_* env vars
-      _env_overrides=()
-      [[ -n "${KSERVE_CONTROLLER_IMAGE:-}" ]] && \
-        _env_overrides+=("RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE=${KSERVE_CONTROLLER_IMAGE}")
-      [[ -n "${LLMISVC_CONTROLLER_IMAGE:-}" ]] && \
-        _env_overrides+=("RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE=${LLMISVC_CONTROLLER_IMAGE}")
-      [[ -n "${KSERVE_AGENT_IMAGE:-}" ]] && \
-        _env_overrides+=("RELATED_IMAGE_ODH_KSERVE_AGENT_IMAGE=${KSERVE_AGENT_IMAGE}")
-      [[ -n "${KSERVE_ROUTER_IMAGE:-}" ]] && \
-        _env_overrides+=("RELATED_IMAGE_ODH_KSERVE_ROUTER_IMAGE=${KSERVE_ROUTER_IMAGE}")
-      [[ -n "${STORAGE_INITIALIZER_IMAGE:-}" ]] && \
-        _env_overrides+=("RELATED_IMAGE_ODH_KSERVE_STORAGE_INITIALIZER_IMAGE=${STORAGE_INITIALIZER_IMAGE}")
-
-      _env_overrides+=("APPLICATIONS_NAMESPACE=${KSERVE_NAMESPACE}")
-
-      if [[ ${#_env_overrides[@]} -gt 0 ]]; then
-        echo "Overriding operand images on kserve-module-controller-manager..."
-        oc set env deployment/kserve-module-controller-manager \
-          "${_env_overrides[@]}" \
-          -n "${KSERVE_NAMESPACE}"
-        oc rollout status deployment/kserve-module-controller-manager \
-          -n "${KSERVE_NAMESPACE}" --timeout=120s
-      fi
-
+      
       # Create Kserve CR to trigger reconciliation (deploys operands + ConfigMap)
       echo "Creating Kserve CR..."
       oc apply -f - <<'KSERVE_CR'


### PR DESCRIPTION
**What this PR does / why we need it**:
Relocate the RELATED_IMAGE_* operand image override block from the openshift-ci setup-kserve.sh into deploy_kserve_module in the shared setup-cluster.sh, so both XKS and OCP paths pick it up. Use ${KUBECTL} instead of hardcoded oc for XKS compatibility, and document the env vars in --help.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added help text for configuring controller operand images.
  - Deployment setup now supports optional controller image overrides.
  - The application namespace is configured automatically during deployment.

- **Bug Fixes**
  - Improved reliability for initial KServe resource readiness checks by allowing additional time for cold starts and image pulls.
  - Simplified cluster setup by proceeding directly to KServe resource creation after setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->