### PR TITLE
[WIP] feat(llmisvc): optimize versioned LLMISVCConfig preset lifecycle

### DIFF
--- a/config/overlays/odh/accelerators/amd-rocm-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/amd-rocm-config-llm-template.yaml
@@ -6,6 +6,7 @@ metadata:
     openshift.io/display-name: vLLM AMD ROCm GPU LLMInferenceServiceConfig
     openshift.io/description: vLLM AMD ROCm GPU LLMInferenceServiceConfig for LLMInferenceService.
     opendatahub.io/recommended-accelerators: '["amd.com/gpu"]'
+    opendatahub.io/recommended-dra-drivers: '["gpu.amd.com"]'
     opendatahub.io/runtime-version: ""
     # supported-topologies values must be consistent with the samples API and Dashboard usage.
     # See https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/samples/llm-d/llm-d-ui-flow-mechanics.md

--- a/config/overlays/odh/accelerators/ibm-spyre-ppc64le-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/ibm-spyre-ppc64le-config-llm-template.yaml
@@ -6,6 +6,7 @@ metadata:
     openshift.io/display-name: vLLM IBM Spyre ppc64le LLMInferenceServiceConfig
     openshift.io/description: vLLM IBM Spyre ppc64le LLMInferenceServiceConfig for LLMInferenceService.
     opendatahub.io/recommended-accelerators: '["ibm.com/spyre_pf"]'
+    opendatahub.io/recommended-dra-drivers: '["spyre.ibm.com"]'
     opendatahub.io/runtime-version: ""
     # supported-topologies values must be consistent with the samples API and Dashboard usage.
     # See https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/samples/llm-d/llm-d-ui-flow-mechanics.md

--- a/config/overlays/odh/accelerators/ibm-spyre-s390x-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/ibm-spyre-s390x-config-llm-template.yaml
@@ -6,6 +6,7 @@ metadata:
     openshift.io/display-name: vLLM IBM Spyre s390x LLMInferenceServiceConfig
     openshift.io/description: vLLM IBM Spyre s390x LLMInferenceServiceConfig for LLMInferenceService.
     opendatahub.io/recommended-accelerators: '["ibm.com/spyre_vf"]'
+    opendatahub.io/recommended-dra-drivers: '["spyre.ibm.com"]'
     opendatahub.io/runtime-version: ""
     # supported-topologies values must be consistent with the samples API and Dashboard usage.
     # See https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/samples/llm-d/llm-d-ui-flow-mechanics.md

--- a/config/overlays/odh/accelerators/ibm-spyre-x86-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/ibm-spyre-x86-config-llm-template.yaml
@@ -6,6 +6,7 @@ metadata:
     openshift.io/display-name: vLLM IBM Spyre x86 LLMInferenceServiceConfig
     openshift.io/description: vLLM IBM Spyre x86 LLMInferenceServiceConfig for LLMInferenceService.
     opendatahub.io/recommended-accelerators: '["ibm.com/spyre_pf"]'
+    opendatahub.io/recommended-dra-drivers: '["spyre.ibm.com"]'
     opendatahub.io/runtime-version: ""
     # supported-topologies values must be consistent with the samples API and Dashboard usage.
     # See https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/samples/llm-d/llm-d-ui-flow-mechanics.md

--- a/config/overlays/odh/accelerators/intel-gaudi-config-llm-template.yaml
+++ b/config/overlays/odh/accelerators/intel-gaudi-config-llm-template.yaml
@@ -6,6 +6,7 @@ metadata:
     openshift.io/display-name: vLLM Intel Gaudi LLMInferenceServiceConfig
     openshift.io/description: vLLM Intel Gaudi LLMInferenceServiceConfig for LLMInferenceService.
     opendatahub.io/recommended-accelerators: '["habana.ai/gaudi"]'
+    opendatahub.io/recommended-dra-drivers: '["gaudi.intel.com"]'
     opendatahub.io/runtime-version: ""
     # supported-topologies values must be consistent with the samples API and Dashboard usage.
     # See https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/samples/llm-d/llm-d-ui-flow-mechanics.md

--- a/config/overlays/odh/accelerators/nvidia-cuda-config-llm-multi-node-pd-template.yaml
+++ b/config/overlays/odh/accelerators/nvidia-cuda-config-llm-multi-node-pd-template.yaml
@@ -6,6 +6,7 @@ metadata:
     openshift.io/display-name: vLLM NVIDIA CUDA GPU LLMInferenceServiceConfig (Prefill/Decode)
     openshift.io/description: vLLM NVIDIA CUDA GPU LLMInferenceServiceConfig (Prefill/Decode) for LLMInferenceService.
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+    opendatahub.io/recommended-dra-drivers: '["gpu.nvidia.com"]'
     opendatahub.io/runtime-version: ""
     # supported-topologies values must be consistent with the samples API and Dashboard usage.
     # See https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/samples/llm-d/llm-d-ui-flow-mechanics.md

--- a/config/overlays/odh/accelerators/nvidia-cuda-config-llm-multi-node-template.yaml
+++ b/config/overlays/odh/accelerators/nvidia-cuda-config-llm-multi-node-template.yaml
@@ -6,6 +6,7 @@ metadata:
     openshift.io/display-name: vLLM NVIDIA CUDA GPU LLMInferenceServiceConfig Multi Node
     openshift.io/description: vLLM NVIDIA CUDA GPU LLMInferenceServiceConfig Multi Node for LLMInferenceService.
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+    opendatahub.io/recommended-dra-drivers: '["gpu.nvidia.com"]'
     opendatahub.io/runtime-version: ""
     # supported-topologies values must be consistent with the samples API and Dashboard usage.
     # See https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/samples/llm-d/llm-d-ui-flow-mechanics.md

--- a/config/overlays/odh/accelerators/nvidia-cuda-config-llm-single-node-pd-template.yaml
+++ b/config/overlays/odh/accelerators/nvidia-cuda-config-llm-single-node-pd-template.yaml
@@ -6,6 +6,7 @@ metadata:
     openshift.io/display-name: vLLM NVIDIA CUDA GPU LLMInferenceServiceConfig Single Node P/D (Prefill/Decode)
     openshift.io/description: vLLM NVIDIA CUDA GPU LLMInferenceServiceConfig Single Node P/D (Prefill/Decode) for LLMInferenceService.
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+    opendatahub.io/recommended-dra-drivers: '["gpu.nvidia.com"]'
     opendatahub.io/runtime-version: ""
     # supported-topologies values must be consistent with the samples API and Dashboard usage.
     # See https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/samples/llm-d/llm-d-ui-flow-mechanics.md

--- a/config/overlays/odh/accelerators/nvidia-cuda-config-llm-single-node-template.yaml
+++ b/config/overlays/odh/accelerators/nvidia-cuda-config-llm-single-node-template.yaml
@@ -6,6 +6,7 @@ metadata:
     openshift.io/display-name: vLLM NVIDIA CUDA GPU LLMInferenceServiceConfig Single Node
     openshift.io/description: vLLM NVIDIA CUDA GPU LLMInferenceServiceConfig Single Node for LLMInferenceService.
     opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+    opendatahub.io/recommended-dra-drivers: '["gpu.nvidia.com"]'
     opendatahub.io/runtime-version: ""
     # supported-topologies values must be consistent with the samples API and Dashboard usage.
     # See https://github.com/opendatahub-io/odh-model-controller/blob/incubating/server/docs/features/samples/llm-d/llm-d-ui-flow-mechanics.md

--- a/kserve-module/config/crd/components.platform.opendatahub.io_kserves.yaml
+++ b/kserve-module/config/crd/components.platform.opendatahub.io_kserves.yaml
@@ -56,6 +56,14 @@ spec:
                 - Managed
                 - Removed
                 type: string
+              enableHardwareAwarePresets:
+                description: |-
+                  Enables hardware-aware creation of accelerator LLMInferenceServiceConfig presets:
+                  presets for an accelerator are only created when a matching resource is present in
+                  some node's status.allocatable (vendor-domain matching also covers MIG devices).
+                  Enabled by default. Set to false on clusters using accelerator resource names that
+                  do not share a vendor domain, so that all presets are always created.
+                type: boolean
               enableLLMInferenceServiceConsoleDashboards:
                 description: |-
                   Enables OpenShift Developer Console dashboards for LLMInferenceService.

--- a/kserve-module/config/rbac/role.yaml
+++ b/kserve-module/config/rbac/role.yaml
@@ -330,6 +330,14 @@ rules:
   - bind
   - escalate
 - apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - security.openshift.io
   resources:
   - securitycontextconstraints

