### PR TITLE
chore: add more make target for kserve module test

### DIFF
--- a/Makefile.kserve-module.mk
+++ b/Makefile.kserve-module.mk
@@ -5,7 +5,8 @@ E2E_IMG ?=
 .PHONY: docker-build-kserve-module docker-push-kserve-module deploy-kserve-module \
 	kustomize-build-kserve-module generate-kserve-module manifests-kserve-module \
 	test-kserve-module setup-envtest-kserve-module precommit-km \
-	e2e-setup-kserve-module e2e-cleanup-kserve-module e2e-kserve-module check-km
+	e2e-setup-kserve-module e2e-cleanup-kserve-module e2e-kserve-module check-km kind-create kind-delete \
+	kind-dev-kserve-module kind-reinstall
 
 
 docker-build-kserve-module:
@@ -72,3 +73,22 @@ check-km: precommit-km
 		echo "Fix: make precommit-km && git add kserve-module/ && git commit --amend"; \
 		exit 1; \
 	fi
+
+kind-create:
+	hack/setup/dev/manage.kind-with-registry.sh
+
+kind-delete:
+	hack/setup/dev/manage.kind-with-registry.sh --uninstall
+
+kind-reinstall:
+	hack/setup/dev/manage.kind-with-registry.sh --reinstall
+
+kind-dev-kserve-module:
+	@set -eo pipefail; \
+	KO_DOCKER_REPO=localhost:5001; \
+	TAG=$${TAG:-dev-$$RANDOM$$RANDOM}; \
+	echo "Building and deploying kserve-module with TAG=$$TAG"; \
+	$(MAKE) docker-build-kserve-module docker-push-kserve-module \
+		KO_DOCKER_REPO=$$KO_DOCKER_REPO ENGINE=$(ENGINE) TAG=$$TAG; \
+	$(MAKE) e2e-setup-kserve-module \
+		E2E_IMG=$$KO_DOCKER_REPO/$(KSERVE_MODULE_IMG):$$TAG PLATFORM=$(PLATFORM)

--- a/kserve-module/docs/prerequisite/setup.cluster.md
+++ b/kserve-module/docs/prerequisite/setup.cluster.md
@@ -10,7 +10,22 @@ Prepares a cluster for E2E testing by deploying the KServe manifests and the KSe
 * Create KIND Cluster:
 ```bash
 ./hack/setup/dev/manage.kind-with-registry.sh
+
+or
+
+make kind-create
 ```
+
+
+* Rmoeve KIND Cluster:
+```bash
+./hack/setup/dev/manage.kind-with-registry.sh --uninstall
+
+or
+
+make kind-uninstall
+```
+
 
 * Build the operator image and push it to a registry the cluster can pull from,
   then pass it via `E2E_IMG`. Keep the default `KSERVE_NAMESPACE=opendatahub` —
@@ -32,6 +47,10 @@ export KO_DOCKER_REPO=localhost:5001 TAG=dev ENGINE=docker
 make docker-build-kserve-module
 make docker-push-kserve-module
 E2E_IMG=${KO_DOCKER_REPO}/kserve-module-controller:${TAG} make e2e-setup-kserve-module
+
+or 
+
+make kind-dev-kserve-module
 ```
 
 ## All-in-One


### PR DESCRIPTION
**What this PR does / why we need it**:
Added useful commands to test kserve-module opeator on kind

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added commands to create, delete, and reinstall local KIND clusters.
  - Added a development workflow that builds, publishes, and deploys the KServe module for end-to-end testing.
- **Documentation**
  - Updated cluster setup guidance with KIND-based alternatives.
  - Added instructions for uninstalling KIND and deploying the KServe module through the new development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->