### PR TITLE
fix(ci): allow UBI9 sqlite-libs upgrade in Python runtime Dockerfiles

### DIFF
--- a/python/custom_model_grpc.Dockerfile
+++ b/python/custom_model_grpc.Dockerfile
@@ -5,7 +5,7 @@ FROM ${BASE_IMAGE} AS builder
 WORKDIR /
 USER 0
 
-RUN dnf install -y gcc gcc-c++ make python3.11-devel && dnf clean all
+RUN dnf install -y --allowerasing gcc gcc-c++ make python3.11-devel && dnf clean all
 
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \

--- a/python/custom_transformer.Dockerfile
+++ b/python/custom_transformer.Dockerfile
@@ -5,7 +5,7 @@ FROM ${BASE_IMAGE} AS builder
 WORKDIR /
 USER 0
 
-RUN dnf install -y gcc gcc-c++ make python3.11-devel && dnf clean all
+RUN dnf install -y --allowerasing gcc gcc-c++ make python3.11-devel && dnf clean all
 
 # Install uv and ensure it's in PATH
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \

--- a/python/error_404_isvc.Dockerfile
+++ b/python/error_404_isvc.Dockerfile
@@ -5,7 +5,7 @@ FROM ${BASE_IMAGE} AS builder
 WORKDIR /
 USER 0
 
-RUN dnf install -y gcc python3.11-devel && dnf clean all
+RUN dnf install -y --allowerasing gcc python3.11-devel && dnf clean all
 
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \

--- a/python/predictiveserver.Dockerfile
+++ b/python/predictiveserver.Dockerfile
@@ -8,7 +8,7 @@ FROM ${BASE_IMAGE} AS builder
 USER 0
 
 # Install system dependencies
-RUN dnf install -y python3.11-devel gcc gcc-c++ make && \
+RUN dnf install -y --allowerasing python3.11-devel gcc gcc-c++ make && \
     dnf clean all
 
 # Install uv

--- a/python/sklearn.Dockerfile
+++ b/python/sklearn.Dockerfile
@@ -5,7 +5,7 @@ FROM ${BASE_IMAGE} AS builder
 WORKDIR /
 USER 0
 
-RUN dnf install -y gcc gcc-c++ make python3.11-devel && dnf clean all
+RUN dnf install -y --allowerasing gcc gcc-c++ make python3.11-devel && dnf clean all
 
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \

--- a/python/success_200_isvc.Dockerfile
+++ b/python/success_200_isvc.Dockerfile
@@ -5,7 +5,7 @@ FROM ${BASE_IMAGE} AS builder
 WORKDIR /
 USER 0
 
-RUN dnf install -y gcc python3.11-devel && dnf clean all
+RUN dnf install -y --allowerasing gcc python3.11-devel && dnf clean all
 
 # Install uv
 RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \


### PR DESCRIPTION
## Summary

- Add `--allowerasing` to `dnf install` in six UBI9 Python runtime Dockerfiles
- Unblocks image builds when AppStream ships `el9_8` `python3.11-devel` while `ubi9/python-311:9.7` still has `el9_7` `sqlite-libs`

## Problem

`ci/prow/images` and GHA `predictor-runtime-build` fail with:

```
Problem: sqlite-libs-3.34.1-11.el9_8.i686 does not belong to a distupgrade repository
```

Affected images: `sklearn-serving-runtime`, `custom-transformer`, `custom-model-grpc`, `error-404-isvc`, `success-200-isvc`.

## Test plan

- [ ] `ci/prow/images` green
- [ ] GHA `predictor-runtime-build` green
- [ ] Local repro: `podman run --user 0 registry.access.redhat.com/ubi9/python-311:9.7 bash -c 'dnf install -y --allowerasing gcc gcc-c++ make python3.11-devel'`

Extracted from sync work on #1905; targets `master` so release sync PR stays a pure merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container build reliability by allowing compatible package replacements during dependency installation.
  * Applied the build improvement across Python model serving and inference images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->