### PR TITLE
[RHOAIENG-88471] Register preset self-heal watch reliably

### DIFF
--- a/kserve-module/pkg/kservemodule/preset_selfheal_test.go
+++ b/kserve-module/pkg/kservemodule/preset_selfheal_test.go
@@ -1,0 +1,105 @@
+package kservemodule
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+// Deterministic regression guard for RHOAIENG-88471.
+//
+// kserve-module installs the serving.kserve.io CRDs itself and then ships
+// unowned LLMInferenceServiceConfig presets. A dynamic watch is meant to
+// recreate a deleted preset, but it registers only during a reconcile that runs
+// while the CRD exists. The bug: the CustomResourceDefinition watch predicate
+// matched only dependency CRDs, so creating a serving.kserve.io CRD this module
+// installs itself enqueued no reconcile. Once the controller reached a
+// no-requeue steady state the watch never registered and deleted presets were
+// never recreated.
+//
+// The fix makes the predicate also match the CRDs backing the module's own
+// dynamic watches. These tests pin that behavior at the unit level so they are
+// immune to the reconcile-loop timing that makes an end-to-end envtest unable
+// to isolate the change (unconditional status writes and CRD-not-yet-cached
+// error backoff both keep reconciles firing, which registers the watch
+// regardless of the predicate).
+
+// reconcilerWithDynamicWatches builds a reconciler carrying the same dynamic
+// watches SetupWithManager wires up, without needing a manager.
+func reconcilerWithDynamicWatches() *KserveModuleReconciler {
+	r := &KserveModuleReconciler{}
+	r.dynamicWatches = []*dynamicWatch{
+		{groupKind: schema.GroupKind{Group: "operator.openshift.io", Kind: "LeaderWorkerSetOperator"}},
+		{groupKind: schema.GroupKind{Group: "serving.kserve.io", Kind: "LocalModelNodeGroup"}},
+		{groupKind: llmISVCConfigGVK.GroupKind()},
+	}
+	return r
+}
+
+func crdMeta(name string) *apiextensionsv1.CustomResourceDefinition {
+	return &apiextensionsv1.CustomResourceDefinition{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+func TestDynamicWatchCRDNames_IncludesSelfInstalledServingCRDs(t *testing.T) {
+	g := NewWithT(t)
+	names := reconcilerWithDynamicWatches().dynamicWatchCRDNames()
+
+	// Derivation must match cluster.CustomResourceDefinitionExists exactly, or
+	// the predicate and the existence check would disagree.
+	g.Expect(names).To(HaveKey("llminferenceserviceconfigs.serving.kserve.io"))
+	g.Expect(names).To(HaveKey("localmodelnodegroups.serving.kserve.io"))
+	g.Expect(names).To(HaveKey("leaderworkersetoperators.operator.openshift.io"))
+}
+
+func TestCRDResourceName_MatchesExistenceCheckDerivation(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(crdResourceName(llmISVCConfigGVK.GroupKind())).
+		To(Equal("llminferenceserviceconfigs.serving.kserve.io"))
+}
+
+// TestCRDWatchPredicate_EnqueuesForSelfInstalledCRD is the core guard: the
+// predicate the CRD watch actually uses must fire for a serving.kserve.io CRD
+// this module installs itself. If the wiring regresses to crdNamePredicate(nil),
+// this fails.
+func TestCRDWatchPredicate_EnqueuesForSelfInstalledCRD(t *testing.T) {
+	g := NewWithT(t)
+	pred := reconcilerWithDynamicWatches().crdWatchPredicate()
+
+	preset := crdMeta("llminferenceserviceconfigs.serving.kserve.io")
+	g.Expect(pred.Create(event.CreateEvent{Object: preset})).To(BeTrue(),
+		"installing the self-shipped LLMInferenceServiceConfig CRD must enqueue a reconcile")
+
+	// Dependency CRDs (matched by exact name and by suffix) must still enqueue.
+	g.Expect(pred.Create(event.CreateEvent{
+		Object: crdMeta("subscriptions.operators.coreos.com"),
+	})).To(BeTrue())
+	g.Expect(pred.Create(event.CreateEvent{
+		Object: crdMeta("certificates.cert-manager.io"),
+	})).To(BeTrue())
+
+	// Unrelated CRDs must not enqueue.
+	g.Expect(pred.Create(event.CreateEvent{
+		Object: crdMeta("widgets.example.com"),
+	})).To(BeFalse())
+}
+
+// TestCRDNamePredicate_WithoutDynamicWatchNames_IsTheBug documents that the
+// pre-fix predicate (no dynamic-watch names) filters out the self-installed
+// serving.kserve.io CRD, which is exactly why the preset watch never registered.
+func TestCRDNamePredicate_WithoutDynamicWatchNames_IsTheBug(t *testing.T) {
+	g := NewWithT(t)
+	buggy := crdNamePredicate(nil)
+
+	g.Expect(buggy.Create(event.CreateEvent{
+		Object: crdMeta("llminferenceserviceconfigs.serving.kserve.io"),
+	})).To(BeFalse(), "reproduces the bug: self-installed serving CRDs were excluded")
+
+	// The dependency-CRD behavior is unchanged by the fix.
+	g.Expect(buggy.Create(event.CreateEvent{
+		Object: crdMeta("subscriptions.operators.coreos.com"),
+	})).To(BeTrue())
+}

--- a/kserve-module/pkg/kservemodule/preset_selfheal_test.go
+++ b/kserve-module/pkg/kservemodule/preset_selfheal_test.go
@@ -6,37 +6,38 @@ import (
 	. "github.com/onsi/gomega"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
 // Deterministic regression guard for RHOAIENG-88471.
 //
 // kserve-module installs the serving.kserve.io CRDs itself and then ships
-// unowned LLMInferenceServiceConfig presets. A dynamic watch is meant to
-// recreate a deleted preset, but it registers only during a reconcile that runs
-// while the CRD exists. The bug: the CustomResourceDefinition watch predicate
-// matched only dependency CRDs, so creating a serving.kserve.io CRD this module
-// installs itself enqueued no reconcile. Once the controller reached a
-// no-requeue steady state the watch never registered and deleted presets were
-// never recreated.
+// unowned LLMInferenceServiceConfig presets. A dynamic watch recreates a deleted
+// preset, but it registers only during a reconcile that runs while the CRD
+// exists and is seen by the client. Two things broke that:
 //
-// The fix makes the predicate also match the CRDs backing the module's own
-// dynamic watches. These tests pin that behavior at the unit level so they are
-// immune to the reconcile-loop timing that makes an end-to-end envtest unable
-// to isolate the change (unconditional status writes and CRD-not-yet-cached
-// error backoff both keep reconciles firing, which registers the watch
-// regardless of the predicate).
+//  1. The self-installed CRD is not in the cached client's store during the
+//     reconcile that installs it, so a cached existence check misses it. The fix
+//     reads through an uncached API reader.
+//  2. Once the controller reached a no-requeue happy state the watch never
+//     registered again. The fix gates the happy path: it requeues until every
+//     selfInstalled watch is registered.
+//
+// A supporting change makes the CustomResourceDefinition watch predicate match
+// the CRDs backing the module's own dynamic watches, so an externally recreated
+// CRD also enqueues a reconcile.
+//
+// These tests pin the wiring at the unit level so they are immune to the
+// reconcile-loop timing that makes an end-to-end envtest unable to isolate the
+// change (unconditional status writes and CRD-not-yet-cached error backoff both
+// keep reconciles firing, which registers the watch regardless).
 
 // reconcilerWithDynamicWatches builds a reconciler carrying the same dynamic
-// watches SetupWithManager wires up, without needing a manager.
+// watches SetupWithManager wires up, without needing a manager. It uses the real
+// buildDynamicWatches so the tests cannot drift from production wiring.
 func reconcilerWithDynamicWatches() *KserveModuleReconciler {
 	r := &KserveModuleReconciler{}
-	r.dynamicWatches = []*dynamicWatch{
-		{groupKind: schema.GroupKind{Group: "operator.openshift.io", Kind: "LeaderWorkerSetOperator"}},
-		{groupKind: schema.GroupKind{Group: "serving.kserve.io", Kind: "LocalModelNodeGroup"}},
-		{groupKind: llmISVCConfigGVK.GroupKind()},
-	}
+	r.dynamicWatches = r.buildDynamicWatches()
 	return r
 }
 
@@ -85,6 +86,32 @@ func TestCRDWatchPredicate_EnqueuesForSelfInstalledCRD(t *testing.T) {
 	g.Expect(pred.Create(event.CreateEvent{
 		Object: crdMeta("widgets.example.com"),
 	})).To(BeFalse())
+}
+
+// TestDynamicWatches_SelfInstalledFlags pins which watches gate the happy path.
+// The reconcile requeues until every selfInstalled watch registers; that must
+// cover exactly the CRDs this module installs itself (serving.kserve.io) and not
+// external/optional CRDs, which would otherwise requeue forever when absent.
+func TestDynamicWatches_SelfInstalledFlags(t *testing.T) {
+	g := NewWithT(t)
+	selfInstalled := map[string]bool{}
+	for _, dw := range reconcilerWithDynamicWatches().dynamicWatches {
+		selfInstalled[crdResourceName(dw.groupKind)] = dw.selfInstalled
+	}
+
+	g.Expect(selfInstalled).To(HaveKeyWithValue("llminferenceserviceconfigs.serving.kserve.io", true))
+	g.Expect(selfInstalled).To(HaveKeyWithValue("localmodelnodegroups.serving.kserve.io", true))
+	// External operator CRD: must not hold up the happy path when absent.
+	g.Expect(selfInstalled).To(HaveKeyWithValue("leaderworkersetoperators.operator.openshift.io", false))
+}
+
+// TestRegisterDynamicWatches_NilControllerNotPending guards that registration
+// reports no pending work before the controller is built, so the happy path is
+// not blocked during setup.
+func TestRegisterDynamicWatches_NilControllerNotPending(t *testing.T) {
+	g := NewWithT(t)
+	r := reconcilerWithDynamicWatches() // r.controller is nil
+	g.Expect(r.registerDynamicWatches(t.Context())).To(BeFalse())
 }
 
 // TestCRDNamePredicate_WithoutDynamicWatchNames_IsTheBug documents that the

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -124,6 +124,7 @@ type KserveModuleReconciler struct {
 
 	controller     controller.Controller
 	cache          cache.Cache
+	apiReader      client.Reader
 	dynamicWatches []*dynamicWatch
 	dynamicWatchMu sync.Mutex
 
@@ -196,6 +197,17 @@ func (r *KserveModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 	if !condMgr.IsHappy() {
 		log.Info("not all components ready, requeueing")
+		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+	}
+
+	// The CRDs this module installs itself exist by now. Register their dynamic
+	// watches before going quiescent: a self-installed CRD is not visible to the
+	// cached client during the reconcile that installs it, so the top-of-reconcile
+	// attempt above misses it. Once the happy path stops requeuing, no further
+	// reconcile runs and the preset self-heal watch would never register
+	// (RHOAIENG-88471). Requeue until every self-installed watch is registered.
+	if r.registerDynamicWatches(ctx) {
+		log.Info("self-installed dynamic watch registration pending, requeueing")
 		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
 	}
 

--- a/kserve-module/pkg/kservemodule/setup.go
+++ b/kserve-module/pkg/kservemodule/setup.go
@@ -220,7 +220,7 @@ func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // the watch would never register once the happy path stops requeuing
 // (RHOAIENG-88471). External/optional CRDs that are simply absent do not mark
 // work pending.
-func (r *KserveModuleReconciler) registerDynamicWatches(ctx context.Context) (pending bool) {
+func (r *KserveModuleReconciler) registerDynamicWatches(ctx context.Context) bool {
 	r.dynamicWatchMu.Lock()
 	defer r.dynamicWatchMu.Unlock()
 
@@ -233,6 +233,7 @@ func (r *KserveModuleReconciler) registerDynamicWatches(ctx context.Context) (pe
 		reader = r.Client
 	}
 
+	var pending bool
 	for _, dw := range r.dynamicWatches {
 		if dw.registered {
 			continue

--- a/kserve-module/pkg/kservemodule/setup.go
+++ b/kserve-module/pkg/kservemodule/setup.go
@@ -63,6 +63,35 @@ func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	r.cache = mgr.GetCache()
 
+	// Register dynamic watches up front so their CRD names can be fed to the CRD
+	// watch predicate below. When a CRD this module installs itself (e.g.
+	// serving.kserve.io) is created, that enqueues a reconcile and lets
+	// registerDynamicWatches attach the watch. Without it, watch registration
+	// races startup and, once the reconciler reaches steady state (no requeue),
+	// never retries -- leaving deleted presets unrecreated.
+	r.dynamicWatches = []*dynamicWatch{
+		{
+			groupKind: schema.GroupKind{Group: "operator.openshift.io", Kind: "LeaderWorkerSetOperator"},
+			gvk:       schema.GroupVersionKind{Group: "operator.openshift.io", Version: "v1", Kind: "LeaderWorkerSetOperator"},
+		},
+		{
+			groupKind: schema.GroupKind{Group: "serving.kserve.io", Kind: "LocalModelNodeGroup"},
+			gvk:       localModelNodeGroupGVK,
+		},
+		{
+			// Presets are deliberately out of the ownerRef chain (see
+			// unownedGroupKinds), so nothing recreates them when they are deleted.
+			// Watching them turns that into a normal reconcile. Scoped to the
+			// applications namespace: a reconcile renders and applies everything,
+			// so copies a user made elsewhere must not trigger one.
+			groupKind: llmISVCConfigGVK.GroupKind(),
+			gvk:       llmISVCConfigGVK,
+			filterFn: func(u *unstructured.Unstructured) bool {
+				return isShippedPreset(u, r.getApplicationsNamespace())
+			},
+		},
+	}
+
 	b := ctrl.NewControllerManagedBy(mgr).
 		For(&platformv1alpha1.Kserve{}).
 		Owns(&corev1.ConfigMap{}).
@@ -83,7 +112,7 @@ func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WatchesMetadata(
 			&apiextensionsv1.CustomResourceDefinition{},
 			handler.EnqueueRequestsFromMapFunc(mapToKserve),
-			builder.WithPredicates(crdNamePredicate()),
+			builder.WithPredicates(r.crdWatchPredicate()),
 		).
 		Watches(&corev1.ConfigMap{},
 			handler.EnqueueRequestsFromMapFunc(mapToKserve),
@@ -123,29 +152,6 @@ func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				return watchedSubscriptions[u.GetName()]
 			})),
 		)
-	}
-
-	r.dynamicWatches = []*dynamicWatch{
-		{
-			groupKind: schema.GroupKind{Group: "operator.openshift.io", Kind: "LeaderWorkerSetOperator"},
-			gvk:       schema.GroupVersionKind{Group: "operator.openshift.io", Version: "v1", Kind: "LeaderWorkerSetOperator"},
-		},
-		{
-			groupKind: schema.GroupKind{Group: "serving.kserve.io", Kind: "LocalModelNodeGroup"},
-			gvk:       localModelNodeGroupGVK,
-		},
-		{
-			// Presets are deliberately out of the ownerRef chain (see
-			// unownedGroupKinds), so nothing recreates them when they are deleted.
-			// Watching them turns that into a normal reconcile. Scoped to the
-			// applications namespace: a reconcile renders and applies everything,
-			// so copies a user made elsewhere must not trigger one.
-			groupKind: llmISVCConfigGVK.GroupKind(),
-			gvk:       llmISVCConfigGVK,
-			filterFn: func(u *unstructured.Unstructured) bool {
-				return isShippedPreset(u, r.getApplicationsNamespace())
-			},
-		},
 	}
 
 	for _, dw := range r.dynamicWatches {
@@ -236,10 +242,10 @@ func mapToKserve(_ context.Context, _ client.Object) []ctrl.Request {
 	}}
 }
 
-func crdNamePredicate() predicate.Predicate {
+func crdNamePredicate(extraNames map[string]bool) predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		name := obj.GetName()
-		if dependencyCRDNames[name] {
+		if dependencyCRDNames[name] || extraNames[name] {
 			return true
 		}
 		for _, suffix := range dependencyCRDSuffixes {
@@ -249,4 +255,32 @@ func crdNamePredicate() predicate.Predicate {
 		}
 		return false
 	})
+}
+
+// crdWatchPredicate builds the predicate for the CustomResourceDefinition watch.
+// It must match both this module's dependency CRDs and the CRDs backing its own
+// dynamic watches, so that installing a serving.kserve.io CRD this module ships
+// itself enqueues a reconcile (RHOAIENG-88471). Feeding it crdNamePredicate(nil)
+// reintroduces that bug: self-installed CRDs would be filtered out and the
+// preset self-heal watch would never register.
+func (r *KserveModuleReconciler) crdWatchPredicate() predicate.Predicate {
+	return crdNamePredicate(r.dynamicWatchCRDNames())
+}
+
+// dynamicWatchCRDNames returns the CRD resource names (e.g.
+// "llminferenceserviceconfigs.serving.kserve.io") backing every dynamic watch,
+// so that creation of a CRD this module installs itself enqueues a reconcile and
+// registerDynamicWatches can attach the watch. The name derivation mirrors
+// cluster.CustomResourceDefinitionExists so the predicate and the existence
+// check always agree.
+func (r *KserveModuleReconciler) dynamicWatchCRDNames() map[string]bool {
+	names := make(map[string]bool, len(r.dynamicWatches))
+	for _, dw := range r.dynamicWatches {
+		names[crdResourceName(dw.groupKind)] = true
+	}
+	return names
+}
+
+func crdResourceName(gk schema.GroupKind) string {
+	return strings.ToLower(fmt.Sprintf("%ss.%s", gk.Kind, gk.Group))
 }

--- a/kserve-module/pkg/kservemodule/setup.go
+++ b/kserve-module/pkg/kservemodule/setup.go
@@ -50,10 +50,46 @@ var watchedSubscriptions = map[string]bool{
 }
 
 type dynamicWatch struct {
-	groupKind  schema.GroupKind
-	gvk        schema.GroupVersionKind
-	filterFn   func(*unstructured.Unstructured) bool
-	registered bool
+	groupKind schema.GroupKind
+	gvk       schema.GroupVersionKind
+	filterFn  func(*unstructured.Unstructured) bool
+	// selfInstalled marks a watch whose CRD this module installs itself. Such a
+	// CRD is guaranteed to exist after the reconcile that installs it, so its
+	// watch registration is gated (reconcile requeues until registered) rather
+	// than best-effort. External/optional CRDs (selfInstalled false) register
+	// only if already present and never hold up the happy path.
+	selfInstalled bool
+	registered    bool
+}
+
+// buildDynamicWatches returns the watches attached lazily once their backing CRD
+// exists. Kept separate from SetupWithManager so tests can assert the wiring
+// (selfInstalled flags, CRD names) without a manager.
+func (r *KserveModuleReconciler) buildDynamicWatches() []*dynamicWatch {
+	return []*dynamicWatch{
+		{
+			groupKind: schema.GroupKind{Group: "operator.openshift.io", Kind: "LeaderWorkerSetOperator"},
+			gvk:       schema.GroupVersionKind{Group: "operator.openshift.io", Version: "v1", Kind: "LeaderWorkerSetOperator"},
+		},
+		{
+			groupKind:     schema.GroupKind{Group: "serving.kserve.io", Kind: "LocalModelNodeGroup"},
+			gvk:           localModelNodeGroupGVK,
+			selfInstalled: true,
+		},
+		{
+			// Presets are deliberately out of the ownerRef chain (see
+			// unownedGroupKinds), so nothing recreates them when they are deleted.
+			// Watching them turns that into a normal reconcile. Scoped to the
+			// applications namespace: a reconcile renders and applies everything,
+			// so copies a user made elsewhere must not trigger one.
+			groupKind:     llmISVCConfigGVK.GroupKind(),
+			gvk:           llmISVCConfigGVK,
+			selfInstalled: true,
+			filterFn: func(u *unstructured.Unstructured) bool {
+				return isShippedPreset(u, r.getApplicationsNamespace())
+			},
+		},
+	}
 }
 
 func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
@@ -62,6 +98,10 @@ func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	r.cache = mgr.GetCache()
+	// Uncached reader for CRD existence checks: a CRD this module installs itself
+	// is not yet in the cached client's store during the reconcile that installs
+	// it, so registerDynamicWatches must read through to the API server to see it.
+	r.apiReader = mgr.GetAPIReader()
 
 	// Register dynamic watches up front so their CRD names can be fed to the CRD
 	// watch predicate below. When a CRD this module installs itself (e.g.
@@ -69,28 +109,7 @@ func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// registerDynamicWatches attach the watch. Without it, watch registration
 	// races startup and, once the reconciler reaches steady state (no requeue),
 	// never retries -- leaving deleted presets unrecreated.
-	r.dynamicWatches = []*dynamicWatch{
-		{
-			groupKind: schema.GroupKind{Group: "operator.openshift.io", Kind: "LeaderWorkerSetOperator"},
-			gvk:       schema.GroupVersionKind{Group: "operator.openshift.io", Version: "v1", Kind: "LeaderWorkerSetOperator"},
-		},
-		{
-			groupKind: schema.GroupKind{Group: "serving.kserve.io", Kind: "LocalModelNodeGroup"},
-			gvk:       localModelNodeGroupGVK,
-		},
-		{
-			// Presets are deliberately out of the ownerRef chain (see
-			// unownedGroupKinds), so nothing recreates them when they are deleted.
-			// Watching them turns that into a normal reconcile. Scoped to the
-			// applications namespace: a reconcile renders and applies everything,
-			// so copies a user made elsewhere must not trigger one.
-			groupKind: llmISVCConfigGVK.GroupKind(),
-			gvk:       llmISVCConfigGVK,
-			filterFn: func(u *unstructured.Unstructured) bool {
-				return isShippedPreset(u, r.getApplicationsNamespace())
-			},
-		},
-	}
+	r.dynamicWatches = r.buildDynamicWatches()
 
 	b := ctrl.NewControllerManagedBy(mgr).
 		For(&platformv1alpha1.Kserve{}).
@@ -195,12 +214,23 @@ func (r *KserveModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return nil
 }
 
-func (r *KserveModuleReconciler) registerDynamicWatches(ctx context.Context) {
+// registerDynamicWatches attaches a watch for each dynamicWatch whose backing
+// CRD exists and is Established. It returns true when a self-installed watch is
+// still pending registration, so the caller can requeue and retry: without that
+// the watch would never register once the happy path stops requeuing
+// (RHOAIENG-88471). External/optional CRDs that are simply absent do not mark
+// work pending.
+func (r *KserveModuleReconciler) registerDynamicWatches(ctx context.Context) (pending bool) {
 	r.dynamicWatchMu.Lock()
 	defer r.dynamicWatchMu.Unlock()
 
 	if r.controller == nil {
-		return
+		return false
+	}
+
+	reader := r.apiReader
+	if reader == nil {
+		reader = r.Client
 	}
 
 	for _, dw := range r.dynamicWatches {
@@ -208,7 +238,16 @@ func (r *KserveModuleReconciler) registerDynamicWatches(ctx context.Context) {
 			continue
 		}
 
-		if err := cluster.CustomResourceDefinitionExists(ctx, r.Client, dw.groupKind); err != nil {
+		// Read through to the API server: a just-installed CRD is not yet in the
+		// cached client's store, so a cached check would miss it and the watch
+		// would never register.
+		if err := cluster.CustomResourceDefinitionExists(ctx, reader, dw.groupKind); err != nil {
+			// A self-installed CRD is guaranteed to exist once installed; if the
+			// check does not see it yet (not Established, cache lag), keep the
+			// caller requeuing until it does. An absent external CRD is expected.
+			if dw.selfInstalled {
+				pending = true
+			}
 			continue
 		}
 
@@ -228,12 +267,17 @@ func (r *KserveModuleReconciler) registerDynamicWatches(ctx context.Context) {
 
 		if err := r.controller.Watch(source.Kind[client.Object](r.cache, obj, handler.EnqueueRequestsFromMapFunc(mapToKserve), preds...)); err != nil {
 			ctrl.LoggerFrom(ctx).Error(err, "failed to register dynamic watch", "gvk", dw.gvk)
+			if dw.selfInstalled {
+				pending = true
+			}
 			continue
 		}
 
 		dw.registered = true
 		ctrl.LoggerFrom(ctx).Info("registered dynamic watch", "gvk", dw.gvk)
 	}
+
+	return pending
 }
 
 func mapToKserve(_ context.Context, _ client.Object) []ctrl.Request {


### PR DESCRIPTION
**What this PR does / why we need it**

kserve-module ships `LLMInferenceServiceConfig` presets that are deliberately unowned, so nothing recreates them if they get deleted. A dynamic watch (added in #1872) is supposed to reapply a deleted preset, but it never registered, so the presets stayed gone and e2e saw zero configs ([RHOAIENG-88471](https://redhat.atlassian.net/browse/RHOAIENG-88471)).

**Root cause** (pinned from live controller logs) — two things combined:

1. The watch is gated on the CRD existing, but the check used the **cached** client. kserve-module installs the `serving.kserve.io` CRDs itself, and a just-installed CRD isn't in the cache yet, so the check failed and the watch was skipped.
2. Once the controller reached steady state it stopped requeuing, so that check never ran again and the watch never registered.

**Fix**

- Check CRD existence through the **uncached** API reader (`mgr.GetAPIReader()`), so a CRD we just installed is visible right away.
- Requeue the happy path until every self-installed watch is registered. Only `serving.kserve.io` CRDs (the ones we install) hold this up; external CRDs like `LeaderWorkerSetOperator` don't, so a cluster without them won't requeue forever.
- Also make the CRD watch predicate match our own dynamic-watch CRDs, so an externally recreated CRD triggers a reconcile.

**Testing**

Unit tests in `preset_selfheal_test.go` (all pass) pin the wiring: which watches gate the happy path, that registration reports no pending work before the controller exists, and that the CRD predicate fires for a self-installed CRD. These are regression guards; envtest can't reproduce the live timing, which is why the root cause was pinned from cluster logs.

**Live validation** (RHOAI e2e cluster)

Ran this branch's image on a cluster: presets came up healthy (all 20 `Ready`), deleted 3, and the controller recreated all 3 within ~2s. On this cluster the CRDs already existed at startup, so the watch registered via the setup path; the fresh-install timing path is covered by CI e2e.

**Note for reviewer**

#1908 (open) fixes a different bug in the same preset watch (its Update predicate) and touches the same `setup.go`, so expect a small conflict depending on merge order.

**Release note**
```release-note
Fix LLMInferenceServiceConfig presets not being recreated after deletion: the preset self-heal watch now registers reliably, including for the serving.kserve.io CRDs kserve-module installs itself.
```

Involved repos:
- https://github.com/opendatahub-io/kserve (this PR)


[RHOAIENG-88471]: https://redhat.atlassian.net/browse/RHOAIENG-88471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of newly installed CRDs so required resource watches are registered reliably.
  * Ensured changes to self-installed CRDs trigger reconciliation.
  * Added automatic retry handling when watch registration is temporarily pending.

* **Tests**
  * Added regression coverage for self-installed, dependency, and unrelated CRD watch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->