--- a/kserve-module/pkg/apis/v1alpha1/types.go
+++ b/kserve-module/pkg/apis/v1alpha1/types.go
@@ -71,6 +71,13 @@ type KserveSpec struct {
 	// Enabled by default.
 	EnableLLMInferenceServiceConsoleDashboards *bool `json:"enableLLMInferenceServiceConsoleDashboards,omitempty"`
 
+	// Enables hardware-aware creation of accelerator LLMInferenceServiceConfig presets:
+	// presets for an accelerator are only created when a matching resource is present in
+	// some node's status.allocatable (vendor-domain matching also covers MIG devices).
+	// Enabled by default. Set to false on clusters using accelerator resource names that
+	// do not share a vendor domain, so that all presets are always created.
+	EnableHardwareAwarePresets *bool `json:"enableHardwareAwarePresets,omitempty"`
+
 	// AuditLogging controls inference request audit logging.
 	// Managed writes openshiftConfig.enableAuditLogging=true on inferenceservice-config.
 	// Removed writes openshiftConfig.enableAuditLogging=false.

--- a/kserve-module/pkg/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/kserve-module/pkg/apis/v1alpha1/zz_generated.deepcopy.go
@@ -90,6 +90,11 @@ func (in *KserveSpec) DeepCopyInto(out *KserveSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableHardwareAwarePresets != nil {
+		in, out := &in.EnableHardwareAwarePresets, &out.EnableHardwareAwarePresets
+		*out = new(bool)
+		**out = **in
+	}
 	if in.ModelCache != nil {
 		in, out := &in.ModelCache, &out.ModelCache
 		*out = new(ModelCacheSpec)

--- a/kserve-module/pkg/kservemodule/components.go
+++ b/kserve-module/pkg/kservemodule/components.go
@@ -109,6 +109,14 @@ func kservePostRender(ctx context.Context, r *KserveModuleReconciler,
 		return nil, fmt.Errorf("versioning LLMInferenceServiceConfigs: %w", err)
 	}
 
+	// Optimize versioned accelerator preset lifecycle. Skipped during cleanup renders
+	// (kserve == nil), which must see the full set to delete it. Hardware filtering runs
+	// first so differential versioning never compares presets already excluded.
+	if kserve != nil {
+		resources = r.filterHardwareUnavailablePresets(ctx, kserve, resources)
+		resources = r.dedupeVersionedAcceleratorPresets(ctx, resources)
+	}
+
 	return resources, nil
 }
 

--- a/kserve-module/pkg/kservemodule/constants.go
+++ b/kserve-module/pkg/kservemodule/constants.go
@@ -26,13 +26,13 @@ const (
 	ConsoleDashboardsComponentName  = "console-dashboards"
 
 	// Manifest source paths
-	KserveManifestSourcePath        = "overlays/odh"
-	KserveManifestSourcePathXKS     = "overlays/odh-xks"
-	KserveCRDManifestSourcePath     = "overlays/odh-crds"
-	ModelCacheManifestSourcePath    = "overlays/odh-modelcache"
-	ModelControllerSourcePath       = "overlays/odh"
-	WVAManifestSourcePathOCP        = "overlays/namespace-scoped/openshift"
-	ObservabilityManifestSourcePath      = "monitoring/llmisvc/dashboards"
+	KserveManifestSourcePath            = "overlays/odh"
+	KserveManifestSourcePathXKS         = "overlays/odh-xks"
+	KserveCRDManifestSourcePath         = "overlays/odh-crds"
+	ModelCacheManifestSourcePath        = "overlays/odh-modelcache"
+	ModelControllerSourcePath           = "overlays/odh"
+	WVAManifestSourcePathOCP            = "overlays/namespace-scoped/openshift"
+	ObservabilityManifestSourcePath     = "monitoring/llmisvc/dashboards"
 	ConsoleDashboardsManifestSourcePath = "monitoring/llmisvc/dashboards-odc"
 
 	// Deployment names
@@ -69,16 +69,26 @@ const (
 	// filtering to know which allocatable resource a preset needs.
 	recommendedAcceleratorsAnnotationKey = "opendatahub.io/recommended-accelerators"
 
+	// recommendedDRADriversAnnotationKey holds a JSON array of the Dynamic Resource
+	// Allocation driver names a preset targets, e.g. '["gpu.nvidia.com"]'. It is an optional,
+	// additive escape hatch for vendors whose DRA driver name does not share the vendor domain
+	// of their recommended-accelerators resource name (so the domain bridge in acceleratorPresent
+	// would miss them). A preset is kept when its recommended-accelerators OR its
+	// recommended-dra-drivers are satisfied; drivers here are matched exactly against the drivers
+	// publishing ResourceSlices. Presets whose driver already shares the vendor domain need not
+	// set it.
+	recommendedDRADriversAnnotationKey = "opendatahub.io/recommended-dra-drivers"
+
 	// configTypeLabelKey / configTypeAcceleratorValue mark a preset as accelerator-specific.
 	// The accelerator overlays stamp this label via kustomize commonLabels; generic llm-d
 	// templates do not carry it. It is the canonical identity signal for hardware-aware and
 	// differential handling (see isAcceleratorPreset).
 	configTypeLabelKey         = "opendatahub.io/config-type"
 	configTypeAcceleratorValue = "accelerator"
-	llmISVCConfigPrefixEnv   = "LLM_INFERENCE_SERVICE_CONFIG_PREFIX"
-	llmISVCConfigGroup       = "serving.kserve.io"
-	llmISVCConfigVersion     = "v1alpha2"
-	llmISVCConfigKind        = "LLMInferenceServiceConfig"
+	llmISVCConfigPrefixEnv     = "LLM_INFERENCE_SERVICE_CONFIG_PREFIX"
+	llmISVCConfigGroup         = "serving.kserve.io"
+	llmISVCConfigVersion       = "v1alpha2"
+	llmISVCConfigKind          = "LLMInferenceServiceConfig"
 
 	// Template (ServingRuntime) resource type
 	templateGroup = "template.openshift.io"

--- a/kserve-module/pkg/kservemodule/constants.go
+++ b/kserve-module/pkg/kservemodule/constants.go
@@ -63,6 +63,18 @@ const (
 	// LLMInferenceServiceConfig versioning
 	wellKnownAnnotationKey   = "serving.kserve.io/well-known-config"
 	wellKnownAnnotationValue = "true"
+
+	// recommendedAcceleratorsAnnotationKey holds a JSON array of the accelerator
+	// resource names a preset targets, e.g. '["nvidia.com/gpu"]'. Used by hardware-aware
+	// filtering to know which allocatable resource a preset needs.
+	recommendedAcceleratorsAnnotationKey = "opendatahub.io/recommended-accelerators"
+
+	// configTypeLabelKey / configTypeAcceleratorValue mark a preset as accelerator-specific.
+	// The accelerator overlays stamp this label via kustomize commonLabels; generic llm-d
+	// templates do not carry it. It is the canonical identity signal for hardware-aware and
+	// differential handling (see isAcceleratorPreset).
+	configTypeLabelKey         = "opendatahub.io/config-type"
+	configTypeAcceleratorValue = "accelerator"
 	llmISVCConfigPrefixEnv   = "LLM_INFERENCE_SERVICE_CONFIG_PREFIX"
 	llmISVCConfigGroup       = "serving.kserve.io"
 	llmISVCConfigVersion     = "v1alpha2"

--- a/kserve-module/pkg/kservemodule/differential_versioning.go
+++ b/kserve-module/pkg/kservemodule/differential_versioning.go
@@ -1,0 +1,143 @@
+package kservemodule
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	odhLabels "github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
+)
+
+// presetContentFingerprint returns a stable hash of the meaningful content of an
+// LLMInferenceServiceConfig preset: its labels, annotations, and spec. The name and all
+// server-managed metadata are excluded, so two versions of the same preset that differ
+// only by version-prefixed name collide; a changed image (which lives in spec) does not.
+//
+// The operator-managed part-of label is excluded because it is constant across every
+// preset and, unlike the other fields, is applied only after this comparison runs
+// (commonPostRender), so including it would make a freshly rendered preset never match an
+// already-deployed one.
+func presetContentFingerprint(obj *unstructured.Unstructured) (string, error) {
+	labels := map[string]string{}
+	for k, v := range obj.GetLabels() {
+		if k == odhLabels.PlatformPartOf {
+			continue
+		}
+		labels[k] = v
+	}
+
+	spec, _, err := unstructured.NestedMap(obj.Object, "spec")
+	if err != nil {
+		return "", fmt.Errorf("reading spec of %s: %w", obj.GetName(), err)
+	}
+
+	payload := map[string]any{
+		"labels":      labels,
+		"annotations": obj.GetAnnotations(),
+		"spec":        spec,
+	}
+	// encoding/json sorts map keys, so the marshalled form is deterministic.
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshalling content of %s: %w", obj.GetName(), err)
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// dedupeVersionedAcceleratorPresets drops rendered accelerator presets whose content is
+// identical to an already-deployed preset carrying a different (prior-version) name. This
+// avoids piling up a fresh versioned copy on patch releases where an accelerator's config
+// and image are unchanged. Only accelerator presets (identified by isAcceleratorPreset) are
+// considered; generic templates and other resources pass through untouched.
+//
+// It fails open: if existing presets cannot be listed, all rendered presets are kept.
+func (r *KserveModuleReconciler) dedupeVersionedAcceleratorPresets(ctx context.Context,
+	resources []unstructured.Unstructured) []unstructured.Unstructured {
+
+	log := ctrl.LoggerFrom(ctx)
+
+	hasAccelPreset := false
+	for i := range resources {
+		if isAcceleratorPreset(&resources[i]) {
+			hasAccelPreset = true
+			break
+		}
+	}
+	if !hasAccelPreset {
+		return resources
+	}
+
+	ns := r.getApplicationsNamespace()
+	existing := &unstructured.UnstructuredList{}
+	existing.SetGroupVersionKind(llmISVCConfigListGVK)
+	if err := r.List(ctx, existing, client.InNamespace(ns)); err != nil {
+		log.Error(err, "differential versioning: failed to list existing presets, keeping all")
+		return resources
+	}
+
+	// fingerprint -> names of existing accelerator presets with that content.
+	existingByFingerprint := make(map[string]map[string]struct{})
+	for i := range existing.Items {
+		item := &existing.Items[i]
+		if item.GetNamespace() != ns || !isAcceleratorPreset(item) {
+			continue
+		}
+		fp, err := presetContentFingerprint(item)
+		if err != nil {
+			log.Error(err, "differential versioning: skipping unreadable existing preset", "name", item.GetName())
+			continue
+		}
+		if existingByFingerprint[fp] == nil {
+			existingByFingerprint[fp] = make(map[string]struct{})
+		}
+		existingByFingerprint[fp][item.GetName()] = struct{}{}
+	}
+
+	filtered := make([]unstructured.Unstructured, 0, len(resources))
+	var skipped []string
+	for i := range resources {
+		if !isAcceleratorPreset(&resources[i]) {
+			filtered = append(filtered, resources[i])
+			continue
+		}
+
+		fp, err := presetContentFingerprint(&resources[i])
+		if err != nil {
+			log.Error(err, "differential versioning: keeping preset with unreadable content", "name", resources[i].GetName())
+			filtered = append(filtered, resources[i])
+			continue
+		}
+
+		if hasContentTwinUnderDifferentName(existingByFingerprint[fp], resources[i].GetName()) {
+			skipped = append(skipped, resources[i].GetName())
+			continue
+		}
+		filtered = append(filtered, resources[i])
+	}
+
+	if len(skipped) > 0 {
+		log.Info("differential versioning: skipped creating presets identical to an existing prior version",
+			"count", len(skipped), "presets", skipped)
+	}
+	return filtered
+}
+
+// hasContentTwinUnderDifferentName reports whether the fingerprint bucket contains an
+// existing preset with a name other than the candidate's, i.e. a content-identical prior
+// version. A match on the same name only means the current version is already deployed and
+// should keep being reconciled, so it does not count.
+func hasContentTwinUnderDifferentName(names map[string]struct{}, candidate string) bool {
+	for name := range names {
+		if name != candidate {
+			return true
+		}
+	}
+	return false
+}

--- a/kserve-module/pkg/kservemodule/differential_versioning_test.go
+++ b/kserve-module/pkg/kservemodule/differential_versioning_test.go
@@ -1,0 +1,195 @@
+package kservemodule
+
+import (
+	"context"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/onsi/gomega"
+)
+
+// accelPresetSpec builds a well-known accelerator preset whose spec carries an image, so
+// content changes (image, labels, annotations) can be exercised by differential versioning.
+func accelPresetSpec(name, accelerator, image string) unstructured.Unstructured {
+	return unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "serving.kserve.io/v1alpha2",
+		"kind":       "LLMInferenceServiceConfig",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": "opendatahub",
+			"labels": map[string]any{
+				configTypeLabelKey: configTypeAcceleratorValue,
+			},
+			"annotations": map[string]any{
+				wellKnownAnnotationKey:               wellKnownAnnotationValue,
+				recommendedAcceleratorsAnnotationKey: `["` + accelerator + `"]`,
+			},
+		},
+		"spec": map[string]any{
+			"template": map[string]any{
+				"containers": []any{
+					map[string]any{"name": "main", "image": image},
+				},
+			},
+		},
+	}}
+}
+
+// accelPresetSpecNoLabel builds the same content as accelPresetSpec but WITHOUT the
+// config-type label, so it is not identified as an accelerator preset for dedup purposes.
+func accelPresetSpecNoLabel(name, accelerator, image string) unstructured.Unstructured {
+	obj := accelPresetSpec(name, accelerator, image)
+	unstructured.RemoveNestedField(obj.Object, "metadata", "labels")
+	return obj
+}
+
+func dedupeReconciler(existing ...unstructured.Unstructured) *KserveModuleReconciler {
+	s := runtime.NewScheme()
+	s.AddKnownTypeWithName(llmISVCConfigGVK, &unstructured.Unstructured{})
+	s.AddKnownTypeWithName(llmISVCConfigListGVK, &unstructured.UnstructuredList{})
+	objs := make([]client.Object, len(existing))
+	for i := range existing {
+		objs[i] = &existing[i]
+	}
+	cli := fake.NewClientBuilder().WithScheme(s).WithObjects(objs...).Build()
+	return &KserveModuleReconciler{Client: cli, applicationsNamespace: "opendatahub"}
+}
+
+func TestPresetContentFingerprint(t *testing.T) {
+	g := NewWithT(t)
+
+	a := accelPresetSpec("v1-nvidia", "nvidia.com/gpu", "img:1")
+	b := accelPresetSpec("v2-nvidia", "nvidia.com/gpu", "img:1")
+	c := accelPresetSpec("v2-nvidia", "nvidia.com/gpu", "img:2")
+
+	fpA, err := presetContentFingerprint(&a)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	fpB, err := presetContentFingerprint(&b)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	fpC, err := presetContentFingerprint(&c)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	// Same content, different name → same fingerprint.
+	g.Expect(fpA).Should(Equal(fpB))
+	// Different image → different fingerprint.
+	g.Expect(fpA).ShouldNot(Equal(fpC))
+}
+
+func TestPresetContentFingerprint_IgnoresPartOfLabel(t *testing.T) {
+	g := NewWithT(t)
+
+	rendered := accelPresetSpec("v2-nvidia", "nvidia.com/gpu", "img:1")
+	deployed := accelPresetSpec("v1-nvidia", "nvidia.com/gpu", "img:1")
+	// The deployed copy has the operator-managed part-of label applied post-render,
+	// on top of the config-type label both copies already carry.
+	labels := deployed.GetLabels()
+	labels["platform.opendatahub.io/part-of"] = "kserve"
+	deployed.SetLabels(labels)
+
+	fpRendered, err := presetContentFingerprint(&rendered)
+	g.Expect(err).ShouldNot(HaveOccurred())
+	fpDeployed, err := presetContentFingerprint(&deployed)
+	g.Expect(err).ShouldNot(HaveOccurred())
+
+	g.Expect(fpRendered).Should(Equal(fpDeployed))
+}
+
+func TestDedupeVersionedAcceleratorPresets(t *testing.T) {
+	tests := []struct {
+		name      string
+		existing  []unstructured.Unstructured
+		rendered  []unstructured.Unstructured
+		wantNames []string
+	}{
+		{
+			name:      "identical content under prior version is skipped",
+			existing:  []unstructured.Unstructured{accelPresetSpec("v1-nvidia", "nvidia.com/gpu", "img:1")},
+			rendered:  []unstructured.Unstructured{accelPresetSpec("v2-nvidia", "nvidia.com/gpu", "img:1")},
+			wantNames: nil,
+		},
+		{
+			name:      "changed image is kept",
+			existing:  []unstructured.Unstructured{accelPresetSpec("v1-nvidia", "nvidia.com/gpu", "img:1")},
+			rendered:  []unstructured.Unstructured{accelPresetSpec("v2-nvidia", "nvidia.com/gpu", "img:2")},
+			wantNames: []string{"v2-nvidia"},
+		},
+		{
+			name:      "no existing preset keeps rendered",
+			existing:  nil,
+			rendered:  []unstructured.Unstructured{accelPresetSpec("v2-nvidia", "nvidia.com/gpu", "img:1")},
+			wantNames: []string{"v2-nvidia"},
+		},
+		{
+			name:      "same-name current version is kept",
+			existing:  []unstructured.Unstructured{accelPresetSpec("v2-nvidia", "nvidia.com/gpu", "img:1")},
+			rendered:  []unstructured.Unstructured{accelPresetSpec("v2-nvidia", "nvidia.com/gpu", "img:1")},
+			wantNames: []string{"v2-nvidia"},
+		},
+		{
+			name:      "non-accelerator preset ignored",
+			existing:  []unstructured.Unstructured{accelPreset("kserve-config-llm-template")},
+			rendered:  []unstructured.Unstructured{accelPreset("kserve-config-llm-template")},
+			wantNames: []string{"kserve-config-llm-template"},
+		},
+		{
+			// Identical content but no config-type label: not an accelerator preset, so
+			// differential versioning leaves it alone (kept, not deduped).
+			name:      "annotation without config-type label kept",
+			existing:  []unstructured.Unstructured{accelPresetSpecNoLabel("v1-nvidia", "nvidia.com/gpu", "img:1")},
+			rendered:  []unstructured.Unstructured{accelPresetSpecNoLabel("v2-nvidia", "nvidia.com/gpu", "img:1")},
+			wantNames: []string{"v2-nvidia"},
+		},
+		{
+			name: "only matching preset skipped, others kept",
+			existing: []unstructured.Unstructured{
+				accelPresetSpec("v1-nvidia", "nvidia.com/gpu", "img:1"),
+			},
+			rendered: []unstructured.Unstructured{
+				accelPresetSpec("v2-nvidia", "nvidia.com/gpu", "img:1"),
+				accelPresetSpec("v2-amd", "amd.com/gpu", "img:1"),
+			},
+			wantNames: []string{"v2-amd"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			r := dedupeReconciler(tc.existing...)
+			result := r.dedupeVersionedAcceleratorPresets(context.Background(), tc.rendered)
+
+			var names []string
+			for _, res := range result {
+				names = append(names, res.GetName())
+			}
+			g.Expect(names).Should(ConsistOf(tc.wantNames))
+		})
+	}
+}
+
+func TestDedupeVersionedAcceleratorPresets_ChangedAnnotationKept(t *testing.T) {
+	g := NewWithT(t)
+
+	existing := accelPresetSpec("v1-nvidia", "nvidia.com/gpu", "img:1")
+	rendered := accelPresetSpec("v2-nvidia", "nvidia.com/gpu", "img:1")
+	// A meaningful annotation change means the content differs, so it must be kept.
+	anns := rendered.GetAnnotations()
+	anns["opendatahub.io/extra"] = "changed"
+	rendered.SetAnnotations(anns)
+
+	r := dedupeReconciler(existing)
+	result := r.dedupeVersionedAcceleratorPresets(context.Background(), []unstructured.Unstructured{rendered})
+	g.Expect(result).Should(HaveLen(1))
+}
+
+func TestHasContentTwinUnderDifferentName(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(hasContentTwinUnderDifferentName(nil, "v2")).Should(BeFalse())
+	g.Expect(hasContentTwinUnderDifferentName(map[string]struct{}{"v2": {}}, "v2")).Should(BeFalse())
+	g.Expect(hasContentTwinUnderDifferentName(map[string]struct{}{"v1": {}}, "v2")).Should(BeTrue())
+	g.Expect(hasContentTwinUnderDifferentName(map[string]struct{}{"v1": {}, "v2": {}}, "v2")).Should(BeTrue())
+}

--- a/kserve-module/pkg/kservemodule/hardware_filter.go
+++ b/kserve-module/pkg/kservemodule/hardware_filter.go
@@ -1,0 +1,151 @@
+package kservemodule
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	platformv1alpha1 "github.com/opendatahub-io/kserve-module/pkg/apis/v1alpha1"
+)
+
+// acceleratorRequirements returns the accelerator resource names a preset targets,
+// parsed from the opendatahub.io/recommended-accelerators annotation (a JSON array).
+// It returns nil for non-accelerator presets (annotation absent) and for presets whose
+// annotation is empty or unparseable, which are then treated as always-available.
+func acceleratorRequirements(obj *unstructured.Unstructured) []string {
+	raw := obj.GetAnnotations()[recommendedAcceleratorsAnnotationKey]
+	if raw == "" {
+		return nil
+	}
+	var names []string
+	if err := json.Unmarshal([]byte(raw), &names); err != nil {
+		return nil
+	}
+	// Drop empty entries so a malformed '[""]' does not filter everything out.
+	out := names[:0]
+	for _, n := range names {
+		if n != "" {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// resourceDomain returns the vendor domain of a Kubernetes resource name, i.e. the
+// part before the first "/". For nvidia.com/gpu and nvidia.com/mig-1g.5gb this is
+// "nvidia.com", so MIG-partitioned and vendor-variant devices satisfy a plain
+// nvidia.com/gpu requirement. Names without a "/" (e.g. cpu, memory) have no domain.
+func resourceDomain(name string) string {
+	if before, _, ok := strings.Cut(name, "/"); ok {
+		return before
+	}
+	return ""
+}
+
+// presentAcceleratorResources lists all nodes and collects the set of resource names
+// and vendor domains that appear in any node's status.allocatable. The domains set lets
+// a requirement match MIG/vendor-variant devices under the same domain.
+func (r *KserveModuleReconciler) presentAcceleratorResources(ctx context.Context) (names, domains map[string]struct{}, err error) {
+	nodes := &corev1.NodeList{}
+	if err := r.List(ctx, nodes); err != nil {
+		return nil, nil, fmt.Errorf("listing nodes: %w", err)
+	}
+
+	names = make(map[string]struct{})
+	domains = make(map[string]struct{})
+	for i := range nodes.Items {
+		for resName := range nodes.Items[i].Status.Allocatable {
+			name := resName.String()
+			names[name] = struct{}{}
+			if d := resourceDomain(name); d != "" {
+				domains[d] = struct{}{}
+			}
+		}
+	}
+	return names, domains, nil
+}
+
+// acceleratorPresent reports whether an accelerator requirement is satisfied by the
+// cluster: an exact allocatable match, or a match on the vendor domain (covering MIG
+// devices such as nvidia.com/mig-1g.5gb against a nvidia.com/gpu requirement).
+func acceleratorPresent(req string, names, domains map[string]struct{}) bool {
+	if _, ok := names[req]; ok {
+		return true
+	}
+	if d := resourceDomain(req); d != "" {
+		if _, ok := domains[d]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// filterHardwareUnavailablePresets drops accelerator LLMInferenceServiceConfig presets
+// whose required accelerator is not present in any node's status.allocatable. Presets
+// without the recommended-accelerators annotation (generic templates, non-config kinds)
+// are always kept. The behavior is disabled when spec.enableHardwareAwarePresets is false.
+//
+// It fails open: if the node list cannot be read, all presets are kept so a transient
+// API error never blocks a rollout.
+func (r *KserveModuleReconciler) filterHardwareUnavailablePresets(ctx context.Context,
+	kserve *platformv1alpha1.Kserve, resources []unstructured.Unstructured) []unstructured.Unstructured {
+
+	log := ctrl.LoggerFrom(ctx)
+
+	if kserve == nil || !ptr.Deref(kserve.Spec.EnableHardwareAwarePresets, true) {
+		return resources
+	}
+
+	// Cheap pre-check: skip the node list when nothing is a filterable accelerator preset.
+	hasAccelPreset := false
+	for i := range resources {
+		if isAcceleratorPreset(&resources[i]) && len(acceleratorRequirements(&resources[i])) > 0 {
+			hasAccelPreset = true
+			break
+		}
+	}
+	if !hasAccelPreset {
+		return resources
+	}
+
+	names, domains, err := r.presentAcceleratorResources(ctx)
+	if err != nil {
+		log.Error(err, "hardware-aware filtering: failed to list nodes, keeping all presets")
+		return resources
+	}
+
+	filtered := make([]unstructured.Unstructured, 0, len(resources))
+	var dropped []string
+	for i := range resources {
+		reqs := acceleratorRequirements(&resources[i])
+		if len(reqs) == 0 || !isAcceleratorPreset(&resources[i]) {
+			filtered = append(filtered, resources[i])
+			continue
+		}
+
+		available := false
+		for _, req := range reqs {
+			if acceleratorPresent(req, names, domains) {
+				available = true
+				break
+			}
+		}
+		if available {
+			filtered = append(filtered, resources[i])
+		} else {
+			dropped = append(dropped, resources[i].GetName())
+		}
+	}
+
+	if len(dropped) > 0 {
+		log.Info("hardware-aware filtering: skipped accelerator presets with no matching node hardware",
+			"count", len(dropped), "presets", dropped)
+	}
+	return filtered
+}

--- a/kserve-module/pkg/kservemodule/hardware_filter.go
+++ b/kserve-module/pkg/kservemodule/hardware_filter.go
@@ -38,6 +38,28 @@ func acceleratorRequirements(obj *unstructured.Unstructured) []string {
 	return out
 }
 
+// draDriverRequirements returns the DRA driver names a preset explicitly targets, parsed
+// from the opendatahub.io/recommended-dra-drivers annotation (a JSON array). It returns nil
+// when the annotation is absent, empty, or unparseable. These are matched exactly against the
+// drivers publishing ResourceSlices, complementing the vendor-domain bridge in acceleratorPresent.
+func draDriverRequirements(obj *unstructured.Unstructured) []string {
+	raw := obj.GetAnnotations()[recommendedDRADriversAnnotationKey]
+	if raw == "" {
+		return nil
+	}
+	var names []string
+	if err := json.Unmarshal([]byte(raw), &names); err != nil {
+		return nil
+	}
+	out := names[:0]
+	for _, n := range names {
+		if n != "" {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
 // resourceDomain returns the vendor domain of a Kubernetes resource name, i.e. the
 // part before the first "/". For nvidia.com/gpu and nvidia.com/mig-1g.5gb this is
 // "nvidia.com", so MIG-partitioned and vendor-variant devices satisfy a plain
@@ -133,10 +155,13 @@ func acceleratorPresent(req string, names, domains, draDrivers map[string]struct
 	return false
 }
 
-// filterHardwareUnavailablePresets drops accelerator LLMInferenceServiceConfig presets
-// whose required accelerator is not present in any node's status.allocatable. Presets
-// without the recommended-accelerators annotation (generic templates, non-config kinds)
-// are always kept. The behavior is disabled when spec.enableHardwareAwarePresets is false.
+// filterHardwareUnavailablePresets drops accelerator LLMInferenceServiceConfig presets whose
+// required accelerator is present neither in any node's status.allocatable nor via a DRA
+// ResourceSlice. A preset is kept when its recommended-accelerators (matched by exact resource
+// name or vendor domain, including the DRA driver domain bridge) OR its optional
+// recommended-dra-drivers (matched exactly against publishing drivers) are satisfied. Presets
+// carrying neither annotation (generic templates, non-config kinds) are always kept. The
+// behavior is disabled when spec.enableHardwareAwarePresets is false.
 //
 // It fails open: if the node list cannot be read, all presets are kept so a transient
 // API error never blocks a rollout.
@@ -152,7 +177,8 @@ func (r *KserveModuleReconciler) filterHardwareUnavailablePresets(ctx context.Co
 	// Cheap pre-check: skip the node list when nothing is a filterable accelerator preset.
 	hasAccelPreset := false
 	for i := range resources {
-		if isAcceleratorPreset(&resources[i]) && len(acceleratorRequirements(&resources[i])) > 0 {
+		if isAcceleratorPreset(&resources[i]) &&
+			(len(acceleratorRequirements(&resources[i])) > 0 || len(draDriverRequirements(&resources[i])) > 0) {
 			hasAccelPreset = true
 			break
 		}
@@ -176,7 +202,8 @@ func (r *KserveModuleReconciler) filterHardwareUnavailablePresets(ctx context.Co
 	var dropped []string
 	for i := range resources {
 		reqs := acceleratorRequirements(&resources[i])
-		if len(reqs) == 0 || !isAcceleratorPreset(&resources[i]) {
+		draReqs := draDriverRequirements(&resources[i])
+		if (len(reqs) == 0 && len(draReqs) == 0) || !isAcceleratorPreset(&resources[i]) {
 			filtered = append(filtered, resources[i])
 			continue
 		}
@@ -186,6 +213,16 @@ func (r *KserveModuleReconciler) filterHardwareUnavailablePresets(ctx context.Co
 			if acceleratorPresent(req, names, domains, draDrivers) {
 				available = true
 				break
+			}
+		}
+		// An explicit DRA driver requirement is satisfied by an exact driver match,
+		// independent of the vendor-domain bridge above.
+		if !available {
+			for _, req := range draReqs {
+				if _, ok := draDrivers[req]; ok {
+					available = true
+					break
+				}
 			}
 		}
 		if available {

--- a/kserve-module/pkg/kservemodule/hardware_filter.go
+++ b/kserve-module/pkg/kservemodule/hardware_filter.go
@@ -8,6 +8,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -71,15 +72,61 @@ func (r *KserveModuleReconciler) presentAcceleratorResources(ctx context.Context
 	return names, domains, nil
 }
 
-// acceleratorPresent reports whether an accelerator requirement is satisfied by the
-// cluster: an exact allocatable match, or a match on the vendor domain (covering MIG
-// devices such as nvidia.com/mig-1g.5gb against a nvidia.com/gpu requirement).
-func acceleratorPresent(req string, names, domains map[string]struct{}) bool {
+// presentDRADrivers lists Dynamic Resource Allocation ResourceSlices and returns the set of
+// driver names publishing devices in the cluster (e.g. gpu.nvidia.com). ResourceSlices are
+// the DRA analog of node status.allocatable: a driver only publishes them where its hardware
+// is actually present, so they signal accelerator availability on DRA-based clusters.
+//
+// When the cluster does not serve the resource.k8s.io API (draResourceSliceGVK unset, decided
+// at setup via the RESTMapper), it returns an empty set and no error. A genuine list error is
+// returned so the caller can fail open.
+func (r *KserveModuleReconciler) presentDRADrivers(ctx context.Context) (map[string]struct{}, error) {
+	drivers := make(map[string]struct{})
+	if r.draResourceSliceGVK.Empty() {
+		return drivers, nil
+	}
+
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   r.draResourceSliceGVK.Group,
+		Version: r.draResourceSliceGVK.Version,
+		Kind:    r.draResourceSliceGVK.Kind + "List",
+	})
+	if err := r.List(ctx, list); err != nil {
+		return nil, fmt.Errorf("listing ResourceSlices: %w", err)
+	}
+
+	for i := range list.Items {
+		driver, _, err := unstructured.NestedString(list.Items[i].Object, "spec", "driver")
+		if err != nil || driver == "" {
+			continue
+		}
+		drivers[driver] = struct{}{}
+	}
+	return drivers, nil
+}
+
+// acceleratorPresent reports whether an accelerator requirement is satisfied by the cluster:
+//   - an exact allocatable match (device-plugin extended resources), or
+//   - a match on the vendor domain (covering MIG devices such as nvidia.com/mig-1g.5gb
+//     against a nvidia.com/gpu requirement), or
+//   - a DRA ResourceSlice whose driver belongs to the same vendor domain (e.g. driver
+//     gpu.nvidia.com satisfies a nvidia.com/gpu requirement).
+func acceleratorPresent(req string, names, domains, draDrivers map[string]struct{}) bool {
 	if _, ok := names[req]; ok {
 		return true
 	}
-	if d := resourceDomain(req); d != "" {
-		if _, ok := domains[d]; ok {
+	d := resourceDomain(req)
+	if d == "" {
+		return false
+	}
+	if _, ok := domains[d]; ok {
+		return true
+	}
+	for driver := range draDrivers {
+		// gpu.nvidia.com (and compute-domain.nvidia.com, etc.) all end in ".nvidia.com";
+		// a bare driver equal to the domain is matched too.
+		if driver == d || strings.HasSuffix(driver, "."+d) {
 			return true
 		}
 	}
@@ -119,6 +166,11 @@ func (r *KserveModuleReconciler) filterHardwareUnavailablePresets(ctx context.Co
 		log.Error(err, "hardware-aware filtering: failed to list nodes, keeping all presets")
 		return resources
 	}
+	draDrivers, err := r.presentDRADrivers(ctx)
+	if err != nil {
+		log.Error(err, "hardware-aware filtering: failed to list DRA ResourceSlices, keeping all presets")
+		return resources
+	}
 
 	filtered := make([]unstructured.Unstructured, 0, len(resources))
 	var dropped []string
@@ -131,7 +183,7 @@ func (r *KserveModuleReconciler) filterHardwareUnavailablePresets(ctx context.Co
 
 		available := false
 		for _, req := range reqs {
-			if acceleratorPresent(req, names, domains) {
+			if acceleratorPresent(req, names, domains, draDrivers) {
 				available = true
 				break
 			}

--- a/kserve-module/pkg/kservemodule/hardware_filter_int_test.go
+++ b/kserve-module/pkg/kservemodule/hardware_filter_int_test.go
@@ -1,0 +1,176 @@
+package kservemodule_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster"
+
+	platformv1alpha1 "github.com/opendatahub-io/kserve-module/pkg/apis/v1alpha1"
+	kservemodule "github.com/opendatahub-io/kserve-module/pkg/kservemodule"
+	"github.com/opendatahub-io/kserve-module/pkg/kservemodule/fixture"
+)
+
+// acceleratorPresetName is the well-known accelerator preset injected into the kserve
+// overlay for this suite; it requires an nvidia.com/gpu allocatable to be rendered.
+const acceleratorPresetName = "kserve-config-llm-nvidia-cuda"
+
+func acceleratorPresetYAML(name string) string {
+	return `apiVersion: serving.kserve.io/v1alpha2
+kind: LLMInferenceServiceConfig
+metadata:
+  name: ` + name + `
+  labels:
+    opendatahub.io/config-type: accelerator
+  annotations:
+    serving.kserve.io/well-known-config: "true"
+    opendatahub.io/recommended-accelerators: '["nvidia.com/gpu"]'
+spec:
+  template:
+    containers:
+    - name: main
+      image: registry.example.com/vllm:latest
+`
+}
+
+// deployInputContainsPreset reports whether any resource captured by the mock deployer
+// carries the preset's base name. Presets are version-prefixed before deployment
+// (e.g. v0-0-0-kserve-config-llm-nvidia-cuda), so a suffix match is used.
+func deployInputContainsPreset(m *fixture.MockDeployer, name string) bool {
+	for i := range m.Calls {
+		for j := range m.Calls[i].Resources {
+			if strings.HasSuffix(m.Calls[i].Resources[j].GetName(), name) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func deployedResourceNames(m *fixture.MockDeployer) []string {
+	var names []string
+	for i := range m.Calls {
+		for j := range m.Calls[i].Resources {
+			names = append(names, m.Calls[i].Resources[j].GetKind()+"/"+m.Calls[i].Resources[j].GetName())
+		}
+	}
+	return names
+}
+
+var _ = Describe("Hardware-aware preset filtering", Ordered, func() {
+	var kserve *platformv1alpha1.Kserve
+	var overlayResourcePath string
+	var originalManifest []byte
+
+	BeforeAll(func(ctx SpecContext) {
+		testEnv.Reconciler.Deployer = &fixture.MockDeployer{}
+		testEnv.Reconciler.SetClusterType(cluster.ClusterTypeOpenShift)
+
+		// Inject an accelerator preset into the kserve overlay so the render carries something
+		// for hardware-aware filtering to act on; restored in AfterAll.
+		overlayResourcePath = filepath.Join(testEnv.Reconciler.ManifestsTemplatePath,
+			kservemodule.KserveComponentName, kservemodule.KserveManifestSourcePath, "resource.yaml")
+		var err error
+		originalManifest, err = os.ReadFile(overlayResourcePath)
+		Expect(err).NotTo(HaveOccurred())
+		withPreset := string(originalManifest) + "\n---\n" + acceleratorPresetYAML(acceleratorPresetName)
+		Expect(os.WriteFile(overlayResourcePath, []byte(withPreset), 0o644)).To(Succeed())
+
+		kserve = fixture.KserveCR()
+		Expect(client.IgnoreNotFound(testEnv.Client.Delete(ctx, kserve))).To(Succeed())
+		Eventually(func(g Gomega) {
+			err := testEnv.Client.Get(ctx, client.ObjectKeyFromObject(kserve), kserve)
+			g.Expect(k8serr.IsNotFound(err)).To(BeTrue())
+		}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
+
+		kserve = fixture.KserveCR()
+		Expect(testEnv.Client.Create(ctx, kserve)).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(testEnv.Client.Get(ctx, client.ObjectKeyFromObject(kserve), kserve)).To(Succeed())
+			g.Expect(kserve.Status.ObservedGeneration).To(Equal(kserve.Generation))
+		}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
+	})
+
+	AfterAll(func(ctx SpecContext) {
+		if originalManifest != nil {
+			Expect(os.WriteFile(overlayResourcePath, originalManifest, 0o644)).To(Succeed())
+		}
+		if kserve != nil {
+			Expect(client.IgnoreNotFound(testEnv.Client.Delete(ctx, kserve))).To(Succeed())
+			Eventually(func(g Gomega) {
+				err := testEnv.Client.Get(ctx, client.ObjectKeyFromObject(kserve), kserve)
+				g.Expect(k8serr.IsNotFound(err)).To(BeTrue())
+			}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
+		}
+		testEnv.Reconciler.SetClusterType(cluster.ClusterTypeOpenShift)
+	})
+
+	It("omits the accelerator preset when no matching node hardware is present", func(ctx SpecContext) {
+		// Fresh deployer so only this reconcile's rendered resources are inspected.
+		testEnv.Reconciler.Deployer = &fixture.MockDeployer{}
+		triggerReconcile(ctx, kserve, "hw-no-gpu")
+
+		Eventually(func(g Gomega) {
+			g.Expect(testEnv.Client.Get(ctx, client.ObjectKeyFromObject(kserve), kserve)).To(Succeed())
+			g.Expect(kserve.Status.ObservedGeneration).To(Equal(kserve.Generation))
+			g.Expect(mockDeployer().LastCall()).NotTo(BeNil())
+		}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
+
+		Consistently(func(g Gomega) {
+			g.Expect(deployInputContainsPreset(mockDeployer(), acceleratorPresetName)).To(BeFalse(),
+				"accelerator preset must not be rendered on a cluster with no GPU nodes")
+		}).WithContext(ctx).WithTimeout(3 * time.Second).Should(Succeed())
+	})
+
+	It("renders the accelerator preset once a GPU node appears", func(ctx SpecContext) {
+		testEnv.Reconciler.Deployer = &fixture.MockDeployer{}
+
+		gpuNode := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "gpu-node"}}
+		Expect(testEnv.Client.Create(ctx, gpuNode)).To(Succeed())
+		DeferCleanup(func(ctx SpecContext) {
+			client.IgnoreNotFound(testEnv.Client.Delete(ctx, gpuNode))
+		})
+
+		Expect(testEnv.Client.Get(ctx, client.ObjectKey{Name: "gpu-node"}, gpuNode)).To(Succeed())
+		gpuNode.Status.Allocatable = corev1.ResourceList{
+			"nvidia.com/gpu": resource.MustParse("1"),
+			corev1.ResourceCPU: resource.MustParse("4"),
+		}
+		Expect(testEnv.Client.Status().Update(ctx, gpuNode)).To(Succeed())
+
+		// Sanity: the direct client must reflect the allocatable update.
+		Expect(testEnv.Client.Get(ctx, client.ObjectKey{Name: "gpu-node"}, gpuNode)).To(Succeed())
+		Expect(gpuNode.Status.Allocatable).To(HaveKey(corev1.ResourceName("nvidia.com/gpu")))
+
+		// The reconciler's cache must observe the node before a reconcile can keep the preset.
+		Eventually(func(g Gomega) {
+			nodes := &corev1.NodeList{}
+			g.Expect(testEnv.Reconciler.Client.List(ctx, nodes)).To(Succeed())
+			found := false
+			for i := range nodes.Items {
+				if _, ok := nodes.Items[i].Status.Allocatable["nvidia.com/gpu"]; ok {
+					found = true
+				}
+			}
+			g.Expect(found).To(BeTrue(), "reconciler cache should see a node with nvidia.com/gpu allocatable")
+		}).WithContext(ctx).WithTimeout(30 * time.Second).Should(Succeed())
+
+		// Re-trigger each poll: a reconcile must run after the cache observed the GPU.
+		Eventually(func(g Gomega) {
+			triggerReconcile(ctx, kserve, "hw-gpu-present")
+			g.Expect(deployInputContainsPreset(mockDeployer(), acceleratorPresetName)).To(BeTrue(),
+				"accelerator preset must be rendered once a node exposes nvidia.com/gpu; deployed=%v",
+				deployedResourceNames(mockDeployer()))
+		}).WithContext(ctx).WithTimeout(30 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
+	})
+})

--- a/kserve-module/pkg/kservemodule/hardware_filter_test.go
+++ b/kserve-module/pkg/kservemodule/hardware_filter_test.go
@@ -9,6 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -73,6 +74,35 @@ func nodeSchemeReconciler(objs ...runtime.Object) *KserveModuleReconciler {
 	return &KserveModuleReconciler{Client: cli, applicationsNamespace: "opendatahub"}
 }
 
+// draResourceSliceGVKTest is the ResourceSlice GVK used in DRA-aware tests, mirroring the
+// served GVK the reconciler discovers via the RESTMapper at setup.
+var draResourceSliceGVKTest = schema.GroupVersionKind{Group: "resource.k8s.io", Version: "v1", Kind: "ResourceSlice"}
+
+func resourceSlice(name, driver string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(draResourceSliceGVKTest)
+	u.SetName(name)
+	_ = unstructured.SetNestedField(u.Object, driver, "spec", "driver")
+	return u
+}
+
+// draReconciler builds a reconciler whose scheme knows the ResourceSlice GVK and whose
+// draResourceSliceGVK is set, so presentDRADrivers lists the seeded slices.
+func draReconciler(objs ...runtime.Object) *KserveModuleReconciler {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	s.AddKnownTypeWithName(llmISVCConfigGVK, &unstructured.Unstructured{})
+	s.AddKnownTypeWithName(llmISVCConfigListGVK, &unstructured.UnstructuredList{})
+	s.AddKnownTypeWithName(draResourceSliceGVKTest, &unstructured.Unstructured{})
+	s.AddKnownTypeWithName(draResourceSliceGVKTest.GroupVersion().WithKind("ResourceSliceList"), &unstructured.UnstructuredList{})
+	cli := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
+	return &KserveModuleReconciler{
+		Client:                cli,
+		applicationsNamespace: "opendatahub",
+		draResourceSliceGVK:   draResourceSliceGVKTest,
+	}
+}
+
 func TestAcceleratorRequirements(t *testing.T) {
 	tests := []struct {
 		name string
@@ -124,17 +154,35 @@ func TestResourceDomain(t *testing.T) {
 func TestAcceleratorPresent(t *testing.T) {
 	names := map[string]struct{}{"nvidia.com/mig-1g.5gb": {}, "cpu": {}}
 	domains := map[string]struct{}{"nvidia.com": {}}
+	noDRA := map[string]struct{}{}
 
 	g := NewWithT(t)
 	// Exact match on a MIG device.
-	g.Expect(acceleratorPresent("nvidia.com/mig-1g.5gb", names, domains)).Should(BeTrue())
+	g.Expect(acceleratorPresent("nvidia.com/mig-1g.5gb", names, domains, noDRA)).Should(BeTrue())
 	// Domain match: nvidia.com/gpu satisfied by a MIG device under the same domain.
-	g.Expect(acceleratorPresent("nvidia.com/gpu", names, domains)).Should(BeTrue())
+	g.Expect(acceleratorPresent("nvidia.com/gpu", names, domains, noDRA)).Should(BeTrue())
 	// No node exposes amd.com at all.
-	g.Expect(acceleratorPresent("amd.com/gpu", names, domains)).Should(BeFalse())
+	g.Expect(acceleratorPresent("amd.com/gpu", names, domains, noDRA)).Should(BeFalse())
 	// A domain-less requirement only matches exact names.
-	g.Expect(acceleratorPresent("cpu", names, domains)).Should(BeTrue())
-	g.Expect(acceleratorPresent("hugepages", names, domains)).Should(BeFalse())
+	g.Expect(acceleratorPresent("cpu", names, domains, noDRA)).Should(BeTrue())
+	g.Expect(acceleratorPresent("hugepages", names, domains, noDRA)).Should(BeFalse())
+}
+
+func TestAcceleratorPresent_DRA(t *testing.T) {
+	g := NewWithT(t)
+	// No device-plugin allocatable at all; presence comes only from DRA ResourceSlices.
+	noNames := map[string]struct{}{}
+	noDomains := map[string]struct{}{}
+	draDrivers := map[string]struct{}{"gpu.nvidia.com": {}}
+
+	// A driver under the vendor domain satisfies the requirement.
+	g.Expect(acceleratorPresent("nvidia.com/gpu", noNames, noDomains, draDrivers)).Should(BeTrue())
+	// A different vendor's requirement is not satisfied.
+	g.Expect(acceleratorPresent("amd.com/gpu", noNames, noDomains, draDrivers)).Should(BeFalse())
+	// A driver named exactly as the domain also matches.
+	g.Expect(acceleratorPresent("amd.com/gpu", noNames, noDomains, map[string]struct{}{"amd.com": {}})).Should(BeTrue())
+	// A domain-less requirement never matches a DRA driver.
+	g.Expect(acceleratorPresent("cpu", noNames, noDomains, draDrivers)).Should(BeFalse())
 }
 
 // accelPresetNoLabel builds a well-known preset with the recommended-accelerators annotation
@@ -177,11 +225,11 @@ func TestFilterHardwareUnavailablePresets(t *testing.T) {
 	generic := accelPreset("kserve-config-llm-template")
 
 	tests := []struct {
-		name       string
-		nodes      []runtime.Object
-		enable     *bool
-		resources  []unstructured.Unstructured
-		wantNames  []string
+		name        string
+		nodes       []runtime.Object
+		enable      *bool
+		resources   []unstructured.Unstructured
+		wantNames   []string
 		wantDropped []string
 	}{
 		{
@@ -285,4 +333,49 @@ func TestFilterHardwareUnavailablePresets_NilKserve(t *testing.T) {
 	resources := []unstructured.Unstructured{accelPreset("nvidia", "nvidia.com/gpu")}
 	result := r.filterHardwareUnavailablePresets(context.Background(), nil, resources)
 	g.Expect(result).Should(HaveLen(1))
+}
+
+func TestPresentDRADrivers(t *testing.T) {
+	g := NewWithT(t)
+
+	// GVK unset (DRA not served): empty set, no error, no list attempted.
+	rNoDRA := &KserveModuleReconciler{applicationsNamespace: "opendatahub"}
+	drivers, err := rNoDRA.presentDRADrivers(context.Background())
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(drivers).Should(BeEmpty())
+
+	// GVK set: driver names collected from spec.driver of each ResourceSlice.
+	r := draReconciler(
+		resourceSlice("gpu-node-a", "gpu.nvidia.com"),
+		resourceSlice("gpu-node-b", "gpu.nvidia.com"),
+		resourceSlice("amd-node", "gpu.amd.com"),
+	)
+	drivers, err = r.presentDRADrivers(context.Background())
+	g.Expect(err).ShouldNot(HaveOccurred())
+	g.Expect(drivers).Should(HaveKey("gpu.nvidia.com"))
+	g.Expect(drivers).Should(HaveKey("gpu.amd.com"))
+	g.Expect(drivers).Should(HaveLen(2))
+}
+
+func TestFilterHardwareUnavailablePresets_DRA(t *testing.T) {
+	g := NewWithT(t)
+
+	// A cluster with no device-plugin GPU allocatable, but an nvidia DRA driver publishing a
+	// ResourceSlice: the nvidia preset must be kept, the amd one dropped.
+	r := draReconciler(
+		node("n1", "cpu"),
+		resourceSlice("gpu-node", "gpu.nvidia.com"),
+	)
+	kserve := &platformv1alpha1.Kserve{}
+	resources := []unstructured.Unstructured{
+		accelPreset("nvidia", "nvidia.com/gpu"),
+		accelPreset("amd", "amd.com/gpu"),
+	}
+	result := r.filterHardwareUnavailablePresets(context.Background(), kserve, resources)
+
+	var names []string
+	for _, res := range result {
+		names = append(names, res.GetName())
+	}
+	g.Expect(names).Should(ConsistOf("nvidia"))
 }

--- a/kserve-module/pkg/kservemodule/hardware_filter_test.go
+++ b/kserve-module/pkg/kservemodule/hardware_filter_test.go
@@ -1,0 +1,288 @@
+package kservemodule
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/onsi/gomega"
+
+	platformv1alpha1 "github.com/opendatahub-io/kserve-module/pkg/apis/v1alpha1"
+)
+
+// accelPreset builds a well-known accelerator LLMInferenceServiceConfig preset carrying
+// the recommended-accelerators annotation. Passing no accelerators omits the annotation,
+// producing a generic (non-accelerator) preset.
+func accelPreset(name string, accelerators ...string) unstructured.Unstructured {
+	annotations := map[string]any{wellKnownAnnotationKey: wellKnownAnnotationValue}
+	metadata := map[string]any{
+		"name":        name,
+		"namespace":   "opendatahub",
+		"annotations": annotations,
+	}
+	if len(accelerators) > 0 {
+		quoted := make([]string, len(accelerators))
+		for i, a := range accelerators {
+			quoted[i] = `"` + a + `"`
+		}
+		raw := "["
+		for i, q := range quoted {
+			if i > 0 {
+				raw += ","
+			}
+			raw += q
+		}
+		raw += "]"
+		annotations[recommendedAcceleratorsAnnotationKey] = raw
+		// The config-type label is what identifies an accelerator preset (see
+		// isAcceleratorPreset); omit it for the generic-preset case (no accelerators).
+		metadata["labels"] = map[string]any{configTypeLabelKey: configTypeAcceleratorValue}
+	}
+	return unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "serving.kserve.io/v1alpha2",
+		"kind":       "LLMInferenceServiceConfig",
+		"metadata":   metadata,
+		"spec":       map[string]any{},
+	}}
+}
+
+func node(name string, allocatable ...string) *corev1.Node {
+	rl := corev1.ResourceList{}
+	for _, a := range allocatable {
+		rl[corev1.ResourceName(a)] = resource.MustParse("1")
+	}
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Status:     corev1.NodeStatus{Allocatable: rl},
+	}
+}
+
+func nodeSchemeReconciler(objs ...runtime.Object) *KserveModuleReconciler {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	s.AddKnownTypeWithName(llmISVCConfigGVK, &unstructured.Unstructured{})
+	s.AddKnownTypeWithName(llmISVCConfigListGVK, &unstructured.UnstructuredList{})
+	cli := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(objs...).Build()
+	return &KserveModuleReconciler{Client: cli, applicationsNamespace: "opendatahub"}
+}
+
+func TestAcceleratorRequirements(t *testing.T) {
+	tests := []struct {
+		name string
+		anno string
+		want []string
+	}{
+		{"absent", "", nil},
+		{"single", `["nvidia.com/gpu"]`, []string{"nvidia.com/gpu"}},
+		{"multiple", `["nvidia.com/gpu","amd.com/gpu"]`, []string{"nvidia.com/gpu", "amd.com/gpu"}},
+		{"empty array", `[]`, nil},
+		{"empty entry dropped", `[""]`, nil},
+		{"malformed", `not-json`, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			obj := &unstructured.Unstructured{Object: map[string]any{}}
+			if tc.anno != "" {
+				obj.SetAnnotations(map[string]string{recommendedAcceleratorsAnnotationKey: tc.anno})
+			}
+			got := acceleratorRequirements(obj)
+			if tc.want == nil {
+				g.Expect(got).Should(BeEmpty())
+				return
+			}
+			g.Expect(got).Should(Equal(tc.want))
+		})
+	}
+}
+
+func TestResourceDomain(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"nvidia.com/gpu", "nvidia.com"},
+		{"nvidia.com/mig-1g.5gb", "nvidia.com"},
+		{"cpu", ""},
+		{"memory", ""},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			NewWithT(t).Expect(resourceDomain(tc.in)).Should(Equal(tc.want))
+		})
+	}
+}
+
+func TestAcceleratorPresent(t *testing.T) {
+	names := map[string]struct{}{"nvidia.com/mig-1g.5gb": {}, "cpu": {}}
+	domains := map[string]struct{}{"nvidia.com": {}}
+
+	g := NewWithT(t)
+	// Exact match on a MIG device.
+	g.Expect(acceleratorPresent("nvidia.com/mig-1g.5gb", names, domains)).Should(BeTrue())
+	// Domain match: nvidia.com/gpu satisfied by a MIG device under the same domain.
+	g.Expect(acceleratorPresent("nvidia.com/gpu", names, domains)).Should(BeTrue())
+	// No node exposes amd.com at all.
+	g.Expect(acceleratorPresent("amd.com/gpu", names, domains)).Should(BeFalse())
+	// A domain-less requirement only matches exact names.
+	g.Expect(acceleratorPresent("cpu", names, domains)).Should(BeTrue())
+	g.Expect(acceleratorPresent("hugepages", names, domains)).Should(BeFalse())
+}
+
+// accelPresetNoLabel builds a well-known preset with the recommended-accelerators annotation
+// but WITHOUT the config-type label, i.e. not identified as an accelerator preset.
+func accelPresetNoLabel(name, accelerator string) unstructured.Unstructured {
+	return unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "serving.kserve.io/v1alpha2",
+		"kind":       "LLMInferenceServiceConfig",
+		"metadata": map[string]any{
+			"name":      name,
+			"namespace": "opendatahub",
+			"annotations": map[string]any{
+				wellKnownAnnotationKey:               wellKnownAnnotationValue,
+				recommendedAcceleratorsAnnotationKey: `["` + accelerator + `"]`,
+			},
+		},
+		"spec": map[string]any{},
+	}}
+}
+
+func TestIsAcceleratorPreset(t *testing.T) {
+	g := NewWithT(t)
+	withLabel := accelPreset("nvidia", "nvidia.com/gpu")
+	g.Expect(isAcceleratorPreset(&withLabel)).To(BeTrue())
+
+	generic := accelPreset("kserve-config-llm-template")
+	g.Expect(isAcceleratorPreset(&generic)).To(BeFalse())
+
+	// Annotation present but config-type label missing: not an accelerator preset.
+	noLabel := accelPresetNoLabel("nvidia", "nvidia.com/gpu")
+	g.Expect(isAcceleratorPreset(&noLabel)).To(BeFalse())
+
+	// Wrong label value.
+	wrong := accelPreset("nvidia", "nvidia.com/gpu")
+	wrong.SetLabels(map[string]string{configTypeLabelKey: "runtime"})
+	g.Expect(isAcceleratorPreset(&wrong)).To(BeFalse())
+}
+
+func TestFilterHardwareUnavailablePresets(t *testing.T) {
+	generic := accelPreset("kserve-config-llm-template")
+
+	tests := []struct {
+		name       string
+		nodes      []runtime.Object
+		enable     *bool
+		resources  []unstructured.Unstructured
+		wantNames  []string
+		wantDropped []string
+	}{
+		{
+			name:      "nvidia preset kept when gpu present",
+			nodes:     []runtime.Object{node("n1", "nvidia.com/gpu", "cpu")},
+			resources: []unstructured.Unstructured{accelPreset("nvidia", "nvidia.com/gpu")},
+			wantNames: []string{"nvidia"},
+		},
+		{
+			name:        "nvidia preset dropped when no gpu",
+			nodes:       []runtime.Object{node("n1", "cpu")},
+			resources:   []unstructured.Unstructured{accelPreset("nvidia", "nvidia.com/gpu")},
+			wantDropped: []string{"nvidia"},
+		},
+		{
+			name:      "mig device satisfies plain gpu via domain match",
+			nodes:     []runtime.Object{node("n1", "nvidia.com/mig-1g.5gb")},
+			resources: []unstructured.Unstructured{accelPreset("nvidia", "nvidia.com/gpu")},
+			wantNames: []string{"nvidia"},
+		},
+		{
+			name:  "mixed: only accelerators with matching hardware kept",
+			nodes: []runtime.Object{node("n1", "nvidia.com/gpu")},
+			resources: []unstructured.Unstructured{
+				accelPreset("nvidia", "nvidia.com/gpu"),
+				accelPreset("amd", "amd.com/gpu"),
+				generic,
+			},
+			wantNames:   []string{"nvidia", "kserve-config-llm-template"},
+			wantDropped: []string{"amd"},
+		},
+		{
+			name:      "generic preset always kept",
+			nodes:     []runtime.Object{node("n1", "cpu")},
+			resources: []unstructured.Unstructured{generic},
+			wantNames: []string{"kserve-config-llm-template"},
+		},
+		{
+			// The recommended-accelerators annotation alone does not make a preset an
+			// accelerator preset; without the config-type label it is treated as generic
+			// and kept even when its accelerator is absent.
+			name:      "annotation without config-type label kept",
+			nodes:     []runtime.Object{node("n1", "cpu")},
+			resources: []unstructured.Unstructured{accelPresetNoLabel("nvidia-nolabel", "nvidia.com/gpu")},
+			wantNames: []string{"nvidia-nolabel"},
+		},
+		{
+			name:      "disable switch keeps everything",
+			nodes:     []runtime.Object{node("n1", "cpu")},
+			enable:    ptr.To(false),
+			resources: []unstructured.Unstructured{accelPreset("nvidia", "nvidia.com/gpu")},
+			wantNames: []string{"nvidia"},
+		},
+		{
+			name:      "multi-accelerator preset kept if any present",
+			nodes:     []runtime.Object{node("n1", "amd.com/gpu")},
+			resources: []unstructured.Unstructured{accelPreset("multi", "nvidia.com/gpu", "amd.com/gpu")},
+			wantNames: []string{"multi"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			r := nodeSchemeReconciler(tc.nodes...)
+			kserve := &platformv1alpha1.Kserve{}
+			kserve.Spec.EnableHardwareAwarePresets = tc.enable
+
+			result := r.filterHardwareUnavailablePresets(context.Background(), kserve, tc.resources)
+
+			var names []string
+			for _, res := range result {
+				names = append(names, res.GetName())
+			}
+			g.Expect(names).Should(ConsistOf(tc.wantNames))
+			for _, d := range tc.wantDropped {
+				g.Expect(names).ShouldNot(ContainElement(d))
+			}
+		})
+	}
+}
+
+func TestFilterHardwareUnavailablePresets_FailOpen(t *testing.T) {
+	g := NewWithT(t)
+	// A scheme without corev1 makes listing nodes fail; the filter must keep all presets.
+	s := runtime.NewScheme()
+	s.AddKnownTypeWithName(llmISVCConfigGVK, &unstructured.Unstructured{})
+	s.AddKnownTypeWithName(llmISVCConfigListGVK, &unstructured.UnstructuredList{})
+	cli := fake.NewClientBuilder().WithScheme(s).Build()
+	r := &KserveModuleReconciler{Client: cli, applicationsNamespace: "opendatahub"}
+
+	kserve := &platformv1alpha1.Kserve{}
+	resources := []unstructured.Unstructured{accelPreset("nvidia", "nvidia.com/gpu")}
+	result := r.filterHardwareUnavailablePresets(context.Background(), kserve, resources)
+	g.Expect(result).Should(HaveLen(1))
+}
+
+func TestFilterHardwareUnavailablePresets_NilKserve(t *testing.T) {
+	g := NewWithT(t)
+	r := nodeSchemeReconciler(node("n1", "cpu"))
+	resources := []unstructured.Unstructured{accelPreset("nvidia", "nvidia.com/gpu")}
+	result := r.filterHardwareUnavailablePresets(context.Background(), nil, resources)
+	g.Expect(result).Should(HaveLen(1))
+}

--- a/kserve-module/pkg/kservemodule/hardware_filter_test.go
+++ b/kserve-module/pkg/kservemodule/hardware_filter_test.go
@@ -335,6 +335,74 @@ func TestFilterHardwareUnavailablePresets_NilKserve(t *testing.T) {
 	g.Expect(result).Should(HaveLen(1))
 }
 
+func TestDRADriverRequirements(t *testing.T) {
+	tests := []struct {
+		name string
+		anno string
+		want []string
+	}{
+		{"absent", "", nil},
+		{"single", `["gpu.nvidia.com"]`, []string{"gpu.nvidia.com"}},
+		{"multiple", `["gpu.nvidia.com","gpu.amd.com"]`, []string{"gpu.nvidia.com", "gpu.amd.com"}},
+		{"empty array", `[]`, nil},
+		{"empty entry dropped", `[""]`, nil},
+		{"malformed", `not-json`, nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+			obj := &unstructured.Unstructured{Object: map[string]any{}}
+			if tc.anno != "" {
+				obj.SetAnnotations(map[string]string{recommendedDRADriversAnnotationKey: tc.anno})
+			}
+			got := draDriverRequirements(obj)
+			if tc.want == nil {
+				g.Expect(got).Should(BeEmpty())
+				return
+			}
+			g.Expect(got).Should(Equal(tc.want))
+		})
+	}
+}
+
+// accelPresetDRADriver builds an accelerator preset targeting an explicit DRA driver via the
+// recommended-dra-drivers annotation, plus a recommended-accelerators resource name whose vendor
+// domain deliberately differs from the driver's (so only the explicit driver match can keep it).
+func accelPresetDRADriver(name, accelerator, draDriver string) unstructured.Unstructured {
+	obj := accelPreset(name, accelerator)
+	anns := obj.GetAnnotations()
+	anns[recommendedDRADriversAnnotationKey] = `["` + draDriver + `"]`
+	obj.SetAnnotations(anns)
+	return obj
+}
+
+func TestFilterHardwareUnavailablePresets_DRADriverAnnotation(t *testing.T) {
+	g := NewWithT(t)
+
+	// The preset's resource domain (custom.example) does not match the driver's domain
+	// (accel.vendor.io), so only the explicit recommended-dra-drivers match can keep it.
+	kserve := &platformv1alpha1.Kserve{}
+
+	// Driver present: kept.
+	rPresent := draReconciler(
+		node("n1", "cpu"),
+		resourceSlice("accel-node", "accel.vendor.io"),
+	)
+	preset := accelPresetDRADriver("custom", "custom.example/device", "accel.vendor.io")
+	result := rPresent.filterHardwareUnavailablePresets(context.Background(), kserve, []unstructured.Unstructured{preset})
+	g.Expect(result).Should(HaveLen(1))
+
+	// Driver absent (a different driver publishes): dropped.
+	rAbsent := draReconciler(
+		node("n1", "cpu"),
+		resourceSlice("other-node", "gpu.nvidia.com"),
+	)
+	result = rAbsent.filterHardwareUnavailablePresets(context.Background(), kserve, []unstructured.Unstructured{
+		accelPresetDRADriver("custom", "custom.example/device", "accel.vendor.io"),
+	})
+	g.Expect(result).Should(BeEmpty())
+}
+
 func TestPresentDRADrivers(t *testing.T) {
 	g := NewWithT(t)
 

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -16,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -95,6 +96,7 @@ import (
 //
 // ModelCache RBAC
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;patch;update
+// +kubebuilder:rbac:groups=resource.k8s.io,resources=resourceslices,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=persistentvolumes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;patch;update
@@ -126,6 +128,12 @@ type KserveModuleReconciler struct {
 	cache          cache.Cache
 	dynamicWatches []*dynamicWatch
 	dynamicWatchMu sync.Mutex
+
+	// draResourceSliceGVK is the served resource.k8s.io ResourceSlice GVK discovered at
+	// setup (empty when the cluster does not serve Dynamic Resource Allocation). When set,
+	// hardware-aware filtering also treats accelerators published via DRA ResourceSlices as
+	// present, not just those in a node's status.allocatable.
+	draResourceSliceGVK schema.GroupVersionKind
 
 	// expectedPresets holds the preset names from the most recent render, written
 	// by reconcile and read by updateComponentReadiness later in the same call.

--- a/kserve-module/pkg/kservemodule/setup.go
+++ b/kserve-module/pkg/kservemodule/setup.go
@@ -104,6 +104,20 @@ func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			)),
 		)
 
+	// Dynamic Resource Allocation ResourceSlices are a built-in API (resource.k8s.io) whose
+	// served version varies by cluster version (v1beta1/v1beta2/v1). Discover the served GVK
+	// via the RESTMapper; when present, watch it so an accelerator appearing/disappearing via
+	// DRA re-renders hardware-aware presets, and record the GVK for the read side to list.
+	draGK := schema.GroupKind{Group: "resource.k8s.io", Kind: "ResourceSlice"}
+	if mapping, err := mgr.GetRESTMapper().RESTMapping(draGK); err == nil {
+		r.draResourceSliceGVK = mapping.GroupVersionKind
+		sliceObj := &unstructured.Unstructured{}
+		sliceObj.SetGroupVersionKind(mapping.GroupVersionKind)
+		b.Watches(sliceObj, handler.EnqueueRequestsFromMapFunc(mapToKserve),
+			builder.WithPredicates(predicate.GenerationChangedPredicate{}),
+		)
+	}
+
 	// SecurityContextConstraints CRD is always present on OpenShift (OLM); never on XKS.
 	sccGK := schema.GroupKind{Group: "security.openshift.io", Kind: "SecurityContextConstraints"}
 	if err := cluster.CustomResourceDefinitionExists(context.Background(), mgr.GetAPIReader(), sccGK); err == nil {

--- a/kserve-module/pkg/kservemodule/setup.go
+++ b/kserve-module/pkg/kservemodule/setup.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
@@ -93,11 +94,13 @@ func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			})),
 		).
 		// Watch Nodes so that newly added or relabeled nodes trigger
-		// reconciliation of labelModelCacheNodes.
+		// reconciliation of labelModelCacheNodes, and so a node gaining or losing an
+		// accelerator in status.allocatable re-renders hardware-aware presets.
 		Watches(&corev1.Node{}, handler.EnqueueRequestsFromMapFunc(mapToKserve),
 			builder.WithPredicates(predicate.Or(
 				predicate.GenerationChangedPredicate{},
 				predicate.LabelChangedPredicate{},
+				nodeAllocatableChangedPredicate(),
 			)),
 		)
 
@@ -234,6 +237,40 @@ func mapToKserve(_ context.Context, _ client.Object) []ctrl.Request {
 	return []ctrl.Request{{
 		NamespacedName: client.ObjectKey{Name: platformv1alpha1.KserveInstanceName},
 	}}
+}
+
+// nodeAllocatableChangedPredicate fires on node updates where the set of resource names
+// in status.allocatable changes (e.g. a GPU device plugin registering nvidia.com/gpu),
+// which the generation- and label-based predicates do not observe. Create and delete
+// events default to firing, matching GenerationChangedPredicate.
+func nodeAllocatableChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldNode, ok := e.ObjectOld.(*corev1.Node)
+			if !ok {
+				return false
+			}
+			newNode, ok := e.ObjectNew.(*corev1.Node)
+			if !ok {
+				return false
+			}
+			return !allocatableNamesEqual(oldNode.Status.Allocatable, newNode.Status.Allocatable)
+		},
+	}
+}
+
+// allocatableNamesEqual reports whether two ResourceLists expose the same set of resource
+// names, ignoring quantity changes (device plugins add or remove keys rather than mutate them).
+func allocatableNamesEqual(a, b corev1.ResourceList) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for name := range a {
+		if _, ok := b[name]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func crdNamePredicate() predicate.Predicate {

--- a/kserve-module/pkg/kservemodule/versioning.go
+++ b/kserve-module/pkg/kservemodule/versioning.go
@@ -24,6 +24,15 @@ func isShippedPreset(obj *unstructured.Unstructured, applicationsNS string) bool
 	return obj.GetNamespace() == applicationsNS && isWellKnownConfig(obj)
 }
 
+// isAcceleratorPreset reports whether the object is an accelerator-specific preset, i.e.
+// a well-known LLMInferenceServiceConfig carrying the accelerator config-type label the
+// accelerator overlays stamp on. Generic llm-d templates are well-known but lack the label,
+// so this cleanly separates accelerator presets from generic ones without parsing the
+// recommended-accelerators annotation.
+func isAcceleratorPreset(obj *unstructured.Unstructured) bool {
+	return isWellKnownConfig(obj) && obj.GetLabels()[configTypeLabelKey] == configTypeAcceleratorValue
+}
+
 // wellKnownPresetNames returns the names of the presets in a rendered resource
 // set, after versionedWellKnownLLMInferenceServiceConfigs has prefixed them.
 func wellKnownPresetNames(resources []unstructured.Unstructured) []string {


### PR DESCRIPTION
Implements two optimizations from the "Optimizing Versioned Resources Lifecycle" design for accelerator LLMInferenceServiceConfig presets in kserve-module:

1. Hardware-aware creation: only render accelerator presets whose required accelerator is present in a node's status.allocatable. Vendor-domain matching lets MIG and vendor-variant devices satisfy a plain nvidia.com/gpu requirement. Gated by a new nilable Kserve CR field spec.enableHardwareAwarePresets (default on) and fails open on node-list errors. The Node watch predicate is broadened to re-trigger on allocatable changes.

2. Differential versioning: skip rendering a versioned accelerator preset whose full content (spec + labels + annotations) is identical to an already-deployed prior-version preset, avoiding pile-up across patch releases. Fails open on list errors.

Accelerator presets are identified by the opendatahub.io/config-type: accelerator label (stamped by the accelerator kustomize overlays) via a shared isAcceleratorPreset helper; generic llm-d templates lack the label and are always kept.

Ref: https://docs.google.com/document/d/1YFctEsr0EquOgwnkgn9T2jBxJnSfSOaZzVaoz6v2jv4/edit?usp=sharing
